### PR TITLE
bun-types: add a resolved type inventory and check it in CI

### DIFF
--- a/.github/workflows/bun-types.yml
+++ b/.github/workflows/bun-types.yml
@@ -41,3 +41,5 @@ jobs:
           bun install --cwd test
       - name: Check types
         run: bun test test/integration/bun-types/bun-types.test.ts
+      - name: Check the type inventory
+        run: bun test test/integration/bun-types/inventory.test.ts

--- a/.github/workflows/bun-types.yml
+++ b/.github/workflows/bun-types.yml
@@ -12,12 +12,18 @@ on:
       - "test/integration/bun-types/**"
       - "src/cli/init/tsconfig.default.json"
       - ".github/workflows/bun-types.yml"
+      # the inventory snapshots record the typescript and @types/node versions
+      - "package.json"
+      - "bun.lock"
   pull_request:
     paths:
       - "packages/bun-types/**"
       - "test/integration/bun-types/**"
       - "src/cli/init/tsconfig.default.json"
       - ".github/workflows/bun-types.yml"
+      # the inventory snapshots record the typescript and @types/node versions
+      - "package.json"
+      - "bun.lock"
 
 env:
   BUN_VERSION: "canary"

--- a/packages/bun-types/authoring.md
+++ b/packages/bun-types/authoring.md
@@ -110,7 +110,7 @@ For example, if you're adding types for a new API, you should just add code to `
 
 ## The type inventory
 
-`test/integration/bun-types/inventory/<preset>.txt` lists every global and every module export that bun-types contributes, with the shape the TypeScript checker resolves it to. Interface merging with `lib.dom.d.ts` and `@types/node`, `UseLibDomIfAvailable`, and every other conditional alias are resolved, so a file shows what a user sees, not what the `.d.ts` source says. There is one file per `lib` preset: `esnext`, `esnext-dom`, `es2022`, `es2022-dom`, and `no-lib`.
+`test/integration/bun-types/inventory/<preset>.txt` lists every symbol that has a declaration in bun-types, with the shape the TypeScript checker resolves it to: the globals, the exports of the modules bun-types declares (`bun`, `bun:test`, `*.html`), and the exports it adds to node modules and namespaces (`node:tls`, `NodeJS`). The members of a listed symbol are printed in full, wherever they come from. Interface merging with `lib.dom.d.ts` and `@types/node`, `UseLibDomIfAvailable`, and every other conditional alias are resolved, so a file shows what a user sees, not what the `.d.ts` source says. There is one file per `lib` preset: `esnext`, `esnext-dom`, `es2022`, `es2022-dom`, and `no-lib`. `ts7.1/` is not covered.
 
 `test/integration/bun-types/inventory.test.ts` fails when the files no longer match the package. After a change to `packages/bun-types`, regenerate them and commit the result:
 

--- a/packages/bun-types/authoring.md
+++ b/packages/bun-types/authoring.md
@@ -108,6 +108,18 @@ Your type definitions must work properly in both environments. This ensures that
 
 For example, if you're adding types for a new API, you should just add code to `fixture/index.ts` that uses your new API. Doesn't need to work at runtime (e.g. you can fake api keys for example), it's just checking that the types are correct.
 
+## The type inventory
+
+`test/integration/bun-types/inventory/<preset>.txt` lists every global and every module export that bun-types contributes, with the shape the TypeScript checker resolves it to. Interface merging with `lib.dom.d.ts` and `@types/node`, `UseLibDomIfAvailable`, and every other conditional alias are resolved, so a file shows what a user sees, not what the `.d.ts` source says. There is one file per `lib` preset: `esnext`, `esnext-dom`, `es2022`, `es2022-dom`, and `no-lib`.
+
+`test/integration/bun-types/inventory.test.ts` fails when the files no longer match the package. After a change to `packages/bun-types`, regenerate them and commit the result:
+
+```sh
+bun packages/bun-types/scripts/inventory.ts
+```
+
+Read the diff before you commit it. A line that disappears from a preset, or a member whose type changed, is a breaking change for the users on that preset. A change that only moves declarations between files produces no diff.
+
 ## Questions
 
 Feel free to open an issue or speak to any of the more TypeScript-focused team members if you need help authoring types or fixing type tests.

--- a/packages/bun-types/scripts/inventory.ts
+++ b/packages/bun-types/scripts/inventory.ts
@@ -4,19 +4,27 @@
 // Usage:
 //   bun scripts/inventory.ts [--out <dir>] [--preset <name>]... [--check] [--keep]
 //
-// Each preset writes one file, <out>/<preset>.txt, with one line per global, per
-// module export, and per member. Interface merging, `UseLibDomIfAvailable`, and
-// every other conditional alias are resolved, so the file shows what a user sees,
-// not what the .d.ts source says. The files are plain text sorted by name, so
-// `git diff` on them is the review surface for a change to packages/bun-types.
+// Each preset writes one file, <out>/<preset>.txt. A symbol is listed when at
+// least one of its declarations is in bun-types: the globals, the exports of the
+// modules bun-types declares (`bun`, `bun:test`, `*.html`, ...) and of the node
+// modules and namespaces it augments (`node:tls`, `NodeJS`). The members of a
+// listed symbol are printed in full, wherever they come from. Interface merging,
+// `UseLibDomIfAvailable`, and every other conditional alias are resolved, so the
+// file shows what a user sees, not what the .d.ts source says. The files are
+// plain text sorted by name, so `git diff` on them is the review surface for a
+// change to packages/bun-types.
 //
 // With --check the tool writes nothing. It exits 1 and prints a diff when a
 // preset's output differs from the file in <out>.
 //
 // The default output directory is test/integration/bun-types/inventory.
+//
+// Not covered: ts7.1/, which only TypeScript 7.1 can parse. This script runs the
+// compiler API of the repository's own `typescript` dependency.
 import { $ } from "bun";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import ts from "typescript";
@@ -57,19 +65,38 @@ function parseArgs(argv: string[]) {
   return out;
 }
 
+/** TypeScript reports file names with forward slashes on every platform. */
+const toPosix = (path: string) => path.replaceAll("\\", "/");
+
 function readVersion(packageJson: string): string | undefined {
   return existsSync(packageJson) ? JSON.parse(readFileSync(packageJson, "utf8")).version : undefined;
 }
 
 /**
- * Builds and packs bun-types into a scratch project, the same way
- * test/integration/bun-types/bun-types.test.ts does, so module resolution
- * matches what a user gets from `bun add -d @types/bun`. @types/node is pinned
- * to the version in this repository's lockfile, so the output only changes when
- * bun-types or that lockfile changes.
+ * The versions of @types/node and undici-types that this repository's lockfile
+ * installed for packages/bun-types. The scratch project pins both, so the
+ * output only changes when bun-types or that lockfile changes.
  */
-async function createProject(): Promise<{ dir: string; versions: Record<string, string> }> {
-  const tempDir = await mkdtemp(join(tmpdir(), "bun-types-inventory-"));
+function pinnedDependencies(): string[] {
+  const nodeTypesDir = join(PACKAGE_ROOT, "node_modules", "@types", "node");
+  const nodeTypesVersion = readVersion(join(nodeTypesDir, "package.json"));
+  if (!nodeTypesVersion) {
+    throw new Error(`@types/node is not installed in ${nodeTypesDir}. Run \`bun install\` in the repository first.`);
+  }
+  const pins = [`@types/node@${nodeTypesVersion}`];
+  // undici-types is a dependency of @types/node, so resolve it from there.
+  const requireFromNodeTypes = createRequire(join(realpathSync(nodeTypesDir), "index.d.ts"));
+  const undiciVersion = readVersion(requireFromNodeTypes.resolve("undici-types/package.json"));
+  if (undiciVersion) pins.push(`undici-types@${undiciVersion}`);
+  return pins;
+}
+
+/**
+ * Builds and packs bun-types into a scratch project under `tempDir`, the same
+ * way test/integration/bun-types/bun-types.test.ts does, so module resolution
+ * matches what a user gets from `bun add -d @types/bun`.
+ */
+async function createProject(tempDir: string): Promise<{ projectDir: string; versions: Record<string, string> }> {
   const buildDir = join(tempDir, "bun-types");
   const projectDir = join(tempDir, "project");
   await mkdir(projectDir);
@@ -80,11 +107,9 @@ async function createProject(): Promise<{ dir: string; versions: Record<string, 
   await $`cd ${PACKAGE_ROOT} && BUN_VERSION=${version} bun run build ${buildDir}`.quiet();
   await $`cd ${buildDir} && bun pm pack --destination ${projectDir}`.quiet();
   await Bun.write(join(projectDir, "package.json"), JSON.stringify({ name: "inventory", private: true }));
-  const nodeTypesVersion = readVersion(join(PACKAGE_ROOT, "node_modules/@types/node/package.json"));
-  const nodeTypes = nodeTypesVersion ? [`@types/node@${nodeTypesVersion}`] : [];
-  await $`cd ${projectDir} && bun add bun-types@${tarball} ${nodeTypes} && rm ${tarball}`.quiet();
+  await $`cd ${projectDir} && bun add bun-types@${tarball} ${pinnedDependencies()} && rm ${tarball}`.quiet();
 
-  const atTypesBun = join(projectDir, "node_modules/@types/bun");
+  const atTypesBun = join(projectDir, "node_modules", "@types", "bun");
   await mkdir(atTypesBun, { recursive: true });
   await Bun.write(join(atTypesBun, "index.d.ts"), '/// <reference types="bun-types" />\n');
   await Bun.write(join(atTypesBun, "package.json"), JSON.stringify({ name: "@types/bun", version }));
@@ -94,11 +119,13 @@ async function createProject(): Promise<{ dir: string; versions: Record<string, 
     const found = readVersion(join(projectDir, "node_modules", name, "package.json"));
     if (found) versions[name] = found;
   }
-  return { dir: tempDir, versions };
+  return { projectDir, versions };
 }
 
+const ENTRY_SOURCE = "export {};\n";
+
 function createProgram(projectDir: string, lib: string[]) {
-  const entry = join(projectDir, "entry.ts");
+  const entry = toPosix(join(projectDir, "entry.ts"));
   const options: ts.CompilerOptions = {
     lib,
     target: ts.ScriptTarget.ESNext,
@@ -113,44 +140,71 @@ function createProgram(projectDir: string, lib: string[]) {
   };
   const host = ts.createCompilerHost(options, true);
   const readFile = host.readFile;
-  host.readFile = file => (file === entry ? "export {};\n" : readFile(file));
+  host.readFile = file => (toPosix(file) === entry ? ENTRY_SOURCE : readFile(file));
   const fileExists = host.fileExists;
-  host.fileExists = file => file === entry || fileExists(file);
+  host.fileExists = file => toPosix(file) === entry || fileExists(file);
   host.getCurrentDirectory = () => projectDir;
-  return ts.createProgram({ rootNames: [entry], options, host });
+  const program = ts.createProgram({ rootNames: [entry], options, host });
+  return { program, entry: program.getSourceFile(entry)! };
 }
 
 const byName = (a: { name: string }, b: { name: string }) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
 
-function inventory(program: ts.Program, projectDir: string): string[] {
+function inventory(program: ts.Program, entry: ts.SourceFile, projectDir: string): string[] {
   const checker = program.getTypeChecker();
-  const entry = program.getSourceFile(join(projectDir, "entry.ts"))!;
-  const packageDir = realpathSync(join(projectDir, "node_modules/bun-types"));
-  const nodeModules = join(projectDir, "node_modules");
-  const tsLibDir = dirname(ts.getDefaultLibFilePath(program.getCompilerOptions()));
+  const nodeModules = toPosix(join(projectDir, "node_modules"));
+  const packageDir = toPosix(realpathSync(join(projectDir, "node_modules", "bun-types")));
+  const tsLibDir = toPosix(dirname(ts.getDefaultLibFilePath(program.getCompilerOptions())));
 
-  function displayFile(fileName: string): string {
-    const real = realpathSync(fileName);
-    if (real.startsWith(packageDir + "/")) return "bun-types/" + relative(packageDir, real);
-    if (real.startsWith(tsLibDir + "/")) return relative(tsLibDir, real);
-    if (real.startsWith(nodeModules + "/")) return relative(nodeModules, real);
-    const store = real.lastIndexOf("/node_modules/");
-    if (store >= 0) return real.slice(store + "/node_modules/".length);
-    return relative(projectDir, real);
+  const realPaths = new Map<string, string>();
+  function realPath(fileName: string): string {
+    let real = realPaths.get(fileName);
+    if (real === undefined) {
+      try {
+        real = toPosix(realpathSync(fileName));
+      } catch {
+        // A module path inside `import("...")` type text has no extension.
+        real = toPosix(fileName);
+      }
+      realPaths.set(fileName, real);
+    }
+    return real;
   }
 
+  function displayFile(fileName: string): string {
+    const real = realPath(fileName);
+    if (real.startsWith(packageDir + "/")) return "bun-types/" + real.slice(packageDir.length + 1);
+    if (real.startsWith(tsLibDir + "/")) return real.slice(tsLibDir.length + 1);
+    if (real.startsWith(nodeModules + "/")) return real.slice(nodeModules.length + 1);
+    // bun's isolated installs link node_modules/<name> into node_modules/.bun/<name>@<version>/node_modules/<name>.
+    const store = real.lastIndexOf("/node_modules/");
+    if (store >= 0) return real.slice(store + "/node_modules/".length);
+    return toPosix(relative(projectDir, fileName));
+  }
+
+  const isPackageFile = (sourceFile: ts.SourceFile) => realPath(sourceFile.fileName).startsWith(packageDir + "/");
+
+  /**
+   * True when bun-types declares or augments the symbol. Declarations that merge
+   * into a symbol from another package (lib.dom, @types/node) live on the merged
+   * symbol, so always test that one.
+   */
   const isFromPackage = (sym: ts.Symbol) =>
-    (sym.declarations ?? []).some(decl => realpathSync(decl.getSourceFile().fileName).startsWith(packageDir + "/"));
+    (checker.getMergedSymbol(sym).declarations ?? []).some(decl => isPackageFile(decl.getSourceFile()));
 
   const typeFormat =
     ts.TypeFormatFlags.NoTruncation |
+    ts.TypeFormatFlags.UseFullyQualifiedType |
     ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
     ts.TypeFormatFlags.WriteArrayAsGenericType;
 
   // Paths inside `import("...")` type references would leak the temp directory,
   // and TypeScript names a well-known symbol property `__@iterator@123` with an
   // id that changes between programs.
-  const pathPattern = new RegExp(projectDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "/node_modules/[^\"']+", "g");
+  const pathPattern = new RegExp(
+    toPosix(projectDir).replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "/node_modules/[^\"']+",
+    "g",
+  );
   const clean = (text: string) =>
     text
       .replace(pathPattern, match => displayFile(match))
@@ -159,6 +213,34 @@ function inventory(program: ts.Program, projectDir: string): string[] {
 
   const rawTypeText = (type: ts.Type) => clean(checker.typeToString(type, undefined, typeFormat));
 
+  /** The type arguments TypeScript prints after the name of an alias, class, or interface instantiation. */
+  function referenceTypeArguments(type: ts.Type): readonly ts.Type[] | undefined {
+    if (type.aliasSymbol) return type.aliasTypeArguments;
+    if (!(type.flags & ts.TypeFlags.Object) || !((type as ts.ObjectType).objectFlags & ts.ObjectFlags.Reference)) {
+      return undefined;
+    }
+    const reference = type as ts.TypeReference;
+    // The full list is the outer type parameters, then the declared ones, then
+    // the implicit `this` type. Only the declared ones are printed.
+    const outer = reference.target.outerTypeParameters?.length ?? 0;
+    const declared = reference.target.typeParameters?.length ?? 0;
+    return checker.getTypeArguments(reference).slice(outer, declared);
+  }
+
+  /**
+   * A member of a union or an intersection, in parentheses where TypeScript
+   * would put them: function types, conditional types, and (`wrap`) an
+   * intersection inside a union or a union inside an intersection.
+   */
+  function memberText(member: ts.Type, wrap: boolean): string {
+    const text = typeText(member);
+    // An aliased member prints as its name, `Bun.X` or `Bun.X<T>`.
+    if (member.aliasSymbol) return text;
+    const isFunction = /^(new )?[(<]/.test(text) && text.includes("=> ");
+    const isConditional = !!(member.flags & ts.TypeFlags.Conditional);
+    return wrap || isFunction || isConditional ? `(${text})` : text;
+  }
+
   /**
    * TypeScript orders union members by internal type id, which shifts whenever a
    * declaration moves. Sort them so that a refactor with no type change is a
@@ -166,25 +248,49 @@ function inventory(program: ts.Program, projectDir: string): string[] {
    * for the same reason: `signatureToString` is stable, the anonymous object
    * type around it is not.
    */
-  function typeText(type: ts.Type): string {
-    if (type.isUnion() && !type.aliasSymbol) {
+  function typeText(type: ts.Type, expandAlias?: ts.Symbol): string {
+    if (type.isUnion() && (!type.aliasSymbol || type.aliasSymbol === expandAlias)) {
       // A union built from an aliased union plus extra members (`FormDataEntryValue | null`)
       // keeps the alias in `origin`. Print through it so the alias name survives.
       // A `keyof X` origin is not a union: TypeScript prints it as `keyof X`, keep that.
       const origin = (type as ts.Type & { origin?: ts.Type }).origin;
       if (origin && !origin.isUnion()) return rawTypeText(type);
       const parts = origin?.isUnion() ? origin.types : type.types;
-      const hasTrue = parts.some(t => t.flags & ts.TypeFlags.BooleanLiteral && (t as any).intrinsicName === "true");
-      const hasFalse = parts.some(t => t.flags & ts.TypeFlags.BooleanLiteral && (t as any).intrinsicName === "false");
+      const isBooleanLiteral = (t: ts.Type, name: string) =>
+        !!(t.flags & ts.TypeFlags.BooleanLiteral) && (t as ts.Type & { intrinsicName?: string }).intrinsicName === name;
+      const hasTrue = parts.some(t => isBooleanLiteral(t, "true"));
+      const hasFalse = parts.some(t => isBooleanLiteral(t, "false"));
       const texts = parts
         .filter(t => !(hasTrue && hasFalse && t.flags & ts.TypeFlags.BooleanLiteral))
-        .map(t => typeText(t));
+        .map(t => memberText(t, t.isIntersection()));
       if (hasTrue && hasFalse) texts.push("boolean");
-      // A function type inside a union needs parentheses: `((x: T) => void) | null`.
-      return texts
-        .map(t => (/^[(<]/.test(t) && t.includes(" => ") ? `(${t})` : t))
-        .sort()
-        .join(" | ");
+      return texts.sort().join(" | ");
+    }
+    if (type.isIntersection() && !type.aliasSymbol) {
+      // TypeScript keeps intersection members in source order, so only recurse.
+      return type.types.map(t => memberText(t, t.isUnion())).join(" & ");
+    }
+    // `Name<Arg, Arg>`: a class, interface, or alias instantiation. Print the
+    // arguments through typeText so unions inside them are sorted too. The
+    // positional mapping is only trusted when re-rendering the arguments the way
+    // TypeScript does reproduces its own text.
+    const typeArguments = referenceTypeArguments(type);
+    if (typeArguments && typeArguments.length > 0) {
+      const raw = rawTypeText(type);
+      const open = raw.indexOf("<");
+      const name = open > 0 ? raw.slice(0, open) : "";
+      if (/^[\w$.]+$/.test(name)) {
+        // TypeScript drops trailing arguments that equal their defaults, so try each prefix.
+        const rawArguments = typeArguments.map(rawTypeText);
+        for (let count = rawArguments.length; count > 0; count--) {
+          if (raw === `${name}<${rawArguments.slice(0, count).join(", ")}>`) {
+            return `${name}<${typeArguments
+              .slice(0, count)
+              .map(t => typeText(t))
+              .join(", ")}>`;
+          }
+        }
+      }
     }
     const callSignatures = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
     if (
@@ -201,6 +307,20 @@ function inventory(program: ts.Program, projectDir: string): string[] {
     return rawTypeText(type);
   }
 
+  function typeParamsText(params: readonly ts.TypeParameter[] | undefined): string {
+    if (!params || params.length === 0) return "";
+    return `<${params
+      .map(tp => {
+        let text = rawTypeText(tp);
+        const constraint = tp.getConstraint();
+        if (constraint) text += ` extends ${typeText(constraint)}`;
+        const fallback = tp.getDefault();
+        if (fallback) text += ` = ${typeText(fallback)}`;
+        return text;
+      })
+      .join(", ")}>`;
+  }
+
   function signatureText(sig: ts.Signature, kind: ts.SignatureKind, arrow: string): string {
     const params = sig.parameters.map(param => {
       const decl = param.valueDeclaration as ts.ParameterDeclaration | undefined;
@@ -211,19 +331,11 @@ function inventory(program: ts.Program, projectDir: string): string[] {
     if (sig.thisParameter) {
       params.unshift(`this: ${typeText(checker.getTypeOfSymbol(sig.thisParameter))}`);
     }
-    const typeParams = sig.typeParameters?.map(tp => {
-      let text = rawTypeText(tp);
-      const constraint = tp.getConstraint();
-      if (constraint) text += ` extends ${typeText(constraint)}`;
-      const fallback = tp.getDefault();
-      if (fallback) text += ` = ${typeText(fallback)}`;
-      return text;
-    });
     const predicate = checker.getTypePredicateOfSignature(sig);
     const returns = predicate
       ? clean(checker.typePredicateToString(predicate))
       : typeText(checker.getReturnTypeOfSignature(sig));
-    const head = `${typeParams?.length ? `<${typeParams.join(", ")}>` : ""}(${params.join(", ")})`;
+    const head = `${typeParamsText(sig.typeParameters)}(${params.join(", ")})`;
     return `${kind === ts.SignatureKind.Construct ? "new " : ""}${head}${arrow}${returns}`;
   }
 
@@ -265,22 +377,21 @@ function inventory(program: ts.Program, projectDir: string): string[] {
     return [...files].sort().join(", ");
   }
 
-  function typeParamsText(params: readonly ts.TypeParameter[] | undefined): string {
-    if (!params || params.length === 0) return "";
-    return `<${params
-      .map(tp => {
-        let text = rawTypeText(tp);
-        const constraint = tp.getConstraint();
-        if (constraint) text += ` extends ${typeText(constraint)}`;
-        const fallback = tp.getDefault();
-        if (fallback) text += ` = ${typeText(fallback)}`;
-        return text;
-      })
-      .join(", ")}>`;
-  }
+  /** Follows an alias (`export import Bun = BunModule`, `export = contents`) to the merged symbol it names. */
+  const resolveSymbol = (sym: ts.Symbol) =>
+    checker.getMergedSymbol(sym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym) : sym);
+
+  /** The exports of a module or namespace that bun-types declares, augments, or re-exports. */
+  const packageExportsOf = (container: ts.Symbol) =>
+    checker
+      .getExportsOfModule(container)
+      .map(member => checker.getMergedSymbol(member))
+      .filter(member => member.name !== "prototype" && !member.name.startsWith("export="))
+      .filter(isFromPackage)
+      .sort(byName);
 
   function emitSymbol(sym: ts.Symbol, path: string, indent: string) {
-    const target = sym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym) : sym;
+    const target = resolveSymbol(sym);
     const earlier = seen.get(target);
     if (earlier !== undefined) {
       lines.push(`${indent}${path} -> ${earlier}`);
@@ -307,7 +418,10 @@ function inventory(program: ts.Program, projectDir: string): string[] {
         const params = decl?.typeParameters?.map(
           p => checker.getDeclaredTypeOfSymbol(checker.getSymbolAtLocation(p.name)!) as ts.TypeParameter,
         );
-        const aliasText = clean(checker.typeToString(declared, undefined, typeFormat | ts.TypeFormatFlags.InTypeAlias));
+        // A union on the right-hand side goes through typeText for a stable member order.
+        const aliasText = declared.isUnion()
+          ? typeText(declared, target)
+          : clean(checker.typeToString(declared, undefined, typeFormat | ts.TypeFormatFlags.InTypeAlias));
         lines.push(`${indent}type ${path}${typeParamsText(params)} (${where}) = ${aliasText}`);
       } else if (target.flags & ts.SymbolFlags.Enum) {
         lines.push(`${indent}enum ${path} (${where})`);
@@ -336,22 +450,31 @@ function inventory(program: ts.Program, projectDir: string): string[] {
       if (!(target.flags & ts.SymbolFlags.Class)) {
         lines.push(`${indent}namespace ${path} (${where})`);
       }
-      const exports = [...checker.getExportsOfModule(target)].sort(byName);
-      for (const member of exports) {
-        if (member.name === "prototype" || member.name === "default") continue;
+      for (const member of packageExportsOf(target)) {
+        if (member.name === "default") continue;
         emitSymbol(member, `${path}.${member.name}`, inner);
       }
     }
   }
 
-  // Ambient modules: `declare module "bun"`, `declare module "bun:test"`, the
-  // `declare module "*.html"` wildcards, and the augmentations of node modules.
-  const modules = checker.getAmbientModules().filter(isFromPackage).sort(byName);
+  // Modules: the ones bun-types declares (`declare module "bun"`, `declare module
+  // "bun:test"`, the `declare module "*.html"` wildcards) and the ones it augments
+  // from a module file (`declare module "node:tls"` in overrides.d.ts). An
+  // augmentation merges into a copy of the target module's symbol, so
+  // getMergedSymbol is what carries the bun-types declarations.
+  const modules = checker
+    .getAmbientModules()
+    .map(mod => checker.getMergedSymbol(mod))
+    .filter(isFromPackage)
+    .sort(byName);
   for (const mod of modules) {
     lines.push(`# module ${mod.name}`);
     seen.set(mod, `module ${mod.name}`);
-    const exports = [...checker.getExportsOfModule(mod)].sort(byName);
-    for (const member of exports) emitSymbol(member, member.name, "");
+    const exportEquals = mod.exports?.get(ts.InternalSymbolName.ExportEquals as ts.__String);
+    if (exportEquals) {
+      lines.push(`export = ${typeText(checker.getTypeOfSymbol(resolveSymbol(exportEquals)))}`);
+    }
+    for (const member of packageExportsOf(mod)) emitSymbol(member, member.name, "");
     lines.push("");
   }
 
@@ -361,6 +484,7 @@ function inventory(program: ts.Program, projectDir: string): string[] {
       entry,
       ts.SymbolFlags.Value | ts.SymbolFlags.Type | ts.SymbolFlags.Namespace | ts.SymbolFlags.Alias,
     )
+    .map(sym => checker.getMergedSymbol(sym))
     .filter(sym => !sym.name.startsWith('"'))
     .filter(sym => !sym.declarations?.some(d => d.getSourceFile() === entry))
     .filter(isFromPackage)
@@ -374,31 +498,32 @@ function inventory(program: ts.Program, projectDir: string): string[] {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const project = await createProject();
-  const projectDir = join(project.dir, "project");
+  const tempDir = await mkdtemp(join(tmpdir(), "bun-types-inventory-"));
   try {
+    const { projectDir, versions } = await createProject(tempDir);
     let failed = false;
     for (const preset of args.presets) {
       const { lib } = PRESETS[preset]!;
-      const lines = inventory(createProgram(projectDir, lib), projectDir);
+      const { program, entry } = createProgram(projectDir, lib);
+      const lines = inventory(program, entry, projectDir);
       const header = [
         `# bun-types inventory: preset ${preset}`,
         `# lib: ${lib.join(", ") || "(none)"}`,
-        ...Object.entries(project.versions).map(([name, version]) => `# ${name}: ${version}`),
+        ...Object.entries(versions).map(([name, version]) => `# ${name}: ${version}`),
         "",
       ];
       const text = header.concat(lines).join("\n") + "\n";
       const outFile = join(args.out, `${preset}.txt`);
       if (args.check) {
-        const expected = existsSync(outFile) ? readFileSync(outFile, "utf8") : "";
+        const expected = existsSync(outFile) ? readFileSync(outFile, "utf8").replaceAll("\r\n", "\n") : "";
         if (expected === text) {
           console.log(`${preset}: ok`);
         } else {
           failed = true;
-          const actualFile = join(project.dir, `${preset}.actual.txt`);
+          const actualFile = join(tempDir, `${preset}.actual.txt`);
           await Bun.write(actualFile, text);
           console.log(`${preset}: differs from ${outFile}`);
-          console.log(await $`diff -u ${outFile} ${actualFile}`.nothrow().text());
+          console.log(await $`git diff --no-index --no-color -- ${outFile} ${actualFile}`.nothrow().text());
         }
       } else {
         await mkdir(args.out, { recursive: true });
@@ -406,10 +531,13 @@ async function main() {
         console.log(`${preset}: wrote ${lines.length} lines to ${outFile}`);
       }
     }
-    if (failed) process.exitCode = 1;
+    if (failed) {
+      console.log("Regenerate with `bun packages/bun-types/scripts/inventory.ts` when the change is intended.");
+      process.exitCode = 1;
+    }
   } finally {
-    if (args.keep) console.log(`kept ${project.dir}`);
-    else await rm(project.dir, { recursive: true, force: true });
+    if (args.keep) console.log(`kept ${tempDir}`);
+    else await rm(tempDir, { recursive: true, force: true });
   }
 }
 

--- a/packages/bun-types/scripts/inventory.ts
+++ b/packages/bun-types/scripts/inventory.ts
@@ -1,0 +1,416 @@
+// Dumps every type that bun-types contributes to a program, with the shape the
+// TypeScript checker resolves it to, for several `lib` configurations.
+//
+// Usage:
+//   bun scripts/inventory.ts [--out <dir>] [--preset <name>]... [--check] [--keep]
+//
+// Each preset writes one file, <out>/<preset>.txt, with one line per global, per
+// module export, and per member. Interface merging, `UseLibDomIfAvailable`, and
+// every other conditional alias are resolved, so the file shows what a user sees,
+// not what the .d.ts source says. The files are plain text sorted by name, so
+// `git diff` on them is the review surface for a change to packages/bun-types.
+//
+// With --check the tool writes nothing. It exits 1 and prints a diff when a
+// preset's output differs from the file in <out>.
+//
+// The default output directory is test/integration/bun-types/inventory.
+import { $ } from "bun";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import ts from "typescript";
+
+const PACKAGE_ROOT = resolve(import.meta.dir, "..");
+const REPO_ROOT = resolve(PACKAGE_ROOT, "../..");
+const DEFAULT_OUT = join(REPO_ROOT, "test/integration/bun-types/inventory");
+
+const DOM_LIBS = ["lib.dom.d.ts", "lib.dom.iterable.d.ts", "lib.dom.asynciterable.d.ts"];
+
+/**
+ * The `lib` matrix. The names are the file names TypeScript ships in its lib/
+ * directory. `[]` means no lib at all: @types/node then pulls in es2020 through
+ * its own `/// <reference lib>` directives.
+ */
+const PRESETS: Record<string, { lib: string[] }> = {
+  "esnext": { lib: ["lib.esnext.d.ts"] },
+  "esnext-dom": { lib: ["lib.esnext.d.ts", ...DOM_LIBS] },
+  "es2022": { lib: ["lib.es2022.d.ts"] },
+  "es2022-dom": { lib: ["lib.es2022.d.ts", ...DOM_LIBS] },
+  "no-lib": { lib: [] },
+};
+
+function parseArgs(argv: string[]) {
+  const out = { out: DEFAULT_OUT, presets: [] as string[], check: false, keep: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out") out.out = resolve(argv[++i]!);
+    else if (arg === "--preset") out.presets.push(argv[++i]!);
+    else if (arg === "--check") out.check = true;
+    else if (arg === "--keep") out.keep = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (out.presets.length === 0) out.presets = Object.keys(PRESETS);
+  for (const preset of out.presets) {
+    if (!(preset in PRESETS)) throw new Error(`unknown preset ${preset}. Known: ${Object.keys(PRESETS).join(", ")}`);
+  }
+  return out;
+}
+
+function readVersion(packageJson: string): string | undefined {
+  return existsSync(packageJson) ? JSON.parse(readFileSync(packageJson, "utf8")).version : undefined;
+}
+
+/**
+ * Builds and packs bun-types into a scratch project, the same way
+ * test/integration/bun-types/bun-types.test.ts does, so module resolution
+ * matches what a user gets from `bun add -d @types/bun`. @types/node is pinned
+ * to the version in this repository's lockfile, so the output only changes when
+ * bun-types or that lockfile changes.
+ */
+async function createProject(): Promise<{ dir: string; versions: Record<string, string> }> {
+  const tempDir = await mkdtemp(join(tmpdir(), "bun-types-inventory-"));
+  const buildDir = join(tempDir, "bun-types");
+  const projectDir = join(tempDir, "project");
+  await mkdir(projectDir);
+  await cp(PACKAGE_ROOT, buildDir, { recursive: true, filter: source => basename(source) !== "node_modules" });
+
+  const version = (process.env.BUN_VERSION ?? Bun.version).replace(/^.*v/, "");
+  const tarball = `bun-types-${version}.tgz`;
+  await $`cd ${PACKAGE_ROOT} && BUN_VERSION=${version} bun run build ${buildDir}`.quiet();
+  await $`cd ${buildDir} && bun pm pack --destination ${projectDir}`.quiet();
+  await Bun.write(join(projectDir, "package.json"), JSON.stringify({ name: "inventory", private: true }));
+  const nodeTypesVersion = readVersion(join(PACKAGE_ROOT, "node_modules/@types/node/package.json"));
+  const nodeTypes = nodeTypesVersion ? [`@types/node@${nodeTypesVersion}`] : [];
+  await $`cd ${projectDir} && bun add bun-types@${tarball} ${nodeTypes} && rm ${tarball}`.quiet();
+
+  const atTypesBun = join(projectDir, "node_modules/@types/bun");
+  await mkdir(atTypesBun, { recursive: true });
+  await Bun.write(join(atTypesBun, "index.d.ts"), '/// <reference types="bun-types" />\n');
+  await Bun.write(join(atTypesBun, "package.json"), JSON.stringify({ name: "@types/bun", version }));
+
+  const versions: Record<string, string> = { typescript: ts.version };
+  for (const name of ["@types/node", "undici-types"]) {
+    const found = readVersion(join(projectDir, "node_modules", name, "package.json"));
+    if (found) versions[name] = found;
+  }
+  return { dir: tempDir, versions };
+}
+
+function createProgram(projectDir: string, lib: string[]) {
+  const entry = join(projectDir, "entry.ts");
+  const options: ts.CompilerOptions = {
+    lib,
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.Preserve,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    moduleDetection: ts.ModuleDetectionKind.Force,
+    jsx: ts.JsxEmit.ReactJSX,
+    types: ["bun"],
+    strict: true,
+    noEmit: true,
+    skipLibCheck: true,
+  };
+  const host = ts.createCompilerHost(options, true);
+  const readFile = host.readFile;
+  host.readFile = file => (file === entry ? "export {};\n" : readFile(file));
+  const fileExists = host.fileExists;
+  host.fileExists = file => file === entry || fileExists(file);
+  host.getCurrentDirectory = () => projectDir;
+  return ts.createProgram({ rootNames: [entry], options, host });
+}
+
+const byName = (a: { name: string }, b: { name: string }) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+
+function inventory(program: ts.Program, projectDir: string): string[] {
+  const checker = program.getTypeChecker();
+  const entry = program.getSourceFile(join(projectDir, "entry.ts"))!;
+  const packageDir = realpathSync(join(projectDir, "node_modules/bun-types"));
+  const nodeModules = join(projectDir, "node_modules");
+  const tsLibDir = dirname(ts.getDefaultLibFilePath(program.getCompilerOptions()));
+
+  function displayFile(fileName: string): string {
+    const real = realpathSync(fileName);
+    if (real.startsWith(packageDir + "/")) return "bun-types/" + relative(packageDir, real);
+    if (real.startsWith(tsLibDir + "/")) return relative(tsLibDir, real);
+    if (real.startsWith(nodeModules + "/")) return relative(nodeModules, real);
+    const store = real.lastIndexOf("/node_modules/");
+    if (store >= 0) return real.slice(store + "/node_modules/".length);
+    return relative(projectDir, real);
+  }
+
+  const isFromPackage = (sym: ts.Symbol) =>
+    (sym.declarations ?? []).some(decl => realpathSync(decl.getSourceFile().fileName).startsWith(packageDir + "/"));
+
+  const typeFormat =
+    ts.TypeFormatFlags.NoTruncation |
+    ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
+    ts.TypeFormatFlags.WriteArrayAsGenericType;
+
+  // Paths inside `import("...")` type references would leak the temp directory,
+  // and TypeScript names a well-known symbol property `__@iterator@123` with an
+  // id that changes between programs.
+  const pathPattern = new RegExp(projectDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "/node_modules/[^\"']+", "g");
+  const clean = (text: string) =>
+    text
+      .replace(pathPattern, match => displayFile(match))
+      .replace(/__@(\w+)@\d+/g, "[Symbol.$1]")
+      .replace(/\s+/g, " ");
+
+  const rawTypeText = (type: ts.Type) => clean(checker.typeToString(type, undefined, typeFormat));
+
+  /**
+   * TypeScript orders union members by internal type id, which shifts whenever a
+   * declaration moves. Sort them so that a refactor with no type change is a
+   * no-op in the output. Function-typed members print one signature per overload
+   * for the same reason: `signatureToString` is stable, the anonymous object
+   * type around it is not.
+   */
+  function typeText(type: ts.Type): string {
+    if (type.isUnion() && !type.aliasSymbol) {
+      // A union built from an aliased union plus extra members (`FormDataEntryValue | null`)
+      // keeps the alias in `origin`. Print through it so the alias name survives.
+      // A `keyof X` origin is not a union: TypeScript prints it as `keyof X`, keep that.
+      const origin = (type as ts.Type & { origin?: ts.Type }).origin;
+      if (origin && !origin.isUnion()) return rawTypeText(type);
+      const parts = origin?.isUnion() ? origin.types : type.types;
+      const hasTrue = parts.some(t => t.flags & ts.TypeFlags.BooleanLiteral && (t as any).intrinsicName === "true");
+      const hasFalse = parts.some(t => t.flags & ts.TypeFlags.BooleanLiteral && (t as any).intrinsicName === "false");
+      const texts = parts
+        .filter(t => !(hasTrue && hasFalse && t.flags & ts.TypeFlags.BooleanLiteral))
+        .map(t => typeText(t));
+      if (hasTrue && hasFalse) texts.push("boolean");
+      // A function type inside a union needs parentheses: `((x: T) => void) | null`.
+      return texts
+        .map(t => (/^[(<]/.test(t) && t.includes(" => ") ? `(${t})` : t))
+        .sort()
+        .join(" | ");
+    }
+    const callSignatures = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
+    if (
+      callSignatures.length > 0 &&
+      !type.aliasSymbol &&
+      type.symbol &&
+      type.symbol.flags & (ts.SymbolFlags.Method | ts.SymbolFlags.Function | ts.SymbolFlags.TypeLiteral) &&
+      checker.getPropertiesOfType(type).length === 0 &&
+      checker.getSignaturesOfType(type, ts.SignatureKind.Construct).length === 0
+    ) {
+      if (callSignatures.length === 1) return signatureText(callSignatures[0]!, ts.SignatureKind.Call, " => ");
+      return `{ ${callSignatures.map(sig => signatureText(sig, ts.SignatureKind.Call, ": ")).join("; ")} }`;
+    }
+    return rawTypeText(type);
+  }
+
+  function signatureText(sig: ts.Signature, kind: ts.SignatureKind, arrow: string): string {
+    const params = sig.parameters.map(param => {
+      const decl = param.valueDeclaration as ts.ParameterDeclaration | undefined;
+      const rest = decl && decl.dotDotDotToken ? "..." : "";
+      const optional = decl && (decl.questionToken || decl.initializer) ? "?" : "";
+      return `${rest}${param.name}${optional}: ${typeText(checker.getTypeOfSymbol(param))}`;
+    });
+    if (sig.thisParameter) {
+      params.unshift(`this: ${typeText(checker.getTypeOfSymbol(sig.thisParameter))}`);
+    }
+    const typeParams = sig.typeParameters?.map(tp => {
+      let text = rawTypeText(tp);
+      const constraint = tp.getConstraint();
+      if (constraint) text += ` extends ${typeText(constraint)}`;
+      const fallback = tp.getDefault();
+      if (fallback) text += ` = ${typeText(fallback)}`;
+      return text;
+    });
+    const predicate = checker.getTypePredicateOfSignature(sig);
+    const returns = predicate
+      ? clean(checker.typePredicateToString(predicate))
+      : typeText(checker.getReturnTypeOfSignature(sig));
+    const head = `${typeParams?.length ? `<${typeParams.join(", ")}>` : ""}(${params.join(", ")})`;
+    return `${kind === ts.SignatureKind.Construct ? "new " : ""}${head}${arrow}${returns}`;
+  }
+
+  const lines: string[] = [];
+  const seen = new Map<ts.Symbol, string>();
+
+  function modifiers(sym: ts.Symbol): string {
+    const out: string[] = [];
+    if (sym.flags & ts.SymbolFlags.Optional) out.push("?");
+    const decl = sym.valueDeclaration ?? sym.declarations?.[0];
+    if (decl && ts.canHaveModifiers(decl)) {
+      const mods = ts.getCombinedModifierFlags(decl);
+      if (mods & ts.ModifierFlags.Readonly) out.push("readonly");
+      if (mods & ts.ModifierFlags.Static) out.push("static");
+    }
+    return out.length ? ` [${out.join(" ")}]` : "";
+  }
+
+  function emitTypeMembers(type: ts.Type, indent: string) {
+    for (const sig of checker.getSignaturesOfType(type, ts.SignatureKind.Call)) {
+      lines.push(`${indent}call ${signatureText(sig, ts.SignatureKind.Call, ": ")}`);
+    }
+    for (const sig of checker.getSignaturesOfType(type, ts.SignatureKind.Construct)) {
+      lines.push(`${indent}construct ${signatureText(sig, ts.SignatureKind.Construct, ": ")}`);
+    }
+    for (const info of checker.getIndexInfosOfType(type)) {
+      lines.push(
+        `${indent}index [${typeText(info.keyType)}]: ${typeText(info.type)}${info.isReadonly ? " [readonly]" : ""}`,
+      );
+    }
+    const props = [...checker.getPropertiesOfType(type)].sort(byName);
+    for (const prop of props) {
+      lines.push(`${indent}${clean(prop.name)}${modifiers(prop)}: ${typeText(checker.getTypeOfSymbol(prop))}`);
+    }
+  }
+
+  function declaredIn(sym: ts.Symbol): string {
+    const files = new Set((sym.declarations ?? []).map(d => displayFile(d.getSourceFile().fileName)));
+    return [...files].sort().join(", ");
+  }
+
+  function typeParamsText(params: readonly ts.TypeParameter[] | undefined): string {
+    if (!params || params.length === 0) return "";
+    return `<${params
+      .map(tp => {
+        let text = rawTypeText(tp);
+        const constraint = tp.getConstraint();
+        if (constraint) text += ` extends ${typeText(constraint)}`;
+        const fallback = tp.getDefault();
+        if (fallback) text += ` = ${typeText(fallback)}`;
+        return text;
+      })
+      .join(", ")}>`;
+  }
+
+  function emitSymbol(sym: ts.Symbol, path: string, indent: string) {
+    const target = sym.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(sym) : sym;
+    const earlier = seen.get(target);
+    if (earlier !== undefined) {
+      lines.push(`${indent}${path} -> ${earlier}`);
+      return;
+    }
+    seen.set(target, path);
+    const where = declaredIn(target);
+    const inner = indent + "  ";
+
+    if (target.flags & ts.SymbolFlags.Class) {
+      const declared = checker.getDeclaredTypeOfSymbol(target) as ts.InterfaceType;
+      lines.push(`${indent}class ${path}${typeParamsText(declared.typeParameters)} (${where})`);
+      emitTypeMembers(declared, inner);
+      lines.push(`${inner}[static]`);
+      emitTypeMembers(checker.getTypeOfSymbol(target), inner + "  ");
+    } else {
+      if (target.flags & ts.SymbolFlags.Interface) {
+        const declared = checker.getDeclaredTypeOfSymbol(target) as ts.InterfaceType;
+        lines.push(`${indent}interface ${path}${typeParamsText(declared.typeParameters)} (${where})`);
+        emitTypeMembers(declared, inner);
+      } else if (target.flags & ts.SymbolFlags.TypeAlias) {
+        const declared = checker.getDeclaredTypeOfSymbol(target);
+        const decl = target.declarations?.find(ts.isTypeAliasDeclaration);
+        const params = decl?.typeParameters?.map(
+          p => checker.getDeclaredTypeOfSymbol(checker.getSymbolAtLocation(p.name)!) as ts.TypeParameter,
+        );
+        const aliasText = clean(checker.typeToString(declared, undefined, typeFormat | ts.TypeFormatFlags.InTypeAlias));
+        lines.push(`${indent}type ${path}${typeParamsText(params)} (${where}) = ${aliasText}`);
+      } else if (target.flags & ts.SymbolFlags.Enum) {
+        lines.push(`${indent}enum ${path} (${where})`);
+        for (const member of checker.getExportsOfModule(target)) {
+          lines.push(`${inner}${member.name} = ${typeText(checker.getDeclaredTypeOfSymbol(member))}`);
+        }
+      }
+      if (target.flags & (ts.SymbolFlags.Variable | ts.SymbolFlags.Function | ts.SymbolFlags.Property)) {
+        const kind = target.flags & ts.SymbolFlags.Function ? "function" : "var";
+        const type = checker.getTypeOfSymbol(target);
+        const expand =
+          type.flags & ts.TypeFlags.Object &&
+          type.symbol &&
+          !(type.symbol.flags & ts.SymbolFlags.Class) &&
+          (type.symbol.flags & ts.SymbolFlags.TypeLiteral || target.flags & ts.SymbolFlags.Function);
+        if (expand) {
+          lines.push(`${indent}${kind} ${path} (${where})`);
+          emitTypeMembers(type, inner);
+        } else {
+          lines.push(`${indent}${kind} ${path} (${where}): ${typeText(type)}`);
+        }
+      }
+    }
+
+    if (target.flags & (ts.SymbolFlags.Namespace | ts.SymbolFlags.Module) && !(target.flags & ts.SymbolFlags.Enum)) {
+      if (!(target.flags & ts.SymbolFlags.Class)) {
+        lines.push(`${indent}namespace ${path} (${where})`);
+      }
+      const exports = [...checker.getExportsOfModule(target)].sort(byName);
+      for (const member of exports) {
+        if (member.name === "prototype" || member.name === "default") continue;
+        emitSymbol(member, `${path}.${member.name}`, inner);
+      }
+    }
+  }
+
+  // Ambient modules: `declare module "bun"`, `declare module "bun:test"`, the
+  // `declare module "*.html"` wildcards, and the augmentations of node modules.
+  const modules = checker.getAmbientModules().filter(isFromPackage).sort(byName);
+  for (const mod of modules) {
+    lines.push(`# module ${mod.name}`);
+    seen.set(mod, `module ${mod.name}`);
+    const exports = [...checker.getExportsOfModule(mod)].sort(byName);
+    for (const member of exports) emitSymbol(member, member.name, "");
+    lines.push("");
+  }
+
+  // Globals: every symbol in scope at the entry file that bun-types declares or augments.
+  const globals = checker
+    .getSymbolsInScope(
+      entry,
+      ts.SymbolFlags.Value | ts.SymbolFlags.Type | ts.SymbolFlags.Namespace | ts.SymbolFlags.Alias,
+    )
+    .filter(sym => !sym.name.startsWith('"'))
+    .filter(sym => !sym.declarations?.some(d => d.getSourceFile() === entry))
+    .filter(isFromPackage)
+    .sort(byName);
+
+  lines.push("# globals");
+  for (const sym of globals) emitSymbol(sym, sym.name, "");
+
+  return lines;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const project = await createProject();
+  const projectDir = join(project.dir, "project");
+  try {
+    let failed = false;
+    for (const preset of args.presets) {
+      const { lib } = PRESETS[preset]!;
+      const lines = inventory(createProgram(projectDir, lib), projectDir);
+      const header = [
+        `# bun-types inventory: preset ${preset}`,
+        `# lib: ${lib.join(", ") || "(none)"}`,
+        ...Object.entries(project.versions).map(([name, version]) => `# ${name}: ${version}`),
+        "",
+      ];
+      const text = header.concat(lines).join("\n") + "\n";
+      const outFile = join(args.out, `${preset}.txt`);
+      if (args.check) {
+        const expected = existsSync(outFile) ? readFileSync(outFile, "utf8") : "";
+        if (expected === text) {
+          console.log(`${preset}: ok`);
+        } else {
+          failed = true;
+          const actualFile = join(project.dir, `${preset}.actual.txt`);
+          await Bun.write(actualFile, text);
+          console.log(`${preset}: differs from ${outFile}`);
+          console.log(await $`diff -u ${outFile} ${actualFile}`.nothrow().text());
+        }
+      } else {
+        await mkdir(args.out, { recursive: true });
+        await Bun.write(outFile, text);
+        console.log(`${preset}: wrote ${lines.length} lines to ${outFile}`);
+      }
+    }
+    if (failed) process.exitCode = 1;
+  } finally {
+    if (args.keep) console.log(`kept ${project.dir}`);
+    else await rm(project.dir, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/packages/bun-types/scripts/inventory.ts
+++ b/packages/bun-types/scripts/inventory.ts
@@ -50,10 +50,14 @@ const PRESETS: Record<string, { lib: string[] }> = {
 
 function parseArgs(argv: string[]) {
   const out = { out: DEFAULT_OUT, presets: [] as string[], check: false, keep: false };
+  const valueOf = (flag: string, value: string | undefined) => {
+    if (value === undefined) throw new Error(`${flag} needs a value`);
+    return value;
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === "--out") out.out = resolve(argv[++i]!);
-    else if (arg === "--preset") out.presets.push(argv[++i]!);
+    if (arg === "--out") out.out = resolve(valueOf(arg, argv[++i]));
+    else if (arg === "--preset") out.presets.push(valueOf(arg, argv[++i]));
     else if (arg === "--check") out.check = true;
     else if (arg === "--keep") out.keep = true;
     else throw new Error(`unknown argument: ${arg}`);
@@ -67,6 +71,14 @@ function parseArgs(argv: string[]) {
 
 /** TypeScript reports file names with forward slashes on every platform. */
 const toPosix = (path: string) => path.replaceAll("\\", "/");
+
+/**
+ * TypeScript resolves files under node_modules to their real path with the
+ * native realpath. On Windows only the native one expands 8.3 short names
+ * (`C:\Users\RUNNER~1`, which is what `os.tmpdir()` can return), so every path
+ * this script compares against a TypeScript file name goes through it too.
+ */
+const realPathOf = (path: string) => toPosix(realpathSync.native(path));
 
 function readVersion(packageJson: string): string | undefined {
   return existsSync(packageJson) ? JSON.parse(readFileSync(packageJson, "utf8")).version : undefined;
@@ -85,8 +97,14 @@ function pinnedDependencies(): string[] {
   }
   const pins = [`@types/node@${nodeTypesVersion}`];
   // undici-types is a dependency of @types/node, so resolve it from there.
-  const requireFromNodeTypes = createRequire(join(realpathSync(nodeTypesDir), "index.d.ts"));
-  const undiciVersion = readVersion(requireFromNodeTypes.resolve("undici-types/package.json"));
+  const requireFromNodeTypes = createRequire(join(realpathSync.native(nodeTypesDir), "index.d.ts"));
+  let undiciPackageJson: string | undefined;
+  try {
+    undiciPackageJson = requireFromNodeTypes.resolve("undici-types/package.json");
+  } catch {
+    // This @types/node does not depend on undici-types, so there is nothing to pin.
+  }
+  const undiciVersion = undiciPackageJson && readVersion(undiciPackageJson);
   if (undiciVersion) pins.push(`undici-types@${undiciVersion}`);
   return pins;
 }
@@ -152,16 +170,15 @@ const byName = (a: { name: string }, b: { name: string }) => (a.name < b.name ? 
 
 function inventory(program: ts.Program, entry: ts.SourceFile, projectDir: string): string[] {
   const checker = program.getTypeChecker();
-  const nodeModules = toPosix(join(projectDir, "node_modules"));
-  const packageDir = toPosix(realpathSync(join(projectDir, "node_modules", "bun-types")));
-  const tsLibDir = toPosix(dirname(ts.getDefaultLibFilePath(program.getCompilerOptions())));
+  const packageDir = realPathOf(join(projectDir, "node_modules", "bun-types"));
+  const tsLibDir = realPathOf(dirname(ts.getDefaultLibFilePath(program.getCompilerOptions())));
 
   const realPaths = new Map<string, string>();
   function realPath(fileName: string): string {
     let real = realPaths.get(fileName);
     if (real === undefined) {
       try {
-        real = toPosix(realpathSync(fileName));
+        real = realPathOf(fileName);
       } catch {
         // A module path inside `import("...")` type text has no extension.
         real = toPosix(fileName);
@@ -175,10 +192,10 @@ function inventory(program: ts.Program, entry: ts.SourceFile, projectDir: string
     const real = realPath(fileName);
     if (real.startsWith(packageDir + "/")) return "bun-types/" + real.slice(packageDir.length + 1);
     if (real.startsWith(tsLibDir + "/")) return real.slice(tsLibDir.length + 1);
-    if (real.startsWith(nodeModules + "/")) return real.slice(nodeModules.length + 1);
-    // bun's isolated installs link node_modules/<name> into node_modules/.bun/<name>@<version>/node_modules/<name>.
-    const store = real.lastIndexOf("/node_modules/");
-    if (store >= 0) return real.slice(store + "/node_modules/".length);
+    // `<package>/<file>` for both layouts bun can install: hoisted
+    // (node_modules/<package>) and isolated (node_modules/.bun/<package>@<version>/node_modules/<package>).
+    const dependency = real.lastIndexOf("/node_modules/");
+    if (dependency >= 0) return real.slice(dependency + "/node_modules/".length);
     return toPosix(relative(projectDir, fileName));
   }
 
@@ -498,7 +515,8 @@ function inventory(program: ts.Program, entry: ts.SourceFile, projectDir: string
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const tempDir = await mkdtemp(join(tmpdir(), "bun-types-inventory-"));
+  // The canonical form, so the paths built from it match TypeScript's file names (see realPathOf).
+  const tempDir = realpathSync.native(await mkdtemp(join(tmpdir(), "bun-types-inventory-")));
   try {
     const { projectDir, versions } = await createProject(tempDir);
     let failed = false;

--- a/test/integration/bun-types/inventory.test.ts
+++ b/test/integration/bun-types/inventory.test.ts
@@ -1,0 +1,39 @@
+import { expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+import { join } from "node:path";
+
+// The script packs bun-types, installs it into a scratch project, and then
+// type-checks it five times, which outlives the 5s default that a plain
+// `bun test <this file>` runs with. Same reason as bun-types.test.ts.
+setDefaultTimeout(1000 * 60 * 3);
+
+const REPO_ROOT = join(import.meta.dir, "../../..");
+const SCRIPT = join(REPO_ROOT, "packages/bun-types/scripts/inventory.ts");
+
+// packages/bun-types/scripts/inventory.ts resolves every global and module export
+// that bun-types contributes, for each `lib` preset, and writes the result to
+// ./inventory/<preset>.txt. A change to packages/bun-types that moves what a user
+// sees shows up as a diff in those files. When the diff is intended, regenerate
+// them with `bun packages/bun-types/scripts/inventory.ts` and commit the result.
+//
+// Driving the TypeScript checker in-process under a debug build is very slow,
+// so this runs on release builds only, like the type-checking cases in
+// bun-types.test.ts.
+test.skipIf(isDebug)("the inventory snapshots match packages/bun-types", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), SCRIPT, "--check"],
+    env: bunEnv,
+    cwd: REPO_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) {
+    console.log(stdout);
+    console.log(stderr);
+  }
+  expect(stdout).not.toContain("differs from");
+  expect(exitCode).toBe(0);
+});

--- a/test/integration/bun-types/inventory/es2022-dom.txt
+++ b/test/integration/bun-types/inventory/es2022-dom.txt
@@ -5,39 +5,64 @@
 # undici-types: 8.3.0
 
 # module "*.html"
+export = Bun.HTMLBundle
 
 # module "*.json5"
+export = any
 
 # module "*.jsonc"
+export = any
 
 # module "*.toml"
+export = any
 
 # module "*.txt"
+export = string
 
 # module "*.xml"
+export = Bun.XML.Document
 
 # module "*.yaml"
+export = any
 
 # module "*.yml"
+export = any
 
 # module "*/bun.lock"
+export = Bun.BunLockFile
+
+# module "buffer"
+interface Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<NodeJS.NonSharedUint8Array>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
+  json: () => Promise<any>
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<NodeJS.NonSharedUint8Array>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
 
 # module "bun"
-type $ (bun-types/shell.d.ts) = typeof $
+type $ (bun-types/shell.d.ts) = typeof Bun.$
 function $ (bun-types/shell.d.ts)
-  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
-  Shell: new () => typeof $
-  ShellError: typeof ShellError
-  ShellPromise: typeof ShellPromise
+  call (strings: TemplateStringsArray, ...expressions: Array<Bun.ShellExpression>): Bun.$.ShellPromise
+  Shell: new () => typeof Bun.$
+  ShellError: typeof Bun.$.ShellError
+  ShellPromise: typeof Bun.$.ShellPromise
   braces: (pattern: string) => Array<string>
-  cwd: (newCwd?: string | undefined) => typeof $
-  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  cwd: (newCwd?: string | undefined) => typeof Bun.$
+  env: (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => typeof Bun.$
   escape: (input: string) => string
-  nothrow: () => typeof $
-  throws: (shouldThrow: boolean) => typeof $
+  nothrow: () => typeof Bun.$
+  throws: (shouldThrow: boolean) => typeof Bun.$
 namespace $ (bun-types/shell.d.ts)
   var $.Shell (bun-types/shell.d.ts)
-    construct new (): typeof $
+    construct new (): typeof Bun.$
   class $.ShellError (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
     blob: () => Blob
@@ -52,13 +77,13 @@ namespace $ (bun-types/shell.d.ts)
     stdout [readonly]: Buffer<ArrayBufferLike>
     text: (encoding?: BufferEncoding | undefined) => string
     [static]
-      construct new (message?: string | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: ShellError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.$.ShellError
       stackTraceLimit: number
   interface $.ShellOutput (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
@@ -73,26 +98,26 @@ namespace $ (bun-types/shell.d.ts)
     [Symbol.toStringTag] [readonly]: string
     arrayBuffer: () => Promise<ArrayBuffer>
     blob: () => Promise<Blob>
-    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
-    cwd: (newCwd: string) => ShellPromise
-    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
-    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<Bun.$.ShellOutput | TResult>
+    cwd: (newCwd: string) => Bun.$.ShellPromise
+    env: (newEnv: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => Bun.$.ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<Bun.$.ShellOutput>
     json: () => Promise<any>
     lines: () => AsyncIterable<string>
-    nothrow: () => ShellPromise
-    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    nothrow: () => Bun.$.ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => Bun.$.ShellPromise
     stdin: WritableStream<any>
     text: (encoding?: BufferEncoding | undefined) => Promise<string>
-    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    throws: (shouldThrow: boolean) => ShellPromise
+    then: <TResult1 = Bun.$.ShellOutput, TResult2 = never>(onfulfilled?: ((value: Bun.$.ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => Bun.$.ShellPromise
     [static]
-      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      construct new (executor: (resolve: (value: Bun.$.ShellOutput | PromiseLike<Bun.$.ShellOutput>) => void, reject: (reason?: any) => void) => void): Bun.$.ShellPromise
       [Symbol.species] [readonly]: PromiseConstructor
-      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
-      prototype: ShellPromise
-      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
+      prototype: Bun.$.ShellPromise
+      race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
       reject: <T = never>(reason?: any) => Promise<T>
       resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
       try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
@@ -100,19 +125,19 @@ namespace $ (bun-types/shell.d.ts)
   function $.braces (bun-types/shell.d.ts)
     call (pattern: string): Array<string>
   function $.cwd (bun-types/shell.d.ts)
-    call (newCwd?: string | undefined): typeof $
+    call (newCwd?: string | undefined): typeof Bun.$
   function $.env (bun-types/shell.d.ts)
-    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+    call (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined): typeof Bun.$
   function $.escape (bun-types/shell.d.ts)
     call (input: string): string
   function $.nothrow (bun-types/shell.d.ts)
-    call (): typeof $
+    call (): typeof Bun.$
   function $.throws (bun-types/shell.d.ts)
-    call (shouldThrow: boolean): typeof $
+    call (shouldThrow: boolean): typeof Bun.$
 interface AbstractWorker (bun-types/bun.d.ts)
-  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
 interface AbstractWorkerEventMap (bun-types/bun.d.ts)
   error: ErrorEvent
 interface AddEventListenerOptions (bun-types/bun.d.ts)
@@ -124,16 +149,16 @@ type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips
 class Archive (bun-types/bun.d.ts)
   blob: () => Promise<Blob>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
-  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  extract: (path: string, options?: Bun.ArchiveExtractOptions | undefined) => Promise<number>
   files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
   [static]
-    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
-    prototype: Archive
-    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+    construct new (data: Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined): Bun.Archive
+    prototype: Bun.Archive
+    write [static]: (path: string, data: Bun.Archive | Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined) => Promise<void>
 type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
 interface ArchiveExtractOptions (bun-types/bun.d.ts)
   glob [?]: ReadonlyArray<string> | string | undefined
-type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+type ArchiveInput (bun-types/bun.d.ts) = ArrayBufferLike | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Record<string, Bun.BlobPart>
 interface ArchiveOptions (bun-types/bun.d.ts)
   compress [?]: "gzip" | undefined
   level [?]: number | undefined
@@ -141,25 +166,25 @@ class ArrayBufferSink (bun-types/bun.d.ts)
   end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
   flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
   start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
   [static]
-    construct new (): ArrayBufferSink
-    prototype: ArrayBufferSink
-type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+    construct new (): Bun.ArrayBufferSink
+    prototype: Bun.ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = DataView<TArrayBuffer> | NodeJS.TypedArray<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "ACLITEM" | "BIGINT" | "BIT" | "BOOLEAN" | "BOX" | "BYTEA" | "CHAR" | "CID" | "CIDR" | "CIRCLE" | "DATE" | "DOUBLE PRECISION" | "INET" | "INT" | "INT2VECTOR" | "INTEGER" | "INTERVAL" | "JSON" | "JSONB" | "JSONPATH" | "LINE" | "LSEG" | "MACADDR" | "MACADDR8" | "MONEY" | "NAME" | "NUMERIC" | "OID" | "PATH" | "PG_DATABASE" | "POINT" | "POLYGON" | "REAL" | "SMALLINT" | "TEXT" | "TID" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "TIMETZ" | "VARBIT" | "VARCHAR" | "XID" | "XML" | (string & {})
 type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
-type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+type BinaryType (bun-types/bun.d.ts) = keyof Bun.BinaryTypeList
 interface BinaryTypeList (bun-types/bun.d.ts)
   arraybuffer: ArrayBuffer
   buffer: Buffer<ArrayBufferLike>
   uint8array: Uint8Array<ArrayBuffer>
-type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
-type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
-type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
-type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string
+type BlobPart (bun-types/bun.d.ts) = Blob | Bun.BufferSource | string
+type BodyInit (bun-types/fetch.d.ts) = (() => AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any>) | AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any> | AsyncIterable<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string> | Bun.Image | Bun.XMLHttpRequestBodyInit | ReadableStream<any>
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
 namespace Build (bun-types/bun.d.ts)
-  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
-  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Architecture (bun-types/bun.d.ts) = "aarch64" | "arm64" | "x64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-aarch64" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-darwin-arm64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-linux-aarch64" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-modern" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-linux-aarch64-musl" | "bun-linux-arm64" | "bun-linux-arm64-baseline" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-glibc" | "bun-linux-arm64-modern" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-arm64-musl" | "bun-linux-x64" | "bun-linux-x64-baseline" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-modern" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-x64-musl" | "bun-windows-aarch64" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
   type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
   type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
 interface BuildArtifact (bun-types/bun.d.ts)
@@ -167,14 +192,14 @@ interface BuildArtifact (bun-types/bun.d.ts)
   bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
   formData: () => Promise<FormData>
   hash: null | string
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
-  loader: Loader
+  loader: Bun.Loader
   path: string
   size [readonly]: number
   slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
-  sourcemap: BuildArtifact | null
+  sourcemap: Bun.BuildArtifact | null
   stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
@@ -183,7 +208,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   banner [?]: string | undefined
   bytecode [?]: boolean | undefined
   bytecodeDepth [?]: number | undefined
-  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  compile [?]: Bun.Build.CompileTarget | Bun.CompileBuildOptions | boolean | undefined
   conditions [?]: Array<string> | string | undefined
   define [?]: Record<string, string> | undefined
   deprecatedNamespaceObjectSetters [?]: boolean | undefined
@@ -193,12 +218,12 @@ interface BuildConfig (bun-types/bun.d.ts)
   env [?]: "disable" | "inline" | `${string}*` | undefined
   external [?]: Array<string> | undefined
   features [?]: Array<string> | undefined
-  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  files [?]: Record<string, ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string> | undefined
   footer [?]: string | undefined
   format [?]: "cjs" | "esm" | "iife" | undefined
   ignoreDCEAnnotations [?]: boolean | undefined
   jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
-  loader [?]: undefined | { [x: string]: Loader; }
+  loader [?]: undefined | { [x: string]: Bun.Loader; }
   metafile [?]: boolean | undefined
   minChunkSize [?]: number | undefined
   minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
@@ -207,7 +232,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   optimizeImports [?]: Array<string> | undefined
   outdir [?]: string | undefined
   packages [?]: "bundle" | "external" | undefined
-  plugins [?]: Array<BunPlugin> | undefined
+  plugins [?]: Array<Bun.BunPlugin> | undefined
   publicPath [?]: string | undefined
   reactCompiler [?]: boolean | undefined
   reactCompilerOutputMode [?]: "client" | "ssr" | undefined
@@ -216,17 +241,17 @@ interface BuildConfig (bun-types/bun.d.ts)
   sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
   splitRequire [?]: boolean | undefined
   splitting [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   throw [?]: boolean | undefined
   treeShaking [?]: boolean | undefined
   tsconfig [?]: string | undefined
 interface BuildMetafile (bun-types/bun.d.ts)
-  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
-  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: Bun.ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: Bun.ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
 interface BuildOutput (bun-types/bun.d.ts)
   logs: Array<BuildMessage | ResolveMessage>
-  metafile [?]: BuildMetafile | undefined
-  outputs: Array<BuildArtifact>
+  metafile [?]: Bun.BuildMetafile | undefined
+  outputs: Array<Bun.BuildArtifact>
   success: boolean
 interface BunFile (bun-types/bun.d.ts)
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
@@ -234,29 +259,29 @@ interface BunFile (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface BunInspectOptions (bun-types/bun.d.ts)
   colors [?]: boolean | undefined
   compact [?]: boolean | undefined
   depth [?]: number | undefined
   sorted [?]: boolean | undefined
-type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: Bun.BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: Bun.BunLockFilePackageArray; }; }
 type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
-type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
-type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
-type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, info: Bun.BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Bun.BunLockFilePackageInfo] | [pkg: string, info: Pick<Bun.BunLockFileBasePackageInfo, "bin" | "binDir">] | [pkg: string, registry: string, info: Bun.BunLockFilePackageInfo, integrity: string] | [pkg: string]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
 interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
   AT_TARGET [readonly]: 2
   BUBBLING_PHASE [readonly]: 3
@@ -288,10 +313,10 @@ interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.t
   type [readonly]: string
 interface BunPlugin (bun-types/bun.d.ts)
   name: string
-  setup: (build: PluginBuilder) => Promise<void> | void
-  target [?]: Target | undefined
+  setup: (build: Bun.PluginBuilder) => Promise<void> | void
+  target [?]: Bun.Target | undefined
 interface BunRegisterPlugin (bun-types/bun.d.ts)
-  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  call <T extends Bun.BunPlugin>(options: T): ReturnType<T["setup"]>
   clearAll: () => void
 interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
@@ -300,8 +325,8 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   bodyUsed [readonly]: boolean
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   cache [readonly]: RequestCache
-  clone: () => BunRequest<T>
-  cookies [readonly]: CookieMap
+  clone: () => Bun.BunRequest<T>
+  cookies [readonly]: Bun.CookieMap
   credentials [readonly]: RequestCredentials
   destination [readonly]: RequestDestination
   formData: () => Promise<FormData>
@@ -311,7 +336,7 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   keepalive [readonly]: boolean
   method [readonly]: string
   mode [readonly]: RequestMode
-  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  params [readonly]: { [Key in keyof Bun.Serve.ExtractRouteParams<T>]: Bun.Serve.ExtractRouteParams<T>[Key]; }
   redirect [readonly]: RequestRedirect
   referrer [readonly]: string
   referrerPolicy [readonly]: ReferrerPolicy
@@ -321,17 +346,17 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   url [readonly]: string
 namespace CSRF (bun-types/bun.d.ts)
   function CSRF.generate (bun-types/bun.d.ts)
-    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+    call (secret?: string | undefined, options?: Bun.CSRFGenerateOptions | undefined): string
   function CSRF.verify (bun-types/bun.d.ts)
-    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+    call (token: string, options?: Bun.CSRFVerifyOptions | undefined): boolean
 type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
 interface CSRFGenerateOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   expiresIn [?]: number | undefined
   sessionId [?]: string | undefined
 interface CSRFVerifyOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   maxAge [?]: number | undefined
   secret [?]: string | undefined
@@ -343,7 +368,7 @@ interface CloseEventInit (bun-types/bun.d.ts)
   composed [?]: boolean | undefined
   reason [?]: string | undefined
   wasClean [?]: boolean | undefined
-type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+type ColorInput (bun-types/bun.d.ts) = Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | [number, number, number, number] | [number, number, number] | number | string | { r: number; g: number; b: number; a?: number | undefined; } | { toString(): string; }
 interface CompileBuildOptions (bun-types/bun.d.ts)
   assets [?]: Array<string> | undefined
   autoloadBunfig [?]: boolean | undefined
@@ -353,9 +378,9 @@ interface CompileBuildOptions (bun-types/bun.d.ts)
   execArgv [?]: Array<string> | undefined
   executablePath [?]: string | undefined
   outfile [?]: string | undefined
-  target [?]: CompileTarget | undefined
+  target [?]: Bun.Build.CompileTarget | undefined
   windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
-type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+type CompressionFormat (bun-types/bun.d.ts) = "brotli" | "deflate" | "deflate-raw" | "gzip" | "zstd"
 class Cookie (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | undefined
@@ -365,19 +390,19 @@ class Cookie (bun-types/bun.d.ts)
   name [readonly]: string
   partitioned: boolean
   path: string
-  sameSite: CookieSameSite
+  sameSite: Bun.CookieSameSite
   secure: boolean
   serialize: () => string
-  toJSON: () => CookieInit
+  toJSON: () => Bun.CookieInit
   toString: () => string
   value: string
   [static]
-    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
-    construct new (cookieString: string): Cookie
-    construct new (cookieObject?: CookieInit | undefined): Cookie
-    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
-    parse [static]: (cookieString: string) => Cookie
-    prototype: Cookie
+    construct new (name: string, value: string, options?: Bun.CookieInit | undefined): Bun.Cookie
+    construct new (cookieString: string): Bun.Cookie
+    construct new (cookieObject?: Bun.CookieInit | undefined): Bun.Cookie
+    from [static]: (name: string, value: string, options?: Bun.CookieInit | undefined) => Bun.Cookie
+    parse [static]: (cookieString: string) => Bun.Cookie
+    prototype: Bun.Cookie
 interface CookieInit (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | number | string | undefined
@@ -386,26 +411,26 @@ interface CookieInit (bun-types/bun.d.ts)
   name [?]: string | undefined
   partitioned [?]: boolean | undefined
   path [?]: string | undefined
-  sameSite [?]: CookieSameSite | undefined
+  sameSite [?]: Bun.CookieSameSite | undefined
   secure [?]: boolean | undefined
   value [?]: string | undefined
 class CookieMap (bun-types/bun.d.ts)
   [Symbol.iterator]: () => IterableIterator<[string, string]>
-  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  delete: { (name: string): void; (options: Bun.CookieStoreDeleteOptions): void; (name: string, options: Omit<Bun.CookieStoreDeleteOptions, "name">): void }
   entries: () => IterableIterator<[string, string]>
-  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  forEach: (callback: (value: string, key: string, map: Bun.CookieMap) => void) => void
   get: (name: string) => null | string
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
-  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  set: { (name: string, value: string, options?: Bun.CookieInit | undefined): void; (options: Bun.CookieInit): void }
   size [readonly]: number
   toJSON: () => Record<string, string>
   toSetCookieHeaders: () => Array<string>
   values: () => IterableIterator<string>
   [static]
-    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
-    prototype: CookieMap
-type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): Bun.CookieMap
+    prototype: Bun.CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "lax" | "none" | "strict"
 interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
   domain [?]: null | string | undefined
   name: string
@@ -420,30 +445,30 @@ interface CronController (bun-types/bun.d.ts)
 interface CronJob (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   cron [readonly]: string
-  ref: () => CronJob
-  stop: () => CronJob
-  unref: () => CronJob
+  ref: () => Bun.CronJob
+  stop: () => Bun.CronJob
+  unref: () => Bun.CronJob
 interface CronOptions (bun-types/bun.d.ts)
   tz [?]: string | undefined
-type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+type CronWithAutocomplete (bun-types/bun.d.ts) = "@annually" | "@daily" | "@hourly" | "@midnight" | "@monthly" | "@weekly" | "@yearly" | (string & {}) | `${string} ${string} ${string} ${string} ${string}`
 class CryptoHashInterface<T> (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => T
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => T
   [static]
-    construct new <T>(): CryptoHashInterface<T>
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHashInterface<any>
+    construct new <T>(): Bun.CryptoHashInterface<T>
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHashInterface<any>
 class CryptoHasher (bun-types/bun.d.ts)
-  algorithm [readonly]: SupportedCryptoAlgorithms
+  algorithm [readonly]: Bun.SupportedCryptoAlgorithms
   byteLength [readonly]: number
-  copy: () => CryptoHasher
-  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
-  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  copy: () => Bun.CryptoHasher
+  digest: { (encoding: Bun.DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (input: Bun.BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => Bun.CryptoHasher
   [static]
-    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
-    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
-    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHasher
+    construct new (algorithm: Bun.SupportedCryptoAlgorithms, hmacKey?: NodeJS.TypedArray<ArrayBufferLike> | string | undefined): Bun.CryptoHasher
+    algorithms [readonly static]: Array<Bun.SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHasher
 interface CustomEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -454,9 +479,9 @@ interface DNSLookup (bun-types/bun.d.ts)
   family: 4 | 6
   ttl: number
 type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
-type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "base64" | "base64url" | "hex" | "latin1" | "ucs2" | "utf16le" | "utf8"
 interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
   pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
   type: "direct"
 type DisconnectListener (bun-types/bun.d.ts) = () => void
@@ -464,7 +489,7 @@ interface EditorOptions (bun-types/bun.d.ts)
   column [?]: number | undefined
   editor [?]: "subl" | "vscode" | undefined
   line [?]: number | undefined
-type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+type Encoding (bun-types/bun.d.ts) = "866" | "ansi_x3.4-1968" | "arabic" | "ascii" | "asmo-708" | "big5" | "big5-hkscs" | "chinese" | "cn-big5" | "cp1250" | "cp1251" | "cp1252" | "cp1253" | "cp1254" | "cp1255" | "cp1256" | "cp1257" | "cp1258" | "cp819" | "cp866" | "csbig5" | "cseuckr" | "cseucpkdfmtjapanese" | "csgb2312" | "csibm866" | "csiso2022jp" | "csiso58gb231280" | "csiso88596e" | "csiso88596i" | "csiso88598e" | "csiso88598i" | "csisolatin1" | "csisolatin2" | "csisolatin3" | "csisolatin4" | "csisolatin5" | "csisolatin6" | "csisolatin9" | "csisolatinarabic" | "csisolatincyrillic" | "csisolatingreek" | "csisolatinhebrew" | "cskoi8r" | "csksc56011987" | "csmacintosh" | "csshiftjis" | "csunicode" | "cyrillic" | "dos-874" | "ecma-114" | "ecma-118" | "elot_928" | "euc-jp" | "euc-kr" | "gb18030" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "greek" | "greek8" | "hebrew" | "ibm819" | "ibm866" | "iso-10646-ucs-2" | "iso-2022-jp" | "iso-8859-1" | "iso-8859-10" | "iso-8859-11" | "iso-8859-13" | "iso-8859-14" | "iso-8859-15" | "iso-8859-16" | "iso-8859-2" | "iso-8859-3" | "iso-8859-4" | "iso-8859-5" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-8859-7" | "iso-8859-8" | "iso-8859-8-e" | "iso-8859-8-i" | "iso-8859-9" | "iso-ir-100" | "iso-ir-101" | "iso-ir-109" | "iso-ir-110" | "iso-ir-126" | "iso-ir-127" | "iso-ir-138" | "iso-ir-144" | "iso-ir-148" | "iso-ir-149" | "iso-ir-157" | "iso-ir-58" | "iso8859-1" | "iso8859-10" | "iso8859-11" | "iso8859-13" | "iso8859-14" | "iso8859-15" | "iso8859-2" | "iso8859-3" | "iso8859-4" | "iso8859-5" | "iso8859-6" | "iso8859-7" | "iso8859-8" | "iso8859-9" | "iso88591" | "iso885910" | "iso885911" | "iso885913" | "iso885914" | "iso885915" | "iso88592" | "iso88593" | "iso88594" | "iso88595" | "iso88596" | "iso88597" | "iso88598" | "iso88599" | "iso_8859-1" | "iso_8859-15" | "iso_8859-1:1987" | "iso_8859-2" | "iso_8859-2:1987" | "iso_8859-3" | "iso_8859-3:1988" | "iso_8859-4" | "iso_8859-4:1988" | "iso_8859-5" | "iso_8859-5:1988" | "iso_8859-6" | "iso_8859-6:1987" | "iso_8859-7" | "iso_8859-7:1987" | "iso_8859-8" | "iso_8859-8:1988" | "iso_8859-9" | "iso_8859-9:1989" | "koi" | "koi8" | "koi8-r" | "koi8-ru" | "koi8-u" | "koi8_r" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "l1" | "l2" | "l3" | "l4" | "l5" | "l6" | "l9" | "latin1" | "latin2" | "latin3" | "latin4" | "latin5" | "latin6" | "logical" | "mac" | "macintosh" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "sun_eu_greek" | "tis-620" | "ucs-2" | "unicode" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "unicodefeff" | "unicodefffe" | "us-ascii" | "utf-16" | "utf-16be" | "utf-16le" | "utf-8" | "utf8" | "visual" | "windows-1250" | "windows-1251" | "windows-1252" | "windows-1253" | "windows-1254" | "windows-1255" | "windows-1256" | "windows-1257" | "windows-1258" | "windows-31j" | "windows-874" | "windows-949" | "x-cp1250" | "x-cp1251" | "x-cp1252" | "x-cp1253" | "x-cp1254" | "x-cp1255" | "x-cp1256" | "x-cp1257" | "x-cp1258" | "x-euc-jp" | "x-gbk" | "x-mac-cyrillic" | "x-mac-roman" | "x-mac-ukrainian" | "x-sjis" | "x-unicode20utf8" | "x-user-defined" | "x-x-big5"
 interface Env (bun-types/bun.d.ts)
   NODE_ENV [?]: string | undefined
   TZ [?]: string | undefined
@@ -485,7 +510,7 @@ interface ErrorLike (bun-types/bun.d.ts)
   name: string
   stack [?]: string | undefined
   syscall [?]: string | undefined
-type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+type Errorlike (bun-types/deprecated.d.ts) = Bun.ErrorLike
 interface EventInit (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -496,25 +521,25 @@ interface EventListenerObject (bun-types/bun.d.ts)
   handleEvent: (object: Event) => void
 interface EventListenerOptions (bun-types/bun.d.ts)
   capture [?]: boolean | undefined
-type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = Bun.EventListener | Bun.EventListenerObject
 interface EventMap (bun-types/bun.d.ts)
-  fetch: FetchEvent
+  fetch: Bun.FetchEvent
   message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
   messageerror: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
 interface EventSource (bun-types/bun.d.ts)
-  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): Bun.EventSource
   CLOSED [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
-  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   close: () => void
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: EventSource, ev: Event) => any) | null
-  onmessage: ((this: EventSource, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  onopen: ((this: EventSource, ev: Event) => any) | null
+  onerror: ((this: Bun.EventSource, ev: Event) => any) | null
+  onmessage: ((this: Bun.EventSource, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: Bun.EventSource, ev: Event) => any) | null
   readyState [readonly]: number
   ref: () => void
-  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   unref: () => void
   url [readonly]: string
   withCredentials [readonly]: boolean
@@ -528,8 +553,8 @@ interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   fd: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface FetchEvent (bun-types/bun.d.ts)
   AT_TARGET [readonly]: 2
   BUBBLING_PHASE [readonly]: 3
@@ -563,47 +588,47 @@ interface FileBlob (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface FileSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
   ref: () => void
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
 class FileSystemRouter (bun-types/bun.d.ts)
   assetPrefix [readonly]: string
-  match: (input: Request | Response | string) => MatchedRoute | null
+  match: (input: Request | Response | string) => Bun.MatchedRoute | null
   origin [readonly]: string
   reload: () => void
   routes [readonly]: Record<string, string>
   style [readonly]: string
   [static]
-    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
-    prototype: FileSystemRouter
-type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): Bun.FileSystemRouter
+    prototype: Bun.FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = File | string
 interface GenericTransformStream (bun-types/bun.d.ts)
   readable [readonly]: ReadableStream<any>
   writable [readonly]: WritableStream<any>
 class Glob (bun-types/bun.d.ts)
   match: (str: string) => boolean
-  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
-  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  scan: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => IterableIterator<string>
   [static]
-    construct new (pattern: string): Glob
-    prototype: Glob
+    construct new (pattern: string): Bun.Glob
+    prototype: Bun.Glob
 interface GlobScanOptions (bun-types/bun.d.ts)
   absolute [?]: boolean | undefined
   cwd [?]: string | undefined
@@ -611,25 +636,25 @@ interface GlobScanOptions (bun-types/bun.d.ts)
   followSymlinks [?]: boolean | undefined
   onlyFiles [?]: boolean | undefined
   throwErrorOnBrokenSymlink [?]: boolean | undefined
-type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
-type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+type HMREvent (bun-types/devserver.d.ts) = "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:beforeUpdate" | "bun:error" | "bun:invalidate" | "bun:ws:connect" | "bun:ws:disconnect" | (string & {})
+type HMREventNames (bun-types/devserver.d.ts) = "afterUpdate" | "beforeFullReload" | "beforePrune" | "beforeUpdate" | "error" | "invalidate" | "ws:connect" | "ws:disconnect"
 interface HTMLBundle (bun-types/bun.d.ts)
-  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Bun.Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
   index: string
 interface Hash (bun-types/bun.d.ts)
-  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-type HeadersInit (bun-types/fetch.d.ts) = Headers | Array<Array<string>> | Record<string, string | ReadonlyArray<string>>
+  adler32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Headers | Record<string, ReadonlyArray<string> | string>
 interface HeapSnapshot (bun-types/bun.d.ts)
   edgeNames: Array<string>
   edgeTypes: Array<string>
@@ -639,56 +664,56 @@ interface HeapSnapshot (bun-types/bun.d.ts)
   type: string
   version: number
 class Image (bun-types/bun.d.ts)
-  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  avif: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   blob: () => Promise<Blob>
   buffer: () => Promise<Buffer<ArrayBufferLike>>
   bytes: () => Promise<Uint8Array<ArrayBufferLike>>
   dataurl: () => Promise<string>
-  flip: () => Image
-  flop: () => Image
-  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  flip: () => Bun.Image
+  flop: () => Bun.Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   height [readonly]: number
-  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
-  metadata: () => Promise<Metadata>
-  modulate: (options: ModulateOptions) => Image
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Bun.Image
+  metadata: () => Promise<Bun.Image.Metadata>
+  modulate: (options: Bun.Image.ModulateOptions) => Bun.Image
   placeholder: (as?: "dataurl" | undefined) => Promise<string>
-  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
-  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
-  rotate: (degrees: number) => Image
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Bun.Image
+  resize: (width: number, height?: number | undefined, options?: Bun.Image.ResizeOptions | undefined) => Bun.Image
+  rotate: (degrees: number) => Bun.Image
   toBase64: () => Promise<string>
   toBuffer: () => Promise<Buffer<ArrayBufferLike>>
-  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Bun.Image
   width [readonly]: number
-  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  write: (dest: Bun.BunFile | Bun.PathLike | Bun.S3File | number) => Promise<number>
   [static]
-    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    construct new (input: ArrayBuffer | Blob | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.Image.ConstructorOptions | undefined): Bun.Image
     backend [static]: "bun" | "system"
     clipboardChangeCount [static]: () => number
-    fromClipboard [static]: () => Image | null
+    fromClipboard [static]: () => Bun.Image | null
     hasClipboardImage [static]: () => boolean
-    prototype: Image
+    prototype: Bun.Image
   interface Image.ConstructorOptions (bun-types/bun.d.ts)
     autoOrient [?]: boolean | undefined
     maxPixels [?]: number | undefined
-  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
-  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
-  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "bilinear" | "box" | "cubic" | "lanczos2" | "lanczos3" | "linear" | "mitchell" | "mks2013" | "mks2021" | "nearest"
+  type Image.Format (bun-types/bun.d.ts) = "avif" | "bmp" | "gif" | "heic" | "jpeg" | "png" | "tiff" | "webp"
   interface Image.Metadata (bun-types/bun.d.ts)
-    format: Format
+    format: Bun.Image.Format
     height: number
     width: number
   interface Image.ModulateOptions (bun-types/bun.d.ts)
     brightness [?]: number | undefined
     saturation [?]: number | undefined
   interface Image.ResizeOptions (bun-types/bun.d.ts)
-    filter [?]: Filter | undefined
+    filter [?]: Bun.Image.Filter | undefined
     fit [?]: "fill" | "inside" | undefined
     withoutEnlargement [?]: boolean | undefined
   var Image.backend (bun-types/bun.d.ts): "bun" | "system"
 interface Import (bun-types/bun.d.ts)
-  kind: ImportKind
+  kind: Bun.ImportKind
   path: string
-type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+type ImportKind (bun-types/bun.d.ts) = "dynamic-import" | "entry-point-build" | "entry-point-run" | "import-rule" | "import-statement" | "internal" | "require-call" | "require-resolve" | "url-token"
 namespace JSON5 (bun-types/bun.d.ts)
   function JSON5.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -704,30 +729,30 @@ namespace JSONL (bun-types/bun.d.ts)
     read: number
     values: Array<unknown>
   function JSONL.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Array<unknown>
   function JSONL.parseChunk (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): Bun.JSONL.ParseChunkResult
 type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
 interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
   level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
   library [?]: "libdeflate" | undefined
-type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+type Loader (bun-types/bun.d.ts) = "css" | "file" | "html" | "js" | "json" | "jsonc" | "jsx" | "napi" | "text" | "toml" | "ts" | "tsx" | "wasm" | "xml" | "yaml"
 class MD4 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD4
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD4
   [static]
-    construct new (): MD4
+    construct new (): Bun.MD4
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD4
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD4
 class MD5 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD5
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD5
   [static]
-    construct new (): MD5
+    construct new (): Bun.MD5
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD5
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD5
 interface MMapOptions (bun-types/bun.d.ts)
   offset [?]: number | undefined
   shared [?]: boolean | undefined
@@ -742,7 +767,7 @@ interface MatchedRoute (bun-types/bun.d.ts)
   pathname [readonly]: string
   query [readonly]: Record<string, string>
   src [readonly]: string
-type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
+type MaybePromise<T> (bun-types/bun.d.ts) = Promise<T> | T
 type MessageEvent<T = any> (bun-types/bun.d.ts) = { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
 interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
@@ -754,8 +779,8 @@ interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   source [?]: null | undefined
 type MessageEventSource (bun-types/bun.d.ts) = undefined
 type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
-type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
-type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: Bun.MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "reject" | "resolve"
 interface NetworkSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
@@ -763,38 +788,38 @@ interface NetworkSink (bun-types/s3.d.ts)
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   stat: () => Promise<Stats>
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
-type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
-type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
 type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
-type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+type OnEndCallback (bun-types/bun.d.ts) = (result: Bun.BuildOutput) => void | Promise<void>
 interface OnLoadArgs (bun-types/bun.d.ts)
   defer: () => Promise<void>
-  loader: Loader
+  loader: Bun.Loader
   namespace: string
   path: string
-type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
-type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+type OnLoadCallback (bun-types/bun.d.ts) = (args: Bun.OnLoadArgs) => Bun.OnLoadResult | Promise<Bun.OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = Bun.OnLoadResultObject | Bun.OnLoadResultSourceCode | undefined | void
 interface OnLoadResultObject (bun-types/bun.d.ts)
   exports: Record<string, unknown>
   loader: "object"
 interface OnLoadResultSourceCode (bun-types/bun.d.ts)
-  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
-  loader [?]: Loader | undefined
+  contents: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Bun.Loader | undefined
 interface OnResolveArgs (bun-types/bun.d.ts)
   importer: string
-  kind: ImportKind
+  kind: Bun.ImportKind
   namespace: string
   path: string
   resolveDir: string
-type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+type OnResolveCallback (bun-types/bun.d.ts) = (args: Bun.OnResolveArgs) => Bun.OnResolveResult | Promise<Bun.OnResolveResult | null | undefined> | null | undefined
 interface OnResolveResult (bun-types/bun.d.ts)
   external [?]: boolean | undefined
   namespace [?]: string | undefined
   path: string
 type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
 namespace Password (bun-types/bun.d.ts)
-  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "argon2d" | "argon2i" | "argon2id" | "bcrypt"
   interface Password.Argon2Algorithm (bun-types/bun.d.ts)
     algorithm: "argon2d" | "argon2i" | "argon2id"
     memoryCost [?]: number | undefined
@@ -802,243 +827,243 @@ namespace Password (bun-types/bun.d.ts)
   interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
     algorithm: "bcrypt"
     cost [?]: number | undefined
-type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
-type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
-type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+type PathLike (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | URL | string
+type PipedSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "cygwin" | "darwin" | "freebsd" | "haiku" | "linux" | "netbsd" | "openbsd" | "sunos" | "win32"
 interface PluginBuilder (bun-types/bun.d.ts)
-  config: BuildConfig & { plugins: Array<BunPlugin>; }
-  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
-  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
-  onEnd: (callback: OnEndCallback) => PluginBuilder
-  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
-  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
-  onStart: (callback: OnStartCallback) => PluginBuilder
+  config: Bun.BuildConfig & { plugins: Array<Bun.BunPlugin>; }
+  module: (specifier: string, callback: () => Bun.OnLoadResult | Promise<Bun.OnLoadResult>) => Bun.PluginBuilder
+  onBeforeParse: (constraints: Bun.PluginConstraints, callback: Bun.OnBeforeParseCallback) => Bun.PluginBuilder
+  onEnd: (callback: Bun.OnEndCallback) => Bun.PluginBuilder
+  onLoad: (constraints: Bun.PluginConstraints, callback: Bun.OnLoadCallback) => Bun.PluginBuilder
+  onResolve: (constraints: Bun.PluginConstraints, callback: Bun.OnResolveCallback) => Bun.PluginBuilder
+  onStart: (callback: Bun.OnStartCallback) => Bun.PluginBuilder
 interface PluginConstraints (bun-types/bun.d.ts)
   filter: RegExp
   namespace [?]: string | undefined
-type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined
 type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
 interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
   done: boolean
   size: number
   value: Array<T>
-type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadDoneResult | ReadableStreamDefaultReadValueResult<T>
 type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
-type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
-type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+type ReadableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"pipe", "pipe">
 class RedisClient (bun-types/redis.d.ts)
-  append: (key: KeyLike, value: KeyLike) => Promise<number>
-  bitcount: (key: KeyLike) => Promise<number>
-  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
-  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
-  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
-  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
-  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  append: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  bitcount: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  bitfield: (key: Bun.RedisClient.KeyLike, ...operations: Array<number | string>) => Promise<Array<null | number>>
+  bitop: { (operation: "NOT" | "not", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  bitpos: (key: Bun.RedisClient.KeyLike, bit: 0 | 1, ...options: Array<number | string>) => Promise<number>
+  blmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<null | string>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, timeout: number) => Promise<null | string>
   bufferedAmount [readonly]: number
-  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  client: (...args: Array<string | number>) => Promise<any>
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  client: (...args: Array<number | string>) => Promise<any>
   close: () => void
-  command: (...args: Array<string | number>) => Promise<any>
-  config: (...args: Array<string | number>) => Promise<any>
+  command: (...args: Array<number | string>) => Promise<any>
+  config: (...args: Array<number | string>) => Promise<any>
   connect: () => Promise<void>
   connected [readonly]: boolean
-  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  copy: { (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike): Promise<number>; (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, replace: "REPLACE"): Promise<number> }
   dbsize: () => Promise<number>
-  debug: (...args: Array<string | number>) => Promise<any>
-  decr: (key: KeyLike) => Promise<number>
-  decrby: (key: KeyLike, decrement: number) => Promise<number>
-  del: (...keys: Array<KeyLike>) => Promise<number>
-  dump: (key: KeyLike) => Promise<string | null>
-  duplicate: () => Promise<RedisClient>
+  debug: (...args: Array<number | string>) => Promise<any>
+  decr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  decrby: (key: Bun.RedisClient.KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  dump: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  duplicate: () => Promise<Bun.RedisClient>
   echo: (message: string) => Promise<string>
-  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  exists: (key: KeyLike) => Promise<boolean>
-  expire: (key: KeyLike, seconds: number) => Promise<number>
-  expireat: (key: KeyLike, timestamp: number) => Promise<number>
-  expiretime: (key: KeyLike) => Promise<number>
-  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  exists: (key: Bun.RedisClient.KeyLike) => Promise<boolean>
+  expire: (key: Bun.RedisClient.KeyLike, seconds: number) => Promise<number>
+  expireat: (key: Bun.RedisClient.KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
   flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
   flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
-  function: (...args: Array<KeyLike>) => Promise<any>
-  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
-  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
-  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
-  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
-  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
-  get: (key: KeyLike) => Promise<string | null>
-  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
-  getbit: (key: KeyLike, offset: number) => Promise<number>
-  getdel: (key: KeyLike) => Promise<string | null>
-  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
-  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
-  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
-  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
-  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
-  hgetall: (key: KeyLike) => Promise<Record<string, string>>
-  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
-  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
-  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
-  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
-  hkeys: (key: KeyLike) => Promise<Array<string>>
-  hlen: (key: KeyLike) => Promise<number>
-  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
-  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
-  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
-  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
-  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
-  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
-  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
-  hstrlen: (key: KeyLike, field: string) => Promise<number>
-  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hvals: (key: KeyLike) => Promise<Array<string>>
-  incr: (key: KeyLike) => Promise<number>
-  incrby: (key: KeyLike, increment: number) => Promise<number>
-  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  function: (...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  geoadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  geodist: { (key: Bun.RedisClient.KeyLike, member1: string, member2: string): Promise<null | string>; (key: Bun.RedisClient.KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<null | string> }
+  geohash: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<null | string>>
+  geopos: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<unknown>>
+  geosearchstore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  get: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getBuffer: (key: Bun.RedisClient.KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: Bun.RedisClient.KeyLike, offset: number) => Promise<number>
+  getdel: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getex: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST"): Promise<null | string> }
+  getrange: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hdel: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  hexists: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hexpire: { (key: Bun.RedisClient.KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hget: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hgetall: (key: Bun.RedisClient.KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  hgetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>> }
+  hincrby: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  hlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  hmget: { (key: Bun.RedisClient.KeyLike, ...fields: Array<string>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, fields: Array<string>): Promise<Array<null | string>> }
+  hmset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<"OK"> }
+  hpersist: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: Bun.RedisClient.KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpttl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: Bun.RedisClient.KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<number>; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetnx: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hstrlen: (key: Bun.RedisClient.KeyLike, field: string) => Promise<number>
+  httl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hvals: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  incr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  incrby: (key: Bun.RedisClient.KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: Bun.RedisClient.KeyLike, increment: number | string) => Promise<string>
   info: (...sections: Array<string>) => Promise<string>
   keys: (pattern: string) => Promise<Array<string>>
   lastsave: () => Promise<number>
-  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
-  lindex: (key: KeyLike, index: number) => Promise<string | null>
-  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
-  llen: (key: KeyLike) => Promise<number>
-  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
-  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
-  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
-  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
-  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
-  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
-  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
-  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
-  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
-  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
-  onclose: ((this: RedisClient, error: Error) => void) | null
-  onconnect: ((this: RedisClient) => void) | null
-  persist: (key: KeyLike) => Promise<number>
-  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
-  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
-  pexpiretime: (key: KeyLike) => Promise<number>
-  pfadd: (key: KeyLike, element: string) => Promise<number>
-  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
-  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
-  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
-  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
-  pttl: (key: KeyLike) => Promise<number>
+  lcs: (key1: Bun.RedisClient.KeyLike, key2: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<any>
+  lindex: (key: Bun.RedisClient.KeyLike, index: number) => Promise<null | string>
+  linsert: (key: Bun.RedisClient.KeyLike, position: "AFTER" | "BEFORE", pivot: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike) => Promise<number>
+  llen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  lmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<null | string>
+  lmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<Array<number> | null | number>
+  lpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  lpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  lrange: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: Bun.RedisClient.KeyLike, count: number, element: Bun.RedisClient.KeyLike) => Promise<number>
+  lset: (key: Bun.RedisClient.KeyLike, index: number, element: Bun.RedisClient.KeyLike) => Promise<string>
+  ltrim: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  mset: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  onclose: ((this: Bun.RedisClient, error: Error) => void) | null
+  onconnect: ((this: Bun.RedisClient) => void) | null
+  persist: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pexpire: (key: Bun.RedisClient.KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: Bun.RedisClient.KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pfadd: (key: Bun.RedisClient.KeyLike, element: string) => Promise<number>
+  pfcount: (key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  pfmerge: (destkey: Bun.RedisClient.KeyLike, ...sourcekeys: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: Bun.RedisClient.KeyLike): Promise<string> }
+  psetex: (key: Bun.RedisClient.KeyLike, milliseconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  pttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
   publish: (channel: string, message: string) => Promise<number>
-  randomkey: () => Promise<string | null>
-  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
-  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
-  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
-  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
-  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
-  scard: (key: KeyLike) => Promise<number>
+  randomkey: () => Promise<null | string>
+  rename: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<"OK">
+  renamenx: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<number>
+  rpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike) => Promise<null | string>
+  rpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  rpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sadd: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<number | string>): Promise<[string, Array<string>]> }
+  scard: (key: Bun.RedisClient.KeyLike) => Promise<number>
   script: (...args: Array<string>) => Promise<any>
-  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sdiff: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   send: (command: string, args: Array<string>) => Promise<any>
-  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
-  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
-  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
-  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
-  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
-  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
-  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
-  sismember: (key: KeyLike, member: string) => Promise<boolean>
-  smembers: (key: KeyLike) => Promise<Array<string>>
-  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
-  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
-  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
-  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  spublish: (channel: KeyLike, message: string) => Promise<number>
-  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
-  strlen: (key: KeyLike) => Promise<number>
-  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
-  substr: (key: KeyLike, start: number, end: number) => Promise<string>
-  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  set: { (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, nx: "NX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, xx: "XX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, get: "GET"): Promise<null | string>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...options: Array<string>): Promise<null | string> }
+  setbit: (key: Bun.RedisClient.KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: Bun.RedisClient.KeyLike, seconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  setnx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  setrange: (key: Bun.RedisClient.KeyLike, offset: number, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sinter: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: Bun.RedisClient.KeyLike, ...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<number>
+  sinterstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  sismember: (key: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  smembers: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  smismember: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  smove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  sort: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<null | string> | number>
+  spop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: Bun.RedisClient.KeyLike, message: string) => Promise<number>
+  srandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...args: Array<number | string>) => Promise<[string, Array<string>]>
+  strlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<number>; (channels: Array<string>, listener: Bun.RedisClient.StringPubSubListener): Promise<number> }
+  substr: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   time: () => Promise<[string, string]>
-  touch: (...keys: Array<KeyLike>) => Promise<number>
-  ttl: (key: KeyLike) => Promise<number>
-  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
-  unlink: (...keys: Array<KeyLike>) => Promise<number>
-  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  touch: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  ttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  type: (key: Bun.RedisClient.KeyLike) => Promise<"hash" | "list" | "none" | "set" | "stream" | "string" | "zset">
+  unlink: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
   wait: (numreplicas: number, timeout: number) => Promise<number>
-  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
-  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
-  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
-  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
-  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
-  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xlen: (key: KeyLike) => Promise<number>
-  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
-  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xread: (...args: Array<string | number>) => Promise<any>
-  xreadgroup: (...args: Array<string | number>) => Promise<any>
-  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
-  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
-  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  zcard: (key: KeyLike) => Promise<number>
-  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
-  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
-  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
-  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
-  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
-  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
-  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
-  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
-  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
-  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
-  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
-  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
-  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
-  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
-  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
-  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
-  zscore: (key: KeyLike, member: string) => Promise<number | null>
-  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  xack: (key: Bun.RedisClient.KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<null | string>
+  xautoclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<number | string>) => Promise<any>
+  xclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<number | string>) => Promise<any>
+  xdel: (key: Bun.RedisClient.KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  xpending: (key: Bun.RedisClient.KeyLike, group: string, ...args: Array<number | string>) => Promise<any>
+  xrange: (key: Bun.RedisClient.KeyLike, start: string, end: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<number | string>) => Promise<any>
+  xreadgroup: (...args: Array<number | string>) => Promise<any>
+  xrevrange: (key: Bun.RedisClient.KeyLike, end: string, start: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: Bun.RedisClient.KeyLike, lastId: string, ...options: Array<number | string>) => Promise<"OK">
+  xtrim: (key: Bun.RedisClient.KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<number | string>) => Promise<number>
+  zadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  zcard: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  zcount: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: Bun.RedisClient.KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zincrby: (key: Bun.RedisClient.KeyLike, increment: number, member: Bun.RedisClient.KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<number>; (numkeys: number, ...args: Array<Bun.RedisClient.KeyLike | number>): Promise<number> }
+  zinterstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
+  zlexcount: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | number>>
+  zpopmax: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null>; (key: Bun.RedisClient.KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: Bun.RedisClient.KeyLike, min: string, max: string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangebyscore: { (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangestore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zremrangebylex: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: Bun.RedisClient.KeyLike, start: number, stop: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: Bun.RedisClient.KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrevrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: Bun.RedisClient.KeyLike, member: string) => Promise<null | number>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zunionstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
   [static]
-    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
-    prototype: RedisClient
-  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+    construct new (url?: string | undefined, options?: Bun.RedisOptions | undefined): Bun.RedisClient
+    prototype: Bun.RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = Blob | Bun.ArrayBufferView<ArrayBufferLike> | string
   type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
 interface RedisOptions (bun-types/redis.d.ts)
   autoReconnect [?]: boolean | undefined
@@ -1047,34 +1072,34 @@ interface RedisOptions (bun-types/redis.d.ts)
   enableOfflineQueue [?]: boolean | undefined
   idleTimeout [?]: number | undefined
   maxRetries [?]: number | undefined
-  tls [?]: TLSOptions | boolean | undefined
+  tls [?]: Bun.TLSOptions | boolean | undefined
 type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
 interface ReservedSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
   [Symbol.dispose]: () => void
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
   release: () => void
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 interface ResourceUsage (bun-types/bun.d.ts)
   contextSwitches: { voluntary: number; involuntary: number; }
   cpuTime: { user: number; system: number; total: number; }
@@ -1085,27 +1110,27 @@ interface ResourceUsage (bun-types/bun.d.ts)
   signalCount: number
   swapCount: number
 class S3Client (bun-types/s3.d.ts)
-  delete: (path: string, options?: S3Options | undefined) => Promise<void>
-  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
-  file: (path: string, options?: S3Options | undefined) => S3File
-  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
-  size: (path: string, options?: S3Options | undefined) => Promise<number>
-  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
-  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  delete: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+  list: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+  presign: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+  unlink: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  write: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
   [static]
-    construct new (options?: S3Options | undefined): S3Client
-    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
-    file [static]: (path: string, options?: S3Options | undefined) => S3File
-    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
-    prototype: S3Client
-    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
-    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+    construct new (options?: Bun.S3Options | undefined): Bun.S3Client
+    delete [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+    list [static]: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+    presign [static]: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+    prototype: Bun.S3Client
+    size [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+    unlink [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
 interface S3File (bun-types/s3.d.ts)
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
   bucket [? readonly]: string | undefined
@@ -1113,20 +1138,20 @@ interface S3File (bun-types/s3.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   name [? readonly]: string | undefined
-  presign: (options?: S3FilePresignOptions | undefined) => string
+  presign: (options?: Bun.S3FilePresignOptions | undefined) => string
   readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
-  stat: () => Promise<S3Stats>
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.S3File; (begin?: number | undefined, contentType?: string | undefined): Bun.S3File; (contentType?: string | undefined): Bun.S3File }
+  stat: () => Promise<Bun.S3Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
-  writer: (options?: S3Options | undefined) => NetworkSink
+  write: (data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
+  writer: (options?: Bun.S3Options | undefined) => Bun.NetworkSink
 interface S3FilePresignOptions (bun-types/s3.d.ts)
   accessKeyId [?]: string | undefined
   acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
@@ -1194,89 +1219,89 @@ interface S3Stats (bun-types/s3.d.ts)
   size: number
   type: string
 class SHA1 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA1
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA1
   [static]
-    construct new (): SHA1
+    construct new (): Bun.SHA1
     byteLength [readonly static]: 20
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA1
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA1
 class SHA224 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA224
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA224
   [static]
-    construct new (): SHA224
+    construct new (): Bun.SHA224
     byteLength [readonly static]: 28
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA224
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA224
 class SHA256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA256
   [static]
-    construct new (): SHA256
+    construct new (): Bun.SHA256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA256
 class SHA384 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA384
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA384
   [static]
-    construct new (): SHA384
+    construct new (): Bun.SHA384
     byteLength [readonly static]: 48
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA384
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA384
 class SHA512 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512
   [static]
-    construct new (): SHA512
+    construct new (): Bun.SHA512
     byteLength [readonly static]: 64
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512
 class SHA512_256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512_256
   [static]
-    construct new (): SHA512_256
+    construct new (): Bun.SHA512_256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512_256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512_256
 class SQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   [static]
-    construct new (connectionString: URL | string): SQL
-    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
-    construct new (options?: Options | undefined): SQL
-    MySQLError: typeof MySQLError
-    PostgresError: typeof PostgresError
-    SQLError: typeof SQLError
-    SQLiteError: typeof SQLiteError
-    prototype: SQL
+    construct new (connectionString: URL | string): Bun.SQL
+    construct new (connectionString: URL | string, options: Omit<Bun.SQL.PostgresOrMySQLOptions, "filename" | "url"> | Omit<Bun.SQL.SQLiteOptions, "filename" | "url">): Bun.SQL
+    construct new (options?: Bun.SQL.Options | undefined): Bun.SQL
+    MySQLError: typeof Bun.SQL.MySQLError
+    PostgresError: typeof Bun.SQL.PostgresError
+    SQLError: typeof Bun.SQL.SQLError
+    SQLiteError: typeof Bun.SQL.SQLiteError
+    prototype: Bun.SQL
   type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
-  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
-  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => Bun.MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? Bun.SQL.AwaitPromisesArray<T> : Awaited<T>
   interface SQL.Helper<T> (bun-types/sql.d.ts)
     columns [readonly]: Array<keyof T>
     value [readonly]: Array<T>
@@ -1293,13 +1318,13 @@ class SQL (bun-types/sql.d.ts)
     sqlState [? readonly]: string | undefined
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): Bun.SQL.MySQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: MySQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.MySQLError
       stackTraceLimit: number
-  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  type SQL.Options (bun-types/sql.d.ts) = Bun.SQL.PostgresOrMySQLOptions | Bun.SQL.SQLiteOptions
   class SQL.PostgresError (bun-types/sql.d.ts)
     cause [?]: unknown
     code [readonly]: string
@@ -1323,11 +1348,11 @@ class SQL (bun-types/sql.d.ts)
     table [? readonly]: string | undefined
     where [? readonly]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): Bun.SQL.PostgresError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: PostgresError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.PostgresError
       stackTraceLimit: number
   interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
     adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
@@ -1335,7 +1360,7 @@ class SQL (bun-types/sql.d.ts)
     bigint [?]: boolean | undefined
     connectTimeout [?]: number | undefined
     connect_timeout [?]: number | undefined
-    connection [?]: Record<string, string | number | boolean> | undefined
+    connection [?]: Record<string, boolean | number | string> | undefined
     connectionTimeout [?]: number | undefined
     connection_timeout [?]: number | undefined
     database [?]: string | undefined
@@ -1349,39 +1374,39 @@ class SQL (bun-types/sql.d.ts)
     max_lifetime [?]: number | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
-    pass [?]: (() => MaybePromise<string>) | string | undefined
-    password [?]: (() => MaybePromise<string>) | string | undefined
+    pass [?]: (() => Bun.MaybePromise<string>) | string | undefined
+    password [?]: (() => Bun.MaybePromise<string>) | string | undefined
     path [?]: string | undefined
     port [?]: number | string | undefined
     prepare [?]: boolean | undefined
-    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
-    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
     url [?]: URL | string | undefined
     user [?]: string | undefined
     username [?]: string | undefined
   interface SQL.Query<T> (bun-types/sql.d.ts)
     [Symbol.toStringTag] [readonly]: string
     active: boolean
-    cancel: () => Query<T>
+    cancel: () => Bun.SQL.Query<T>
     cancelled: boolean
     catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
-    execute: () => Query<T>
+    execute: () => Bun.SQL.Query<T>
     finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
-    raw: () => Query<T>
-    simple: () => Query<T>
+    raw: () => Bun.SQL.Query<T>
+    simple: () => Bun.SQL.Query<T>
     then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    values: () => Query<T>
+    values: () => Bun.SQL.Query<T>
   class SQL.SQLError (bun-types/sql.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string): SQLError
+      construct new (message: string): Bun.SQL.SQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLError
       stackTraceLimit: number
   class SQL.SQLiteError (bun-types/sql.d.ts)
     byteOffset [? readonly]: number | undefined
@@ -1392,55 +1417,55 @@ class SQL (bun-types/sql.d.ts)
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): Bun.SQL.SQLiteError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLiteError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLiteError
       stackTraceLimit: number
   interface SQL.SQLiteOptions (bun-types/sql.d.ts)
     adapter [?]: "sqlite" | undefined
     create [?]: boolean | undefined
-    filename [?]: ":memory:" | URL | string & {} | undefined
+    filename [?]: ":memory:" | (string & {}) | URL | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
     readonly [?]: boolean | undefined
     readwrite [?]: boolean | undefined
     safeIntegers [?]: boolean | undefined
     strict [?]: boolean | undefined
-  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SQLArrayParameter (bun-types/sql.d.ts)
-  arrayType: ArrayType
+  arrayType: Bun.ArrayType
   serializedValues: string
-type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
-type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
-type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+type SQLOptions (bun-types/deprecated.d.ts) = Bun.SQL.Options
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Bun.SQL.Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SavepointSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 namespace Security (bun-types/security.d.ts)
   interface Security.Advisory (bun-types/security.d.ts)
     description: null | string
@@ -1453,29 +1478,29 @@ namespace Security (bun-types/security.d.ts)
     tarball: string
     version: string
   interface Security.Scanner (bun-types/security.d.ts)
-    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    scan: (info: { packages: Array<Bun.Security.Package>; }) => Promise<Array<Bun.Security.Advisory>>
     version: "1"
 namespace Serve (bun-types/serve.d.ts)
-  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = Bun.BunFile | Bun.HTMLBundle | Bun.Serve.DirectoryRouteOptions | Response | false
   interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
   type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
   interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
     dir: string
     statCache [?]: boolean | undefined
-  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
-  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
-  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
-  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
-  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & Bun.Serve.ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes?: Bun.Serve.Routes<WebSocketData, R> | undefined; } | { fetch?(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes: Bun.Serve.Routes<WebSocketData, R>; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = Bun.Serve.FetchOrRoutesWithWebSocket<WebSocketData, R>
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => Bun.MaybePromise<Res>
   interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
-    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | (string & {}) | undefined
     http1 [?]: boolean | undefined
     http2 [?]: boolean | undefined
     http3 [?]: boolean | undefined
@@ -1485,18 +1510,18 @@ namespace Serve (bun-types/serve.d.ts)
     maxRequestBodySize [?]: number | undefined
     port [?]: number | string | undefined
     reusePort [?]: boolean | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
-  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
-  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
-  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = Bun.Serve.Options<WebSocketData, R>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined>>>; }
   interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
     unix [?]: string | undefined
-type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = Bun.ServeOptions<T, R>
 interface Server<WebSocketData> (bun-types/serve.d.ts)
   [Symbol.dispose]: () => void
   closeIdleConnections: () => number
@@ -1508,41 +1533,41 @@ interface Server<WebSocketData> (bun-types/serve.d.ts)
   pendingWebSockets [readonly]: number
   port [readonly]: number | undefined
   protocol [readonly]: "http" | "https" | null
-  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  publish: (topic: string, data: ArrayBuffer | Blob | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, compress?: boolean | undefined) => number
   ref: () => void
-  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
-  requestIP: (request: Request) => SocketAddress | null
+  reload: <R extends string>(options: Bun.Serve.Options<WebSocketData, R>) => Bun.Server<WebSocketData>
+  requestIP: (request: Request) => Bun.SocketAddress | null
   stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
   subscriberCount: (topic: string) => number
   timeout: (request: Request, seconds: number) => void
   unref: () => void
-  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: Bun.HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: Bun.HeadersInit | undefined; data: WebSocketData; }]) => boolean
   url [readonly]: URL
 interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
   binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
   close: (code?: number | undefined, reason?: string | undefined) => void
-  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  cork: <T = unknown>(callback: (ws: Bun.ServerWebSocket<T>) => T) => T
   data: T
   getBufferedAmount: () => number
   isSubscribed: (topic: string) => boolean
-  ping: (data?: Blob | BufferSource | string | undefined) => number
-  pong: (data?: Blob | BufferSource | string | undefined) => number
-  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  ping: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  pong: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   publishText: (topic: string, data: string, compress?: boolean | undefined) => number
-  readyState [readonly]: WebSocketReadyState
+  readyState [readonly]: Bun.WebSocketReadyState
   remoteAddress [readonly]: string
-  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  send: (data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   sendText: (data: string, compress?: boolean | undefined) => number
   subscribe: (topic: string) => boolean
   subscriptions [readonly]: Array<string>
   terminate: () => void
   unsubscribe: (topic: string) => boolean
 type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
-type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellExpression (bun-types/shell.d.ts) = Array<Bun.ShellExpression> | BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | Blob | Bun.BunFile | Bun.Subprocess<Bun.SpawnOptions.Writable, Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | ReadableStream<any> | ReadableStream<any> | Request | Response | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | null | number | string | undefined | { raw: string; } | { toString(): string; }
 type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
-type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+type SignalsListener (bun-types/bun.d.ts) = (signal: NodeJS.Signals) => void
 interface SliceAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   ellipsis [?]: string | undefined
@@ -1554,8 +1579,8 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   close: () => void
   data: Data
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1572,14 +1597,14 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1589,154 +1614,154 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface SocketAddress (bun-types/bun.d.ts)
   address: string
   family: "IPv4" | "IPv6"
   port: number
-interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
-  binaryType [?]: keyof BinaryTypeList | undefined
-  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
-  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
-  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
-  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof Bun.BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof Bun.BinaryTypeList | undefined
+  close [?]: ((socket: Bun.Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Bun.Socket<Data>, data: Bun.BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Bun.Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
 interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
+  socket: Bun.SocketHandler<Data, "buffer">
 namespace Spawn (bun-types/bun.d.ts)
-  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
-  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
-  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
-  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
-  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  type Spawn.OptionsObject<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = Bun.SpawnOptions.BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | null | number | undefined
+  type Spawn.ReadableToIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | Bun.BunFile | Bun.ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     lazy [?]: boolean | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
-    terminal [?]: Terminal | TerminalOptions | undefined
+    terminal [?]: Bun.Terminal | Bun.TerminalOptions | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.SpawnSyncOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
-  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
-  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | null | number | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = Bun.FileSink | number | undefined
+  type Spawn.WritableToIO<X extends Bun.SpawnOptions.Writable> (bun-types/bun.d.ts) = X extends "pipe" ? Bun.FileSink : X extends number | Bun.BunFile | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
 SpawnOptions -> Spawn
 type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
-type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type StringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | string
 interface StringWidthOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   countAnsiEscapeCodes [?]: boolean | undefined
   perCodePoint [?]: boolean | undefined
 interface StructuredSerializeOptions (bun-types/bun.d.ts)
-  transfer [?]: Array<Transferable> | undefined
-interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  transfer [?]: Array<Bun.Transferable> | undefined
+interface Subprocess<In extends Bun.SpawnOptions.Writable = Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => PromiseLike<void>
   disconnect: () => void
   exitCode [readonly]: null | number
   exited [readonly]: Promise<number>
-  kill: (exitCode?: Signals | number | undefined) => void
+  kill: (exitCode?: NodeJS.Signals | number | undefined) => void
   killed [readonly]: boolean
   pid [readonly]: number
-  readable [readonly]: ReadableToIO<Out>
+  readable [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
   ref: () => void
-  resourceUsage: () => ResourceUsage | undefined
+  resourceUsage: () => Bun.ResourceUsage | undefined
   send: (message: any) => void
-  signalCode [readonly]: Signals | null
-  stderr [readonly]: ReadableToIO<Err>
-  stdin [readonly]: WritableToIO<In>
+  signalCode [readonly]: NodeJS.Signals | null
+  stderr [readonly]: Bun.SpawnOptions.ReadableToIO<Err>
+  stdin [readonly]: Bun.SpawnOptions.WritableToIO<In>
   stdio [readonly]: [null, null, null, ...(number | null)[]]
-  stdout [readonly]: ReadableToIO<Out>
-  terminal [readonly]: Terminal | undefined
+  stdout [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
+  terminal [readonly]: Bun.Terminal | undefined
   unref: () => void
-type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
-interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha256" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "sha384" | "sha512" | "sha512-224" | "sha512-256" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   exitCode: number
   exitedDueToMaxBuffer [?]: boolean | undefined
   exitedDueToTimeout [?]: boolean | undefined
   pid: number
-  resourceUsage: ResourceUsage
+  resourceUsage: Bun.ResourceUsage
   signalCode [?]: string | undefined
-  stderr: ReadableToSyncIO<Err>
-  stdout: ReadableToSyncIO<Out>
+  stderr: Bun.SpawnOptions.ReadableToSyncIO<Err>
+  stdout: Bun.SpawnOptions.ReadableToSyncIO<Out>
   success: boolean
 interface SystemError (bun-types/bun.d.ts)
   cause [?]: unknown
@@ -1755,8 +1780,8 @@ interface TCPSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1773,14 +1798,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1790,14 +1815,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
@@ -1806,36 +1831,36 @@ interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   ipv6Only [?]: boolean | undefined
   port: number
   reusePort [?]: boolean | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   exclusive [?]: boolean | undefined
   hostname: string
   port: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   hostname [readonly]: string
   port [readonly]: number
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -1851,8 +1876,8 @@ interface TLSSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1869,14 +1894,14 @@ interface TLSSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1886,27 +1911,27 @@ interface TLSSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls: TLSOptions | boolean
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls: Bun.TLSOptions | boolean
 namespace TOML (bun-types/bun.d.ts)
   function TOML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): object
   function TOML.stringify (bun-types/bun.d.ts)
     call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
 interface TSConfig (bun-types/bun.d.ts)
   compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
   extends [?]: string | undefined
-type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+type Target (bun-types/bun.d.ts) = "browser" | "bun" | "node"
 class Terminal (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => Promise<void>
   close: () => void
@@ -1919,43 +1944,43 @@ class Terminal (bun-types/bun.d.ts)
   resize: (cols: number, rows: number) => void
   setRawMode: (enabled: boolean) => void
   unref: () => void
-  write: (data: BufferSource | string) => number
+  write: (data: Bun.BufferSource | string) => number
   [static]
-    construct new (options: TerminalOptions): Terminal
-    prototype: Terminal
+    construct new (options: Bun.TerminalOptions): Bun.Terminal
+    prototype: Bun.Terminal
 interface TerminalOptions (bun-types/bun.d.ts)
   cols [?]: number | undefined
-  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
-  drain [?]: ((terminal: Terminal) => void) | undefined
-  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  data [?]: ((terminal: Bun.Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Bun.Terminal) => void) | undefined
+  exit [?]: ((terminal: Bun.Terminal, exitCode: number, signal: null | string) => void) | undefined
   name [?]: string | undefined
   rows [?]: number | undefined
 type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
 interface TransactionSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  savepoint: { <T>(name: string, fn: Bun.SQL.SavepointContextCallback<T>): Promise<T>; <T>(fn: Bun.SQL.SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
 interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
   call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
@@ -1964,13 +1989,13 @@ interface TransformerStartCallback<O> (bun-types/bun.d.ts)
 interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
   call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
 class Transpiler (bun-types/bun.d.ts)
-  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
-  scanImports: (code: StringOrBuffer) => Array<Import>
-  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
-  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  scan: (code: Bun.StringOrBuffer) => { exports: Array<string>; imports: Array<Bun.Import>; }
+  scanImports: (code: Bun.StringOrBuffer) => Array<Bun.Import>
+  transform: (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: Bun.StringOrBuffer, loader: Bun.JavaScriptLoader, ctx: object): string; (code: Bun.StringOrBuffer, ctx: object): string; (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined): string }
   [static]
-    construct new (options?: TranspilerOptions | undefined): Transpiler
-    prototype: Transpiler
+    construct new (options?: Bun.TranspilerOptions | undefined): Bun.Transpiler
+    prototype: Bun.Transpiler
 interface TranspilerOptions (bun-types/bun.d.ts)
   allowBunRuntime [?]: boolean | undefined
   autoImportJSX [?]: boolean | undefined
@@ -1979,23 +2004,23 @@ interface TranspilerOptions (bun-types/bun.d.ts)
   exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
   inline [?]: boolean | undefined
   jsxOptimizationInline [?]: boolean | undefined
-  loader [?]: JavaScriptLoader | undefined
+  loader [?]: Bun.JavaScriptLoader | undefined
   logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
-  macro [?]: MacroMap | undefined
+  macro [?]: Bun.MacroMap | undefined
   minifyWhitespace [?]: boolean | undefined
   replMode [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   treeShaking [?]: boolean | undefined
   trimUnusedImports [?]: boolean | undefined
-  tsconfig [?]: TSConfig | string | undefined
-type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  tsconfig [?]: Bun.TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: Bun.UncaughtExceptionOrigin) => void
 type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
 interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
-  abort [?]: UnderlyingSinkAbortCallback | undefined
-  close [?]: UnderlyingSinkCloseCallback | undefined
-  start [?]: UnderlyingSinkStartCallback | undefined
+  abort [?]: Bun.UnderlyingSinkAbortCallback | undefined
+  close [?]: Bun.UnderlyingSinkCloseCallback | undefined
+  start [?]: Bun.UnderlyingSinkStartCallback | undefined
   type [?]: "bytes" | "default" | undefined
-  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+  write [?]: Bun.UnderlyingSinkWriteCallback<W> | undefined
 interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
@@ -2005,30 +2030,30 @@ interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
 interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
   call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
 interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
-  pull [?]: UnderlyingSourcePullCallback<R> | undefined
-  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
+  pull [?]: Bun.UnderlyingSourcePullCallback<R> | undefined
+  start [?]: Bun.UnderlyingSourceStartCallback<R> | undefined
   type [?]: undefined
 interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+  call (controller: Bun.ReadableStreamController<R>): PromiseLike<void> | void
 interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): any
+  call (controller: Bun.ReadableStreamController<R>): any
 type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
 interface UnixSocketListener<Data> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unix [readonly]: string
   unref: () => void
 interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
   unix: string
 type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
 namespace WebAssembly (bun-types/wasm.d.ts)
@@ -2037,19 +2062,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     message: string
     name: string
     stack [?]: string | undefined
-  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
-  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.Global<keyof Bun.WebAssembly.ValueTypeMap> | Bun.WebAssembly.Memory | Bun.WebAssembly.Table | Function
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ExportValue; }
+  interface WebAssembly.Global<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
-  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
-  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.ExportValue | number
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ModuleImports; }
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2064,13 +2089,13 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
-  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ImportValue; }
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2082,11 +2107,11 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     length [readonly]: number
     set: (index: number, value?: any) => void
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
-  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof Bun.WebAssembly.ValueTypeMap
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
     anyfunc: Function
     externref: any
@@ -2096,36 +2121,36 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
 interface WebSocket (bun-types/bun.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
-type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+type WebSocketCompressor (bun-types/serve.d.ts) = "128KB" | "16KB" | "256KB" | "32KB" | "3KB" | "4KB" | "64KB" | "8KB" | "dedicated" | "disable" | "shared"
 interface WebSocketEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: Event
@@ -2133,33 +2158,33 @@ interface WebSocketEventMap (bun-types/bun.d.ts)
   open: Event
 interface WebSocketHandler<T> (bun-types/serve.d.ts)
   backpressureLimit [?]: number | undefined
-  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  close [?]: ((ws: Bun.ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
   closeOnBackpressureLimit [?]: boolean | undefined
   data [?]: T | undefined
-  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  drain [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
   idleTimeout [?]: number | undefined
   maxPayloadLength [?]: number | undefined
-  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
-  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
-  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
-  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
-  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  message: (ws: Bun.ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | Bun.WebSocketCompressor | undefined; decompress?: boolean | Bun.WebSocketCompressor | undefined; }
+  ping [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
   publishToSelf [?]: boolean | undefined
   sendPings [?]: boolean | undefined
-type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptions (bun-types/bun.d.ts) = Bun.WebSocketOptions
 type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
 type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
-type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocol?: string | undefined; } | { protocols?: string | Array<string> | undefined; }
 type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
-type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: Bun.TLSOptions | undefined; }
 type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
 class WebView (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => void
   [Symbol.dispose]: () => void
-  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => void, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   back: () => Promise<void>
   cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
-  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  click: { (x: number, y: number, options?: Bun.WebView.ClickOptions | undefined): Promise<void>; (selector: string, options?: Bun.WebView.ClickSelectorOptions | undefined): Promise<void> }
   close: () => void
   dispatchEvent: (event: Event) => boolean
   evaluate: <T = unknown>(script: string) => Promise<T>
@@ -2168,58 +2193,58 @@ class WebView (bun-types/bun.d.ts)
   navigate: (url: string) => Promise<void>
   onNavigated: ((url: string, title: string) => void) | null
   onNavigationFailed: ((error: Error) => void) | null
-  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  press: (key: (string & {}) | Bun.WebView.VirtualKey, options?: Bun.WebView.PressOptions | undefined) => Promise<void>
   reload: () => Promise<void>
   removeEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean | undefined) => void
   resize: (width: number, height: number) => Promise<void>
   screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
   scroll: (dx: number, dy: number) => Promise<void>
-  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  scrollTo: (selector: string, options?: Bun.WebView.ScrollToOptions | undefined) => Promise<void>
   title [readonly]: string
   type: (text: string) => Promise<void>
   url [readonly]: string
   [static]
-    construct new (options?: ConstructorOptions | undefined): WebView
+    construct new (options?: Bun.WebView.ConstructorOptions | undefined): Bun.WebView
     closeAll [static]: () => void
-    prototype: WebView
-  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+    prototype: Bun.WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "chrome" | "webkit" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
   interface WebView.ClickOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
     timeout [?]: number | undefined
-  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = ((type: string, ...args: Array<unknown>) => void) | Console
   interface WebView.ConstructorOptions (bun-types/bun.d.ts)
-    backend [?]: Backend | undefined
-    console [?]: ConsoleCapture | undefined
+    backend [?]: Bun.WebView.Backend | undefined
+    console [?]: Bun.WebView.ConsoleCapture | undefined
     dataStore [?]: "ephemeral" | undefined | { directory: string; }
     headless [?]: boolean | undefined
     height [?]: number | undefined
     url [?]: string | undefined
     width [?]: number | undefined
-  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  type WebView.Modifier (bun-types/bun.d.ts) = "Alt" | "Control" | "Meta" | "Shift"
   interface WebView.PressOptions (bun-types/bun.d.ts)
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ScrollToOptions (bun-types/bun.d.ts)
     block [?]: "center" | "end" | "nearest" | "start" | undefined
     timeout [?]: number | undefined
-  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "Backspace" | "Delete" | "End" | "Enter" | "Escape" | "Home" | "PageDown" | "PageUp" | "Space" | "Tab"
 interface WhichOptions (bun-types/bun.d.ts)
   PATH [?]: string | undefined
   cwd [?]: string | undefined
 interface Worker (bun-types/bun.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  onmessageerror: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
@@ -2237,44 +2262,44 @@ interface WorkerOptions (bun-types/bun.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
 interface WrapAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   hard [?]: boolean | undefined
   trim [?]: boolean | undefined
   wordWrap [?]: boolean | undefined
-type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+type WritableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", any, any>
 namespace XML (bun-types/bun.d.ts)
   interface XML.Comment (bun-types/bun.d.ts)
     comment: string
   interface XML.Document (bun-types/bun.d.ts)
-    index [string]: Value
+    index [string]: Bun.XML.Value
   interface XML.Element (bun-types/bun.d.ts)
-    index [string]: Array<Value> | Value
+    index [string]: Array<Bun.XML.Value> | Bun.XML.Value
   interface XML.Node (bun-types/bun.d.ts)
     attributes: Record<string, string>
-    children: Array<string | Comment | Node | ProcessingInstruction>
+    children: Array<Bun.XML.Comment | Bun.XML.Node | Bun.XML.ProcessingInstruction | string>
     name: string
   interface XML.NodeInput (bun-types/bun.d.ts)
-    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
-    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    attributes [?]: null | undefined | { [name: string]: Bun.XML.Scalar | null | undefined; }
+    children [?]: Array<Bun.XML.Comment | Bun.XML.NodeInput | Bun.XML.ProcessingInstruction | Bun.XML.Scalar | null | undefined> | null | undefined
     name: string
   interface XML.ParseOptions (bun-types/bun.d.ts)
     compact [?]: boolean | undefined
   interface XML.ProcessingInstruction (bun-types/bun.d.ts)
     data: string
     target: string
-  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
-  type XML.Value (bun-types/bun.d.ts) = string | Element
+  type XML.Scalar (bun-types/bun.d.ts) = Date | bigint | boolean | number | string
+  type XML.Value (bun-types/bun.d.ts) = Bun.XML.Element | string
   function XML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: (Bun.XML.ParseOptions & { compact?: true | undefined; }) | undefined): Bun.XML.Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options: Bun.XML.ParseOptions & { compact: false; }): Bun.XML.Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.XML.ParseOptions | undefined): Bun.XML.Document | Bun.XML.Node
   function XML.stringify (bun-types/bun.d.ts)
-    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: Bun.XML.Document | Bun.XML.NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
     call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
-type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = Blob | Bun.BufferSource | FormData | URLSearchParams | string
 namespace YAML (bun-types/bun.d.ts)
   function YAML.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -2306,20 +2331,20 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     timeStamp [readonly]: number
     type [readonly]: string
   interface __internal.BunEventTarget (bun-types/globals.d.ts)
-    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
     dispatchEvent: (event: Event) => boolean
-    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+    removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
     count [readonly]: number
     getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
     toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
   interface __internal.BunRequestOverride (bun-types/fetch.d.ts)
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     textStream: () => ReadableStream<string>
   interface __internal.BunResponseOverride (bun-types/fetch.d.ts)
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     textStream: () => ReadableStream<string>
-  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Bun.__internal.Merge<T, Exclude<Else, T>> : never
   type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
   type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
   type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = true
@@ -2356,41 +2381,41 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
   type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = {}
   type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
   type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
-  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
-  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = webcrypto.CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = webcrypto.CryptoKeyPair
   type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = typeof globalThis extends { [K in GlobalThisKeyName]: infer T; } ? T : Otherwise
   type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
-  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Bun.__internal.Without<A, B> | Bun.__internal.Without<B, A>
 function allocUnsafe (bun-types/bun.d.ts)
   call (size: number): Uint8Array<ArrayBuffer>
 var argv (bun-types/bun.d.ts): Array<string>
 function build (bun-types/bun.d.ts)
-  call (config: BuildConfig): Promise<BuildOutput>
+  call (config: Bun.BuildConfig): Promise<Bun.BuildOutput>
 function color (bun-types/bun.d.ts)
-  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
-  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
-  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
-  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
-  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
-  call (input: ColorInput, outputFormat: "number"): null | number
+  call (input: Bun.ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: Bun.ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: Bun.ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: Bun.ColorInput, outputFormat: "number"): null | number
 function concatArrayBuffers (bun-types/bun.d.ts)
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
 function connect (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: Bun.TCPSocketConnectOptions<Data>): Promise<Bun.Socket<Data>>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Promise<Bun.Socket<Data>>
 var cron (bun-types/bun.d.ts)
-  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
-  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
-  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  call (schedule: Bun.CronWithAutocomplete, handler: (this: Bun.CronJob) => unknown, options?: Bun.CronOptions | undefined): Bun.CronJob
+  call (path: string, schedule: Bun.CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: Bun.CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: Bun.CronOptions | undefined) => Date | null
   remove: (title: string) => Promise<void>
 function deepEquals (bun-types/bun.d.ts)
   call (a: any, b: any, strict?: boolean | undefined): boolean
 function deepMatch (bun-types/bun.d.ts)
   call (subset: unknown, a: unknown): boolean
 function deflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 namespace dns (bun-types/bun.d.ts)
   var dns.ADDRCONFIG (bun-types/bun.d.ts): number
   var dns.ALL (bun-types/bun.d.ts): number
@@ -2398,50 +2423,50 @@ namespace dns (bun-types/bun.d.ts)
   function dns.getCacheStats (bun-types/bun.d.ts)
     call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
   function dns.lookup (bun-types/bun.d.ts)
-    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<Bun.DNSLookup>>
   function dns.prefetch (bun-types/bun.d.ts)
     call (hostname: string, port?: number | undefined): void
 var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
 var enableANSIColors (bun-types/bun.d.ts): boolean
-var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+var env (bun-types/bun.d.ts): Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
 function escapeHTML (bun-types/bun.d.ts)
   call (input: boolean | number | object | string): string
 var fetch (bun-types/bun.d.ts): typeof fetch
 function file (bun-types/bun.d.ts)
-  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
-  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
-  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+  call (path: URL | string, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): Bun.BunFile
 function fileURLToPath (bun-types/bun.d.ts)
   call (url: URL | string): string
 function gc (bun-types/bun.d.ts)
   call (force?: boolean | undefined): void
 function generateHeapSnapshot (bun-types/bun.d.ts)
-  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format?: "jsc" | undefined): Bun.HeapSnapshot
   call (format: "v8"): string
   call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
 function gunzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function gzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
-var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | number | undefined) => bigint | number) & Bun.Hash
 function indexOfLine (bun-types/bun.d.ts)
-  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+  call (buffer: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
 function inflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function inspect (bun-types/bun.d.ts)
-  call (arg: any, options?: BunInspectOptions | undefined): string
-  custom: typeof custom
+  call (arg: any, options?: Bun.BunInspectOptions | undefined): string
+  custom: typeof inspect.custom
   table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
 namespace inspect (bun-types/bun.d.ts)
-  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  var inspect.custom (bun-types/bun.d.ts): typeof inspect.custom
   function inspect.table (bun-types/bun.d.ts)
     call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
     call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
 var isMainThread (bun-types/bun.d.ts): boolean
 var isStandaloneExecutable (bun-types/bun.d.ts): boolean
 function listen (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+  call <Data = undefined>(options: Bun.TCPSocketListenOptions<Data>): Bun.TCPSocketListener<Data>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Bun.UnixSocketListener<Data>
 var main (bun-types/bun.d.ts): string
 namespace markdown (bun-types/bun.d.ts)
   interface markdown.AnsiTheme (bun-types/bun.d.ts)
@@ -2462,37 +2487,37 @@ namespace markdown (bun-types/bun.d.ts)
   interface markdown.CodeBlockProps (bun-types/bun.d.ts)
     children: Array<unknown>
     language [?]: string | undefined
-  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = ((props: P) => any) | (new (props: P) => any) | string
   interface markdown.ComponentOverrides (bun-types/bun.d.ts)
-    a [?]: Component<LinkProps> | undefined
-    blockquote [?]: Component<ChildrenProps> | undefined
-    br [?]: Component<{}> | undefined
-    code [?]: Component<ChildrenProps> | undefined
-    del [?]: Component<ChildrenProps> | undefined
-    em [?]: Component<ChildrenProps> | undefined
-    h1 [?]: Component<HeadingProps> | undefined
-    h2 [?]: Component<HeadingProps> | undefined
-    h3 [?]: Component<HeadingProps> | undefined
-    h4 [?]: Component<HeadingProps> | undefined
-    h5 [?]: Component<HeadingProps> | undefined
-    h6 [?]: Component<HeadingProps> | undefined
-    hr [?]: Component<{}> | undefined
-    html [?]: Component<ChildrenProps> | undefined
-    img [?]: Component<ImageProps> | undefined
-    li [?]: Component<ListItemProps> | undefined
-    math [?]: Component<ChildrenProps> | undefined
-    ol [?]: Component<OrderedListProps> | undefined
-    p [?]: Component<ChildrenProps> | undefined
-    pre [?]: Component<CodeBlockProps> | undefined
-    strong [?]: Component<ChildrenProps> | undefined
-    table [?]: Component<ChildrenProps> | undefined
-    tbody [?]: Component<ChildrenProps> | undefined
-    td [?]: Component<CellProps> | undefined
-    th [?]: Component<CellProps> | undefined
-    thead [?]: Component<ChildrenProps> | undefined
-    tr [?]: Component<ChildrenProps> | undefined
-    u [?]: Component<ChildrenProps> | undefined
-    ul [?]: Component<ChildrenProps> | undefined
+    a [?]: Bun.markdown.Component<Bun.markdown.LinkProps> | undefined
+    blockquote [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    br [?]: Bun.markdown.Component<{}> | undefined
+    code [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    del [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    em [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    h1 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h2 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h3 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h4 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h5 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h6 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    hr [?]: Bun.markdown.Component<{}> | undefined
+    html [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    img [?]: Bun.markdown.Component<Bun.markdown.ImageProps> | undefined
+    li [?]: Bun.markdown.Component<Bun.markdown.ListItemProps> | undefined
+    math [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ol [?]: Bun.markdown.Component<Bun.markdown.OrderedListProps> | undefined
+    p [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    pre [?]: Bun.markdown.Component<Bun.markdown.CodeBlockProps> | undefined
+    strong [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    table [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tbody [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    td [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    th [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    thead [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tr [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    u [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ul [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
   interface markdown.HeadingMeta (bun-types/bun.d.ts)
     id [?]: string | undefined
     level: number
@@ -2564,45 +2589,45 @@ namespace markdown (bun-types/bun.d.ts)
     wikiLinks [?]: boolean | undefined
   interface markdown.RenderCallbacks (bun-types/bun.d.ts)
     blockquote [?]: ((children: string) => null | string | undefined) | undefined
-    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: Bun.markdown.CodeBlockMeta | undefined) => null | string | undefined) | undefined
     codespan [?]: ((children: string) => null | string | undefined) | undefined
     emphasis [?]: ((children: string) => null | string | undefined) | undefined
-    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: Bun.markdown.HeadingMeta) => null | string | undefined) | undefined
     hr [?]: ((children: string) => null | string | undefined) | undefined
     html [?]: ((children: string) => null | string | undefined) | undefined
-    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
-    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
-    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
-    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: Bun.markdown.ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: Bun.markdown.LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: Bun.markdown.ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: Bun.markdown.ListItemMeta) => null | string | undefined) | undefined
     paragraph [?]: ((children: string) => null | string | undefined) | undefined
     strikethrough [?]: ((children: string) => null | string | undefined) | undefined
     strong [?]: ((children: string) => null | string | undefined) | undefined
     table [?]: ((children: string) => null | string | undefined) | undefined
     tbody [?]: ((children: string) => null | string | undefined) | undefined
-    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     text [?]: ((text: string) => null | string | undefined) | undefined
-    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     thead [?]: ((children: string) => null | string | undefined) | undefined
     tr [?]: ((children: string) => null | string | undefined) | undefined
   function markdown.ansi (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, theme?: Bun.markdown.AnsiTheme | undefined): string
   function markdown.html (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.markdown.Options | undefined): string
   function markdown.react (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, components?: Bun.markdown.ComponentOverrides | undefined, options?: Bun.markdown.ReactOptions | undefined): unknown
   function markdown.render (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, callbacks?: Bun.markdown.RenderCallbacks | undefined, options?: Bun.markdown.Options | undefined): string
 function mmap (bun-types/bun.d.ts)
-  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+  call (path: Bun.PathLike, opts?: Bun.MMapOptions | undefined): Uint8Array<ArrayBuffer>
 function nanoseconds (bun-types/bun.d.ts)
   call (): number
 function openInEditor (bun-types/bun.d.ts)
-  call (path: string, options?: EditorOptions | undefined): void
+  call (path: string, options?: Bun.EditorOptions | undefined): void
 var password (bun-types/bun.d.ts)
-  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
-  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
-  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
-  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+  hash: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => string
+  verify: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
 function pathToFileURL (bun-types/bun.d.ts)
   call (path: string): URL
 function peek (bun-types/bun.d.ts)
@@ -2611,49 +2636,49 @@ function peek (bun-types/bun.d.ts)
 namespace peek (bun-types/bun.d.ts)
   function peek.status (bun-types/bun.d.ts)
     call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
-var plugin (bun-types/bun.d.ts): BunRegisterPlugin
-var postgres (bun-types/sql.d.ts): SQL
+var plugin (bun-types/bun.d.ts): Bun.BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): Bun.SQL
 function randomUUIDv5 (bun-types/bun.d.ts)
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
 function randomUUIDv7 (bun-types/bun.d.ts)
   call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
   call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
 function readableStreamToArray (bun-types/bun.d.ts)
   call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
 function readableStreamToArrayBuffer (bun-types/bun.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
 function readableStreamToBlob (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<Blob>
 function readableStreamToBytes (bun-types/deprecated.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
 function readableStreamToFormData (bun-types/bun.d.ts)
-  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+  call (stream: ReadableStream<BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
 function readableStreamToJSON (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<any>
 function readableStreamToText (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<string>
-var redis (bun-types/redis.d.ts): RedisClient
+var redis (bun-types/redis.d.ts): Bun.RedisClient
 function resolve (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): Promise<string>
 function resolveSync (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): string
 var revision (bun-types/bun.d.ts): string
-var s3 (bun-types/s3.d.ts): S3Client
+var s3 (bun-types/s3.d.ts): Bun.S3Client
 var secrets (bun-types/bun.d.ts)
   delete: (options: { service: string; name: string; }) => Promise<boolean>
-  get: (options: { service: string; name: string; }) => Promise<string | null>
+  get: (options: { service: string; name: string; }) => Promise<null | string>
   set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
 namespace semver (bun-types/bun.d.ts)
   function semver.order (bun-types/bun.d.ts)
-    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+    call (v1: Bun.StringLike, v2: Bun.StringLike): -1 | 0 | 1
   function semver.satisfies (bun-types/bun.d.ts)
-    call (version: StringLike, range: StringLike): boolean
+    call (version: Bun.StringLike, range: Bun.StringLike): boolean
 function serve (bun-types/serve.d.ts)
-  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+  call <WebSocketData = undefined, R extends string = never>(options: Bun.Serve.Options<WebSocketData, R>): Bun.Server<WebSocketData>
 function sha (bun-types/bun.d.ts)
-  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
-  call (input: StringOrBuffer, encoding: DigestEncoding): string
+  call (input: Bun.StringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>
+  call (input: Bun.StringOrBuffer, encoding: Bun.DigestEncoding): string
 function shrink (bun-types/bun.d.ts)
   call (): void
 function sleep (bun-types/bun.d.ts)
@@ -2661,27 +2686,27 @@ function sleep (bun-types/bun.d.ts)
 function sleepSync (bun-types/bun.d.ts)
   call (ms: number): void
 function sliceAnsi (bun-types/bun.d.ts)
-  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: Bun.SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
 function spawn (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(options: Bun.SpawnOptions.SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Bun.Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnOptions<In, Out, Err> | undefined): Bun.Subprocess<In, Out, Err>
 function spawnSync (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
-var sql (bun-types/sql.d.ts): SQL
-var stderr (bun-types/bun.d.ts): BunFile
-var stdin (bun-types/bun.d.ts): BunFile
-var stdout (bun-types/bun.d.ts): BunFile
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(options: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): Bun.SyncSubprocess<Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> | undefined): Bun.SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): Bun.SQL
+var stderr (bun-types/bun.d.ts): Bun.BunFile
+var stdin (bun-types/bun.d.ts): Bun.BunFile
+var stdout (bun-types/bun.d.ts): Bun.BunFile
 function stringWidth (bun-types/bun.d.ts)
-  call (input: string, options?: StringWidthOptions | undefined): number
+  call (input: string, options?: Bun.StringWidthOptions | undefined): number
 function stripANSI (bun-types/bun.d.ts)
   call (input: string): string
 namespace udp (bun-types/bun.d.ts)
   interface udp.BaseUDPSocket (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2695,17 +2720,17 @@ namespace udp (bun-types/bun.d.ts)
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     connect: { hostname: string; port: number; }
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
-  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    socket [?]: Bun.udp.ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2713,29 +2738,29 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
-    remoteAddress [readonly]: SocketAddress
-    send: (data: Data) => boolean
-    sendMany: (packets: ReadonlyArray<Data>) => number
+    reload: (handler: Bun.udp.ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: Bun.SocketAddress
+    send: (data: Bun.udp.Data) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string
   interface udp.ReceiveFlags (bun-types/bun.d.ts)
     ipv6: boolean
     truncated: boolean
-  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.Socket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2743,27 +2768,27 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: SocketHandler<DataBinaryType>) => void
-    send: (data: Data, port: number, address: string) => boolean
-    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    reload: (handler: Bun.udp.SocketHandler<DataBinaryType>) => void
+    send: (data: Bun.udp.Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data | number>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.SocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.Socket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: SocketHandler<DataBinaryType> | undefined
+    socket [?]: Bun.udp.SocketHandler<DataBinaryType> | undefined
 function udpSocket (bun-types/bun.d.ts)
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.SocketOptions<DataBinaryType>): Promise<Bun.udp.Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.ConnectSocketOptions<DataBinaryType>): Promise<Bun.udp.ConnectedSocket<DataBinaryType>>
 namespace unsafe (bun-types/bun.d.ts)
   function unsafe.arrayBufferToString (bun-types/bun.d.ts)
     call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
@@ -2777,23 +2802,23 @@ namespace unsafe (bun-types/bun.d.ts)
 var version (bun-types/bun.d.ts): string
 var version_with_sha (bun-types/bun.d.ts): string
 function which (bun-types/bun.d.ts)
-  call (command: string, options?: WhichOptions | undefined): null | string
+  call (command: string, options?: Bun.WhichOptions | undefined): null | string
 function wrapAnsi (bun-types/bun.d.ts)
-  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+  call (input: string, columns: number, options?: Bun.WrapAnsiOptions | undefined): string
 function write (bun-types/bun.d.ts)
-  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile | Bun.PathLike | Bun.S3File, input: Array<Bun.BlobPart> | ArrayBufferLike | Blob | Bun.Archive | NodeJS.TypedArray<ArrayBufferLike> | ReadableStream<any> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
 function zstdCompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
 function zstdCompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
 function zstdDecompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
 function zstdDecompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
 
 # module "bun:bundle"
 interface Registry (bun-types/bundle.d.ts)
@@ -2892,17 +2917,17 @@ interface FFITypeToArgsType (bun-types/ffi.d.ts)
   1: number
   10: number
   11: boolean
-  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  12: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null
   13: undefined
-  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  14: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null | string
   15: bigint | number
   16: bigint | number
   17: JSCallback | Pointer
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2924,8 +2949,8 @@ interface FFITypeToReturnsType (bun-types/ffi.d.ts)
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2947,13 +2972,13 @@ type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
 type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
 type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
 function cc (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | Bun.BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
 function dlopen (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(name: Bun.BunFile | URL | string, symbols: Fns): Library<Fns>
 function linkSymbols (bun-types/ffi.d.ts)
   call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
 function ptr (bun-types/ffi.d.ts)
-  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
 namespace read (bun-types/ffi.d.ts)
   function read.f32 (bun-types/ffi.d.ts)
     call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
@@ -3026,7 +3051,7 @@ interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
 function callerSourceOrigin (bun-types/jsc.d.ts)
   call (): null | string
 function deserialize (bun-types/jsc.d.ts)
-  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>): any
 function drainMicrotasks (bun-types/jsc.d.ts)
   call (): void
 function edenGC (bun-types/jsc.d.ts)
@@ -3102,7 +3127,7 @@ class Database (bun-types/sqlite.d.ts)
   [static]
     construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
     MAX_QUERY_CACHE_SIZE [static]: number
-    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    deserialize [static]: { (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
     open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
     prototype: Database
     setCustomSQLite [static]: (path: string) => boolean
@@ -3112,7 +3137,7 @@ interface DatabaseOptions (bun-types/sqlite.d.ts)
   readwrite [?]: boolean | undefined
   safeIntegers [?]: boolean | undefined
   strict [?]: boolean | undefined
-type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+type SQLQueryBindings (bun-types/sqlite.d.ts) = NodeJS.TypedArray<ArrayBufferLike> | Record<string, NodeJS.TypedArray<ArrayBufferLike> | bigint | boolean | null | number | string> | bigint | boolean | null | number | string
 class SQLiteError (bun-types/sqlite.d.ts)
   byteOffset [readonly]: number
   cause [?]: unknown
@@ -3127,7 +3152,7 @@ class SQLiteError (bun-types/sqlite.d.ts)
     construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
     captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
     isError: (value: unknown) => value is Error
-    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
     prototype: SQLiteError
     stackTraceLimit: number
 class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
@@ -3136,8 +3161,8 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   all: (...params: ParamsType) => Array<ReturnType>
   as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
   columnNames [readonly]: Array<string>
-  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
-  declaredTypes [readonly]: Array<string | null>
+  columnTypes [readonly]: Array<"BLOB" | "FLOAT" | "INTEGER" | "NULL" | "TEXT" | null>
+  declaredTypes [readonly]: Array<null | string>
   finalize: () => void
   get: (...params: ParamsType) => ReturnType | null
   iterate: (...params: ParamsType) => IterableIterator<ReturnType>
@@ -3146,7 +3171,7 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
   run: (...params: ParamsType) => Changes
   toString: () => string
-  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  values: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | bigint | boolean | number | string>>
   [static]
     construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
     prototype: Statement<any, any>
@@ -3223,7 +3248,7 @@ var native (bun-types/sqlite.d.ts): any
 # module "bun:test"
 type AsymmetricMatcher (bun-types/test.d.ts) = any
 interface AsymmetricMatchers (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3231,7 +3256,7 @@ interface AsymmetricMatchers (bun-types/test.d.ts)
   stringContaining: (str: String | string) => any
   stringMatching: (regex: RegExp | String | string) => any
 interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3257,7 +3282,7 @@ interface Expect (bun-types/test.d.ts)
   call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
   call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
   call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   assertions: (neededAssertions: number) => void
@@ -3324,13 +3349,13 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3344,7 +3369,7 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3410,13 +3435,13 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3430,7 +3455,7 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3447,9 +3472,9 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toThrowError: (expected?: unknown) => void
   toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
   toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
-type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
 interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
-  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  call (label: string, fn: (...args: __internal.IsTuple<T> extends true ? [...table: __internal.Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
   concurrent: Test<T>
   concurrentIf: (condition: boolean) => Test<T>
   each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
@@ -3485,23 +3510,23 @@ var expectTypeOf (bun-types/test.d.ts)
   call <Actual>(): PositiveExpectTypeOf<Actual>
 var it (bun-types/test.d.ts): Test<[]>
 namespace jest (bun-types/test.d.ts)
-  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
-  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
-  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
-  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
-  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
-  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
-  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = JestMock.Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | JestMock.ClassLike> (bun-types/test.d.ts) = T extends JestMock.ClassLike ? JestMock.SpiedClass<T> : T extends JestMock.FunctionLike ? JestMock.SpiedFunction<T> : never
+  type jest.SpiedClass<T extends JestMock.ClassLike> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<(arg: T) => void>
   function jest.advanceTimersByTime (bun-types/test.d.ts)
-    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.clearAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.clearAllTimers (bun-types/test.d.ts)
     call (): void
   function jest.fn (bun-types/test.d.ts)
-    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): jest.Mock<T>
   function jest.getTimerCount (bun-types/test.d.ts)
     call (): number
   function jest.isFakeTimers (bun-types/test.d.ts)
@@ -3511,19 +3536,19 @@ namespace jest (bun-types/test.d.ts)
   function jest.restoreAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.runAllTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.runOnlyPendingTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.setSystemTime (bun-types/test.d.ts)
     call (now?: Date | number | undefined): void
   function jest.setTimeout (bun-types/test.d.ts)
     call (milliseconds: number): void
   function jest.spyOn (bun-types/test.d.ts)
-    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): jest.Mock<Extract<T[K], (...args: Array<any>) => any>>
   function jest.useFakeTimers (bun-types/test.d.ts)
-    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.useRealTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var mock (bun-types/test.d.ts)
   call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
   clearAllMocks: () => void
@@ -3539,24 +3564,118 @@ function spyOn (bun-types/test.d.ts)
   call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
 test -> it
 var vi (bun-types/test.d.ts)
-  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   clearAllMocks: () => void
   clearAllTimers: () => void
-  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => jest.Mock<T>
   getTimerCount: () => number
   isFakeTimers: () => boolean
   mock: (id: string, factory: () => any) => Promise<void> | void
   resetAllMocks: () => void
   restoreAllMocks: () => void
-  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
-  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var xdescribe (bun-types/test.d.ts): Describe<[]>
 var xit (bun-types/test.d.ts): Test<[]>
 xtest -> xit
+
+# module "node:fs/promises"
+function exists (bun-types/overrides.d.ts)
+  call (path: Bun.PathLike): Promise<boolean>
+
+# module "node:tls"
+interface BunConnectionOptions (bun-types/overrides.d.ts)
+  ALPNCallback [?]: ((arg: { servername: string; protocols: Array<string>; }) => string | undefined) | undefined
+  ALPNProtocols [?]: NodeJS.ArrayBufferView<ArrayBufferLike> | ReadonlyArray<string> | undefined
+  SNICallback [?]: ((servername: string, cb: (err: Error | null, ctx?: SecureContext | undefined) => void) => void) | undefined
+  allowPartialTrustChain [?]: boolean | undefined
+  ca [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  cert [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientCertEngine [?]: string | undefined
+  crl [?]: Array<Buffer<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | string | undefined
+  dhparam [?]: Buffer<ArrayBufferLike> | string | undefined
+  ecdhCurve [?]: string | undefined
+  enableTrace [?]: boolean | undefined
+  honorCipherOrder [?]: boolean | undefined
+  host [?]: string | undefined
+  key [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | KeyObject | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  lookup [?]: LookupFunction | undefined
+  maxVersion [?]: SecureVersion | undefined
+  minDHSize [?]: number | undefined
+  minVersion [?]: SecureVersion | undefined
+  passphrase [?]: string | undefined
+  path [?]: string | undefined
+  pfx [?]: Array<Buffer<ArrayBufferLike> | PxfObject | string> | Buffer<ArrayBufferLike> | string | undefined
+  port [?]: number | undefined
+  privateKeyEngine [?]: string | undefined
+  privateKeyIdentifier [?]: string | undefined
+  pskCallback [?]: ((hint: null | string) => PSKCallbackNegotation | null) | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  requestOCSP [?]: boolean | undefined
+  secureContext [?]: SecureContext | undefined
+  secureOptions [?]: number | undefined
+  secureProtocol [?]: string | undefined
+  servername [?]: string | undefined
+  session [?]: Buffer<ArrayBufferLike> | undefined
+  sessionIdContext [?]: string | undefined
+  sessionTimeout [?]: number | undefined
+  sigalgs [?]: string | undefined
+  socket [?]: Stream.Duplex | undefined
+  ticketKeys [?]: Buffer<ArrayBufferLike> | undefined
+  timeout [?]: number | undefined
+function connect (@types/node/tls.d.ts, bun-types/overrides.d.ts)
+  call (options: ConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, host?: string | undefined, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (options: BunConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+
+# module "stream/web"
+interface ReadableStream<R = any> (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  construct new (underlyingSource: UnderlyingByteSource, strategy?: undefined | { highWaterMark?: number | undefined; }): ReadableStream<NodeJS.NonSharedUint8Array>
+  construct new <R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  from: <R = any>(iterable: AsyncIterable<R> | Iterable<R>) => ReadableStream<R>
+  prototype: ReadableStream<any>
+
+# module "url"
+interface URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  construct new (init?: Array<Array<string>> | Record<string, string> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
 
 # globals
 interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
@@ -3614,7 +3733,7 @@ interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.d
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
   bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   size [readonly]: number
   slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
@@ -3663,11 +3782,11 @@ interface BunFetchRequestInit (bun-types/globals.d.ts)
   mode [?]: RequestMode | undefined
   priority [?]: RequestPriority | undefined
   protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
-  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: Bun.HeadersInit | undefined; }
   redirect [?]: RequestRedirect | undefined
   referrer [?]: string | undefined
   referrerPolicy [?]: ReferrerPolicy | undefined
-  s3 [?]: S3Options | undefined
+  s3 [?]: Bun.S3Options | undefined
   signal [?]: AbortSignal | null | undefined
   timeout [?]: boolean | number | undefined
   tls [?]: BunFetchRequestInitTLS | undefined
@@ -3675,17 +3794,17 @@ interface BunFetchRequestInit (bun-types/globals.d.ts)
   verbose [?]: boolean | undefined
   window [?]: null | undefined
 interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -3735,7 +3854,7 @@ var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d
   construct new (format: CompressionFormat): CompressionStream
   prototype: CompressionStream
 interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
-  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  Console [readonly]: { new (stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
   [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
   assert: { (condition?: boolean | undefined, ...data: Array<any>): void; (condition?: boolean | undefined, ...data: Array<any>): void }
   clear: { (): void; (): void }
@@ -3759,14 +3878,14 @@ interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts,
   timeStamp: { (label?: string | undefined): void; (label?: string | undefined): void }
   trace: { (...data: Array<any>): void; (...data: Array<any>): void }
   warn: { (...data: Array<any>): void; (...data: Array<any>): void }
-  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+  write: (...data: Array<ArrayBuffer | ArrayBufferView<ArrayBufferLike> | string>) => number
 interface ConsoleOptions (bun-types/globals.d.ts)
   colorMode [?]: "auto" | boolean | undefined
   groupIndentation [?]: number | undefined
   ignoreErrors [?]: boolean | undefined
   inspectOptions [?]: InspectOptions | undefined
-  stderr [?]: Writable | undefined
-  stdout: Writable
+  stderr [?]: Stream.Writable | undefined
+  stdout: Stream.Writable
 interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   highWaterMark [readonly]: number
   size [readonly]: QueuingStrategySize<any>
@@ -3777,7 +3896,7 @@ interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, l
   getRandomValues: { <T extends ArrayBufferView<ArrayBuffer>>(array: T): T; <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T): T }
   randomUUID: { (): `${string}-${string}-${string}-${string}-${string}`; (): `${string}-${string}-${string}-${string}-${string}` }
   subtle [readonly]: SubtleCrypto
-  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+  timingSafeEqual: (a: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>) => boolean
 var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   construct new (): Crypto
   prototype: Crypto
@@ -3910,7 +4029,7 @@ interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, li
   construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
   captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
   isError: (value: unknown) => value is Error
-  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
   prototype [readonly]: Error
   stackTraceLimit: number
 interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
@@ -4045,7 +4164,7 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.d
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
   bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified [readonly]: number
   name [readonly]: string
@@ -4063,9 +4182,9 @@ interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, 
   append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
   delete: { (name: string): void; (name: string): void }
   entries: { (): FormDataIterator<[string, FormDataEntryValue]>; (): IterableIterator<[string, string]> }
-  forEach: { (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void; (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void }
-  get: { (name: string): FormDataEntryValue | null; (name: string): FormDataEntryValue | null }
-  getAll: { (name: string): Array<FormDataEntryValue>; (name: string): Array<FormDataEntryValue> }
+  forEach: { (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void; (callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void }
+  get: { (name: string): FormDataEntryValue | null; (name: string): Bun.FormDataEntryValue | null }
+  getAll: { (name: string): Array<FormDataEntryValue>; (name: string): Array<Bun.FormDataEntryValue> }
   has: { (name: string): boolean; (name: string): boolean }
   keys: { (): FormDataIterator<string>; (): IterableIterator<string> }
   set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
@@ -4074,19 +4193,19 @@ var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.do
   construct new (form?: HTMLFormElement | undefined, submitter?: HTMLElement | null | undefined): FormData
   prototype: FormData
 class HTMLRewriter (bun-types/html-rewriter.d.ts)
-  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
-  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
-  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  on: (selector: string, handlers: HTMLRewriterTypes.HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: Bun.BufferSource): ArrayBuffer }
   [static]
     construct new (): HTMLRewriter
     prototype: HTMLRewriter
 namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Comment
-    before: (content: string, options?: ContentOptions | undefined) => Comment
-    remove: () => Comment
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    remove: () => HTMLRewriterTypes.Comment
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
     text: string
   type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
   interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
@@ -4094,52 +4213,52 @@ namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
     name [readonly]: null | string
     publicId [readonly]: null | string
-    remove: () => Doctype
+    remove: () => HTMLRewriterTypes.Doctype
     removed [readonly]: boolean
     systemId [readonly]: null | string
   interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
-    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.DocumentEnd
   interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Element
-    append: (content: string, options?: ContentOptions | undefined) => Element
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     attributes [readonly]: IterableIterator<[string, string]>
-    before: (content: string, options?: ContentOptions | undefined) => Element
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     canHaveContent [readonly]: boolean
     getAttribute: (name: string) => null | string
     hasAttribute: (name: string) => boolean
     namespaceURI [readonly]: string
-    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
-    prepend: (content: string, options?: ContentOptions | undefined) => Element
-    remove: () => Element
-    removeAndKeepContent: () => Element
-    removeAttribute: (name: string) => Element
+    onEndTag: (handler: (tag: HTMLRewriterTypes.EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    remove: () => HTMLRewriterTypes.Element
+    removeAndKeepContent: () => HTMLRewriterTypes.Element
+    removeAttribute: (name: string) => HTMLRewriterTypes.Element
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Element
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     selfClosing [readonly]: boolean
-    setAttribute: (name: string, value: string) => Element
-    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    setAttribute: (name: string, value: string) => HTMLRewriterTypes.Element
+    setInnerContent: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     tagName: string
   interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => EndTag
-    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
     name: string
-    remove: () => EndTag
+    remove: () => HTMLRewriterTypes.EndTag
   interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
-    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: HTMLRewriterTypes.Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: HTMLRewriterTypes.DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    element [?]: ((element: Element) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: HTMLRewriterTypes.Element) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Text
-    before: (content: string, options?: ContentOptions | undefined) => Text
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     lastInTextNode [readonly]: boolean
-    remove: () => Text
+    remove: () => HTMLRewriterTypes.Text
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Text
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     text [readonly]: string
 interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   [Symbol.iterator]: () => HeadersIterator<[string, string]>
@@ -4162,13 +4281,13 @@ var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom
 interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.dom.d.ts, lib.es5.d.ts)
   dir [readonly]: string
   dirname: string
-  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  env [readonly]: Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
   file [readonly]: string
   filename: string
-  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: Bun.HMREvent, callback: () => void): void; off(event: Bun.HMREvent, callback: () => void): void; }
   main: boolean
   path [readonly]: string
-  require: Require
+  require: NodeJS.Require
   resolve: { (specifier: string): string; (specifier: string, parent?: URL | string | undefined): string }
   resolveSync: (moduleId: string, parent?: string | undefined) => string
   url: string
@@ -4280,148 +4399,14 @@ var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, l
   construct new (): Navigator
   prototype: Navigator
 namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
-  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
-  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
-  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.asyncDispose]: () => PromiseLike<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
-    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
-    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
-  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
-  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
-  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
-  interface NodeJS.CallSite (@types/node/globals.d.ts)
-    getColumnNumber: () => null | number
-    getEnclosingColumnNumber: () => null | number
-    getEnclosingLineNumber: () => null | number
-    getEvalOrigin: () => string | undefined
-    getFileName: () => null | string
-    getFunction: () => Function | undefined
-    getFunctionName: () => null | string
-    getLineNumber: () => null | number
-    getMethodName: () => null | string
-    getPosition: () => number
-    getPromiseIndex: () => null | number
-    getScriptHash: () => string
-    getScriptNameOrSourceURL: () => null | string
-    getThis: () => unknown
-    getTypeName: () => null | string
-    isAsync: () => boolean
-    isConstructor: () => boolean
-    isEval: () => boolean
-    isNative: () => boolean
-    isPromiseAll: () => boolean
-    isToplevel: () => boolean
-  interface NodeJS.CpuUsage (@types/node/process.d.ts)
-    system: number
-    user: number
-  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined
-  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
-  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
-    code [?]: string | undefined
-    ctor [?]: Function | undefined
-    detail [?]: string | undefined
-    type [?]: string | undefined
-  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
-    cause [?]: unknown
-    code [?]: string | undefined
-    errno [?]: number | undefined
-    message: string
-    name: string
-    path [?]: string | undefined
-    stack [?]: string | undefined
-    syscall [?]: string | undefined
-  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
-    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
-    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    setMaxListeners: (n: number) => EventEmitter<T>
-  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
-  interface NodeJS.GCFunction (@types/node/globals.d.ts)
-    call (minor?: boolean | undefined): void
-    call (options: GCOptions & { execution: "async"; }): Promise<void>
-    call (options: GCOptions): void
-  interface NodeJS.GCOptions (@types/node/globals.d.ts)
-    execution [?]: "async" | "sync" | undefined
-    filename [?]: string | undefined
-    flavor [?]: "last-resort" | "regular" | undefined
-    type [?]: "major" | "major-snapshot" | "minor" | undefined
-  interface NodeJS.HRTime (@types/node/process.d.ts)
-    call (time?: [number, number] | undefined): [number, number]
-    bigint: () => bigint
-  interface NodeJS.Immediate (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    _onImmediate: (...args: Array<any>) => void
-    hasRef: () => boolean
-    ref: () => Immediate
-    unref: () => Immediate
-  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
-    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
-    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
-  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
-    arrayBuffers: number
-    external: number
-    heapTotal: number
-    heapUsed: number
-    rss: number
-  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
-    call (): MemoryUsage
-    rss: () => number
-  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
-  interface NodeJS.Module (@types/node/module.d.ts)
-    children: Array<Module>
-    exports: any
-    filename: string
-    id: string
-    isPreloading: boolean
-    loaded: boolean
-    parent: Module | null | undefined
-    path: string
-    paths: Array<string>
-    require: (id: string) => any
-  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
-  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
-  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
-  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
-  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
-  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
-  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
-  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
-  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
-  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
-  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
   interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
     [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
     _exiting: boolean
     abort: () => never
-    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
     allowedNodeEnvironmentFlags: ReadonlySet<string>
-    arch [readonly]: Architecture
+    arch [readonly]: NodeJS.Architecture
     argv: Array<string>
     argv0: string
     assert: (value: unknown, message?: Error | string | undefined) => asserts value
@@ -4430,24 +4415,24 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     browser: boolean
     channel [?]: Control | undefined
     chdir: (directory: string) => void
-    config [readonly]: ProcessConfig
+    config [readonly]: NodeJS.ProcessConfig
     connected: boolean
     constrainedMemory: () => number
-    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     cwd: () => string
     debugPort: number
     disconnect [?]: (() => void) | undefined
     dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
     emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
-    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
-    env: ProcessEnv
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: NodeJS.EmitWarningOptions | undefined): void }
+    env: NodeJS.ProcessEnv
     eventNames: () => Array<string | symbol>
     execArgv: Array<string>
     execPath: string
-    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: NodeJS.ProcessEnv | undefined) => never) | undefined
     exit: (code?: null | number | string | undefined) => never
     exitCode: null | number | string | undefined
-    features [readonly]: ProcessFeatures
+    features [readonly]: NodeJS.ProcessFeatures
     finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
     getActiveResourcesInfo: () => Array<string>
     getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
@@ -4458,48 +4443,48 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     getgroups [?]: (() => Array<number>) | undefined
     getuid [?]: (() => number) | undefined
     hasUncaughtExceptionCaptureCallback: () => boolean
-    hrtime: HRTime
+    hrtime: NodeJS.HRTime
     isBun: true
     kill: (pid: number, signal?: number | string | undefined) => true
     listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
     listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     loadEnvFile: (path?: PathLike | undefined) => void
-    mainModule [?]: Module | undefined
-    memoryUsage: MemoryUsageFn
+    mainModule [?]: NodeJS.Module | undefined
+    memoryUsage: NodeJS.MemoryUsageFn
     nextTick: (callback: Function, ...args: Array<any>) => void
     noDeprecation [?]: boolean | undefined
-    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    permission: ProcessPermission
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    permission: NodeJS.ProcessPermission
     pid [readonly]: number
-    platform [readonly]: Platform
+    platform [readonly]: NodeJS.Platform
     ppid [readonly]: number
-    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     reallyExit: (code?: number | undefined) => never
     ref: (maybeRefable: any) => void
-    release [readonly]: ProcessRelease
-    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
-    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    report: ProcessReport
-    resourceUsage: () => ResourceUsage
+    release [readonly]: NodeJS.ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): NodeJS.Process; (eventName?: string | symbol | undefined): NodeJS.Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    report: NodeJS.ProcessReport
+    resourceUsage: () => NodeJS.ResourceUsage
     revision: string
     send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
-    setMaxListeners: (n: number) => Process
+    setMaxListeners: (n: number) => NodeJS.Process
     setSourceMapsEnabled: (value: boolean) => void
     setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
     setegid [?]: ((id: number | string) => void) | undefined
     seteuid [?]: ((id: number | string) => void) | undefined
     setgid [?]: ((id: number | string) => void) | undefined
-    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<number | string>) => void) | undefined
     setuid [?]: ((id: number | string) => void) | undefined
     sourceMapsEnabled [readonly]: boolean
-    stderr: WriteStream & { fd: 2; }
-    stdin: ReadStream & { fd: 0; }
-    stdout: WriteStream & { fd: 1; }
-    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    stderr: NodeJS.WriteStream & { fd: 2; }
+    stdin: NodeJS.ReadStream & { fd: 0; }
+    stdout: NodeJS.WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     throwDeprecation: boolean
     title: string
     traceDeprecation: boolean
@@ -4508,45 +4493,11 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     unref: (maybeRefable: any) => void
     uptime: () => number
     version [readonly]: string
-    versions [readonly]: ProcessVersions
-  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
-    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
-    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+    versions [readonly]: NodeJS.ProcessVersions
   interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     NODE_ENV [?]: string | undefined
     TZ [?]: string | undefined
-  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
-    cached_builtins [readonly]: boolean
-    debug [readonly]: boolean
-    inspector [readonly]: boolean
-    ipv6 [readonly]: boolean
-    require_module [readonly]: boolean
-    tls [readonly]: boolean
-    tls_alpn [readonly]: boolean
-    tls_ocsp [readonly]: boolean
-    tls_sni [readonly]: boolean
-    typescript [readonly]: "strip" | false
-    uv [readonly]: boolean
-  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
-    has: (scope: string, reference?: string | undefined) => boolean
-  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
-    headersUrl [?]: string | undefined
-    libUrl [?]: string | undefined
-    lts [?]: string | undefined
-    name: string
-    sourceUrl [?]: string | undefined
-  interface NodeJS.ProcessReport (@types/node/process.d.ts)
-    compact: boolean
-    directory: string
-    excludeEnv: boolean
-    filename: string
-    getReport: (err?: Error | undefined) => object
-    reportOnFatalError: boolean
-    reportOnSignal: boolean
-    reportOnUncaughtException: boolean
-    signal: Signals
-    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
   interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     ares: string
@@ -4558,404 +4509,14 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     uv: string
     v8: string
     zlib: string
-  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined [readonly]
-  interface NodeJS.ReadStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    closed [readonly]: boolean
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    destroy: (error?: Error | undefined) => ReadStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    isPaused: () => boolean
-    isRaw: boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    pause: () => ReadStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => ReadStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
-    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    resetAndDestroy: () => ReadStream
-    resume: () => ReadStream
-    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
-    setMaxListeners: (n: number) => ReadStream
-    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
-    setRawMode: (mode: boolean) => ReadStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
-    setTypeOfService: (tos: number) => ReadStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => ReadStream
-    unref: () => ReadStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => ReadStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    pause: () => ReadWriteStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    resume: () => ReadWriteStream
-    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
-    setMaxListeners: (n: number) => ReadWriteStream
-    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadWriteStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    pause: () => ReadableStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    resume: () => ReadableStream
-    setEncoding: (encoding: BufferEncoding) => ReadableStream
-    setMaxListeners: (n: number) => ReadableStream
-    unpipe: (destination?: WritableStream | undefined) => ReadableStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadableStream
-  interface NodeJS.RefCounted (@types/node/globals.d.ts)
-    ref: () => RefCounted
-    unref: () => RefCounted
-  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
-  interface NodeJS.Require (@types/node/module.d.ts)
-    call (id: string): any
-    cache: Dict<Module>
-    extensions: RequireExtensions
-    main: Module | undefined
-    resolve: RequireResolve
-  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
-    index [string]: ((module: Module, filename: string) => any) | undefined
-    .js: (module: Module, filename: string) => any
-    .json: (module: Module, filename: string) => any
-    .node: (module: Module, filename: string) => any
-  interface NodeJS.RequireResolve (@types/node/module.d.ts)
-    call (request: string, options?: RequireResolveOptions | undefined): string
-    paths: (request: string) => Array<string> | null
-  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
-    paths [?]: Array<string> | undefined
-  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
-    fsRead: number
-    fsWrite: number
-    involuntaryContextSwitches: number
-    ipcReceived: number
-    ipcSent: number
-    majorPageFault: number
-    maxRSS: number
-    minorPageFault: number
-    sharedMemorySize: number
-    signalsCount: number
-    swappedOut: number
-    systemCPUTime: number
-    unsharedDataSize: number
-    unsharedStackSize: number
-    userCPUTime: number
-    voluntaryContextSwitches: number
-  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
-  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
-  interface NodeJS.Socket (@types/node/process.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    isTTY [?]: true | undefined
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    pause: () => Socket
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    resume: () => Socket
-    setEncoding: (encoding: BufferEncoding) => Socket
-    setMaxListeners: (n: number) => Socket
-    unpipe: (destination?: WritableStream | undefined) => Socket
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => Socket
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.Timeout (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.toPrimitive]: () => number
-    _onTimeout: (...args: Array<any>) => void
-    close: () => Timeout
-    hasRef: () => boolean
-    ref: () => Timeout
-    refresh: () => Timeout
-    unref: () => Timeout
-  interface NodeJS.Timer (@types/node/timers.d.ts)
-    [Symbol.toPrimitive]: () => number
-    hasRef: () => boolean
-    ref: () => Timer
-    refresh: () => Timer
-    unref: () => Timer
-  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
-  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
-  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
-  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
-  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
-  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
-  interface NodeJS.WritableStream (@types/node/stream.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    setMaxListeners: (n: number) => WritableStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.WriteStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
-    clearScreenDown: (callback?: (() => void) | undefined) => boolean
-    closed [readonly]: boolean
-    columns: number
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
-    destroy: (error?: Error | undefined) => WriteStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
-    getColorDepth: (env?: object | undefined) => number
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    getWindowSize: () => [number, number]
-    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
-    isPaused: () => boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
-    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    pause: () => WriteStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => WriteStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
-    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    resetAndDestroy: () => WriteStream
-    resume: () => WriteStream
-    rows: number
-    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
-    setMaxListeners: (n: number) => WriteStream
-    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
-    setTypeOfService: (tos: number) => WriteStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => WriteStream
-    unref: () => WriteStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => WriteStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
 interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
-  children: Array<Module>
+  children: Array<NodeJS.Module>
   exports: any
   filename: string
   id: string
   isPreloading: boolean
   loaded: boolean
-  parent: Module | null | undefined
+  parent: NodeJS.Module | null | undefined
   path: string
   paths: Array<string>
   require: (id: string) => any
@@ -5066,11 +4627,11 @@ interface Position (bun-types/globals.d.ts)
 interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts)
   construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
   [Symbol.species] [readonly]: PromiseConstructor
-  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
   prototype [readonly]: Promise<any>
-  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
   reject: <T = never>(reason?: any) => Promise<T>
   resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
   try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
@@ -5140,8 +4701,8 @@ interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
 interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
   closed [readonly]: Promise<void>
-  read: { (): Promise<ReadableStreamReadResult<R>>; (): Promise<ReadableStreamDefaultReadResult<R>> }
-  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  read: { (): Promise<ReadableStreamReadResult<R>>; (): Promise<Bun.ReadableStreamDefaultReadResult<R>> }
+  readMany: () => Bun.ReadableStreamDefaultReadManyResult<R> | Promise<Bun.ReadableStreamDefaultReadManyResult<R>>
   releaseLock: { (): void; (): void }
 var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
@@ -5151,7 +4712,7 @@ interface ReadableStreamDirectController (bun-types/globals.d.ts)
   end: () => Promise<number> | number
   flush: (wait?: boolean | undefined) => Promise<number> | number
   start: () => void
-  write: (data: BufferSource | string) => Promise<number> | number
+  write: (data: Bun.BufferSource | string) => Promise<number> | number
 interface ReadableStreamGenericReader (bun-types/globals.d.ts, lib.dom.d.ts)
   cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
   closed [readonly]: Promise<void>
@@ -5323,7 +4884,7 @@ var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d
   prototype: TextDecoderStream
 interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   encode: (input?: string | undefined) => Uint8Array<ArrayBuffer>
-  encodeInto: { (source: string, destination: Uint8Array<ArrayBufferLike>): TextEncoderEncodeIntoResult; (src?: string | undefined, dest?: BufferSource | undefined): TextEncoderEncodeIntoResult }
+  encodeInto: { (source: string, destination: Uint8Array<ArrayBufferLike>): TextEncoderEncodeIntoResult; (src?: string | undefined, dest?: Bun.BufferSource | undefined): TextEncoderEncodeIntoResult }
   encoding [readonly]: string
 var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   construct new (): TextEncoder
@@ -5438,7 +4999,7 @@ interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bu
   subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
   toBase64: (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }) => string
   toHex: () => string
-  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: Intl.NumberFormatOptions | undefined): string }
   toString: () => string
   valueOf: () => Uint8Array<TArrayBuffer>
   values: () => ArrayIterator<number>
@@ -5458,113 +5019,87 @@ interface Uint8ArrayConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.t
   of: (...items: Array<number>) => Uint8Array<ArrayBuffer>
   prototype [readonly]: Uint8Array<ArrayBufferLike>
 namespace WebAssembly (bun-types/wasm.d.ts, lib.dom.d.ts)
-  type WebAssembly.AddressType (lib.dom.d.ts) = "i32" | "i64"
-  type WebAssembly.AddressValue (lib.dom.d.ts) = number
   interface WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (message?: string | undefined): CompileError
-    construct new (message?: string | undefined): CompileError
-    prototype: CompileError
-  interface WebAssembly.Exception (lib.dom.d.ts)
-    getArg: (exceptionTag: Tag, index: number) => any
-    is: (exceptionTag: Tag) => boolean
-    stack [readonly]: string | undefined
-  var WebAssembly.Exception (lib.dom.d.ts)
-    construct new (exceptionTag: Tag, payload: Array<any>, options?: ExceptionOptions | undefined): Exception
-    prototype: Exception
-  interface WebAssembly.ExceptionOptions (lib.dom.d.ts)
-    traceStack [?]: boolean | undefined
-  type WebAssembly.ExportValue (lib.dom.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
-  type WebAssembly.Exports (lib.dom.d.ts) = { [x: string]: ExportValue; }
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
+    call (message?: string | undefined): WebAssembly.CompileError
+    construct new (message?: string | undefined): WebAssembly.CompileError
+    prototype: WebAssembly.CompileError
+  interface WebAssembly.Global<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    value: WebAssembly.ValueTypeMap[T]
+    valueOf: () => WebAssembly.ValueTypeMap[T]
   var WebAssembly.Global (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
-    prototype: Global<keyof ValueTypeMap>
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new <T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap>(descriptor: WebAssembly.GlobalDescriptor<T>, v?: WebAssembly.ValueTypeMap[T] | undefined): WebAssembly.Global<T>
+    prototype: WebAssembly.Global<keyof WebAssembly.ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
     mutable [?]: boolean | undefined
     value: T
-  type WebAssembly.ImportExportKind (lib.dom.d.ts) = "function" | "global" | "memory" | "table" | "tag"
-  type WebAssembly.ImportValue (lib.dom.d.ts) = number | ExportValue
-  type WebAssembly.Imports (lib.dom.d.ts) = { [x: string]: ModuleImports; }
   interface WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: WebAssembly.Exports
   var WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (module: Module, importObject?: Imports | undefined): Instance
-    prototype: Instance
-  var WebAssembly.JSTag (lib.dom.d.ts): Tag
+    construct new (module: WebAssembly.Module, importObject?: WebAssembly.Imports | undefined): WebAssembly.Instance
+    prototype: WebAssembly.Instance
   interface WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (message?: string | undefined): LinkError
-    construct new (message?: string | undefined): LinkError
-    prototype: LinkError
+    call (message?: string | undefined): WebAssembly.LinkError
+    construct new (message?: string | undefined): WebAssembly.LinkError
+    prototype: WebAssembly.LinkError
   interface WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
     buffer [readonly]: ArrayBuffer
     grow: (delta: number) => number
     toFixedLengthBuffer: () => ArrayBuffer
     toResizableBuffer: () => ArrayBuffer
   var WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (descriptor: MemoryDescriptor): Memory
-    prototype: Memory
+    construct new (descriptor: WebAssembly.MemoryDescriptor): WebAssembly.Memory
+    prototype: WebAssembly.Memory
   interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    address [?]: AddressType | undefined
+    address [?]: WebAssembly.AddressType | undefined
     initial: number
     maximum [?]: number | undefined
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
   var WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Module
-    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
-    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
-    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
-    prototype: Module
+    construct new (bytes: BufferSource, options?: WebAssembly.WebAssemblyCompileOptions | undefined): WebAssembly.Module
+    customSections: (moduleObject: WebAssembly.Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleExportDescriptor>
+    imports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleImportDescriptor>
+    prototype: WebAssembly.Module
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    kind: ImportExportKind
+    kind: WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    kind: ImportExportKind
+    kind: WebAssembly.ImportExportKind
     module: string
     name: string
-  type WebAssembly.ModuleImports (lib.dom.d.ts) = { [x: string]: ImportValue; }
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (message?: string | undefined): RuntimeError
-    construct new (message?: string | undefined): RuntimeError
-    prototype: RuntimeError
+    call (message?: string | undefined): WebAssembly.RuntimeError
+    construct new (message?: string | undefined): WebAssembly.RuntimeError
+    prototype: WebAssembly.RuntimeError
   interface WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
     get: (index: number) => any
     grow: (delta: number, value?: any) => number
     length [readonly]: number
     set: (index: number, value?: any) => void
   var WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (descriptor: TableDescriptor, value?: any): Table
-    prototype: Table
+    construct new (descriptor: WebAssembly.TableDescriptor, value?: any): WebAssembly.Table
+    prototype: WebAssembly.Table
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    address [?]: AddressType | undefined
-    element: TableKind
+    address [?]: WebAssembly.AddressType | undefined
+    element: WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
-  type WebAssembly.TableKind (lib.dom.d.ts) = "anyfunc" | "externref"
-  interface WebAssembly.Tag (lib.dom.d.ts)
-  var WebAssembly.Tag (lib.dom.d.ts)
-    construct new (type: TagType): Tag
-    prototype: Tag
-  interface WebAssembly.TagType (lib.dom.d.ts)
-    parameters: Array<keyof ValueTypeMap>
-  type WebAssembly.ValueType (lib.dom.d.ts) = keyof ValueTypeMap
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts, lib.dom.d.ts)
     anyfunc: Function
     externref: any
@@ -5573,29 +5108,26 @@ namespace WebAssembly (bun-types/wasm.d.ts, lib.dom.d.ts)
     i32: number
     i64: bigint
     v128: never
-  interface WebAssembly.WebAssemblyCompileOptions (lib.dom.d.ts)
-    builtins [?]: Array<string> | undefined
-    importedStringConstants [?]: null | string | undefined
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts, lib.dom.d.ts)
-    instance: Instance
-    module: Module
+    instance: WebAssembly.Instance
+    module: WebAssembly.Module
   function WebAssembly.compile (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
-    call (bytes: BufferSource): Promise<Module>
+    call (bytes: BufferSource, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.Module>
+    call (bytes: Bun.BufferSource): Promise<WebAssembly.Module>
   function WebAssembly.compileStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (source: PromiseLike<Response> | Response, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
-    call (source: PromiseLike<Response> | Response): Promise<Module>
+    call (source: PromiseLike<Response> | Response, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.Module>
+    call (source: PromiseLike<Response> | Response): Promise<WebAssembly.Module>
   function WebAssembly.instantiate (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (bytes: BufferSource, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
-    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+    call (bytes: BufferSource, importObject?: WebAssembly.Imports | undefined, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (moduleObject: WebAssembly.Module, importObject?: WebAssembly.Imports | undefined): Promise<WebAssembly.Instance>
+    call (bytes: Bun.BufferSource, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (moduleObject: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.Instance>
   function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: WebAssembly.Imports | undefined, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
   function WebAssembly.validate (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): boolean
-    call (bytes: BufferSource): boolean
+    call (bytes: BufferSource, options?: WebAssembly.WebAssemblyCompileOptions | undefined): boolean
+    call (bytes: Bun.BufferSource): boolean
 interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
@@ -5673,21 +5205,21 @@ function addEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
   call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
   call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
   call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
 function alert (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message?: any): void
   call (message?: string | undefined): void
 function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (immediate: Immediate | undefined): void
+  call (immediate: NodeJS.Immediate | undefined): void
 function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (id: number | undefined): void
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (id: number | undefined): void
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function confirm (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message?: string | undefined): boolean
   call (message?: string | undefined): boolean
@@ -5709,7 +5241,7 @@ var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.t
 function postMessage (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message: any, targetOrigin: string, transfer?: Array<Transferable> | undefined): void
   call (message: any, options?: WindowPostMessageOptions | undefined): void
-  call (message: any, transfer?: Array<Transferable> | undefined): void
+  call (message: any, transfer?: Array<Bun.Transferable> | undefined): void
 function prompt (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message?: string | undefined, _default?: string | undefined): null | string
   call (message?: string | undefined, _default?: string | undefined): null | string
@@ -5720,32 +5252,28 @@ function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.
 function removeEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
   call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
   call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
-  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void
 function reportError (bun-types/globals.d.ts, lib.dom.d.ts)
   call (e: any): void
   call (error: any): void
-var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): NodeJS.Require
 function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  call (handler: Bun.TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Immediate
   __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
-  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
 function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
-  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
   __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
-  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T
-  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T>(value: T, options?: Bun.StructuredSerializeOptions | undefined): T
   call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/es2022-dom.txt
+++ b/test/integration/bun-types/inventory/es2022-dom.txt
@@ -1,0 +1,5751 @@
+# bun-types inventory: preset es2022-dom
+# lib: lib.es2022.d.ts, lib.dom.d.ts, lib.dom.iterable.d.ts, lib.dom.asynciterable.d.ts
+# typescript: 6.0.2
+# @types/node: 26.2.0
+# undici-types: 8.3.0
+
+# module "*.html"
+
+# module "*.json5"
+
+# module "*.jsonc"
+
+# module "*.toml"
+
+# module "*.txt"
+
+# module "*.xml"
+
+# module "*.yaml"
+
+# module "*.yml"
+
+# module "*/bun.lock"
+
+# module "bun"
+type $ (bun-types/shell.d.ts) = typeof $
+function $ (bun-types/shell.d.ts)
+  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
+  Shell: new () => typeof $
+  ShellError: typeof ShellError
+  ShellPromise: typeof ShellPromise
+  braces: (pattern: string) => Array<string>
+  cwd: (newCwd?: string | undefined) => typeof $
+  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  escape: (input: string) => string
+  nothrow: () => typeof $
+  throws: (shouldThrow: boolean) => typeof $
+namespace $ (bun-types/shell.d.ts)
+  var $.Shell (bun-types/shell.d.ts)
+    construct new (): typeof $
+  class $.ShellError (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    cause [?]: unknown
+    exitCode [readonly]: number
+    json: () => any
+    message: string
+    name: string
+    stack [?]: string | undefined
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+    [static]
+      construct new (message?: string | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: ShellError
+      stackTraceLimit: number
+  interface $.ShellOutput (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    exitCode [readonly]: number
+    json: () => any
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+  class $.ShellPromise (bun-types/shell.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    arrayBuffer: () => Promise<ArrayBuffer>
+    blob: () => Promise<Blob>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
+    cwd: (newCwd: string) => ShellPromise
+    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    json: () => Promise<any>
+    lines: () => AsyncIterable<string>
+    nothrow: () => ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    stdin: WritableStream<any>
+    text: (encoding?: BufferEncoding | undefined) => Promise<string>
+    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => ShellPromise
+    [static]
+      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      [Symbol.species] [readonly]: PromiseConstructor
+      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+      prototype: ShellPromise
+      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      reject: <T = never>(reason?: any) => Promise<T>
+      resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+      try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
+      withResolvers: <T>() => { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; }
+  function $.braces (bun-types/shell.d.ts)
+    call (pattern: string): Array<string>
+  function $.cwd (bun-types/shell.d.ts)
+    call (newCwd?: string | undefined): typeof $
+  function $.env (bun-types/shell.d.ts)
+    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+  function $.escape (bun-types/shell.d.ts)
+    call (input: string): string
+  function $.nothrow (bun-types/shell.d.ts)
+    call (): typeof $
+  function $.throws (bun-types/shell.d.ts)
+    call (shouldThrow: boolean): typeof $
+interface AbstractWorker (bun-types/bun.d.ts)
+  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+interface AbstractWorkerEventMap (bun-types/bun.d.ts)
+  error: ErrorEvent
+interface AddEventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc" | "ppc64" | "s390" | "s390x" | "x64"
+class Archive (bun-types/bun.d.ts)
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
+  [static]
+    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
+    prototype: Archive
+    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
+interface ArchiveExtractOptions (bun-types/bun.d.ts)
+  glob [?]: ReadonlyArray<string> | string | undefined
+type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+interface ArchiveOptions (bun-types/bun.d.ts)
+  compress [?]: "gzip" | undefined
+  level [?]: number | undefined
+class ArrayBufferSink (bun-types/bun.d.ts)
+  end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
+  flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
+  start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  [static]
+    construct new (): ArrayBufferSink
+    prototype: ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
+type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+interface BinaryTypeList (bun-types/bun.d.ts)
+  arraybuffer: ArrayBuffer
+  buffer: Buffer<ArrayBufferLike>
+  uint8array: Uint8Array<ArrayBuffer>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
+type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+namespace Build (bun-types/bun.d.ts)
+  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
+  type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
+interface BuildArtifact (bun-types/bun.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  hash: null | string
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
+  loader: Loader
+  path: string
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  sourcemap: BuildArtifact | null
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+interface BuildConfig (bun-types/bun.d.ts)
+  allowUnresolved [?]: Array<string> | undefined
+  banner [?]: string | undefined
+  bytecode [?]: boolean | undefined
+  bytecodeDepth [?]: number | undefined
+  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  conditions [?]: Array<string> | string | undefined
+  define [?]: Record<string, string> | undefined
+  deprecatedNamespaceObjectSetters [?]: boolean | undefined
+  drop [?]: Array<string> | undefined
+  emitDCEAnnotations [?]: boolean | undefined
+  entrypoints: Array<string>
+  env [?]: "disable" | "inline" | `${string}*` | undefined
+  external [?]: Array<string> | undefined
+  features [?]: Array<string> | undefined
+  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  footer [?]: string | undefined
+  format [?]: "cjs" | "esm" | "iife" | undefined
+  ignoreDCEAnnotations [?]: boolean | undefined
+  jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
+  loader [?]: undefined | { [x: string]: Loader; }
+  metafile [?]: boolean | undefined
+  minChunkSize [?]: number | undefined
+  minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
+  modulePreload [?]: boolean | undefined
+  naming [?]: string | undefined | { chunk?: string | undefined; entry?: string | undefined; asset?: string | undefined; }
+  optimizeImports [?]: Array<string> | undefined
+  outdir [?]: string | undefined
+  packages [?]: "bundle" | "external" | undefined
+  plugins [?]: Array<BunPlugin> | undefined
+  publicPath [?]: string | undefined
+  reactCompiler [?]: boolean | undefined
+  reactCompilerOutputMode [?]: "client" | "ssr" | undefined
+  reactFastRefresh [?]: boolean | undefined
+  root [?]: string | undefined
+  sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
+  splitRequire [?]: boolean | undefined
+  splitting [?]: boolean | undefined
+  target [?]: Target | undefined
+  throw [?]: boolean | undefined
+  treeShaking [?]: boolean | undefined
+  tsconfig [?]: string | undefined
+interface BuildMetafile (bun-types/bun.d.ts)
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+interface BuildOutput (bun-types/bun.d.ts)
+  logs: Array<BuildMessage | ResolveMessage>
+  metafile [?]: BuildMetafile | undefined
+  outputs: Array<BuildArtifact>
+  success: boolean
+interface BunFile (bun-types/bun.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface BunInspectOptions (bun-types/bun.d.ts)
+  colors [?]: boolean | undefined
+  compact [?]: boolean | undefined
+  depth [?]: number | undefined
+  sorted [?]: boolean | undefined
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+interface BunPlugin (bun-types/bun.d.ts)
+  name: string
+  setup: (build: PluginBuilder) => Promise<void> | void
+  target [?]: Target | undefined
+interface BunRegisterPlugin (bun-types/bun.d.ts)
+  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  clearAll: () => void
+interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  blob: () => Promise<Blob>
+  body [readonly]: ReadableStream<Uint8Array<ArrayBuffer>> | null
+  bodyUsed [readonly]: boolean
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cache [readonly]: RequestCache
+  clone: () => BunRequest<T>
+  cookies [readonly]: CookieMap
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  formData: () => Promise<FormData>
+  headers [readonly]: Headers
+  integrity [readonly]: string
+  json: () => Promise<any>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+namespace CSRF (bun-types/bun.d.ts)
+  function CSRF.generate (bun-types/bun.d.ts)
+    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+  function CSRF.verify (bun-types/bun.d.ts)
+    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
+interface CSRFGenerateOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  expiresIn [?]: number | undefined
+  sessionId [?]: string | undefined
+interface CSRFVerifyOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  maxAge [?]: number | undefined
+  secret [?]: string | undefined
+  sessionId [?]: string | undefined
+interface CloseEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  code [?]: number | undefined
+  composed [?]: boolean | undefined
+  reason [?]: string | undefined
+  wasClean [?]: boolean | undefined
+type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+interface CompileBuildOptions (bun-types/bun.d.ts)
+  assets [?]: Array<string> | undefined
+  autoloadBunfig [?]: boolean | undefined
+  autoloadDotenv [?]: boolean | undefined
+  autoloadPackageJson [?]: boolean | undefined
+  autoloadTsconfig [?]: boolean | undefined
+  execArgv [?]: Array<string> | undefined
+  executablePath [?]: string | undefined
+  outfile [?]: string | undefined
+  target [?]: CompileTarget | undefined
+  windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
+type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+class Cookie (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | undefined
+  httpOnly: boolean
+  isExpired: () => boolean
+  maxAge [?]: number | undefined
+  name [readonly]: string
+  partitioned: boolean
+  path: string
+  sameSite: CookieSameSite
+  secure: boolean
+  serialize: () => string
+  toJSON: () => CookieInit
+  toString: () => string
+  value: string
+  [static]
+    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
+    construct new (cookieString: string): Cookie
+    construct new (cookieObject?: CookieInit | undefined): Cookie
+    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
+    parse [static]: (cookieString: string) => Cookie
+    prototype: Cookie
+interface CookieInit (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | number | string | undefined
+  httpOnly [?]: boolean | undefined
+  maxAge [?]: number | undefined
+  name [?]: string | undefined
+  partitioned [?]: boolean | undefined
+  path [?]: string | undefined
+  sameSite [?]: CookieSameSite | undefined
+  secure [?]: boolean | undefined
+  value [?]: string | undefined
+class CookieMap (bun-types/bun.d.ts)
+  [Symbol.iterator]: () => IterableIterator<[string, string]>
+  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  get: (name: string) => null | string
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  size [readonly]: number
+  toJSON: () => Record<string, string>
+  toSetCookieHeaders: () => Array<string>
+  values: () => IterableIterator<string>
+  [static]
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
+    prototype: CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
+  domain [?]: null | string | undefined
+  name: string
+  path [?]: string | undefined
+interface CookieStoreGetOptions (bun-types/bun.d.ts)
+  name [?]: string | undefined
+  url [?]: string | undefined
+interface CronController (bun-types/bun.d.ts)
+  cron [readonly]: string
+  scheduledTime [readonly]: number
+  type [readonly]: "scheduled"
+interface CronJob (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  cron [readonly]: string
+  ref: () => CronJob
+  stop: () => CronJob
+  unref: () => CronJob
+interface CronOptions (bun-types/bun.d.ts)
+  tz [?]: string | undefined
+type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+class CryptoHashInterface<T> (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => T
+  [static]
+    construct new <T>(): CryptoHashInterface<T>
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHashInterface<any>
+class CryptoHasher (bun-types/bun.d.ts)
+  algorithm [readonly]: SupportedCryptoAlgorithms
+  byteLength [readonly]: number
+  copy: () => CryptoHasher
+  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
+  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  [static]
+    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
+    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHasher
+interface CustomEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  detail [?]: T | undefined
+interface DNSLookup (bun-types/bun.d.ts)
+  address: string
+  family: 4 | 6
+  ttl: number
+type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
+  type: "direct"
+type DisconnectListener (bun-types/bun.d.ts) = () => void
+interface EditorOptions (bun-types/bun.d.ts)
+  column [?]: number | undefined
+  editor [?]: "subl" | "vscode" | undefined
+  line [?]: number | undefined
+type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+interface Env (bun-types/bun.d.ts)
+  NODE_ENV [?]: string | undefined
+  TZ [?]: string | undefined
+interface ErrorEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  colno [?]: number | undefined
+  composed [?]: boolean | undefined
+  error [?]: any
+  filename [?]: string | undefined
+  lineno [?]: number | undefined
+  message [?]: string | undefined
+interface ErrorLike (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+interface EventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+interface EventListener (bun-types/bun.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (bun-types/bun.d.ts)
+  handleEvent: (object: Event) => void
+interface EventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+interface EventMap (bun-types/bun.d.ts)
+  fetch: FetchEvent
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  messageerror: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+interface EventSource (bun-types/bun.d.ts)
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: Event) => any) | null
+  onmessage: ((this: EventSource, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: number
+  ref: () => void
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => void
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+interface EventSourceEventMap (bun-types/bun.d.ts)
+  error: Event
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  open: Event
+type ExitListener (bun-types/bun.d.ts) = (code: number) => void
+type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
+interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  fd: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface FetchEvent (bun-types/bun.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface FileBlob (bun-types/bun.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface FileSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+class FileSystemRouter (bun-types/bun.d.ts)
+  assetPrefix [readonly]: string
+  match: (input: Request | Response | string) => MatchedRoute | null
+  origin [readonly]: string
+  reload: () => void
+  routes [readonly]: Record<string, string>
+  style [readonly]: string
+  [static]
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
+    prototype: FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+interface GenericTransformStream (bun-types/bun.d.ts)
+  readable [readonly]: ReadableStream<any>
+  writable [readonly]: WritableStream<any>
+class Glob (bun-types/bun.d.ts)
+  match: (str: string) => boolean
+  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  [static]
+    construct new (pattern: string): Glob
+    prototype: Glob
+interface GlobScanOptions (bun-types/bun.d.ts)
+  absolute [?]: boolean | undefined
+  cwd [?]: string | undefined
+  dot [?]: boolean | undefined
+  followSymlinks [?]: boolean | undefined
+  onlyFiles [?]: boolean | undefined
+  throwErrorOnBrokenSymlink [?]: boolean | undefined
+type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
+type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+interface HTMLBundle (bun-types/bun.d.ts)
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  index: string
+interface Hash (bun-types/bun.d.ts)
+  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Headers | Array<Array<string>> | Record<string, string | ReadonlyArray<string>>
+interface HeapSnapshot (bun-types/bun.d.ts)
+  edgeNames: Array<string>
+  edgeTypes: Array<string>
+  edges: Array<number>
+  nodeClassNames: Array<string>
+  nodes: Array<number>
+  type: string
+  version: number
+class Image (bun-types/bun.d.ts)
+  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  blob: () => Promise<Blob>
+  buffer: () => Promise<Buffer<ArrayBufferLike>>
+  bytes: () => Promise<Uint8Array<ArrayBufferLike>>
+  dataurl: () => Promise<string>
+  flip: () => Image
+  flop: () => Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  height [readonly]: number
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
+  metadata: () => Promise<Metadata>
+  modulate: (options: ModulateOptions) => Image
+  placeholder: (as?: "dataurl" | undefined) => Promise<string>
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
+  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
+  rotate: (degrees: number) => Image
+  toBase64: () => Promise<string>
+  toBuffer: () => Promise<Buffer<ArrayBufferLike>>
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  width [readonly]: number
+  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  [static]
+    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    backend [static]: "bun" | "system"
+    clipboardChangeCount [static]: () => number
+    fromClipboard [static]: () => Image | null
+    hasClipboardImage [static]: () => boolean
+    prototype: Image
+  interface Image.ConstructorOptions (bun-types/bun.d.ts)
+    autoOrient [?]: boolean | undefined
+    maxPixels [?]: number | undefined
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
+  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  interface Image.Metadata (bun-types/bun.d.ts)
+    format: Format
+    height: number
+    width: number
+  interface Image.ModulateOptions (bun-types/bun.d.ts)
+    brightness [?]: number | undefined
+    saturation [?]: number | undefined
+  interface Image.ResizeOptions (bun-types/bun.d.ts)
+    filter [?]: Filter | undefined
+    fit [?]: "fill" | "inside" | undefined
+    withoutEnlargement [?]: boolean | undefined
+  var Image.backend (bun-types/bun.d.ts): "bun" | "system"
+interface Import (bun-types/bun.d.ts)
+  kind: ImportKind
+  path: string
+type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+namespace JSON5 (bun-types/bun.d.ts)
+  function JSON5.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function JSON5.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+namespace JSONC (bun-types/bun.d.ts)
+  function JSONC.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+namespace JSONL (bun-types/bun.d.ts)
+  interface JSONL.ParseChunkResult (bun-types/bun.d.ts)
+    done: boolean
+    error: SyntaxError | null
+    read: number
+    values: Array<unknown>
+  function JSONL.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+  function JSONL.parseChunk (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
+interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
+  level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "libdeflate" | undefined
+type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+class MD4 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD4
+  [static]
+    construct new (): MD4
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD4
+class MD5 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD5
+  [static]
+    construct new (): MD5
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD5
+interface MMapOptions (bun-types/bun.d.ts)
+  offset [?]: number | undefined
+  shared [?]: boolean | undefined
+  size [?]: number | undefined
+  sync [?]: boolean | undefined
+type MacroMap (bun-types/bun.d.ts) = { [x: string]: Record<string, string>; }
+interface MatchedRoute (bun-types/bun.d.ts)
+  filePath [readonly]: string
+  kind [readonly]: "catch-all" | "dynamic" | "exact" | "optional-catch-all"
+  name [readonly]: string
+  params [readonly]: Record<string, string>
+  pathname [readonly]: string
+  query [readonly]: Record<string, string>
+  src [readonly]: string
+type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
+type MessageEvent<T = any> (bun-types/bun.d.ts) = { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+interface MessageEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  data [?]: T | undefined
+  lastEventId [?]: string | undefined
+  origin [?]: string | undefined
+  source [?]: null | undefined
+type MessageEventSource (bun-types/bun.d.ts) = undefined
+type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+interface NetworkSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  stat: () => Promise<Stats>
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
+type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+interface OnLoadArgs (bun-types/bun.d.ts)
+  defer: () => Promise<void>
+  loader: Loader
+  namespace: string
+  path: string
+type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+interface OnLoadResultObject (bun-types/bun.d.ts)
+  exports: Record<string, unknown>
+  loader: "object"
+interface OnLoadResultSourceCode (bun-types/bun.d.ts)
+  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Loader | undefined
+interface OnResolveArgs (bun-types/bun.d.ts)
+  importer: string
+  kind: ImportKind
+  namespace: string
+  path: string
+  resolveDir: string
+type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+interface OnResolveResult (bun-types/bun.d.ts)
+  external [?]: boolean | undefined
+  namespace [?]: string | undefined
+  path: string
+type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
+namespace Password (bun-types/bun.d.ts)
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  interface Password.Argon2Algorithm (bun-types/bun.d.ts)
+    algorithm: "argon2d" | "argon2i" | "argon2id"
+    memoryCost [?]: number | undefined
+    timeCost [?]: number | undefined
+  interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
+    algorithm: "bcrypt"
+    cost [?]: number | undefined
+type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
+type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+interface PluginBuilder (bun-types/bun.d.ts)
+  config: BuildConfig & { plugins: Array<BunPlugin>; }
+  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
+  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
+  onEnd: (callback: OnEndCallback) => PluginBuilder
+  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
+  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
+  onStart: (callback: OnStartCallback) => PluginBuilder
+interface PluginConstraints (bun-types/bun.d.ts)
+  filter: RegExp
+  namespace [?]: string | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
+interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
+  done: boolean
+  size: number
+  value: Array<T>
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
+type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+class RedisClient (bun-types/redis.d.ts)
+  append: (key: KeyLike, value: KeyLike) => Promise<number>
+  bitcount: (key: KeyLike) => Promise<number>
+  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
+  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
+  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
+  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  bufferedAmount [readonly]: number
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  client: (...args: Array<string | number>) => Promise<any>
+  close: () => void
+  command: (...args: Array<string | number>) => Promise<any>
+  config: (...args: Array<string | number>) => Promise<any>
+  connect: () => Promise<void>
+  connected [readonly]: boolean
+  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  dbsize: () => Promise<number>
+  debug: (...args: Array<string | number>) => Promise<any>
+  decr: (key: KeyLike) => Promise<number>
+  decrby: (key: KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<KeyLike>) => Promise<number>
+  dump: (key: KeyLike) => Promise<string | null>
+  duplicate: () => Promise<RedisClient>
+  echo: (message: string) => Promise<string>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  exists: (key: KeyLike) => Promise<boolean>
+  expire: (key: KeyLike, seconds: number) => Promise<number>
+  expireat: (key: KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  function: (...args: Array<KeyLike>) => Promise<any>
+  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
+  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
+  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
+  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
+  get: (key: KeyLike) => Promise<string | null>
+  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: KeyLike, offset: number) => Promise<number>
+  getdel: (key: KeyLike) => Promise<string | null>
+  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
+  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
+  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
+  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
+  hgetall: (key: KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
+  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
+  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: KeyLike) => Promise<Array<string>>
+  hlen: (key: KeyLike) => Promise<number>
+  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
+  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
+  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
+  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
+  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
+  hstrlen: (key: KeyLike, field: string) => Promise<number>
+  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hvals: (key: KeyLike) => Promise<Array<string>>
+  incr: (key: KeyLike) => Promise<number>
+  incrby: (key: KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  info: (...sections: Array<string>) => Promise<string>
+  keys: (pattern: string) => Promise<Array<string>>
+  lastsave: () => Promise<number>
+  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
+  lindex: (key: KeyLike, index: number) => Promise<string | null>
+  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
+  llen: (key: KeyLike) => Promise<number>
+  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
+  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
+  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
+  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
+  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
+  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
+  onclose: ((this: RedisClient, error: Error) => void) | null
+  onconnect: ((this: RedisClient) => void) | null
+  persist: (key: KeyLike) => Promise<number>
+  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: KeyLike) => Promise<number>
+  pfadd: (key: KeyLike, element: string) => Promise<number>
+  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
+  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
+  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
+  pttl: (key: KeyLike) => Promise<number>
+  publish: (channel: string, message: string) => Promise<number>
+  randomkey: () => Promise<string | null>
+  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
+  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
+  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
+  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
+  scard: (key: KeyLike) => Promise<number>
+  script: (...args: Array<string>) => Promise<any>
+  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  send: (command: string, args: Array<string>) => Promise<any>
+  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
+  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
+  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
+  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
+  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
+  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sismember: (key: KeyLike, member: string) => Promise<boolean>
+  smembers: (key: KeyLike) => Promise<Array<string>>
+  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
+  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
+  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
+  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: KeyLike, message: string) => Promise<number>
+  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
+  strlen: (key: KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
+  substr: (key: KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  time: () => Promise<[string, string]>
+  touch: (...keys: Array<KeyLike>) => Promise<number>
+  ttl: (key: KeyLike) => Promise<number>
+  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
+  unlink: (...keys: Array<KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  wait: (numreplicas: number, timeout: number) => Promise<number>
+  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
+  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
+  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
+  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xlen: (key: KeyLike) => Promise<number>
+  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
+  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<string | number>) => Promise<any>
+  xreadgroup: (...args: Array<string | number>) => Promise<any>
+  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
+  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
+  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  zcard: (key: KeyLike) => Promise<number>
+  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
+  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
+  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
+  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
+  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: KeyLike, member: string) => Promise<number | null>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  [static]
+    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
+    prototype: RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+  type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
+interface RedisOptions (bun-types/redis.d.ts)
+  autoReconnect [?]: boolean | undefined
+  connectionTimeout [?]: number | undefined
+  enableAutoPipelining [?]: boolean | undefined
+  enableOfflineQueue [?]: boolean | undefined
+  idleTimeout [?]: number | undefined
+  maxRetries [?]: number | undefined
+  tls [?]: TLSOptions | boolean | undefined
+type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
+interface ReservedSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  [Symbol.dispose]: () => void
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  release: () => void
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+interface ResourceUsage (bun-types/bun.d.ts)
+  contextSwitches: { voluntary: number; involuntary: number; }
+  cpuTime: { user: number; system: number; total: number; }
+  maxRSS: number
+  messages: { sent: number; received: number; }
+  ops: { in: number; out: number; }
+  shmSize: number
+  signalCount: number
+  swapCount: number
+class S3Client (bun-types/s3.d.ts)
+  delete: (path: string, options?: S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: S3Options | undefined) => S3File
+  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
+  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  [static]
+    construct new (options?: S3Options | undefined): S3Client
+    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: S3Options | undefined) => S3File
+    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
+    prototype: S3Client
+    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+interface S3File (bun-types/s3.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bucket [? readonly]: string | undefined
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  name [? readonly]: string | undefined
+  presign: (options?: S3FilePresignOptions | undefined) => string
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
+  stat: () => Promise<S3Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  writer: (options?: S3Options | undefined) => NetworkSink
+interface S3FilePresignOptions (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endings [?]: EndingType | undefined
+  endpoint [?]: string | undefined
+  expiresIn [?]: number | undefined
+  highWaterMark [?]: number | undefined
+  method [?]: "DELETE" | "GET" | "HEAD" | "POST" | "PUT" | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3ListObjectsOptions (bun-types/s3.d.ts)
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  fetchOwner [?]: boolean | undefined
+  maxKeys [?]: number | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3ListObjectsResponse (bun-types/s3.d.ts)
+  commonPrefixes [?]: Array<{ prefix: string; }> | undefined
+  contents [?]: Array<{ checksumAlgorithm?: "CRC32" | "CRC32C" | "SHA1" | "SHA256" | "CRC64NVME" | undefined; checksumType?: "COMPOSITE" | "FULL_OBJECT" | undefined; eTag?: string | undefined; key: string; lastModified?: string | undefined; owner?: { id?: string | undefined; displayName?: string | undefined; } | undefined; restoreStatus?: { isRestoreInProgress?: boolean | undefined; restoreExpiryDate?: string | undefined; } | undefined; size?: number | undefined; storageClass?: "STANDARD" | "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD_IA" | undefined; }> | undefined
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  isTruncated [?]: boolean | undefined
+  keyCount [?]: number | undefined
+  maxKeys [?]: number | undefined
+  name [?]: string | undefined
+  nextContinuationToken [?]: string | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3Options (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endings [?]: EndingType | undefined
+  endpoint [?]: string | undefined
+  highWaterMark [?]: number | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3Stats (bun-types/s3.d.ts)
+  etag: string
+  lastModified: Date
+  size: number
+  type: string
+class SHA1 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA1
+  [static]
+    construct new (): SHA1
+    byteLength [readonly static]: 20
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA1
+class SHA224 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA224
+  [static]
+    construct new (): SHA224
+    byteLength [readonly static]: 28
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA224
+class SHA256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA256
+  [static]
+    construct new (): SHA256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA256
+class SHA384 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA384
+  [static]
+    construct new (): SHA384
+    byteLength [readonly static]: 48
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA384
+class SHA512 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512
+  [static]
+    construct new (): SHA512
+    byteLength [readonly static]: 64
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512
+class SHA512_256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  [static]
+    construct new (): SHA512_256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512_256
+class SQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  [static]
+    construct new (connectionString: URL | string): SQL
+    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
+    construct new (options?: Options | undefined): SQL
+    MySQLError: typeof MySQLError
+    PostgresError: typeof PostgresError
+    SQLError: typeof SQLError
+    SQLiteError: typeof SQLiteError
+    prototype: SQL
+  type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  interface SQL.Helper<T> (bun-types/sql.d.ts)
+    columns [readonly]: Array<keyof T>
+    value [readonly]: Array<T>
+  interface SQL.ListenSubscription (bun-types/sql.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    channel [readonly]: string
+    unlisten: () => Promise<void>
+  class SQL.MySQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    errno [? readonly]: number | undefined
+    message: string
+    name: string
+    sqlState [? readonly]: string | undefined
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: MySQLError
+      stackTraceLimit: number
+  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  class SQL.PostgresError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    column [? readonly]: string | undefined
+    constraint [? readonly]: string | undefined
+    dataType [? readonly]: string | undefined
+    detail [? readonly]: string | undefined
+    errno [? readonly]: string | undefined
+    file [? readonly]: string | undefined
+    hint [? readonly]: string | undefined
+    internalPosition [? readonly]: string | undefined
+    internalQuery [? readonly]: string | undefined
+    line [? readonly]: string | undefined
+    message: string
+    name: string
+    position [? readonly]: string | undefined
+    routine [? readonly]: string | undefined
+    schema [? readonly]: string | undefined
+    severity [? readonly]: string | undefined
+    stack [?]: string | undefined
+    table [? readonly]: string | undefined
+    where [? readonly]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: PostgresError
+      stackTraceLimit: number
+  interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
+    adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
+    allowPublicKeyRetrieval [?]: boolean | undefined
+    bigint [?]: boolean | undefined
+    connectTimeout [?]: number | undefined
+    connect_timeout [?]: number | undefined
+    connection [?]: Record<string, string | number | boolean> | undefined
+    connectionTimeout [?]: number | undefined
+    connection_timeout [?]: number | undefined
+    database [?]: string | undefined
+    db [?]: string | undefined
+    host [?]: string | undefined
+    hostname [?]: string | undefined
+    idleTimeout [?]: number | undefined
+    idle_timeout [?]: number | undefined
+    max [?]: number | undefined
+    maxLifetime [?]: number | undefined
+    max_lifetime [?]: number | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    pass [?]: (() => MaybePromise<string>) | string | undefined
+    password [?]: (() => MaybePromise<string>) | string | undefined
+    path [?]: string | undefined
+    port [?]: number | string | undefined
+    prepare [?]: boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    url [?]: URL | string | undefined
+    user [?]: string | undefined
+    username [?]: string | undefined
+  interface SQL.Query<T> (bun-types/sql.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    active: boolean
+    cancel: () => Query<T>
+    cancelled: boolean
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
+    execute: () => Query<T>
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
+    raw: () => Query<T>
+    simple: () => Query<T>
+    then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    values: () => Query<T>
+  class SQL.SQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string): SQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLError
+      stackTraceLimit: number
+  class SQL.SQLiteError (bun-types/sql.d.ts)
+    byteOffset [? readonly]: number | undefined
+    cause [?]: unknown
+    code [readonly]: string
+    errno [readonly]: number
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLiteError
+      stackTraceLimit: number
+  interface SQL.SQLiteOptions (bun-types/sql.d.ts)
+    adapter [?]: "sqlite" | undefined
+    create [?]: boolean | undefined
+    filename [?]: ":memory:" | URL | string & {} | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    readonly [?]: boolean | undefined
+    readwrite [?]: boolean | undefined
+    safeIntegers [?]: boolean | undefined
+    strict [?]: boolean | undefined
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SQLArrayParameter (bun-types/sql.d.ts)
+  arrayType: ArrayType
+  serializedValues: string
+type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SavepointSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+namespace Security (bun-types/security.d.ts)
+  interface Security.Advisory (bun-types/security.d.ts)
+    description: null | string
+    level: "fatal" | "warn"
+    package: string
+    url: null | string
+  interface Security.Package (bun-types/security.d.ts)
+    name: string
+    requestedRange: string
+    tarball: string
+    version: string
+  interface Security.Scanner (bun-types/security.d.ts)
+    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    version: "1"
+namespace Serve (bun-types/serve.d.ts)
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
+  interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
+    dir: string
+    statCache [?]: boolean | undefined
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    http1 [?]: boolean | undefined
+    http2 [?]: boolean | undefined
+    http3 [?]: boolean | undefined
+    id [?]: null | string | undefined
+    idleTimeout [?]: number | undefined
+    ipv6Only [?]: boolean | undefined
+    maxRequestBodySize [?]: number | undefined
+    port [?]: number | string | undefined
+    reusePort [?]: boolean | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+  interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    unix [?]: string | undefined
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+interface Server<WebSocketData> (bun-types/serve.d.ts)
+  [Symbol.dispose]: () => void
+  closeIdleConnections: () => number
+  development [readonly]: boolean
+  fetch: (request: Request | string) => Promise<Response> | Response
+  hostname [readonly]: string | undefined
+  id [readonly]: string
+  pendingRequests [readonly]: number
+  pendingWebSockets [readonly]: number
+  port [readonly]: number | undefined
+  protocol [readonly]: "http" | "https" | null
+  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  ref: () => void
+  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
+  requestIP: (request: Request) => SocketAddress | null
+  stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
+  subscriberCount: (topic: string) => number
+  timeout: (request: Request, seconds: number) => void
+  unref: () => void
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  url [readonly]: URL
+interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
+  binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  data: T
+  getBufferedAmount: () => number
+  isSubscribed: (topic: string) => boolean
+  ping: (data?: Blob | BufferSource | string | undefined) => number
+  pong: (data?: Blob | BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  publishText: (topic: string, data: string, compress?: boolean | undefined) => number
+  readyState [readonly]: WebSocketReadyState
+  remoteAddress [readonly]: string
+  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  sendText: (data: string, compress?: boolean | undefined) => number
+  subscribe: (topic: string) => boolean
+  subscriptions [readonly]: Array<string>
+  terminate: () => void
+  unsubscribe: (topic: string) => boolean
+type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
+type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
+type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+interface SliceAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  ellipsis [?]: string | undefined
+interface Socket<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: Data
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface SocketAddress (bun-types/bun.d.ts)
+  address: string
+  family: "IPv4" | "IPv6"
+  port: number
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof BinaryTypeList | undefined
+  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+namespace Spawn (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
+  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    lazy [?]: boolean | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    terminal [?]: Terminal | TerminalOptions | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
+  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+SpawnOptions -> Spawn
+type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
+type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+interface StringWidthOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  countAnsiEscapeCodes [?]: boolean | undefined
+  perCodePoint [?]: boolean | undefined
+interface StructuredSerializeOptions (bun-types/bun.d.ts)
+  transfer [?]: Array<Transferable> | undefined
+interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  disconnect: () => void
+  exitCode [readonly]: null | number
+  exited [readonly]: Promise<number>
+  kill: (exitCode?: Signals | number | undefined) => void
+  killed [readonly]: boolean
+  pid [readonly]: number
+  readable [readonly]: ReadableToIO<Out>
+  ref: () => void
+  resourceUsage: () => ResourceUsage | undefined
+  send: (message: any) => void
+  signalCode [readonly]: Signals | null
+  stderr [readonly]: ReadableToIO<Err>
+  stdin [readonly]: WritableToIO<In>
+  stdio [readonly]: [null, null, null, ...(number | null)[]]
+  stdout [readonly]: ReadableToIO<Out>
+  terminal [readonly]: Terminal | undefined
+  unref: () => void
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  exitCode: number
+  exitedDueToMaxBuffer [?]: boolean | undefined
+  exitedDueToTimeout [?]: boolean | undefined
+  pid: number
+  resourceUsage: ResourceUsage
+  signalCode [?]: string | undefined
+  stderr: ReadableToSyncIO<Err>
+  stdout: ReadableToSyncIO<Out>
+  success: boolean
+interface SystemError (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface TCPSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  ipv6Only [?]: boolean | undefined
+  port: number
+  reusePort [?]: boolean | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  port: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  hostname [readonly]: string
+  port [readonly]: number
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface TLSSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls: TLSOptions | boolean
+namespace TOML (bun-types/bun.d.ts)
+  function TOML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+  function TOML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+interface TSConfig (bun-types/bun.d.ts)
+  compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
+  extends [?]: string | undefined
+type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+class Terminal (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => Promise<void>
+  close: () => void
+  closed [readonly]: boolean
+  controlFlags: number
+  inputFlags: number
+  localFlags: number
+  outputFlags: number
+  ref: () => void
+  resize: (cols: number, rows: number) => void
+  setRawMode: (enabled: boolean) => void
+  unref: () => void
+  write: (data: BufferSource | string) => number
+  [static]
+    construct new (options: TerminalOptions): Terminal
+    prototype: Terminal
+interface TerminalOptions (bun-types/bun.d.ts)
+  cols [?]: number | undefined
+  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Terminal) => void) | undefined
+  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  name [?]: string | undefined
+  rows [?]: number | undefined
+type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
+interface TransactionSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
+interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+interface TransformerStartCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): any
+interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
+  call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+class Transpiler (bun-types/bun.d.ts)
+  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
+  scanImports: (code: StringOrBuffer) => Array<Import>
+  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  [static]
+    construct new (options?: TranspilerOptions | undefined): Transpiler
+    prototype: Transpiler
+interface TranspilerOptions (bun-types/bun.d.ts)
+  allowBunRuntime [?]: boolean | undefined
+  autoImportJSX [?]: boolean | undefined
+  deadCodeElimination [?]: boolean | undefined
+  define [?]: Record<string, string> | undefined
+  exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
+  inline [?]: boolean | undefined
+  jsxOptimizationInline [?]: boolean | undefined
+  loader [?]: JavaScriptLoader | undefined
+  logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
+  macro [?]: MacroMap | undefined
+  minifyWhitespace [?]: boolean | undefined
+  replMode [?]: boolean | undefined
+  target [?]: Target | undefined
+  treeShaking [?]: boolean | undefined
+  trimUnusedImports [?]: boolean | undefined
+  tsconfig [?]: TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
+interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
+  abort [?]: UnderlyingSinkAbortCallback | undefined
+  close [?]: UnderlyingSinkCloseCallback | undefined
+  start [?]: UnderlyingSinkStartCallback | undefined
+  type [?]: "bytes" | "default" | undefined
+  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
+  call (): PromiseLike<void> | void
+interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
+  call (controller: WritableStreamDefaultController): any
+interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
+  call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
+interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull [?]: UnderlyingSourcePullCallback<R> | undefined
+  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  type [?]: undefined
+interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): any
+type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+interface UnixSocketListener<Data> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unix [readonly]: string
+  unref: () => void
+interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+  unix: string
+type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+interface WebSocket (bun-types/bun.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+interface WebSocketEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: Event
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  open: Event
+interface WebSocketHandler<T> (bun-types/serve.d.ts)
+  backpressureLimit [?]: number | undefined
+  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  closeOnBackpressureLimit [?]: boolean | undefined
+  data [?]: T | undefined
+  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  idleTimeout [?]: number | undefined
+  maxPayloadLength [?]: number | undefined
+  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
+  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  publishToSelf [?]: boolean | undefined
+  sendPings [?]: boolean | undefined
+type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
+type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
+class WebView (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => void
+  [Symbol.dispose]: () => void
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  back: () => Promise<void>
+  cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
+  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  evaluate: <T = unknown>(script: string) => Promise<T>
+  forward: () => Promise<void>
+  loading [readonly]: boolean
+  navigate: (url: string) => Promise<void>
+  onNavigated: ((url: string, title: string) => void) | null
+  onNavigationFailed: ((error: Error) => void) | null
+  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  reload: () => Promise<void>
+  removeEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean | undefined) => void
+  resize: (width: number, height: number) => Promise<void>
+  screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
+  scroll: (dx: number, dy: number) => Promise<void>
+  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  title [readonly]: string
+  type: (text: string) => Promise<void>
+  url [readonly]: string
+  [static]
+    construct new (options?: ConstructorOptions | undefined): WebView
+    closeAll [static]: () => void
+    prototype: WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+  interface WebView.ClickOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+    timeout [?]: number | undefined
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  interface WebView.ConstructorOptions (bun-types/bun.d.ts)
+    backend [?]: Backend | undefined
+    console [?]: ConsoleCapture | undefined
+    dataStore [?]: "ephemeral" | undefined | { directory: string; }
+    headless [?]: boolean | undefined
+    height [?]: number | undefined
+    url [?]: string | undefined
+    width [?]: number | undefined
+  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  interface WebView.PressOptions (bun-types/bun.d.ts)
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ScrollToOptions (bun-types/bun.d.ts)
+    block [?]: "center" | "end" | "nearest" | "start" | undefined
+    timeout [?]: number | undefined
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+interface WhichOptions (bun-types/bun.d.ts)
+  PATH [?]: string | undefined
+  cwd [?]: string | undefined
+interface Worker (bun-types/bun.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onmessageerror: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+interface WorkerEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: ErrorEvent
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  messageerror: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  open: Event
+interface WorkerOptions (bun-types/bun.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
+interface WrapAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  hard [?]: boolean | undefined
+  trim [?]: boolean | undefined
+  wordWrap [?]: boolean | undefined
+type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+namespace XML (bun-types/bun.d.ts)
+  interface XML.Comment (bun-types/bun.d.ts)
+    comment: string
+  interface XML.Document (bun-types/bun.d.ts)
+    index [string]: Value
+  interface XML.Element (bun-types/bun.d.ts)
+    index [string]: Array<Value> | Value
+  interface XML.Node (bun-types/bun.d.ts)
+    attributes: Record<string, string>
+    children: Array<string | Comment | Node | ProcessingInstruction>
+    name: string
+  interface XML.NodeInput (bun-types/bun.d.ts)
+    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
+    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    name: string
+  interface XML.ParseOptions (bun-types/bun.d.ts)
+    compact [?]: boolean | undefined
+  interface XML.ProcessingInstruction (bun-types/bun.d.ts)
+    data: string
+    target: string
+  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
+  type XML.Value (bun-types/bun.d.ts) = string | Element
+  function XML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+  function XML.stringify (bun-types/bun.d.ts)
+    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+namespace YAML (bun-types/bun.d.ts)
+  function YAML.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function YAML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string
+interface ZlibCompressionOptions (bun-types/bun.d.ts)
+  level [?]: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "zlib" | undefined
+  memLevel [?]: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  strategy [?]: number | undefined
+  windowBits [?]: -10 | -11 | -12 | -13 | -14 | -15 | -9 | 10 | 11 | 12 | 13 | 14 | 15 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 9 | undefined
+namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/globals.d.ts)
+  interface __internal.BunEvent (bun-types/globals.d.ts)
+    bubbles [readonly]: boolean
+    cancelBubble: boolean
+    cancelable [readonly]: boolean
+    composed [readonly]: boolean
+    composedPath: () => [(EventTarget | undefined)?]
+    currentTarget [readonly]: EventTarget | null
+    defaultPrevented [readonly]: boolean
+    eventPhase [readonly]: number
+    isTrusted [readonly]: boolean
+    preventDefault: () => void
+    returnValue: boolean
+    srcElement [readonly]: EventTarget | null
+    stopImmediatePropagation: () => void
+    stopPropagation: () => void
+    target [readonly]: EventTarget | null
+    timeStamp [readonly]: number
+    type [readonly]: string
+  interface __internal.BunEventTarget (bun-types/globals.d.ts)
+    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    dispatchEvent: (event: Event) => boolean
+    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
+    count [readonly]: number
+    getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+    toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+  interface __internal.BunRequestOverride (bun-types/fetch.d.ts)
+    headers: BunHeadersOverride
+    textStream: () => ReadableStream<string>
+  interface __internal.BunResponseOverride (bun-types/fetch.d.ts)
+    headers: BunHeadersOverride
+    textStream: () => ReadableStream<string>
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
+  type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
+  type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = true
+  type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebDecompressionStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebTextDecoderStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebTextEncoderStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeUtilTextDecoder (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeUtilTextEncoder (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeWritableStream<T> (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceEntry (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceMark (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceMeasure (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceObserver (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceObserverEntryList (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceResourceTiming (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrReadableByteStreamController (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrReadableStreamBYOBReader (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = {}
+  type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = {}
+  type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = {}
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = {}
+  type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
+  type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = typeof globalThis extends { [K in GlobalThisKeyName]: infer T; } ? T : Otherwise
+  type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+function allocUnsafe (bun-types/bun.d.ts)
+  call (size: number): Uint8Array<ArrayBuffer>
+var argv (bun-types/bun.d.ts): Array<string>
+function build (bun-types/bun.d.ts)
+  call (config: BuildConfig): Promise<BuildOutput>
+function color (bun-types/bun.d.ts)
+  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: ColorInput, outputFormat: "number"): null | number
+function concatArrayBuffers (bun-types/bun.d.ts)
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+function connect (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+var cron (bun-types/bun.d.ts)
+  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
+  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  remove: (title: string) => Promise<void>
+function deepEquals (bun-types/bun.d.ts)
+  call (a: any, b: any, strict?: boolean | undefined): boolean
+function deepMatch (bun-types/bun.d.ts)
+  call (subset: unknown, a: unknown): boolean
+function deflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+namespace dns (bun-types/bun.d.ts)
+  var dns.ADDRCONFIG (bun-types/bun.d.ts): number
+  var dns.ALL (bun-types/bun.d.ts): number
+  var dns.V4MAPPED (bun-types/bun.d.ts): number
+  function dns.getCacheStats (bun-types/bun.d.ts)
+    call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
+  function dns.lookup (bun-types/bun.d.ts)
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+  function dns.prefetch (bun-types/bun.d.ts)
+    call (hostname: string, port?: number | undefined): void
+var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
+var enableANSIColors (bun-types/bun.d.ts): boolean
+var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+function escapeHTML (bun-types/bun.d.ts)
+  call (input: boolean | number | object | string): string
+var fetch (bun-types/bun.d.ts): typeof fetch
+function file (bun-types/bun.d.ts)
+  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+function fileURLToPath (bun-types/bun.d.ts)
+  call (url: URL | string): string
+function gc (bun-types/bun.d.ts)
+  call (force?: boolean | undefined): void
+function generateHeapSnapshot (bun-types/bun.d.ts)
+  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format: "v8"): string
+  call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
+function gunzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function gzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+function indexOfLine (bun-types/bun.d.ts)
+  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+function inflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function inspect (bun-types/bun.d.ts)
+  call (arg: any, options?: BunInspectOptions | undefined): string
+  custom: typeof custom
+  table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
+namespace inspect (bun-types/bun.d.ts)
+  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  function inspect.table (bun-types/bun.d.ts)
+    call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
+    call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
+var isMainThread (bun-types/bun.d.ts): boolean
+var isStandaloneExecutable (bun-types/bun.d.ts): boolean
+function listen (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+var main (bun-types/bun.d.ts): string
+namespace markdown (bun-types/bun.d.ts)
+  interface markdown.AnsiTheme (bun-types/bun.d.ts)
+    colors [?]: boolean | undefined
+    columns [?]: number | undefined
+    hyperlinks [?]: boolean | undefined
+    kittyGraphics [?]: boolean | undefined
+    light [?]: boolean | undefined
+  interface markdown.CellMeta (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+  interface markdown.CellProps (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+    children: Array<unknown>
+  interface markdown.ChildrenProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+  interface markdown.CodeBlockMeta (bun-types/bun.d.ts)
+    language [?]: string | undefined
+  interface markdown.CodeBlockProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    language [?]: string | undefined
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  interface markdown.ComponentOverrides (bun-types/bun.d.ts)
+    a [?]: Component<LinkProps> | undefined
+    blockquote [?]: Component<ChildrenProps> | undefined
+    br [?]: Component<{}> | undefined
+    code [?]: Component<ChildrenProps> | undefined
+    del [?]: Component<ChildrenProps> | undefined
+    em [?]: Component<ChildrenProps> | undefined
+    h1 [?]: Component<HeadingProps> | undefined
+    h2 [?]: Component<HeadingProps> | undefined
+    h3 [?]: Component<HeadingProps> | undefined
+    h4 [?]: Component<HeadingProps> | undefined
+    h5 [?]: Component<HeadingProps> | undefined
+    h6 [?]: Component<HeadingProps> | undefined
+    hr [?]: Component<{}> | undefined
+    html [?]: Component<ChildrenProps> | undefined
+    img [?]: Component<ImageProps> | undefined
+    li [?]: Component<ListItemProps> | undefined
+    math [?]: Component<ChildrenProps> | undefined
+    ol [?]: Component<OrderedListProps> | undefined
+    p [?]: Component<ChildrenProps> | undefined
+    pre [?]: Component<CodeBlockProps> | undefined
+    strong [?]: Component<ChildrenProps> | undefined
+    table [?]: Component<ChildrenProps> | undefined
+    tbody [?]: Component<ChildrenProps> | undefined
+    td [?]: Component<CellProps> | undefined
+    th [?]: Component<CellProps> | undefined
+    thead [?]: Component<ChildrenProps> | undefined
+    tr [?]: Component<ChildrenProps> | undefined
+    u [?]: Component<ChildrenProps> | undefined
+    ul [?]: Component<ChildrenProps> | undefined
+  interface markdown.HeadingMeta (bun-types/bun.d.ts)
+    id [?]: string | undefined
+    level: number
+  interface markdown.HeadingProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    id [?]: string | undefined
+  interface markdown.ImageMeta (bun-types/bun.d.ts)
+    src: string
+    title [?]: string | undefined
+  interface markdown.ImageProps (bun-types/bun.d.ts)
+    alt [?]: string | undefined
+    src: string
+    title [?]: string | undefined
+  interface markdown.LinkMeta (bun-types/bun.d.ts)
+    href: string
+    title [?]: string | undefined
+  interface markdown.LinkProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    href: string
+    title [?]: string | undefined
+  interface markdown.ListItemMeta (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    depth: number
+    index: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.ListItemProps (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    children: Array<unknown>
+  interface markdown.ListMeta (bun-types/bun.d.ts)
+    depth: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.Options (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.OrderedListProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    start: number
+  interface markdown.ReactOptions (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    reactVersion [?]: 18 | 19 | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.RenderCallbacks (bun-types/bun.d.ts)
+    blockquote [?]: ((children: string) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    codespan [?]: ((children: string) => null | string | undefined) | undefined
+    emphasis [?]: ((children: string) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    hr [?]: ((children: string) => null | string | undefined) | undefined
+    html [?]: ((children: string) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    paragraph [?]: ((children: string) => null | string | undefined) | undefined
+    strikethrough [?]: ((children: string) => null | string | undefined) | undefined
+    strong [?]: ((children: string) => null | string | undefined) | undefined
+    table [?]: ((children: string) => null | string | undefined) | undefined
+    tbody [?]: ((children: string) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    text [?]: ((text: string) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    thead [?]: ((children: string) => null | string | undefined) | undefined
+    tr [?]: ((children: string) => null | string | undefined) | undefined
+  function markdown.ansi (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+  function markdown.html (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+  function markdown.react (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+  function markdown.render (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+function mmap (bun-types/bun.d.ts)
+  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+function nanoseconds (bun-types/bun.d.ts)
+  call (): number
+function openInEditor (bun-types/bun.d.ts)
+  call (path: string, options?: EditorOptions | undefined): void
+var password (bun-types/bun.d.ts)
+  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
+  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+function pathToFileURL (bun-types/bun.d.ts)
+  call (path: string): URL
+function peek (bun-types/bun.d.ts)
+  call <T = undefined>(promise: Promise<T> | T): Promise<T> | T
+  status: <T = undefined>(promise: Promise<T> | T) => "fulfilled" | "pending" | "rejected"
+namespace peek (bun-types/bun.d.ts)
+  function peek.status (bun-types/bun.d.ts)
+    call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
+var plugin (bun-types/bun.d.ts): BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): SQL
+function randomUUIDv5 (bun-types/bun.d.ts)
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+function randomUUIDv7 (bun-types/bun.d.ts)
+  call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
+  call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
+function readableStreamToArray (bun-types/bun.d.ts)
+  call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
+function readableStreamToArrayBuffer (bun-types/bun.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+function readableStreamToBlob (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<Blob>
+function readableStreamToBytes (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+function readableStreamToFormData (bun-types/bun.d.ts)
+  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+function readableStreamToJSON (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<any>
+function readableStreamToText (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<string>
+var redis (bun-types/redis.d.ts): RedisClient
+function resolve (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): Promise<string>
+function resolveSync (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): string
+var revision (bun-types/bun.d.ts): string
+var s3 (bun-types/s3.d.ts): S3Client
+var secrets (bun-types/bun.d.ts)
+  delete: (options: { service: string; name: string; }) => Promise<boolean>
+  get: (options: { service: string; name: string; }) => Promise<string | null>
+  set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
+namespace semver (bun-types/bun.d.ts)
+  function semver.order (bun-types/bun.d.ts)
+    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+  function semver.satisfies (bun-types/bun.d.ts)
+    call (version: StringLike, range: StringLike): boolean
+function serve (bun-types/serve.d.ts)
+  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+function sha (bun-types/bun.d.ts)
+  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
+  call (input: StringOrBuffer, encoding: DigestEncoding): string
+function shrink (bun-types/bun.d.ts)
+  call (): void
+function sleep (bun-types/bun.d.ts)
+  call (ms: Date | number): Promise<void>
+function sleepSync (bun-types/bun.d.ts)
+  call (ms: number): void
+function sliceAnsi (bun-types/bun.d.ts)
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+function spawn (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+function spawnSync (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): SQL
+var stderr (bun-types/bun.d.ts): BunFile
+var stdin (bun-types/bun.d.ts): BunFile
+var stdout (bun-types/bun.d.ts): BunFile
+function stringWidth (bun-types/bun.d.ts)
+  call (input: string, options?: StringWidthOptions | undefined): number
+function stripANSI (bun-types/bun.d.ts)
+  call (input: string): string
+namespace udp (bun-types/bun.d.ts)
+  interface udp.BaseUDPSocket (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    connect: { hostname: string; port: number; }
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: SocketAddress
+    send: (data: Data) => boolean
+    sendMany: (packets: ReadonlyArray<Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ReceiveFlags (bun-types/bun.d.ts)
+    ipv6: boolean
+    truncated: boolean
+  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: SocketHandler<DataBinaryType>) => void
+    send: (data: Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: SocketHandler<DataBinaryType> | undefined
+function udpSocket (bun-types/bun.d.ts)
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+namespace unsafe (bun-types/bun.d.ts)
+  function unsafe.arrayBufferToString (bun-types/bun.d.ts)
+    call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
+    call (buffer: Uint16Array<ArrayBufferLike>): string
+  function unsafe.gcAggressionLevel (bun-types/bun.d.ts)
+    call (level?: 0 | 1 | 2 | undefined): 0 | 1 | 2
+  function unsafe.memoryFootprint (bun-types/bun.d.ts)
+    call (): number | undefined
+  function unsafe.mimallocDump (bun-types/bun.d.ts)
+    call (): void
+var version (bun-types/bun.d.ts): string
+var version_with_sha (bun-types/bun.d.ts): string
+function which (bun-types/bun.d.ts)
+  call (command: string, options?: WhichOptions | undefined): null | string
+function wrapAnsi (bun-types/bun.d.ts)
+  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+function write (bun-types/bun.d.ts)
+  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+function zstdCompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+function zstdCompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+function zstdDecompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+function zstdDecompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+
+# module "bun:bundle"
+interface Registry (bun-types/bundle.d.ts)
+function feature (bun-types/bundle.d.ts)
+  call (flag: string): boolean
+
+# module "bun:ffi"
+function CFunction (bun-types/ffi.d.ts)
+  call (fn: FFIFunction & { ptr: number | bigint | Pointer; }): CallableFunction & { close(): void; }
+type CString (bun-types/ffi.d.ts) = string
+var CString (bun-types/ffi.d.ts): CStringConstructor
+interface CStringConstructor (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+  construct new (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts) = { [K in keyof Fns]: { (...args: Fns[K]["args"] extends infer A extends ReadonlyArray<FFITypeOrString> ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>]; } : [unknown] extends [Fns[K]["args"]] ? [] : never): [unknown] extends [Fns[K]["returns"]] ? undefined : FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>]; __ffi_function_callable: typeof FFIFunctionCallableSymbol; }; }
+interface FFIFunction (bun-types/ffi.d.ts)
+  args [? readonly]: ReadonlyArray<FFITypeOrString> | undefined
+  ptr [? readonly]: Pointer | bigint | undefined
+  returns [? readonly]: FFITypeOrString | undefined
+  threadsafe [? readonly]: boolean | undefined
+var FFIFunctionCallableSymbol (bun-types/ffi.d.ts): typeof FFIFunctionCallableSymbol
+enum FFIType (bun-types/ffi.d.ts)
+  char = FFIType.char
+  int8_t = FFIType.int8_t
+  i8 = FFIType.int8_t
+  uint8_t = FFIType.uint8_t
+  u8 = FFIType.uint8_t
+  int16_t = FFIType.int16_t
+  i16 = FFIType.int16_t
+  uint16_t = FFIType.uint16_t
+  u16 = FFIType.uint16_t
+  int32_t = FFIType.int32_t
+  i32 = FFIType.int32_t
+  int = FFIType.int32_t
+  uint32_t = FFIType.uint32_t
+  u32 = FFIType.uint32_t
+  int64_t = FFIType.int64_t
+  i64 = FFIType.int64_t
+  uint64_t = FFIType.uint64_t
+  u64 = FFIType.uint64_t
+  double = FFIType.double
+  f64 = FFIType.double
+  float = FFIType.float
+  f32 = FFIType.float
+  bool = FFIType.bool
+  ptr = FFIType.ptr
+  pointer = FFIType.ptr
+  void = FFIType.void
+  cstring = FFIType.cstring
+  i64_fast = FFIType.i64_fast
+  u64_fast = FFIType.u64_fast
+  function = FFIType.function
+  napi_env = FFIType.napi_env
+  napi_value = FFIType.napi_value
+  buffer = FFIType.buffer
+  buffer_length = FFIType.buffer_length
+type FFITypeOrString (bun-types/ffi.d.ts) = FFIType | keyof FFITypeStringToType
+interface FFITypeStringToType (bun-types/ffi.d.ts)
+  bool: FFIType.bool
+  buffer: FFIType.buffer
+  buffer_bytelength: FFIType.buffer_length
+  buffer_length: FFIType.buffer_length
+  callback: FFIType.ptr
+  char: FFIType.char
+  cstring: FFIType.cstring
+  double: FFIType.double
+  f32: FFIType.float
+  f64: FFIType.double
+  float: FFIType.float
+  function: FFIType.ptr
+  i16: FFIType.int16_t
+  i32: FFIType.int32_t
+  i64: FFIType.int64_t
+  i8: FFIType.int8_t
+  int: FFIType.int32_t
+  int16_t: FFIType.int16_t
+  int32_t: FFIType.int32_t
+  int64_t: FFIType.int64_t
+  int8_t: FFIType.int8_t
+  napi_env: FFIType.napi_env
+  napi_value: FFIType.napi_value
+  pointer: FFIType.ptr
+  ptr: FFIType.ptr
+  u16: FFIType.uint16_t
+  u32: FFIType.uint32_t
+  u64: FFIType.uint64_t
+  u8: FFIType.uint8_t
+  uint16_t: FFIType.uint16_t
+  uint32_t: FFIType.uint32_t
+  uint64_t: FFIType.uint64_t
+  uint8_t: FFIType.uint8_t
+  usize: FFIType.uint64_t
+  void: FFIType.void
+interface FFITypeToArgsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  13: undefined
+  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  15: bigint | number
+  16: bigint | number
+  17: JSCallback | Pointer
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint | number
+  8: bigint | number
+  9: number
+interface FFITypeToReturnsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | bigint | null
+  13: undefined
+  14: null | string
+  15: bigint | number
+  16: bigint | number
+  17: Pointer | bigint | null
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint
+  8: bigint
+  9: number
+class JSCallback (bun-types/ffi.d.ts)
+  close: () => void
+  ptr [readonly]: Pointer | null
+  threadsafe [readonly]: boolean
+  [static]
+    construct new (callback: (...args: Array<any>) => any, definition: FFIFunction): JSCallback
+    prototype: JSCallback
+interface Library<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts)
+  close: () => void
+  symbols: ConvertFns<Fns>
+type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
+type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
+type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
+function cc (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+function dlopen (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+function linkSymbols (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
+function ptr (bun-types/ffi.d.ts)
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+namespace read (bun-types/ffi.d.ts)
+  function read.f32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.f64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.i8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.intptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.ptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.u8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+var suffix (bun-types/ffi.d.ts): string
+function toArrayBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): ArrayBuffer
+function toBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): Buffer<ArrayBufferLike>
+function viewSource (bun-types/ffi.d.ts)
+  call (symbols: Readonly<Record<string, FFIFunction>>, is_callback?: false | undefined): Array<string>
+  call (callback: FFIFunction, is_callback: true): string
+
+# module "bun:jsc"
+interface HeapStats (bun-types/jsc.d.ts)
+  extraMemorySize: number
+  globalObjectCount: number
+  heapCapacity: number
+  heapSize: number
+  objectCount: number
+  objectTypeCounts: Record<string, number>
+  protectedGlobalObjectCount: number
+  protectedObjectCount: number
+  protectedObjectTypeCounts: Record<string, number>
+interface MemoryUsage (bun-types/jsc.d.ts)
+  current: number
+  currentCommit: number
+  pageFaults: number
+  peak: number
+  peakCommit: number
+interface SamplingProfile (bun-types/jsc.d.ts)
+  bytecodes: string
+  functions: string
+  stackTraces: SamplingProfileStackTraces
+interface SamplingProfileStackFrame (bun-types/jsc.d.ts)
+  category: string
+  column: number
+  flags: number
+  inliner [?]: undefined | { name: string; location: string; line: number; column: number; category: string; }
+  line: number
+  location: string
+  name: string
+  sourceID: number
+  sourceURL [?]: string | undefined
+interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
+  interval: number
+  sources: Array<{ sourceID: number; url?: string | undefined; sourceURL?: string | undefined; sourceMappingURL?: string | undefined; }>
+  traces: Array<{ timestamp: number; frames: Array<SamplingProfileStackFrame>; }>
+function callerSourceOrigin (bun-types/jsc.d.ts)
+  call (): null | string
+function deserialize (bun-types/jsc.d.ts)
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+function drainMicrotasks (bun-types/jsc.d.ts)
+  call (): void
+function edenGC (bun-types/jsc.d.ts)
+  call (): number
+function estimateShallowMemoryUsageOf (bun-types/jsc.d.ts)
+  call (value: CallableFunction | bigint | object | string | symbol): number
+function fullGC (bun-types/jsc.d.ts)
+  call (): number
+function gcAndSweep (bun-types/jsc.d.ts)
+  call (): number
+function getProtectedObjects (bun-types/jsc.d.ts)
+  call (): Array<any>
+function getRandomSeed (bun-types/jsc.d.ts)
+  call (): number
+function heapSize (bun-types/jsc.d.ts)
+  call (): number
+function heapStats (bun-types/jsc.d.ts)
+  call (): HeapStats
+function isRope (bun-types/jsc.d.ts)
+  call (input: string): boolean
+function jscDescribe (bun-types/jsc.d.ts)
+  call (value: any): string
+function jscDescribeArray (bun-types/jsc.d.ts)
+  call (array: Array<any>): string
+function memoryUsage (bun-types/jsc.d.ts)
+  call (): MemoryUsage
+function noFTL (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function noOSRExitFuzzing (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function numberOfDFGCompiles (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function optimizeNextInvocation (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function profile (bun-types/jsc.d.ts)
+  call <T extends (...args: Array<any>) => any>(callback: T, sampleInterval?: number | undefined, ...args: Parameters<T>): ReturnType<T> extends Promise<infer U> ? Promise<SamplingProfile> : SamplingProfile
+function releaseWeakRefs (bun-types/jsc.d.ts)
+  call (): void
+function reoptimizationRetryCount (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function serialize (bun-types/jsc.d.ts)
+  call (value: any, options?: undefined | { binaryType?: "arraybuffer" | undefined; }): SharedArrayBuffer
+  call (value: any, options?: undefined | { binaryType: "nodebuffer"; }): Buffer<ArrayBufferLike>
+function setRandomSeed (bun-types/jsc.d.ts)
+  call (value: number): void
+function setTimeZone (bun-types/jsc.d.ts)
+  call (timeZone: string): string
+function startRemoteDebugger (bun-types/jsc.d.ts)
+  call (host?: string | undefined, port?: number | undefined): void
+function startSamplingProfiler (bun-types/jsc.d.ts)
+  call (optionalDirectory?: string | undefined, sampleInterval?: number | undefined): void
+function totalCompileTime (bun-types/jsc.d.ts)
+  call (): number
+
+# module "bun:sqlite"
+interface Changes (bun-types/sqlite.d.ts)
+  changes: number
+  lastInsertRowid: bigint | number
+class Database (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  close: (throwOnError?: boolean | undefined) => void
+  exec: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  fileControl: { (op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number; (zDbName: string, op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number }
+  filename [readonly]: string
+  handle [readonly]: number
+  inTransaction: boolean
+  loadExtension: (extension: string, entryPoint?: string | undefined) => void
+  prepare: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string, params?: ParamsType | undefined) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  query: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  run: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  serialize: (name?: string | undefined) => Buffer<ArrayBufferLike>
+  transaction: <A extends Array<any>, T>(insideTransaction: (...args: A) => T) => { (...args: A): T; deferred: (...args: A) => T; immediate: (...args: A) => T; exclusive: (...args: A) => T; }
+  [static]
+    construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
+    MAX_QUERY_CACHE_SIZE [static]: number
+    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
+    prototype: Database
+    setCustomSQLite [static]: (path: string) => boolean
+interface DatabaseOptions (bun-types/sqlite.d.ts)
+  create [?]: boolean | undefined
+  readonly [?]: boolean | undefined
+  readwrite [?]: boolean | undefined
+  safeIntegers [?]: boolean | undefined
+  strict [?]: boolean | undefined
+type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+class SQLiteError (bun-types/sqlite.d.ts)
+  byteOffset [readonly]: number
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno: number
+  message: string
+  name [readonly]: "SQLiteError"
+  stack [?]: string | undefined
+  [static]
+    construct new (message?: string | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+    isError: (value: unknown) => value is Error
+    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prototype: SQLiteError
+    stackTraceLimit: number
+class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  [Symbol.iterator]: () => IterableIterator<ReturnType>
+  all: (...params: ParamsType) => Array<ReturnType>
+  as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
+  columnNames [readonly]: Array<string>
+  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
+  declaredTypes [readonly]: Array<string | null>
+  finalize: () => void
+  get: (...params: ParamsType) => ReturnType | null
+  iterate: (...params: ParamsType) => IterableIterator<ReturnType>
+  native [readonly]: any
+  paramsCount [readonly]: number
+  raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
+  run: (...params: ParamsType) => Changes
+  toString: () => string
+  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  [static]
+    construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
+    prototype: Statement<any, any>
+namespace constants (bun-types/sqlite.d.ts)
+  var constants.SQLITE_FCNTL_BEGIN_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_BUSYHANDLER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CHUNK_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_DONE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_START (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKSM_FILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_PHASETWO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_DATA_VERSION (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_EXTERNAL_READER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_FILE_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_GET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_HAS_MOVED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_JOURNAL_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LAST_ERRNO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCKSTATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCK_TIMEOUT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_MMAP_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PDB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PERSIST_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_POWERSAFE_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PRAGMA (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RBU (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESERVE_BYTES (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESET_CACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_HINT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_LIMIT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC_OMITTED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TEMPFILENAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TRACE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFSNAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFS_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WAL_BLOCK (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_AV_RETRY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_GET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_SET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ZIPVFS (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_AUTOPROXY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_CREATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_DELETEONCLOSE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXCLUSIVE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXRESCODE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_FULLMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MEMORY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOFOLLOW (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_PRIVATECACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READONLY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SHAREDCACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUBJOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUPER_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TRANSIENT_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_URI (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NORMALIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NO_VTAB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_PERSISTENT (bun-types/sqlite.d.ts): number
+default -> Database
+var native (bun-types/sqlite.d.ts): any
+
+# module "bun:test"
+type AsymmetricMatcher (bun-types/test.d.ts) = any
+interface AsymmetricMatchers (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+type CustomMatcher<E, P extends Array<any>> (bun-types/test.d.ts) = (this: MatcherContext, expected: E, ...matcherArguments: P) => MatcherResult | Promise<MatcherResult>
+type CustomMatchersDetected (bun-types/test.d.ts) = Omit<Matchers<unknown>, keyof MatchersBuiltin<unknown>> & Omit<AsymmetricMatchers, keyof AsymmetricMatchersBuiltin>
+interface Describe<T extends ReadonlyArray<any>> (bun-types/test.d.ts)
+  call (fn: () => void): void
+  call (label: DescribeLabel, fn: (...args: T) => void): void
+  concurrent: Describe<T>
+  each: { <T extends readonly [any, ...any[]]>(table: ReadonlyArray<T>): Describe<[...T]>; <T extends Array<any>>(table: ReadonlyArray<T>): Describe<[...T]>; <T>(table: Array<T>): Describe<[T]> }
+  if: (condition: boolean) => Describe<T>
+  only: Describe<T>
+  serial: Describe<T>
+  skip: Describe<T>
+  skipIf: (condition: boolean) => Describe<T>
+  todo: Describe<T>
+  todoIf: (condition: boolean) => Describe<T>
+type EqualsFunction (bun-types/test.d.ts) = (a: unknown, b: unknown) => boolean
+interface Expect (bun-types/test.d.ts)
+  call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
+  call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
+  call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  assertions: (neededAssertions: number) => void
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  extend: <M>(matchers: ExpectExtendMatchers<M>) => void
+  hasAssertions: () => void
+  not: ExpectNot
+  objectContaining: (obj: object) => any
+  rejectsTo: AsymmetricMatchers
+  resolvesTo: AsymmetricMatchers
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+  unreachable: (msg?: Error | string | undefined) => never
+type ExpectExtendMatchers<M> (bun-types/test.d.ts) = { [k in keyof M]: k extends never ? CustomMatcher<unknown, Parameters<CustomMatchersDetected[k]>> : CustomMatcher<unknown, Array<any>>; }
+interface MatcherResult (bun-types/test.d.ts)
+  message [?]: (() => string) | string | undefined
+  pass: boolean
+interface Matchers<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
+  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  concurrent: Test<T>
+  concurrentIf: (condition: boolean) => Test<T>
+  each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
+  failing: Test<T>
+  failingIf: (condition: boolean) => Test<T>
+  if: (condition: boolean) => Test<T>
+  only: Test<T>
+  serial: Test<T>
+  serialIf: (condition: boolean) => Test<T>
+  skip: Test<T>
+  skipIf: (condition: boolean) => Test<T>
+  todo: Test<T>
+  todoIf: (condition: boolean) => Test<T>
+interface TestOptions (bun-types/test.d.ts)
+  repeats [?]: number | undefined
+  retry [?]: number | undefined
+  timeout [?]: number | undefined
+type Tester (bun-types/test.d.ts) = (this: TesterContext, a: any, b: any, customTesters: Array<Tester>) => boolean | undefined
+interface TesterContext (bun-types/test.d.ts)
+  equals: EqualsFunction
+function afterAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function afterEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+var describe (bun-types/test.d.ts): Describe<[]>
+var expect (bun-types/test.d.ts): Expect
+var expectTypeOf (bun-types/test.d.ts)
+  call <Actual>(actual: Actual): PositiveExpectTypeOf<Actual>
+  call <Actual>(): PositiveExpectTypeOf<Actual>
+var it (bun-types/test.d.ts): Test<[]>
+namespace jest (bun-types/test.d.ts)
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
+  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  function jest.advanceTimersByTime (bun-types/test.d.ts)
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.clearAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.clearAllTimers (bun-types/test.d.ts)
+    call (): void
+  function jest.fn (bun-types/test.d.ts)
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+  function jest.getTimerCount (bun-types/test.d.ts)
+    call (): number
+  function jest.isFakeTimers (bun-types/test.d.ts)
+    call (): boolean
+  function jest.resetAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.restoreAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.runAllTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.runOnlyPendingTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.setSystemTime (bun-types/test.d.ts)
+    call (now?: Date | number | undefined): void
+  function jest.setTimeout (bun-types/test.d.ts)
+    call (milliseconds: number): void
+  function jest.spyOn (bun-types/test.d.ts)
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+  function jest.useFakeTimers (bun-types/test.d.ts)
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.useRealTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var mock (bun-types/test.d.ts)
+  call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
+  clearAllMocks: () => void
+  module: (id: string, factory: () => any) => Promise<void> | void
+  restore: () => void
+function onTestFinished (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function setDefaultTimeout (bun-types/test.d.ts)
+  call (milliseconds: number): void
+function setSystemTime (bun-types/test.d.ts)
+  call (now?: Date | number | undefined): ThisType<void>
+function spyOn (bun-types/test.d.ts)
+  call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+test -> it
+var vi (bun-types/test.d.ts)
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  clearAllMocks: () => void
+  clearAllTimers: () => void
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  getTimerCount: () => number
+  isFakeTimers: () => boolean
+  mock: (id: string, factory: () => any) => Promise<void> | void
+  resetAllMocks: () => void
+  restoreAllMocks: () => void
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var xdescribe (bun-types/test.d.ts): Describe<[]>
+var xit (bun-types/test.d.ts): Test<[]>
+xtest -> xit
+
+# globals
+interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  abort: { (reason?: any): void; (reason?: any): void }
+  signal [readonly]: AbortSignal
+var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): AbortController
+  prototype: AbortController
+interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  aborted [readonly]: boolean
+  addEventListener: { <K extends "abort">(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onabort: ((this: AbortSignal, ev: Event) => any) | null
+  reason [readonly]: any
+  removeEventListener: { <K extends "abort">(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  throwIfAborted: { (): void; (): void }
+var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): AbortSignal
+  abort: (reason?: any) => AbortSignal
+  any: (signals: Array<AbortSignal>) => AbortSignal
+  prototype: AbortSignal
+  timeout: (milliseconds: number) => AbortSignal
+interface AddEventListenerOptions (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  [Symbol.toStringTag] [readonly]: "ArrayBuffer"
+  byteLength [readonly]: number
+  resize: (byteLength: number) => ArrayBuffer
+  slice: { (begin?: number | undefined, end?: number | undefined): ArrayBuffer; (begin: number, end?: number | undefined): ArrayBuffer }
+var ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts): ArrayBufferConstructor
+interface ArrayBufferConstructor (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2017.arraybuffer.d.ts, lib.es5.d.ts)
+  construct new (byteLength: number): ArrayBuffer
+  construct new (): ArrayBuffer
+  construct new (byteLength: number, options: { maxByteLength?: number | undefined; }): ArrayBuffer
+  [Symbol.species] [readonly]: ArrayBufferConstructor
+  isView: (arg: any) => arg is ArrayBufferView<ArrayBufferLike>
+  prototype [readonly]: ArrayBuffer
+interface ArrayConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  call (arrayLength?: number | undefined): Array<any>
+  call <T>(arrayLength: number): Array<T>
+  call <T>(...items: Array<T>): Array<T>
+  construct new (arrayLength?: number | undefined): Array<any>
+  construct new <T>(arrayLength: number): Array<T>
+  construct new <T>(...items: Array<T>): Array<T>
+  [Symbol.species] [readonly]: ArrayConstructor
+  from: { <T>(arrayLike: ArrayLike<T>): Array<T>; <T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>; <T>(iterable: ArrayLike<T> | Iterable<T>): Array<T>; <T, U>(iterable: ArrayLike<T> | Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U> }
+  fromAsync: { <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
+  isArray: (arg: any) => arg is any[]
+  of: <T>(...items: Array<T>) => Array<T>
+  prototype [readonly]: Array<any>
+interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
+interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  endings [?]: EndingType | undefined
+  type [?]: string | undefined
+interface BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  name [readonly]: string
+  onmessage: ((this: BroadcastChannel, ev: MessageEvent<any>) => any) | null
+  onmessageerror: ((this: BroadcastChannel, ev: MessageEvent<any>) => any) | null
+  postMessage: (message: any) => void
+  removeEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+var BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (name: string): BroadcastChannel
+  prototype: BroadcastChannel
+var BuildError (bun-types/deprecated.d.ts): typeof BuildMessage
+class BuildMessage (bun-types/globals.d.ts)
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "BuildMessage"
+  position [readonly]: Position | null
+  [static]
+    construct new (): BuildMessage
+    prototype: BuildMessage
+Bun -> module "bun"
+interface BunFetchRequestInit (bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
+  credentials [?]: RequestCredentials | undefined
+  decompress [?]: boolean | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  maxRedirects [?]: number | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  priority [?]: RequestPriority | undefined
+  protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  s3 [?]: S3Options | undefined
+  signal [?]: AbortSignal | null | undefined
+  timeout [?]: boolean | number | undefined
+  tls [?]: BunFetchRequestInitTLS | undefined
+  unix [?]: string | undefined
+  verbose [?]: boolean | undefined
+  window [?]: null | undefined
+interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<ArrayBufferView<ArrayBufferLike>>
+var ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init: QueuingStrategyInit): ByteLengthQueuingStrategy
+  prototype: ByteLengthQueuingStrategy
+interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  code [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  reason [readonly]: string
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  wasClean [readonly]: boolean
+var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  prototype: CloseEvent
+interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  writable [readonly]: WritableStream<BufferSource>
+var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (format: CompressionFormat): CompressionStream
+  prototype: CompressionStream
+interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
+  assert: { (condition?: boolean | undefined, ...data: Array<any>): void; (condition?: boolean | undefined, ...data: Array<any>): void }
+  clear: { (): void; (): void }
+  count: { (label?: string | undefined): void; (label?: string | undefined): void }
+  countReset: { (label?: string | undefined): void; (label?: string | undefined): void }
+  debug: { (...data: Array<any>): void; (...data: Array<any>): void }
+  dir: { (item?: any, options?: any): void; (item?: any, options?: any): void }
+  dirxml: { (...data: Array<any>): void; (...data: Array<any>): void }
+  error: { (...data: Array<any>): void; (...data: Array<any>): void }
+  group: { (...data: Array<any>): void; (...data: Array<any>): void }
+  groupCollapsed: { (...data: Array<any>): void; (...data: Array<any>): void }
+  groupEnd: { (): void; (): void }
+  info: { (...data: Array<any>): void; (...data: Array<any>): void }
+  log: { (...data: Array<any>): void; (...data: Array<any>): void }
+  profile: (label?: string | undefined) => void
+  profileEnd: (label?: string | undefined) => void
+  table: { (tabularData?: any, properties?: Array<string> | undefined): void; (tabularData?: any, properties?: Array<string> | undefined): void }
+  time: { (label?: string | undefined): void; (label?: string | undefined): void }
+  timeEnd: { (label?: string | undefined): void; (label?: string | undefined): void }
+  timeLog: { (label?: string | undefined, ...data: Array<any>): void; (label?: string | undefined, ...data: Array<any>): void }
+  timeStamp: { (label?: string | undefined): void; (label?: string | undefined): void }
+  trace: { (...data: Array<any>): void; (...data: Array<any>): void }
+  warn: { (...data: Array<any>): void; (...data: Array<any>): void }
+  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+interface ConsoleOptions (bun-types/globals.d.ts)
+  colorMode [?]: "auto" | boolean | undefined
+  groupIndentation [?]: number | undefined
+  ignoreErrors [?]: boolean | undefined
+  inspectOptions [?]: InspectOptions | undefined
+  stderr [?]: Writable | undefined
+  stdout: Writable
+interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<any>
+var CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init: QueuingStrategyInit): CountQueuingStrategy
+  prototype: CountQueuingStrategy
+interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  getRandomValues: { <T extends ArrayBufferView<ArrayBuffer>>(array: T): T; <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T): T }
+  randomUUID: { (): `${string}-${string}-${string}-${string}-${string}`; (): `${string}-${string}-${string}-${string}-${string}` }
+  subtle [readonly]: SubtleCrypto
+  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): Crypto
+  prototype: Crypto
+interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  algorithm [readonly]: KeyAlgorithm
+  extractable [readonly]: boolean
+  type [readonly]: KeyType
+  usages [readonly]: Array<KeyUsage>
+var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): CryptoKey
+  prototype: CryptoKey
+interface CryptoKeyPair (bun-types/globals.d.ts, lib.dom.d.ts)
+  privateKey: CryptoKey
+  publicKey: CryptoKey
+interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  detail [readonly]: T
+  eventPhase [readonly]: number
+  initCustomEvent: { (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, detail?: T | undefined): void; (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, detail?: T | undefined): void }
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  prototype: CustomEvent<any>
+interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  cause [?]: unknown
+  code [readonly]: number
+  message [readonly]: string
+  name [readonly]: string
+  stack [?]: string | undefined
+var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (message?: string | undefined, name?: string | undefined): DOMException
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  prototype: DOMException
+interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  writable [readonly]: WritableStream<BufferSource>
+var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (format: CompressionFormat): DecompressionStream
+  prototype: DecompressionStream
+interface Dict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined
+interface ErrnoException (bun-types/globals.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts)
+  cause [?]: unknown
+  message: string
+  name: string
+  stack [?]: string | undefined
+var Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts): ErrorConstructor
+interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts)
+  call (message?: string | undefined): Error
+  call (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+  isError: (value: unknown) => value is Error
+  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prototype [readonly]: Error
+  stackTraceLimit: number
+interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  colno [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  error [readonly]: any
+  eventPhase [readonly]: number
+  filename [readonly]: string
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  lineno [readonly]: number
+  message [readonly]: string
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  prototype: ErrorEvent
+interface ErrorOptions (bun-types/globals.d.ts, lib.es2022.error.d.ts)
+  cause [?]: unknown
+interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  prototype: Event
+interface EventListener (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (evt: Event): void
+  call (evt: Event): void
+interface EventListenerObject (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  handleEvent: { (object: Event): void; (object: Event): void }
+interface EventMap (bun-types/globals.d.ts)
+  fetch: FetchEvent
+  message: MessageEvent<any>
+  messageerror: MessageEvent<any>
+interface EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: MessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: Event) => any) | null
+  onmessage: ((this: EventSource, ev: MessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: number
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: MessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  prototype: EventSource
+interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  withCredentials [?]: boolean | undefined
+interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  removeEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean | undefined) => void
+var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): EventTarget
+  prototype: EventTarget
+interface FetchEvent (bun-types/globals.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified [readonly]: number
+  name [readonly]: string
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  webkitRelativePath [readonly]: string
+var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (fileBits: Array<BlobPart>, fileName: string, options?: FilePropertyBag | undefined): File
+  prototype: File
+interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.iterator]: () => FormDataIterator<[string, FormDataEntryValue]>
+  append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  delete: { (name: string): void; (name: string): void }
+  entries: { (): FormDataIterator<[string, FormDataEntryValue]>; (): IterableIterator<[string, string]> }
+  forEach: { (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void; (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void }
+  get: { (name: string): FormDataEntryValue | null; (name: string): FormDataEntryValue | null }
+  getAll: { (name: string): Array<FormDataEntryValue>; (name: string): Array<FormDataEntryValue> }
+  has: { (name: string): boolean; (name: string): boolean }
+  keys: { (): FormDataIterator<string>; (): IterableIterator<string> }
+  set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  values: { (): FormDataIterator<FormDataEntryValue>; (): IterableIterator<string> }
+var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (form?: HTMLFormElement | undefined, submitter?: HTMLElement | null | undefined): FormData
+  prototype: FormData
+class HTMLRewriter (bun-types/html-rewriter.d.ts)
+  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  [static]
+    construct new (): HTMLRewriter
+    prototype: HTMLRewriter
+namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
+  interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Comment
+    before: (content: string, options?: ContentOptions | undefined) => Comment
+    remove: () => Comment
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    text: string
+  type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
+  interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
+    html [?]: boolean | undefined
+  interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
+    name [readonly]: null | string
+    publicId [readonly]: null | string
+    remove: () => Doctype
+    removed [readonly]: boolean
+    systemId [readonly]: null | string
+  interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
+    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+  interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Element
+    append: (content: string, options?: ContentOptions | undefined) => Element
+    attributes [readonly]: IterableIterator<[string, string]>
+    before: (content: string, options?: ContentOptions | undefined) => Element
+    canHaveContent [readonly]: boolean
+    getAttribute: (name: string) => null | string
+    hasAttribute: (name: string) => boolean
+    namespaceURI [readonly]: string
+    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: ContentOptions | undefined) => Element
+    remove: () => Element
+    removeAndKeepContent: () => Element
+    removeAttribute: (name: string) => Element
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Element
+    selfClosing [readonly]: boolean
+    setAttribute: (name: string, value: string) => Element
+    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    tagName: string
+  interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => EndTag
+    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    name: string
+    remove: () => EndTag
+  interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: Element) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Text
+    before: (content: string, options?: ContentOptions | undefined) => Text
+    lastInTextNode [readonly]: boolean
+    remove: () => Text
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Text
+    text [readonly]: string
+interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.iterator]: () => HeadersIterator<[string, string]>
+  append: (name: string, value: string) => void
+  count [readonly]: number
+  delete: (name: string) => void
+  entries: () => HeadersIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+  getSetCookie: () => Array<string>
+  has: (name: string) => boolean
+  keys: () => HeadersIterator<string>
+  set: (name: string, value: string) => void
+  toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+  values: () => HeadersIterator<string>
+var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init?: HeadersInit | undefined): Headers
+  prototype: Headers
+interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.dom.d.ts, lib.es5.d.ts)
+  dir [readonly]: string
+  dirname: string
+  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  file [readonly]: string
+  filename: string
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  main: boolean
+  path [readonly]: string
+  require: Require
+  resolve: { (specifier: string): string; (specifier: string, parent?: URL | string | undefined): string }
+  resolveSync: (moduleId: string, parent?: string | undefined) => string
+  url: string
+interface ImportMetaEnv (bun-types/globals.d.ts)
+  index [string]: string | undefined
+var Loader (bun-types/globals.d.ts)
+  dependencyKeysIfEvaluated: (specifier: string) => Array<string>
+  registry: Map<string, { key: string; state: number; fetch: Promise<any>; instantiate: Promise<any>; satisfy: Promise<any>; dependencies: Array<any>; module: { dependenciesMap: Map<string, any>; }; linkError?: any; linkSucceeded: boolean; evaluated: boolean; then?: any; isAsync: boolean; }>
+  resolve: (specifier: string, referrer: string) => string
+interface MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  port1 [readonly]: MessagePort
+  port2 [readonly]: MessagePort
+var MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): MessageChannel
+  prototype: MessageChannel
+interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  initMessageEvent: { (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: MessageEventSource | null | undefined, ports?: Array<MessagePort> | undefined): void; (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: MessageEventSource | null | undefined, ports?: Iterable<MessagePort> | undefined): void }
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  prototype: MessageEvent<any>
+  returnValue: boolean
+  source [readonly]: MessageEventSource | null
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>
+  prototype: MessageEvent<any>
+interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (this: MessagePort, ev: MessagePortEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onmessage: ((this: MessagePort, ev: MessageEvent<any>) => any) | null
+  onmessageerror: ((this: MessagePort, ev: MessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  removeEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (this: MessagePort, ev: MessagePortEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  start: () => void
+var MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): MessagePort
+  prototype: MessagePort
+interface Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  appCodeName [readonly]: string
+  appName [readonly]: string
+  appVersion [readonly]: string
+  canShare: (data?: ShareData | undefined) => boolean
+  clearAppBadge: () => Promise<void>
+  clipboard [readonly]: Clipboard
+  cookieEnabled [readonly]: boolean
+  credentials [readonly]: CredentialsContainer
+  doNotTrack [readonly]: null | string
+  geolocation [readonly]: Geolocation
+  getGamepads: () => Array<Gamepad | null>
+  gpu [readonly]: GPU
+  hardwareConcurrency [readonly]: number
+  javaEnabled: () => boolean
+  language [readonly]: string
+  languages [readonly]: ReadonlyArray<string>
+  locks [readonly]: LockManager
+  login [readonly]: NavigatorLogin
+  maxTouchPoints [readonly]: number
+  mediaCapabilities [readonly]: MediaCapabilities
+  mediaDevices [readonly]: MediaDevices
+  mediaSession [readonly]: MediaSession
+  mimeTypes [readonly]: MimeTypeArray
+  onLine [readonly]: boolean
+  pdfViewerEnabled [readonly]: boolean
+  permissions [readonly]: Permissions
+  platform [readonly]: "Linux x86_64" | "MacIntel" | "Win32"
+  plugins [readonly]: PluginArray
+  product [readonly]: string
+  productSub [readonly]: string
+  registerProtocolHandler: (scheme: string, url: URL | string) => void
+  requestMIDIAccess: (options?: MIDIOptions | undefined) => Promise<MIDIAccess>
+  requestMediaKeySystemAccess: { (keySystem: string, supportedConfigurations: Array<MediaKeySystemConfiguration>): Promise<MediaKeySystemAccess>; (keySystem: string, supportedConfigurations: Iterable<MediaKeySystemConfiguration>): Promise<MediaKeySystemAccess> }
+  sendBeacon: (url: URL | string, data?: BodyInit | null | undefined) => boolean
+  serviceWorker [readonly]: ServiceWorkerContainer
+  setAppBadge: (contents?: number | undefined) => Promise<void>
+  share: (data?: ShareData | undefined) => Promise<void>
+  storage [readonly]: StorageManager
+  userActivation [readonly]: UserActivation
+  userAgent [readonly]: string
+  vendor [readonly]: string
+  vendorSub [readonly]: string
+  vibrate: { (pattern: VibratePattern): boolean; (pattern: Iterable<number>): boolean }
+  wakeLock [readonly]: WakeLock
+  webdriver [readonly]: boolean
+var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): Navigator
+  prototype: Navigator
+namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
+  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
+    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
+    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
+  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
+  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
+  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
+  interface NodeJS.CallSite (@types/node/globals.d.ts)
+    getColumnNumber: () => null | number
+    getEnclosingColumnNumber: () => null | number
+    getEnclosingLineNumber: () => null | number
+    getEvalOrigin: () => string | undefined
+    getFileName: () => null | string
+    getFunction: () => Function | undefined
+    getFunctionName: () => null | string
+    getLineNumber: () => null | number
+    getMethodName: () => null | string
+    getPosition: () => number
+    getPromiseIndex: () => null | number
+    getScriptHash: () => string
+    getScriptNameOrSourceURL: () => null | string
+    getThis: () => unknown
+    getTypeName: () => null | string
+    isAsync: () => boolean
+    isConstructor: () => boolean
+    isEval: () => boolean
+    isNative: () => boolean
+    isPromiseAll: () => boolean
+    isToplevel: () => boolean
+  interface NodeJS.CpuUsage (@types/node/process.d.ts)
+    system: number
+    user: number
+  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined
+  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
+  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
+    code [?]: string | undefined
+    ctor [?]: Function | undefined
+    detail [?]: string | undefined
+    type [?]: string | undefined
+  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
+    cause [?]: unknown
+    code [?]: string | undefined
+    errno [?]: number | undefined
+    message: string
+    name: string
+    path [?]: string | undefined
+    stack [?]: string | undefined
+    syscall [?]: string | undefined
+  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
+    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
+    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    setMaxListeners: (n: number) => EventEmitter<T>
+  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
+  interface NodeJS.GCFunction (@types/node/globals.d.ts)
+    call (minor?: boolean | undefined): void
+    call (options: GCOptions & { execution: "async"; }): Promise<void>
+    call (options: GCOptions): void
+  interface NodeJS.GCOptions (@types/node/globals.d.ts)
+    execution [?]: "async" | "sync" | undefined
+    filename [?]: string | undefined
+    flavor [?]: "last-resort" | "regular" | undefined
+    type [?]: "major" | "major-snapshot" | "minor" | undefined
+  interface NodeJS.HRTime (@types/node/process.d.ts)
+    call (time?: [number, number] | undefined): [number, number]
+    bigint: () => bigint
+  interface NodeJS.Immediate (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    _onImmediate: (...args: Array<any>) => void
+    hasRef: () => boolean
+    ref: () => Immediate
+    unref: () => Immediate
+  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
+    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
+    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
+  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
+    arrayBuffers: number
+    external: number
+    heapTotal: number
+    heapUsed: number
+    rss: number
+  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
+    call (): MemoryUsage
+    rss: () => number
+  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
+  interface NodeJS.Module (@types/node/module.d.ts)
+    children: Array<Module>
+    exports: any
+    filename: string
+    id: string
+    isPreloading: boolean
+    loaded: boolean
+    parent: Module | null | undefined
+    path: string
+    paths: Array<string>
+    require: (id: string) => any
+  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
+  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
+  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
+  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
+  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
+  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
+  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
+  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
+  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
+  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
+  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+  interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    _exiting: boolean
+    abort: () => never
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
+    allowedNodeEnvironmentFlags: ReadonlySet<string>
+    arch [readonly]: Architecture
+    argv: Array<string>
+    argv0: string
+    assert: (value: unknown, message?: Error | string | undefined) => asserts value
+    availableMemory: () => number
+    binding: { (m: "constants"): { os: typeof constants; fs: typeof constants; crypto: typeof constants; zlib: typeof constants; trace: { TRACE_EVENT_PHASE_BEGIN: number; TRACE_EVENT_PHASE_END: number; TRACE_EVENT_PHASE_COMPLETE: number; TRACE_EVENT_PHASE_INSTANT: number; TRACE_EVENT_PHASE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_ASYNC_STEP_INTO: number; TRACE_EVENT_PHASE_ASYNC_STEP_PAST: number; TRACE_EVENT_PHASE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_INSTANT: number; TRACE_EVENT_PHASE_FLOW_BEGIN: number; TRACE_EVENT_PHASE_FLOW_STEP: number; TRACE_EVENT_PHASE_FLOW_END: number; TRACE_EVENT_PHASE_METADATA: number; TRACE_EVENT_PHASE_COUNTER: number; TRACE_EVENT_PHASE_SAMPLE: number; TRACE_EVENT_PHASE_CREATE_OBJECT: number; TRACE_EVENT_PHASE_SNAPSHOT_OBJECT: number; TRACE_EVENT_PHASE_DELETE_OBJECT: number; TRACE_EVENT_PHASE_MEMORY_DUMP: number; TRACE_EVENT_PHASE_MARK: number; TRACE_EVENT_PHASE_CLOCK_SYNC: number; TRACE_EVENT_PHASE_ENTER_CONTEXT: number; TRACE_EVENT_PHASE_LEAVE_CONTEXT: number; TRACE_EVENT_PHASE_LINK_IDS: number; }; }; (m: "uv"): { errname(code: number): string; UV_E2BIG: number; UV_EACCES: number; UV_EADDRINUSE: number; UV_EADDRNOTAVAIL: number; UV_EAFNOSUPPORT: number; UV_EAGAIN: number; UV_EAI_ADDRFAMILY: number; UV_EAI_AGAIN: number; UV_EAI_BADFLAGS: number; UV_EAI_BADHINTS: number; UV_EAI_CANCELED: number; UV_EAI_FAIL: number; UV_EAI_FAMILY: number; UV_EAI_MEMORY: number; UV_EAI_NODATA: number; UV_EAI_NONAME: number; UV_EAI_OVERFLOW: number; UV_EAI_PROTOCOL: number; UV_EAI_SERVICE: number; UV_EAI_SOCKTYPE: number; UV_EALREADY: number; UV_EBADF: number; UV_EBUSY: number; UV_ECANCELED: number; UV_ECHARSET: number; UV_ECONNABORTED: number; UV_ECONNREFUSED: number; UV_ECONNRESET: number; UV_EDESTADDRREQ: number; UV_EEXIST: number; UV_EFAULT: number; UV_EFBIG: number; UV_EHOSTUNREACH: number; UV_EINTR: number; UV_EINVAL: number; UV_EIO: number; UV_EISCONN: number; UV_EISDIR: number; UV_ELOOP: number; UV_EMFILE: number; UV_EMSGSIZE: number; UV_ENAMETOOLONG: number; UV_ENETDOWN: number; UV_ENETUNREACH: number; UV_ENFILE: number; UV_ENOBUFS: number; UV_ENODEV: number; UV_ENOENT: number; UV_ENOMEM: number; UV_ENONET: number; UV_ENOPROTOOPT: number; UV_ENOSPC: number; UV_ENOSYS: number; UV_ENOTCONN: number; UV_ENOTDIR: number; UV_ENOTEMPTY: number; UV_ENOTSOCK: number; UV_ENOTSUP: number; UV_EOVERFLOW: number; UV_EPERM: number; UV_EPIPE: number; UV_EPROTO: number; UV_EPROTONOSUPPORT: number; UV_EPROTOTYPE: number; UV_ERANGE: number; UV_EROFS: number; UV_ESHUTDOWN: number; UV_ESPIPE: number; UV_ESRCH: number; UV_ETIMEDOUT: number; UV_ETXTBSY: number; UV_EXDEV: number; UV_UNKNOWN: number; UV_EOF: number; UV_ENXIO: number; UV_EMLINK: number; UV_EHOSTDOWN: number; UV_EREMOTEIO: number; UV_ENOTTY: number; UV_EFTYPE: number; UV_EILSEQ: number; UV_ESOCKTNOSUPPORT: number; UV_ENODATA: number; UV_EUNATCH: number; }; (m: "http_parser"): { methods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "QUERY"]; allMethods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "PRI", "DESCRIBE", "ANNOUNCE", "SETUP", "PLAY", "PAUSE", "TEARDOWN", "GET_PARAMETER", "SET_PARAMETER", "REDIRECT", "RECORD", "FLUSH", "QUERY"]; HTTPParser: unknown; ConnectionsList: unknown; }; (m: string): object }
+    browser: boolean
+    channel [?]: Control | undefined
+    chdir: (directory: string) => void
+    config [readonly]: ProcessConfig
+    connected: boolean
+    constrainedMemory: () => number
+    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cwd: () => string
+    debugPort: number
+    disconnect [?]: (() => void) | undefined
+    dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
+    emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
+    env: ProcessEnv
+    eventNames: () => Array<string | symbol>
+    execArgv: Array<string>
+    execPath: string
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    exit: (code?: null | number | string | undefined) => never
+    exitCode: null | number | string | undefined
+    features [readonly]: ProcessFeatures
+    finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
+    getActiveResourcesInfo: () => Array<string>
+    getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
+    getMaxListeners: () => number
+    getegid [?]: (() => number) | undefined
+    geteuid [?]: (() => number) | undefined
+    getgid [?]: (() => number) | undefined
+    getgroups [?]: (() => Array<number>) | undefined
+    getuid [?]: (() => number) | undefined
+    hasUncaughtExceptionCaptureCallback: () => boolean
+    hrtime: HRTime
+    isBun: true
+    kill: (pid: number, signal?: number | string | undefined) => true
+    listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    loadEnvFile: (path?: PathLike | undefined) => void
+    mainModule [?]: Module | undefined
+    memoryUsage: MemoryUsageFn
+    nextTick: (callback: Function, ...args: Array<any>) => void
+    noDeprecation [?]: boolean | undefined
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    permission: ProcessPermission
+    pid [readonly]: number
+    platform [readonly]: Platform
+    ppid [readonly]: number
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    reallyExit: (code?: number | undefined) => never
+    ref: (maybeRefable: any) => void
+    release [readonly]: ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    report: ProcessReport
+    resourceUsage: () => ResourceUsage
+    revision: string
+    send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
+    setMaxListeners: (n: number) => Process
+    setSourceMapsEnabled: (value: boolean) => void
+    setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
+    setegid [?]: ((id: number | string) => void) | undefined
+    seteuid [?]: ((id: number | string) => void) | undefined
+    setgid [?]: ((id: number | string) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setuid [?]: ((id: number | string) => void) | undefined
+    sourceMapsEnabled [readonly]: boolean
+    stderr: WriteStream & { fd: 2; }
+    stdin: ReadStream & { fd: 0; }
+    stdout: WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    throwDeprecation: boolean
+    title: string
+    traceDeprecation: boolean
+    traceProcessWarnings: boolean
+    umask: { (): number; (mask: number | string): number }
+    unref: (maybeRefable: any) => void
+    uptime: () => number
+    version [readonly]: string
+    versions [readonly]: ProcessVersions
+  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
+    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
+    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+  interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    NODE_ENV [?]: string | undefined
+    TZ [?]: string | undefined
+  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
+    cached_builtins [readonly]: boolean
+    debug [readonly]: boolean
+    inspector [readonly]: boolean
+    ipv6 [readonly]: boolean
+    require_module [readonly]: boolean
+    tls [readonly]: boolean
+    tls_alpn [readonly]: boolean
+    tls_ocsp [readonly]: boolean
+    tls_sni [readonly]: boolean
+    typescript [readonly]: "strip" | false
+    uv [readonly]: boolean
+  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
+    has: (scope: string, reference?: string | undefined) => boolean
+  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
+    headersUrl [?]: string | undefined
+    libUrl [?]: string | undefined
+    lts [?]: string | undefined
+    name: string
+    sourceUrl [?]: string | undefined
+  interface NodeJS.ProcessReport (@types/node/process.d.ts)
+    compact: boolean
+    directory: string
+    excludeEnv: boolean
+    filename: string
+    getReport: (err?: Error | undefined) => object
+    reportOnFatalError: boolean
+    reportOnSignal: boolean
+    reportOnUncaughtException: boolean
+    signal: Signals
+    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
+  interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    ares: string
+    bun: string
+    http_parser: string
+    modules: string
+    node: string
+    openssl: string
+    uv: string
+    v8: string
+    zlib: string
+  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined [readonly]
+  interface NodeJS.ReadStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    closed [readonly]: boolean
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    destroy: (error?: Error | undefined) => ReadStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    isPaused: () => boolean
+    isRaw: boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    pause: () => ReadStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => ReadStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
+    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    resetAndDestroy: () => ReadStream
+    resume: () => ReadStream
+    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
+    setMaxListeners: (n: number) => ReadStream
+    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
+    setRawMode: (mode: boolean) => ReadStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
+    setTypeOfService: (tos: number) => ReadStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => ReadStream
+    unref: () => ReadStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => ReadStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    pause: () => ReadWriteStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    resume: () => ReadWriteStream
+    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
+    setMaxListeners: (n: number) => ReadWriteStream
+    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadWriteStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    pause: () => ReadableStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    resume: () => ReadableStream
+    setEncoding: (encoding: BufferEncoding) => ReadableStream
+    setMaxListeners: (n: number) => ReadableStream
+    unpipe: (destination?: WritableStream | undefined) => ReadableStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadableStream
+  interface NodeJS.RefCounted (@types/node/globals.d.ts)
+    ref: () => RefCounted
+    unref: () => RefCounted
+  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
+  interface NodeJS.Require (@types/node/module.d.ts)
+    call (id: string): any
+    cache: Dict<Module>
+    extensions: RequireExtensions
+    main: Module | undefined
+    resolve: RequireResolve
+  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
+    index [string]: ((module: Module, filename: string) => any) | undefined
+    .js: (module: Module, filename: string) => any
+    .json: (module: Module, filename: string) => any
+    .node: (module: Module, filename: string) => any
+  interface NodeJS.RequireResolve (@types/node/module.d.ts)
+    call (request: string, options?: RequireResolveOptions | undefined): string
+    paths: (request: string) => Array<string> | null
+  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
+    paths [?]: Array<string> | undefined
+  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
+    fsRead: number
+    fsWrite: number
+    involuntaryContextSwitches: number
+    ipcReceived: number
+    ipcSent: number
+    majorPageFault: number
+    maxRSS: number
+    minorPageFault: number
+    sharedMemorySize: number
+    signalsCount: number
+    swappedOut: number
+    systemCPUTime: number
+    unsharedDataSize: number
+    unsharedStackSize: number
+    userCPUTime: number
+    voluntaryContextSwitches: number
+  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
+  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
+  interface NodeJS.Socket (@types/node/process.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    isTTY [?]: true | undefined
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    pause: () => Socket
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    resume: () => Socket
+    setEncoding: (encoding: BufferEncoding) => Socket
+    setMaxListeners: (n: number) => Socket
+    unpipe: (destination?: WritableStream | undefined) => Socket
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => Socket
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.Timeout (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.toPrimitive]: () => number
+    _onTimeout: (...args: Array<any>) => void
+    close: () => Timeout
+    hasRef: () => boolean
+    ref: () => Timeout
+    refresh: () => Timeout
+    unref: () => Timeout
+  interface NodeJS.Timer (@types/node/timers.d.ts)
+    [Symbol.toPrimitive]: () => number
+    hasRef: () => boolean
+    ref: () => Timer
+    refresh: () => Timer
+    unref: () => Timer
+  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
+  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
+  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
+  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
+  interface NodeJS.WritableStream (@types/node/stream.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    setMaxListeners: (n: number) => WritableStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.WriteStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
+    clearScreenDown: (callback?: (() => void) | undefined) => boolean
+    closed [readonly]: boolean
+    columns: number
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
+    destroy: (error?: Error | undefined) => WriteStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
+    getColorDepth: (env?: object | undefined) => number
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    getWindowSize: () => [number, number]
+    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
+    isPaused: () => boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
+    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    pause: () => WriteStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => WriteStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
+    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    resetAndDestroy: () => WriteStream
+    resume: () => WriteStream
+    rows: number
+    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
+    setMaxListeners: (n: number) => WriteStream
+    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
+    setTypeOfService: (tos: number) => WriteStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => WriteStream
+    unref: () => WriteStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => WriteStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
+  children: Array<Module>
+  exports: any
+  filename: string
+  id: string
+  isPreloading: boolean
+  loaded: boolean
+  parent: Module | null | undefined
+  path: string
+  paths: Array<string>
+  require: (id: string) => any
+interface Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (this: Performance, ev: PerformanceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  clearMarks: (markName?: string | undefined) => void
+  clearMeasures: (measureName?: string | undefined) => void
+  clearResourceTimings: () => void
+  dispatchEvent: (event: Event) => boolean
+  eventCounts [readonly]: EventCounts
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: string | undefined) => PerformanceEntryList
+  getEntriesByType: (type: string) => PerformanceEntryList
+  interactionCount [readonly]: number
+  mark: (markName: string, markOptions?: PerformanceMarkOptions | undefined) => PerformanceMark
+  measure: (measureName: string, startOrMeasureOptions?: PerformanceMeasureOptions | string | undefined, endMark?: string | undefined) => PerformanceMeasure
+  navigation [readonly]: PerformanceNavigation
+  now: () => number
+  onresourcetimingbufferfull: ((this: Performance, ev: Event) => any) | null
+  removeEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (this: Performance, ev: PerformanceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  setResourceTimingBufferSize: (maxSize: number) => void
+  timeOrigin [readonly]: number
+  timing [readonly]: PerformanceTiming
+  toJSON: () => any
+var Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): Performance
+  prototype: Performance
+interface PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  duration [readonly]: number
+  entryType [readonly]: string
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceEntry
+  prototype: PerformanceEntry
+interface PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: string
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (markName: string, markOptions?: PerformanceMarkOptions | undefined): PerformanceMark
+  prototype: PerformanceMark
+interface PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: string
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceMeasure
+  prototype: PerformanceMeasure
+interface PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  disconnect: () => void
+  observe: (options?: PerformanceObserverInit | undefined) => void
+  takeRecords: () => PerformanceEntryList
+var PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (callback: PerformanceObserverCallback): PerformanceObserver
+  prototype: PerformanceObserver
+  supportedEntryTypes [readonly]: ReadonlyArray<string>
+interface PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: string | undefined) => PerformanceEntryList
+  getEntriesByType: (type: string) => PerformanceEntryList
+var PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceObserverEntryList
+  prototype: PerformanceObserverEntryList
+interface PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  connectEnd [readonly]: number
+  connectStart [readonly]: number
+  decodedBodySize [readonly]: number
+  domainLookupEnd [readonly]: number
+  domainLookupStart [readonly]: number
+  duration [readonly]: number
+  encodedBodySize [readonly]: number
+  entryType [readonly]: string
+  fetchStart [readonly]: number
+  initiatorType [readonly]: string
+  name [readonly]: string
+  nextHopProtocol [readonly]: string
+  redirectEnd [readonly]: number
+  redirectStart [readonly]: number
+  requestStart [readonly]: number
+  responseEnd [readonly]: number
+  responseStart [readonly]: number
+  responseStatus [readonly]: number
+  secureConnectionStart [readonly]: number
+  serverTiming [readonly]: ReadonlyArray<PerformanceServerTiming>
+  startTime [readonly]: number
+  toJSON: () => any
+  transferSize [readonly]: number
+  workerStart [readonly]: number
+var PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceResourceTiming
+  prototype: PerformanceResourceTiming
+interface Position (bun-types/globals.d.ts)
+  column: number
+  file: string
+  length: number
+  line: number
+  lineText: string
+  namespace: string
+  offset: number
+interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts)
+  construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
+  [Symbol.species] [readonly]: PromiseConstructor
+  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  prototype [readonly]: Promise<any>
+  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  reject: <T = never>(reason?: any) => Promise<T>
+  resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+  try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
+  withResolvers: <T>() => { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; }
+interface QueuingStrategy<T = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark [?]: number | undefined
+  size [?]: QueuingStrategySize<T> | undefined
+interface QueuingStrategyInit (bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark: number
+interface QueuingStrategySize<T = any> (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (chunk: T): number
+  call (chunk?: T | undefined): number
+interface ReadOnlyDict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined [readonly]
+interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  byobRequest [readonly]: ReadableStreamBYOBRequest | null
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk: ArrayBufferView<ArrayBuffer>) => void
+  error: (e?: any) => void
+var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): ReadableByteStreamController
+  prototype: ReadableByteStreamController
+interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (underlyingSource: UnderlyingByteSource, strategy?: undefined | { highWaterMark?: number | undefined; }): ReadableStream<Uint8Array<ArrayBuffer>>
+  construct new <R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  prototype: ReadableStream<any>
+interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  closed [readonly]: Promise<void>
+  read: <T extends ArrayBufferView<ArrayBuffer>>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  releaseLock: () => void
+var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (stream: ReadableStream<Uint8Array<ArrayBuffer>>): ReadableStreamBYOBReader
+  prototype: ReadableStreamBYOBReader
+interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  respond: (bytesWritten: number) => void
+  respondWithNewView: (view: ArrayBufferView<ArrayBuffer>) => void
+  view [readonly]: ArrayBufferView<ArrayBuffer> | null
+var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): ReadableStreamBYOBRequest
+  prototype: ReadableStreamBYOBRequest
+interface ReadableStreamDefaultController<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  close: { (): void; (): void }
+  desiredSize [readonly]: null | number
+  enqueue: { (chunk: R): void; (chunk?: R | undefined): void }
+  error: { (e?: any): void; (e?: any): void }
+var ReadableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): ReadableStreamDefaultController<any>
+  prototype: ReadableStreamDefaultController<any>
+interface ReadableStreamDefaultReadDoneResult (bun-types/globals.d.ts)
+  done: true
+  value [?]: undefined
+interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
+  done: false
+  value: T
+interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  closed [readonly]: Promise<void>
+  read: { (): Promise<ReadableStreamReadResult<R>>; (): Promise<ReadableStreamDefaultReadResult<R>> }
+  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  releaseLock: { (): void; (): void }
+var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
+  prototype: ReadableStreamDefaultReader<any>
+interface ReadableStreamDirectController (bun-types/globals.d.ts)
+  close: (error?: Error | undefined) => void
+  end: () => Promise<number> | number
+  flush: (wait?: boolean | undefined) => Promise<number> | number
+  start: () => void
+  write: (data: BufferSource | string) => Promise<number> | number
+interface ReadableStreamGenericReader (bun-types/globals.d.ts, lib.dom.d.ts)
+  cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  closed [readonly]: Promise<void>
+interface ReadableWritablePair<R = any, W = any> (bun-types/globals.d.ts, lib.dom.d.ts)
+  readable: ReadableStream<R>
+  writable: WritableStream<W>
+interface RegExpConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  call (pattern: RegExp | string): RegExp
+  call (pattern: string, flags?: string | undefined): RegExp
+  call (pattern: RegExp | string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string): RegExp
+  construct new (pattern: string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string, flags?: string | undefined): RegExp
+  $&: string
+  $': string
+  $+: string
+  $1: string
+  $2: string
+  $3: string
+  $4: string
+  $5: string
+  $6: string
+  $7: string
+  $8: string
+  $9: string
+  $_: string
+  $`: string
+  [Symbol.species] [readonly]: RegExpConstructor
+  escape: (string: string) => string
+  input: string
+  lastMatch: string
+  lastParen: string
+  leftContext: string
+  prototype [readonly]: RegExp
+  rightContext: string
+interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  blob: () => Promise<Blob>
+  body [readonly]: ReadableStream<Uint8Array<ArrayBuffer>> | null
+  bodyUsed [readonly]: boolean
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cache [readonly]: RequestCache
+  clone: () => Request
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  formData: () => Promise<FormData>
+  headers [readonly]: Headers
+  integrity [readonly]: string
+  json: () => Promise<any>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (input: RequestInfo | URL, init?: RequestInit | undefined): Request
+  prototype: Request
+interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  credentials [?]: RequestCredentials | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  priority [?]: RequestPriority | undefined
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  signal [?]: AbortSignal | null | undefined
+  window [?]: null | undefined
+var ResolveError (bun-types/deprecated.d.ts): typeof ResolveMessage
+class ResolveMessage (bun-types/globals.d.ts)
+  code [readonly]: string
+  importKind [readonly]: "at" | "at_conditional" | "dynamic" | "entry_point" | "import" | "internal" | "require" | "require_resolve" | "stmt" | "url"
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "ResolveMessage"
+  position [readonly]: Position | null
+  referrer [readonly]: string
+  specifier [readonly]: string
+  toString: () => string
+  [static]
+    construct new (): ResolveMessage
+    prototype: ResolveMessage
+interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  blob: () => Promise<Blob>
+  body [readonly]: ReadableStream<Uint8Array<ArrayBuffer>> | null
+  bodyUsed [readonly]: boolean
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  clone: () => Response
+  formData: () => Promise<FormData>
+  headers [readonly]: Headers
+  json: () => Promise<any>
+  ok [readonly]: boolean
+  redirected [readonly]: boolean
+  status [readonly]: number
+  statusText [readonly]: string
+  text: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  type [readonly]: ResponseType
+  url [readonly]: string
+var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  error: () => Response
+  json: (data: any, init?: ResponseInit | undefined) => Response
+  prototype: Response
+  redirect: (url: URL | string, status?: number | undefined) => Response
+interface ResponseInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  headers [?]: HeadersInit | undefined
+  status [?]: number | undefined
+  statusText [?]: string | undefined
+interface ShadowRealm (bun-types/globals.d.ts)
+  evaluate: (sourceText: string) => any
+  importValue: (specifier: string, bindingName: string) => Promise<any>
+var ShadowRealm (bun-types/globals.d.ts)
+  construct new (): ShadowRealm
+  prototype: ShadowRealm
+interface SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts)
+  [Symbol.toStringTag] [readonly]: "SharedArrayBuffer"
+  byteLength [readonly]: number
+  grow: (size: number) => SharedArrayBuffer
+  slice: (begin?: number | undefined, end?: number | undefined) => SharedArrayBuffer
+var SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts): SharedArrayBufferConstructor
+interface StreamPipeOptions (bun-types/globals.d.ts, lib.dom.d.ts)
+  preventAbort [?]: boolean | undefined
+  preventCancel [?]: boolean | undefined
+  preventClose [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: { (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HkdfParams | HmacImportParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HkdfParams | HmacImportParams | Pbkdf2Params, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey> }
+  digest: (algorithm: AlgorithmIdentifier, data: BufferSource) => Promise<ArrayBuffer>
+  encrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
+  generateKey: { (algorithm: "Ed25519" | { name: "Ed25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"sign" | "verify">): Promise<CryptoKeyPair>; (algorithm: "X25519" | { name: "X25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"deriveBits" | "deriveKey">): Promise<CryptoKeyPair>; (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair>; (algorithm: "Ed25519" | { name: "Ed25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"sign" | "verify">): Promise<CryptoKeyPair>; (algorithm: "X25519" | { name: "X25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"deriveBits" | "deriveKey">): Promise<CryptoKeyPair>; (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
+  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey> }
+  sign: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: { (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey> }
+  verify: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
+  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): SubtleCrypto
+  prototype: SubtleCrypto
+interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (label?: string | undefined, options?: TextDecoderOptions | undefined): TextDecoder
+  prototype: TextDecoder
+interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+  readable [readonly]: ReadableStream<string>
+  writable [readonly]: WritableStream<BufferSource>
+var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (label?: string | undefined, options?: TextDecoderOptions | undefined): TextDecoderStream
+  prototype: TextDecoderStream
+interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  encode: (input?: string | undefined) => Uint8Array<ArrayBuffer>
+  encodeInto: { (source: string, destination: Uint8Array<ArrayBufferLike>): TextEncoderEncodeIntoResult; (src?: string | undefined, dest?: BufferSource | undefined): TextEncoderEncodeIntoResult }
+  encoding [readonly]: string
+var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): TextEncoder
+  prototype: TextEncoder
+interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  encoding [readonly]: string
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  writable [readonly]: WritableStream<string>
+var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): TextEncoderStream
+  prototype: TextEncoderStream
+interface Timer (bun-types/globals.d.ts)
+  [Symbol.toPrimitive]: () => number
+  hasRef: () => boolean
+  ref: () => Timer
+  refresh: () => Timer
+  unref: () => Timer
+interface TransformStream<I = any, O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  readable [readonly]: ReadableStream<O>
+  writable [readonly]: WritableStream<I>
+var TransformStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <I = any, O = any>(transformer?: Transformer<I, O> | undefined, writableStrategy?: QueuingStrategy<I> | undefined, readableStrategy?: QueuingStrategy<O> | undefined): TransformStream<I, O>
+  prototype: TransformStream<any, any>
+interface TransformStreamDefaultController<O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  desiredSize [readonly]: null | number
+  enqueue: { (chunk?: O | undefined): void; (chunk?: O | undefined): void }
+  error: { (reason?: any): void; (reason?: any): void }
+  terminate: { (): void; (): void }
+var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): TransformStreamDefaultController<any>
+  prototype: TransformStreamDefaultController<any>
+interface Transformer<I = any, O = any> (bun-types/globals.d.ts, lib.dom.d.ts)
+  flush [?]: TransformerFlushCallback<O> | undefined
+  readableType [?]: undefined
+  start [?]: TransformerStartCallback<O> | undefined
+  transform [?]: TransformerTransformCallback<I, O> | undefined
+  writableType [?]: undefined
+interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  hash: string
+  host: string
+  hostname: string
+  href: string
+  origin [readonly]: string
+  password: string
+  pathname: string
+  port: string
+  protocol: string
+  search: string
+  searchParams [readonly]: URLSearchParams
+  toJSON: () => string
+  toString: () => string
+  username: string
+var URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (url: URL | string, base?: URL | string | undefined): URL
+  canParse: (url: URL | string, base?: URL | string | undefined) => boolean
+  createObjectURL: (obj: Blob | MediaSource) => string
+  parse: (url: URL | string, base?: URL | string | undefined) => URL | null
+  prototype: URL
+  revokeObjectURL: (url: string) => void
+interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  toString: () => string
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init?: Array<Array<string>> | Record<string, string> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es5.d.ts)
+  index [number]: number
+  BYTES_PER_ELEMENT [readonly]: number
+  [Symbol.iterator]: () => ArrayIterator<number>
+  [Symbol.toStringTag] [readonly]: "Uint8Array"
+  at: (index: number) => number | undefined
+  buffer [readonly]: TArrayBuffer
+  byteLength [readonly]: number
+  byteOffset [readonly]: number
+  copyWithin: (target: number, start: number, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  entries: () => ArrayIterator<[number, number]>
+  every: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  fill: (value: number, start?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  filter: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => any, thisArg?: any) => Uint8Array<ArrayBuffer>
+  find: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number | undefined
+  findIndex: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number
+  forEach: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => void, thisArg?: any) => void
+  includes: (searchElement: number, fromIndex?: number | undefined) => boolean
+  indexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  join: (separator?: string | undefined) => string
+  keys: () => ArrayIterator<number>
+  lastIndexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  length [readonly]: number
+  map: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => number, thisArg?: any) => Uint8Array<ArrayBuffer>
+  reduce: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reduceRight: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reverse: () => Uint8Array<TArrayBuffer>
+  set: (array: ArrayLike<number>, offset?: number | undefined) => void
+  setFromBase64: (base64: string, offset?: number | undefined) => { read: number; written: number; }
+  setFromHex: (hex: string) => { read: number; written: number; }
+  slice: (start?: number | undefined, end?: number | undefined) => Uint8Array<ArrayBuffer>
+  some: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  sort: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<TArrayBuffer>
+  subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  toBase64: (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }) => string
+  toHex: () => string
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toString: () => string
+  valueOf: () => Uint8Array<TArrayBuffer>
+  values: () => ArrayIterator<number>
+var Uint8Array (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es5.d.ts): Uint8ArrayConstructor
+interface Uint8ArrayConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2017.typedarrays.d.ts, lib.es5.d.ts)
+  construct new (length: number): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<TArrayBuffer>
+  construct new (buffer: ArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayBuffer | ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new (elements: Iterable<number>): Uint8Array<ArrayBuffer>
+  construct new (): Uint8Array<ArrayBuffer>
+  BYTES_PER_ELEMENT [readonly]: number
+  from: { (arrayLike: ArrayLike<number>): Uint8Array<ArrayBuffer>; <T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array<ArrayBuffer>; (elements: Iterable<number>): Uint8Array<ArrayBuffer>; <T>(elements: Iterable<T>, mapfn?: ((v: T, k: number) => number) | undefined, thisArg?: any): Uint8Array<ArrayBuffer> }
+  fromBase64: (base64: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }) => Uint8Array<ArrayBuffer>
+  fromHex: (hex: string) => Uint8Array<ArrayBuffer>
+  of: (...items: Array<number>) => Uint8Array<ArrayBuffer>
+  prototype [readonly]: Uint8Array<ArrayBufferLike>
+namespace WebAssembly (bun-types/wasm.d.ts, lib.dom.d.ts)
+  type WebAssembly.AddressType (lib.dom.d.ts) = "i32" | "i64"
+  type WebAssembly.AddressValue (lib.dom.d.ts) = number
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (message?: string | undefined): CompileError
+    construct new (message?: string | undefined): CompileError
+    prototype: CompileError
+  interface WebAssembly.Exception (lib.dom.d.ts)
+    getArg: (exceptionTag: Tag, index: number) => any
+    is: (exceptionTag: Tag) => boolean
+    stack [readonly]: string | undefined
+  var WebAssembly.Exception (lib.dom.d.ts)
+    construct new (exceptionTag: Tag, payload: Array<any>, options?: ExceptionOptions | undefined): Exception
+    prototype: Exception
+  interface WebAssembly.ExceptionOptions (lib.dom.d.ts)
+    traceStack [?]: boolean | undefined
+  type WebAssembly.ExportValue (lib.dom.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
+  type WebAssembly.Exports (lib.dom.d.ts) = { [x: string]: ExportValue; }
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  var WebAssembly.Global (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
+    prototype: Global<keyof ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  type WebAssembly.ImportExportKind (lib.dom.d.ts) = "function" | "global" | "memory" | "table" | "tag"
+  type WebAssembly.ImportValue (lib.dom.d.ts) = number | ExportValue
+  type WebAssembly.Imports (lib.dom.d.ts) = { [x: string]: ModuleImports; }
+  interface WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
+    exports [readonly]: Exports
+  var WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (module: Module, importObject?: Imports | undefined): Instance
+    prototype: Instance
+  var WebAssembly.JSTag (lib.dom.d.ts): Tag
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (message?: string | undefined): LinkError
+    construct new (message?: string | undefined): LinkError
+    prototype: LinkError
+  interface WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+    toFixedLengthBuffer: () => ArrayBuffer
+    toResizableBuffer: () => ArrayBuffer
+  var WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (descriptor: MemoryDescriptor): Memory
+    prototype: Memory
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    address [?]: AddressType | undefined
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
+  var WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Module
+    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
+    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
+    prototype: Module
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  type WebAssembly.ModuleImports (lib.dom.d.ts) = { [x: string]: ImportValue; }
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (message?: string | undefined): RuntimeError
+    construct new (message?: string | undefined): RuntimeError
+    prototype: RuntimeError
+  interface WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  var WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (descriptor: TableDescriptor, value?: any): Table
+    prototype: Table
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    address [?]: AddressType | undefined
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  type WebAssembly.TableKind (lib.dom.d.ts) = "anyfunc" | "externref"
+  interface WebAssembly.Tag (lib.dom.d.ts)
+  var WebAssembly.Tag (lib.dom.d.ts)
+    construct new (type: TagType): Tag
+    prototype: Tag
+  interface WebAssembly.TagType (lib.dom.d.ts)
+    parameters: Array<keyof ValueTypeMap>
+  type WebAssembly.ValueType (lib.dom.d.ts) = keyof ValueTypeMap
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts, lib.dom.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyCompileOptions (lib.dom.d.ts)
+    builtins [?]: Array<string> | undefined
+    importedStringConstants [?]: null | string | undefined
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts, lib.dom.d.ts)
+    instance: Instance
+    module: Module
+  function WebAssembly.compile (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
+    call (bytes: BufferSource): Promise<Module>
+  function WebAssembly.compileStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (source: PromiseLike<Response> | Response, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
+    call (source: PromiseLike<Response> | Response): Promise<Module>
+  function WebAssembly.instantiate (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (bytes: BufferSource, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+  function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+  function WebAssembly.validate (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): boolean
+    call (bytes: BufferSource): boolean
+interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: BinaryType
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: MessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  send: (data: Blob | BufferSource | string) => void
+  url [readonly]: string
+var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  prototype: WebSocket
+interface Worker (bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: MessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+var Worker (bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  prototype: Worker
+interface WorkerOptions (bun-types/globals.d.ts, lib.dom.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  getWriter: () => WritableStreamDefaultWriter<W>
+  locked [readonly]: boolean
+var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  prototype: WritableStream<any>
+interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  error: { (e?: any): void; (e?: any): void }
+  signal [readonly]: AbortSignal
+var WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): WritableStreamDefaultController
+  prototype: WritableStreamDefaultController
+interface WritableStreamDefaultWriter<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  abort: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  close: { (): Promise<void>; (): Promise<void> }
+  closed [readonly]: Promise<void>
+  desiredSize [readonly]: null | number
+  ready [readonly]: Promise<void>
+  releaseLock: { (): void; (): void }
+  write: { (chunk?: W | undefined): Promise<void>; (chunk?: W | undefined): Promise<void> }
+var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>
+  prototype: WritableStreamDefaultWriter<any>
+function addEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
+  call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+function alert (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message?: any): void
+  call (message?: string | undefined): void
+function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (immediate: Immediate | undefined): void
+function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (id: number | undefined): void
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (id: number | undefined): void
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function confirm (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message?: string | undefined): boolean
+  call (message?: string | undefined): boolean
+var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Console
+var crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Crypto
+var exports (@types/node/module.d.ts, bun-types/globals.d.ts): any
+function fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>
+  call (input: Request | URL | string, init?: BunFetchRequestInit | undefined): Promise<Response>
+  call (input: Request | URL | string, init?: RequestInit | undefined): Promise<Response>
+  preconnect: (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }) => void
+namespace fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  function fetch.preconnect (bun-types/globals.d.ts)
+    call (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }): void
+var module (@types/node/module.d.ts, bun-types/globals.d.ts): NodeModule
+var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Navigator
+var onmessage (bun-types/index.d.ts, lib.dom.d.ts): ((this: Window, ev: MessageEvent<any>) => any) | null
+var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Performance
+function postMessage (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message: any, targetOrigin: string, transfer?: Array<Transferable> | undefined): void
+  call (message: any, options?: WindowPostMessageOptions | undefined): void
+  call (message: any, transfer?: Array<Transferable> | undefined): void
+function prompt (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message?: string | undefined, _default?: string | undefined): null | string
+  call (message?: string | undefined, _default?: string | undefined): null | string
+function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (callback: VoidFunction): void
+  call (callback: (...args: Array<any>) => void): void
+  call (callback: () => void): void
+function removeEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
+  call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+function reportError (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (e: any): void
+  call (error: any): void
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
+  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/es2022.txt
+++ b/test/integration/bun-types/inventory/es2022.txt
@@ -5,39 +5,64 @@
 # undici-types: 8.3.0
 
 # module "*.html"
+export = Bun.HTMLBundle
 
 # module "*.json5"
+export = any
 
 # module "*.jsonc"
+export = any
 
 # module "*.toml"
+export = any
 
 # module "*.txt"
+export = string
 
 # module "*.xml"
+export = Bun.XML.Document
 
 # module "*.yaml"
+export = any
 
 # module "*.yml"
+export = any
 
 # module "*/bun.lock"
+export = Bun.BunLockFile
+
+# module "buffer"
+interface Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<NodeJS.NonSharedUint8Array>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
+  json: () => Promise<any>
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<NodeJS.NonSharedUint8Array>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
 
 # module "bun"
-type $ (bun-types/shell.d.ts) = typeof $
+type $ (bun-types/shell.d.ts) = typeof Bun.$
 function $ (bun-types/shell.d.ts)
-  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
-  Shell: new () => typeof $
-  ShellError: typeof ShellError
-  ShellPromise: typeof ShellPromise
+  call (strings: TemplateStringsArray, ...expressions: Array<Bun.ShellExpression>): Bun.$.ShellPromise
+  Shell: new () => typeof Bun.$
+  ShellError: typeof Bun.$.ShellError
+  ShellPromise: typeof Bun.$.ShellPromise
   braces: (pattern: string) => Array<string>
-  cwd: (newCwd?: string | undefined) => typeof $
-  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  cwd: (newCwd?: string | undefined) => typeof Bun.$
+  env: (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => typeof Bun.$
   escape: (input: string) => string
-  nothrow: () => typeof $
-  throws: (shouldThrow: boolean) => typeof $
+  nothrow: () => typeof Bun.$
+  throws: (shouldThrow: boolean) => typeof Bun.$
 namespace $ (bun-types/shell.d.ts)
   var $.Shell (bun-types/shell.d.ts)
-    construct new (): typeof $
+    construct new (): typeof Bun.$
   class $.ShellError (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
     blob: () => Blob
@@ -52,13 +77,13 @@ namespace $ (bun-types/shell.d.ts)
     stdout [readonly]: Buffer<ArrayBufferLike>
     text: (encoding?: BufferEncoding | undefined) => string
     [static]
-      construct new (message?: string | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: ShellError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.$.ShellError
       stackTraceLimit: number
   interface $.ShellOutput (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
@@ -73,26 +98,26 @@ namespace $ (bun-types/shell.d.ts)
     [Symbol.toStringTag] [readonly]: string
     arrayBuffer: () => Promise<ArrayBuffer>
     blob: () => Promise<Blob>
-    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
-    cwd: (newCwd: string) => ShellPromise
-    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
-    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<Bun.$.ShellOutput | TResult>
+    cwd: (newCwd: string) => Bun.$.ShellPromise
+    env: (newEnv: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => Bun.$.ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<Bun.$.ShellOutput>
     json: () => Promise<any>
     lines: () => AsyncIterable<string>
-    nothrow: () => ShellPromise
-    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    nothrow: () => Bun.$.ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => Bun.$.ShellPromise
     stdin: WritableStream<any>
     text: (encoding?: BufferEncoding | undefined) => Promise<string>
-    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    throws: (shouldThrow: boolean) => ShellPromise
+    then: <TResult1 = Bun.$.ShellOutput, TResult2 = never>(onfulfilled?: ((value: Bun.$.ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => Bun.$.ShellPromise
     [static]
-      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      construct new (executor: (resolve: (value: Bun.$.ShellOutput | PromiseLike<Bun.$.ShellOutput>) => void, reject: (reason?: any) => void) => void): Bun.$.ShellPromise
       [Symbol.species] [readonly]: PromiseConstructor
-      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
-      prototype: ShellPromise
-      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
+      prototype: Bun.$.ShellPromise
+      race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
       reject: <T = never>(reason?: any) => Promise<T>
       resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
       try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
@@ -100,19 +125,19 @@ namespace $ (bun-types/shell.d.ts)
   function $.braces (bun-types/shell.d.ts)
     call (pattern: string): Array<string>
   function $.cwd (bun-types/shell.d.ts)
-    call (newCwd?: string | undefined): typeof $
+    call (newCwd?: string | undefined): typeof Bun.$
   function $.env (bun-types/shell.d.ts)
-    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+    call (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined): typeof Bun.$
   function $.escape (bun-types/shell.d.ts)
     call (input: string): string
   function $.nothrow (bun-types/shell.d.ts)
-    call (): typeof $
+    call (): typeof Bun.$
   function $.throws (bun-types/shell.d.ts)
-    call (shouldThrow: boolean): typeof $
+    call (shouldThrow: boolean): typeof Bun.$
 interface AbstractWorker (bun-types/bun.d.ts)
-  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
 interface AbstractWorkerEventMap (bun-types/bun.d.ts)
   error: ErrorEvent
 interface AddEventListenerOptions (bun-types/bun.d.ts)
@@ -124,16 +149,16 @@ type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips
 class Archive (bun-types/bun.d.ts)
   blob: () => Promise<Blob>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
-  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  extract: (path: string, options?: Bun.ArchiveExtractOptions | undefined) => Promise<number>
   files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
   [static]
-    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
-    prototype: Archive
-    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+    construct new (data: Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined): Bun.Archive
+    prototype: Bun.Archive
+    write [static]: (path: string, data: Bun.Archive | Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined) => Promise<void>
 type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
 interface ArchiveExtractOptions (bun-types/bun.d.ts)
   glob [?]: ReadonlyArray<string> | string | undefined
-type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+type ArchiveInput (bun-types/bun.d.ts) = ArrayBufferLike | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Record<string, Bun.BlobPart>
 interface ArchiveOptions (bun-types/bun.d.ts)
   compress [?]: "gzip" | undefined
   level [?]: number | undefined
@@ -141,25 +166,25 @@ class ArrayBufferSink (bun-types/bun.d.ts)
   end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
   flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
   start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
   [static]
-    construct new (): ArrayBufferSink
-    prototype: ArrayBufferSink
-type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+    construct new (): Bun.ArrayBufferSink
+    prototype: Bun.ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = DataView<TArrayBuffer> | NodeJS.TypedArray<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "ACLITEM" | "BIGINT" | "BIT" | "BOOLEAN" | "BOX" | "BYTEA" | "CHAR" | "CID" | "CIDR" | "CIRCLE" | "DATE" | "DOUBLE PRECISION" | "INET" | "INT" | "INT2VECTOR" | "INTEGER" | "INTERVAL" | "JSON" | "JSONB" | "JSONPATH" | "LINE" | "LSEG" | "MACADDR" | "MACADDR8" | "MONEY" | "NAME" | "NUMERIC" | "OID" | "PATH" | "PG_DATABASE" | "POINT" | "POLYGON" | "REAL" | "SMALLINT" | "TEXT" | "TID" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "TIMETZ" | "VARBIT" | "VARCHAR" | "XID" | "XML" | (string & {})
 type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
-type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+type BinaryType (bun-types/bun.d.ts) = keyof Bun.BinaryTypeList
 interface BinaryTypeList (bun-types/bun.d.ts)
   arraybuffer: ArrayBuffer
   buffer: Buffer<ArrayBufferLike>
   uint8array: Uint8Array<ArrayBuffer>
-type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
-type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
-type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
-type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string
+type BlobPart (bun-types/bun.d.ts) = Blob | Bun.BufferSource | string
+type BodyInit (bun-types/fetch.d.ts) = (() => AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any>) | AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any> | AsyncIterable<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string> | Bun.Image | Bun.XMLHttpRequestBodyInit | ReadableStream<any>
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
 namespace Build (bun-types/bun.d.ts)
-  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
-  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Architecture (bun-types/bun.d.ts) = "aarch64" | "arm64" | "x64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-aarch64" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-darwin-arm64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-linux-aarch64" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-modern" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-linux-aarch64-musl" | "bun-linux-arm64" | "bun-linux-arm64-baseline" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-glibc" | "bun-linux-arm64-modern" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-arm64-musl" | "bun-linux-x64" | "bun-linux-x64-baseline" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-modern" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-x64-musl" | "bun-windows-aarch64" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
   type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
   type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
 interface BuildArtifact (bun-types/bun.d.ts)
@@ -167,13 +192,13 @@ interface BuildArtifact (bun-types/bun.d.ts)
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
   hash: null | string
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
-  loader: Loader
+  loader: Bun.Loader
   path: string
   size [readonly]: number
-  sourcemap: BuildArtifact | null
+  sourcemap: Bun.BuildArtifact | null
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
@@ -182,7 +207,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   banner [?]: string | undefined
   bytecode [?]: boolean | undefined
   bytecodeDepth [?]: number | undefined
-  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  compile [?]: Bun.Build.CompileTarget | Bun.CompileBuildOptions | boolean | undefined
   conditions [?]: Array<string> | string | undefined
   define [?]: Record<string, string> | undefined
   deprecatedNamespaceObjectSetters [?]: boolean | undefined
@@ -192,12 +217,12 @@ interface BuildConfig (bun-types/bun.d.ts)
   env [?]: "disable" | "inline" | `${string}*` | undefined
   external [?]: Array<string> | undefined
   features [?]: Array<string> | undefined
-  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  files [?]: Record<string, ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string> | undefined
   footer [?]: string | undefined
   format [?]: "cjs" | "esm" | "iife" | undefined
   ignoreDCEAnnotations [?]: boolean | undefined
   jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
-  loader [?]: undefined | { [x: string]: Loader; }
+  loader [?]: undefined | { [x: string]: Bun.Loader; }
   metafile [?]: boolean | undefined
   minChunkSize [?]: number | undefined
   minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
@@ -206,7 +231,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   optimizeImports [?]: Array<string> | undefined
   outdir [?]: string | undefined
   packages [?]: "bundle" | "external" | undefined
-  plugins [?]: Array<BunPlugin> | undefined
+  plugins [?]: Array<Bun.BunPlugin> | undefined
   publicPath [?]: string | undefined
   reactCompiler [?]: boolean | undefined
   reactCompilerOutputMode [?]: "client" | "ssr" | undefined
@@ -215,17 +240,17 @@ interface BuildConfig (bun-types/bun.d.ts)
   sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
   splitRequire [?]: boolean | undefined
   splitting [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   throw [?]: boolean | undefined
   treeShaking [?]: boolean | undefined
   tsconfig [?]: string | undefined
 interface BuildMetafile (bun-types/bun.d.ts)
-  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
-  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: Bun.ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: Bun.ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
 interface BuildOutput (bun-types/bun.d.ts)
   logs: Array<BuildMessage | ResolveMessage>
-  metafile [?]: BuildMetafile | undefined
-  outputs: Array<BuildArtifact>
+  metafile [?]: Bun.BuildMetafile | undefined
+  outputs: Array<Bun.BuildArtifact>
   success: boolean
 interface BunFile (bun-types/bun.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
@@ -233,29 +258,29 @@ interface BunFile (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface BunInspectOptions (bun-types/bun.d.ts)
   colors [?]: boolean | undefined
   compact [?]: boolean | undefined
   depth [?]: number | undefined
   sorted [?]: boolean | undefined
-type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: Bun.BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: Bun.BunLockFilePackageArray; }; }
 type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
-type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
-type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
-type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, info: Bun.BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Bun.BunLockFilePackageInfo] | [pkg: string, info: Pick<Bun.BunLockFileBasePackageInfo, "bin" | "binDir">] | [pkg: string, registry: string, info: Bun.BunLockFilePackageInfo, integrity: string] | [pkg: string]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
 interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -282,10 +307,10 @@ interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.t
   type [readonly]: string
 interface BunPlugin (bun-types/bun.d.ts)
   name: string
-  setup: (build: PluginBuilder) => Promise<void> | void
-  target [?]: Target | undefined
+  setup: (build: Bun.PluginBuilder) => Promise<void> | void
+  target [?]: Bun.Target | undefined
 interface BunRegisterPlugin (bun-types/bun.d.ts)
-  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  call <T extends Bun.BunPlugin>(options: T): ReturnType<T["setup"]>
   clearAll: () => void
 interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   arrayBuffer [readonly]: () => Promise<ArrayBuffer>
@@ -294,19 +319,19 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   bodyUsed [readonly]: boolean
   bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
   cache [readonly]: RequestCache
-  clone: () => BunRequest<T>
-  cookies [readonly]: CookieMap
+  clone: () => Bun.BunRequest<T>
+  cookies [readonly]: Bun.CookieMap
   credentials [readonly]: RequestCredentials
   destination [readonly]: RequestDestination
   duplex [readonly]: "half"
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   integrity [readonly]: string
   json [readonly]: () => Promise<unknown>
   keepalive [readonly]: boolean
   method [readonly]: string
   mode [readonly]: RequestMode
-  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  params [readonly]: { [Key in keyof Bun.Serve.ExtractRouteParams<T>]: Bun.Serve.ExtractRouteParams<T>[Key]; }
   redirect [readonly]: RequestRedirect
   referrer [readonly]: string
   referrerPolicy [readonly]: ReferrerPolicy
@@ -316,17 +341,17 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   url [readonly]: string
 namespace CSRF (bun-types/bun.d.ts)
   function CSRF.generate (bun-types/bun.d.ts)
-    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+    call (secret?: string | undefined, options?: Bun.CSRFGenerateOptions | undefined): string
   function CSRF.verify (bun-types/bun.d.ts)
-    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+    call (token: string, options?: Bun.CSRFVerifyOptions | undefined): boolean
 type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
 interface CSRFGenerateOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   expiresIn [?]: number | undefined
   sessionId [?]: string | undefined
 interface CSRFVerifyOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   maxAge [?]: number | undefined
   secret [?]: string | undefined
@@ -338,7 +363,7 @@ interface CloseEventInit (bun-types/bun.d.ts)
   composed [?]: boolean | undefined
   reason [?]: string | undefined
   wasClean [?]: boolean | undefined
-type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+type ColorInput (bun-types/bun.d.ts) = Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | [number, number, number, number] | [number, number, number] | number | string | { r: number; g: number; b: number; a?: number | undefined; } | { toString(): string; }
 interface CompileBuildOptions (bun-types/bun.d.ts)
   assets [?]: Array<string> | undefined
   autoloadBunfig [?]: boolean | undefined
@@ -348,9 +373,9 @@ interface CompileBuildOptions (bun-types/bun.d.ts)
   execArgv [?]: Array<string> | undefined
   executablePath [?]: string | undefined
   outfile [?]: string | undefined
-  target [?]: CompileTarget | undefined
+  target [?]: Bun.Build.CompileTarget | undefined
   windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
-type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+type CompressionFormat (bun-types/bun.d.ts) = "brotli" | "deflate" | "deflate-raw" | "gzip" | "zstd"
 class Cookie (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | undefined
@@ -360,19 +385,19 @@ class Cookie (bun-types/bun.d.ts)
   name [readonly]: string
   partitioned: boolean
   path: string
-  sameSite: CookieSameSite
+  sameSite: Bun.CookieSameSite
   secure: boolean
   serialize: () => string
-  toJSON: () => CookieInit
+  toJSON: () => Bun.CookieInit
   toString: () => string
   value: string
   [static]
-    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
-    construct new (cookieString: string): Cookie
-    construct new (cookieObject?: CookieInit | undefined): Cookie
-    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
-    parse [static]: (cookieString: string) => Cookie
-    prototype: Cookie
+    construct new (name: string, value: string, options?: Bun.CookieInit | undefined): Bun.Cookie
+    construct new (cookieString: string): Bun.Cookie
+    construct new (cookieObject?: Bun.CookieInit | undefined): Bun.Cookie
+    from [static]: (name: string, value: string, options?: Bun.CookieInit | undefined) => Bun.Cookie
+    parse [static]: (cookieString: string) => Bun.Cookie
+    prototype: Bun.Cookie
 interface CookieInit (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | number | string | undefined
@@ -381,26 +406,26 @@ interface CookieInit (bun-types/bun.d.ts)
   name [?]: string | undefined
   partitioned [?]: boolean | undefined
   path [?]: string | undefined
-  sameSite [?]: CookieSameSite | undefined
+  sameSite [?]: Bun.CookieSameSite | undefined
   secure [?]: boolean | undefined
   value [?]: string | undefined
 class CookieMap (bun-types/bun.d.ts)
   [Symbol.iterator]: () => IterableIterator<[string, string]>
-  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  delete: { (name: string): void; (options: Bun.CookieStoreDeleteOptions): void; (name: string, options: Omit<Bun.CookieStoreDeleteOptions, "name">): void }
   entries: () => IterableIterator<[string, string]>
-  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  forEach: (callback: (value: string, key: string, map: Bun.CookieMap) => void) => void
   get: (name: string) => null | string
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
-  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  set: { (name: string, value: string, options?: Bun.CookieInit | undefined): void; (options: Bun.CookieInit): void }
   size [readonly]: number
   toJSON: () => Record<string, string>
   toSetCookieHeaders: () => Array<string>
   values: () => IterableIterator<string>
   [static]
-    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
-    prototype: CookieMap
-type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): Bun.CookieMap
+    prototype: Bun.CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "lax" | "none" | "strict"
 interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
   domain [?]: null | string | undefined
   name: string
@@ -415,30 +440,30 @@ interface CronController (bun-types/bun.d.ts)
 interface CronJob (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   cron [readonly]: string
-  ref: () => CronJob
-  stop: () => CronJob
-  unref: () => CronJob
+  ref: () => Bun.CronJob
+  stop: () => Bun.CronJob
+  unref: () => Bun.CronJob
 interface CronOptions (bun-types/bun.d.ts)
   tz [?]: string | undefined
-type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+type CronWithAutocomplete (bun-types/bun.d.ts) = "@annually" | "@daily" | "@hourly" | "@midnight" | "@monthly" | "@weekly" | "@yearly" | (string & {}) | `${string} ${string} ${string} ${string} ${string}`
 class CryptoHashInterface<T> (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => T
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => T
   [static]
-    construct new <T>(): CryptoHashInterface<T>
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHashInterface<any>
+    construct new <T>(): Bun.CryptoHashInterface<T>
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHashInterface<any>
 class CryptoHasher (bun-types/bun.d.ts)
-  algorithm [readonly]: SupportedCryptoAlgorithms
+  algorithm [readonly]: Bun.SupportedCryptoAlgorithms
   byteLength [readonly]: number
-  copy: () => CryptoHasher
-  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
-  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  copy: () => Bun.CryptoHasher
+  digest: { (encoding: Bun.DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (input: Bun.BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => Bun.CryptoHasher
   [static]
-    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
-    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
-    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHasher
+    construct new (algorithm: Bun.SupportedCryptoAlgorithms, hmacKey?: NodeJS.TypedArray<ArrayBufferLike> | string | undefined): Bun.CryptoHasher
+    algorithms [readonly static]: Array<Bun.SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHasher
 interface CustomEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -449,9 +474,9 @@ interface DNSLookup (bun-types/bun.d.ts)
   family: 4 | 6
   ttl: number
 type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
-type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "base64" | "base64url" | "hex" | "latin1" | "ucs2" | "utf16le" | "utf8"
 interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
   pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
   type: "direct"
 type DisconnectListener (bun-types/bun.d.ts) = () => void
@@ -459,7 +484,7 @@ interface EditorOptions (bun-types/bun.d.ts)
   column [?]: number | undefined
   editor [?]: "subl" | "vscode" | undefined
   line [?]: number | undefined
-type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+type Encoding (bun-types/bun.d.ts) = "866" | "ansi_x3.4-1968" | "arabic" | "ascii" | "asmo-708" | "big5" | "big5-hkscs" | "chinese" | "cn-big5" | "cp1250" | "cp1251" | "cp1252" | "cp1253" | "cp1254" | "cp1255" | "cp1256" | "cp1257" | "cp1258" | "cp819" | "cp866" | "csbig5" | "cseuckr" | "cseucpkdfmtjapanese" | "csgb2312" | "csibm866" | "csiso2022jp" | "csiso58gb231280" | "csiso88596e" | "csiso88596i" | "csiso88598e" | "csiso88598i" | "csisolatin1" | "csisolatin2" | "csisolatin3" | "csisolatin4" | "csisolatin5" | "csisolatin6" | "csisolatin9" | "csisolatinarabic" | "csisolatincyrillic" | "csisolatingreek" | "csisolatinhebrew" | "cskoi8r" | "csksc56011987" | "csmacintosh" | "csshiftjis" | "csunicode" | "cyrillic" | "dos-874" | "ecma-114" | "ecma-118" | "elot_928" | "euc-jp" | "euc-kr" | "gb18030" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "greek" | "greek8" | "hebrew" | "ibm819" | "ibm866" | "iso-10646-ucs-2" | "iso-2022-jp" | "iso-8859-1" | "iso-8859-10" | "iso-8859-11" | "iso-8859-13" | "iso-8859-14" | "iso-8859-15" | "iso-8859-16" | "iso-8859-2" | "iso-8859-3" | "iso-8859-4" | "iso-8859-5" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-8859-7" | "iso-8859-8" | "iso-8859-8-e" | "iso-8859-8-i" | "iso-8859-9" | "iso-ir-100" | "iso-ir-101" | "iso-ir-109" | "iso-ir-110" | "iso-ir-126" | "iso-ir-127" | "iso-ir-138" | "iso-ir-144" | "iso-ir-148" | "iso-ir-149" | "iso-ir-157" | "iso-ir-58" | "iso8859-1" | "iso8859-10" | "iso8859-11" | "iso8859-13" | "iso8859-14" | "iso8859-15" | "iso8859-2" | "iso8859-3" | "iso8859-4" | "iso8859-5" | "iso8859-6" | "iso8859-7" | "iso8859-8" | "iso8859-9" | "iso88591" | "iso885910" | "iso885911" | "iso885913" | "iso885914" | "iso885915" | "iso88592" | "iso88593" | "iso88594" | "iso88595" | "iso88596" | "iso88597" | "iso88598" | "iso88599" | "iso_8859-1" | "iso_8859-15" | "iso_8859-1:1987" | "iso_8859-2" | "iso_8859-2:1987" | "iso_8859-3" | "iso_8859-3:1988" | "iso_8859-4" | "iso_8859-4:1988" | "iso_8859-5" | "iso_8859-5:1988" | "iso_8859-6" | "iso_8859-6:1987" | "iso_8859-7" | "iso_8859-7:1987" | "iso_8859-8" | "iso_8859-8:1988" | "iso_8859-9" | "iso_8859-9:1989" | "koi" | "koi8" | "koi8-r" | "koi8-ru" | "koi8-u" | "koi8_r" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "l1" | "l2" | "l3" | "l4" | "l5" | "l6" | "l9" | "latin1" | "latin2" | "latin3" | "latin4" | "latin5" | "latin6" | "logical" | "mac" | "macintosh" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "sun_eu_greek" | "tis-620" | "ucs-2" | "unicode" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "unicodefeff" | "unicodefffe" | "us-ascii" | "utf-16" | "utf-16be" | "utf-16le" | "utf-8" | "utf8" | "visual" | "windows-1250" | "windows-1251" | "windows-1252" | "windows-1253" | "windows-1254" | "windows-1255" | "windows-1256" | "windows-1257" | "windows-1258" | "windows-31j" | "windows-874" | "windows-949" | "x-cp1250" | "x-cp1251" | "x-cp1252" | "x-cp1253" | "x-cp1254" | "x-cp1255" | "x-cp1256" | "x-cp1257" | "x-cp1258" | "x-euc-jp" | "x-gbk" | "x-mac-cyrillic" | "x-mac-roman" | "x-mac-ukrainian" | "x-sjis" | "x-unicode20utf8" | "x-user-defined" | "x-x-big5"
 interface Env (bun-types/bun.d.ts)
   NODE_ENV [?]: string | undefined
   TZ [?]: string | undefined
@@ -480,7 +505,7 @@ interface ErrorLike (bun-types/bun.d.ts)
   name: string
   stack [?]: string | undefined
   syscall [?]: string | undefined
-type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+type Errorlike (bun-types/deprecated.d.ts) = Bun.ErrorLike
 interface EventInit (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -491,31 +516,31 @@ interface EventListenerObject (bun-types/bun.d.ts)
   handleEvent: (object: Event) => void
 interface EventListenerOptions (bun-types/bun.d.ts)
   capture [?]: boolean | undefined
-type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = Bun.EventListener | Bun.EventListenerObject
 interface EventMap (bun-types/bun.d.ts)
-  fetch: FetchEvent
-  message: BunMessageEvent<any>
-  messageerror: BunMessageEvent<any>
+  fetch: Bun.FetchEvent
+  message: Bun.BunMessageEvent<any>
+  messageerror: Bun.BunMessageEvent<any>
 interface EventSource (bun-types/bun.d.ts)
-  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): Bun.EventSource
   CLOSED [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
-  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: Bun.BunMessageEvent<any>) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   close: () => void
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: EventSource, ev: Event) => any) | null
-  onmessage: ((this: EventSource, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: EventSource, ev: Event) => any) | null
+  onerror: ((this: Bun.EventSource, ev: Event) => any) | null
+  onmessage: ((this: Bun.EventSource, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.EventSource, ev: Event) => any) | null
   readyState [readonly]: number
   ref: () => void
-  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: Bun.BunMessageEvent<any>) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   unref: () => void
   url [readonly]: string
   withCredentials [readonly]: boolean
 interface EventSourceEventMap (bun-types/bun.d.ts)
   error: Event
-  message: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
   open: Event
 type ExitListener (bun-types/bun.d.ts) = (code: number) => void
 type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
@@ -523,8 +548,8 @@ interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   fd: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface FetchEvent (bun-types/bun.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -553,47 +578,47 @@ interface FileBlob (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface FileSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
   ref: () => void
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
 class FileSystemRouter (bun-types/bun.d.ts)
   assetPrefix [readonly]: string
-  match: (input: Request | Response | string) => MatchedRoute | null
+  match: (input: Request | Response | string) => Bun.MatchedRoute | null
   origin [readonly]: string
   reload: () => void
   routes [readonly]: Record<string, string>
   style [readonly]: string
   [static]
-    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
-    prototype: FileSystemRouter
-type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): Bun.FileSystemRouter
+    prototype: Bun.FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = File | string
 interface GenericTransformStream (bun-types/bun.d.ts)
   readable [readonly]: ReadableStream<any>
   writable [readonly]: WritableStream<any>
 class Glob (bun-types/bun.d.ts)
   match: (str: string) => boolean
-  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
-  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  scan: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => IterableIterator<string>
   [static]
-    construct new (pattern: string): Glob
-    prototype: Glob
+    construct new (pattern: string): Bun.Glob
+    prototype: Bun.Glob
 interface GlobScanOptions (bun-types/bun.d.ts)
   absolute [?]: boolean | undefined
   cwd [?]: string | undefined
@@ -601,25 +626,25 @@ interface GlobScanOptions (bun-types/bun.d.ts)
   followSymlinks [?]: boolean | undefined
   onlyFiles [?]: boolean | undefined
   throwErrorOnBrokenSymlink [?]: boolean | undefined
-type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
-type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+type HMREvent (bun-types/devserver.d.ts) = "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:beforeUpdate" | "bun:error" | "bun:invalidate" | "bun:ws:connect" | "bun:ws:disconnect" | (string & {})
+type HMREventNames (bun-types/devserver.d.ts) = "afterUpdate" | "beforeFullReload" | "beforePrune" | "beforeUpdate" | "error" | "invalidate" | "ws:connect" | "ws:disconnect"
 interface HTMLBundle (bun-types/bun.d.ts)
-  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Bun.Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
   index: string
 interface Hash (bun-types/bun.d.ts)
-  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Record<string, string | ReadonlyArray<string>> | Headers
+  adler32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Headers | Record<string, ReadonlyArray<string> | string>
 interface HeapSnapshot (bun-types/bun.d.ts)
   edgeNames: Array<string>
   edgeTypes: Array<string>
@@ -629,56 +654,56 @@ interface HeapSnapshot (bun-types/bun.d.ts)
   type: string
   version: number
 class Image (bun-types/bun.d.ts)
-  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  avif: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   blob: () => Promise<Blob>
   buffer: () => Promise<Buffer<ArrayBufferLike>>
   bytes: () => Promise<Uint8Array<ArrayBufferLike>>
   dataurl: () => Promise<string>
-  flip: () => Image
-  flop: () => Image
-  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  flip: () => Bun.Image
+  flop: () => Bun.Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   height [readonly]: number
-  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
-  metadata: () => Promise<Metadata>
-  modulate: (options: ModulateOptions) => Image
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Bun.Image
+  metadata: () => Promise<Bun.Image.Metadata>
+  modulate: (options: Bun.Image.ModulateOptions) => Bun.Image
   placeholder: (as?: "dataurl" | undefined) => Promise<string>
-  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
-  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
-  rotate: (degrees: number) => Image
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Bun.Image
+  resize: (width: number, height?: number | undefined, options?: Bun.Image.ResizeOptions | undefined) => Bun.Image
+  rotate: (degrees: number) => Bun.Image
   toBase64: () => Promise<string>
   toBuffer: () => Promise<Buffer<ArrayBufferLike>>
-  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Bun.Image
   width [readonly]: number
-  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  write: (dest: Bun.BunFile | Bun.PathLike | Bun.S3File | number) => Promise<number>
   [static]
-    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    construct new (input: ArrayBuffer | Blob | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.Image.ConstructorOptions | undefined): Bun.Image
     backend [static]: "bun" | "system"
     clipboardChangeCount [static]: () => number
-    fromClipboard [static]: () => Image | null
+    fromClipboard [static]: () => Bun.Image | null
     hasClipboardImage [static]: () => boolean
-    prototype: Image
+    prototype: Bun.Image
   interface Image.ConstructorOptions (bun-types/bun.d.ts)
     autoOrient [?]: boolean | undefined
     maxPixels [?]: number | undefined
-  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
-  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
-  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "bilinear" | "box" | "cubic" | "lanczos2" | "lanczos3" | "linear" | "mitchell" | "mks2013" | "mks2021" | "nearest"
+  type Image.Format (bun-types/bun.d.ts) = "avif" | "bmp" | "gif" | "heic" | "jpeg" | "png" | "tiff" | "webp"
   interface Image.Metadata (bun-types/bun.d.ts)
-    format: Format
+    format: Bun.Image.Format
     height: number
     width: number
   interface Image.ModulateOptions (bun-types/bun.d.ts)
     brightness [?]: number | undefined
     saturation [?]: number | undefined
   interface Image.ResizeOptions (bun-types/bun.d.ts)
-    filter [?]: Filter | undefined
+    filter [?]: Bun.Image.Filter | undefined
     fit [?]: "fill" | "inside" | undefined
     withoutEnlargement [?]: boolean | undefined
   var Image.backend (bun-types/bun.d.ts): "bun" | "system"
 interface Import (bun-types/bun.d.ts)
-  kind: ImportKind
+  kind: Bun.ImportKind
   path: string
-type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+type ImportKind (bun-types/bun.d.ts) = "dynamic-import" | "entry-point-build" | "entry-point-run" | "import-rule" | "import-statement" | "internal" | "require-call" | "require-resolve" | "url-token"
 namespace JSON5 (bun-types/bun.d.ts)
   function JSON5.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -694,30 +719,30 @@ namespace JSONL (bun-types/bun.d.ts)
     read: number
     values: Array<unknown>
   function JSONL.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Array<unknown>
   function JSONL.parseChunk (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): Bun.JSONL.ParseChunkResult
 type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
 interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
   level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
   library [?]: "libdeflate" | undefined
-type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+type Loader (bun-types/bun.d.ts) = "css" | "file" | "html" | "js" | "json" | "jsonc" | "jsx" | "napi" | "text" | "toml" | "ts" | "tsx" | "wasm" | "xml" | "yaml"
 class MD4 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD4
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD4
   [static]
-    construct new (): MD4
+    construct new (): Bun.MD4
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD4
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD4
 class MD5 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD5
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD5
   [static]
-    construct new (): MD5
+    construct new (): Bun.MD5
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD5
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD5
 interface MMapOptions (bun-types/bun.d.ts)
   offset [?]: number | undefined
   shared [?]: boolean | undefined
@@ -732,8 +757,8 @@ interface MatchedRoute (bun-types/bun.d.ts)
   pathname [readonly]: string
   query [readonly]: Record<string, string>
   src [readonly]: string
-type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
-type MessageEvent<T = any> (bun-types/bun.d.ts) = BunMessageEvent<T>
+type MaybePromise<T> (bun-types/bun.d.ts) = Promise<T> | T
+type MessageEvent<T = any> (bun-types/bun.d.ts) = Bun.BunMessageEvent<T>
 interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -744,8 +769,8 @@ interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   source [?]: null | undefined
 type MessageEventSource (bun-types/bun.d.ts) = undefined
 type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
-type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
-type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: Bun.MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "reject" | "resolve"
 interface NetworkSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
@@ -753,38 +778,38 @@ interface NetworkSink (bun-types/s3.d.ts)
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   stat: () => Promise<Stats>
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
-type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
-type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
 type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
-type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+type OnEndCallback (bun-types/bun.d.ts) = (result: Bun.BuildOutput) => void | Promise<void>
 interface OnLoadArgs (bun-types/bun.d.ts)
   defer: () => Promise<void>
-  loader: Loader
+  loader: Bun.Loader
   namespace: string
   path: string
-type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
-type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+type OnLoadCallback (bun-types/bun.d.ts) = (args: Bun.OnLoadArgs) => Bun.OnLoadResult | Promise<Bun.OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = Bun.OnLoadResultObject | Bun.OnLoadResultSourceCode | undefined | void
 interface OnLoadResultObject (bun-types/bun.d.ts)
   exports: Record<string, unknown>
   loader: "object"
 interface OnLoadResultSourceCode (bun-types/bun.d.ts)
-  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
-  loader [?]: Loader | undefined
+  contents: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Bun.Loader | undefined
 interface OnResolveArgs (bun-types/bun.d.ts)
   importer: string
-  kind: ImportKind
+  kind: Bun.ImportKind
   namespace: string
   path: string
   resolveDir: string
-type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+type OnResolveCallback (bun-types/bun.d.ts) = (args: Bun.OnResolveArgs) => Bun.OnResolveResult | Promise<Bun.OnResolveResult | null | undefined> | null | undefined
 interface OnResolveResult (bun-types/bun.d.ts)
   external [?]: boolean | undefined
   namespace [?]: string | undefined
   path: string
 type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
 namespace Password (bun-types/bun.d.ts)
-  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "argon2d" | "argon2i" | "argon2id" | "bcrypt"
   interface Password.Argon2Algorithm (bun-types/bun.d.ts)
     algorithm: "argon2d" | "argon2i" | "argon2id"
     memoryCost [?]: number | undefined
@@ -792,243 +817,243 @@ namespace Password (bun-types/bun.d.ts)
   interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
     algorithm: "bcrypt"
     cost [?]: number | undefined
-type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
-type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
-type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+type PathLike (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | URL | string
+type PipedSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "cygwin" | "darwin" | "freebsd" | "haiku" | "linux" | "netbsd" | "openbsd" | "sunos" | "win32"
 interface PluginBuilder (bun-types/bun.d.ts)
-  config: BuildConfig & { plugins: Array<BunPlugin>; }
-  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
-  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
-  onEnd: (callback: OnEndCallback) => PluginBuilder
-  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
-  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
-  onStart: (callback: OnStartCallback) => PluginBuilder
+  config: Bun.BuildConfig & { plugins: Array<Bun.BunPlugin>; }
+  module: (specifier: string, callback: () => Bun.OnLoadResult | Promise<Bun.OnLoadResult>) => Bun.PluginBuilder
+  onBeforeParse: (constraints: Bun.PluginConstraints, callback: Bun.OnBeforeParseCallback) => Bun.PluginBuilder
+  onEnd: (callback: Bun.OnEndCallback) => Bun.PluginBuilder
+  onLoad: (constraints: Bun.PluginConstraints, callback: Bun.OnLoadCallback) => Bun.PluginBuilder
+  onResolve: (constraints: Bun.PluginConstraints, callback: Bun.OnResolveCallback) => Bun.PluginBuilder
+  onStart: (callback: Bun.OnStartCallback) => Bun.PluginBuilder
 interface PluginConstraints (bun-types/bun.d.ts)
   filter: RegExp
   namespace [?]: string | undefined
-type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined
 type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
 interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
   done: boolean
   size: number
   value: Array<T>
-type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadDoneResult | ReadableStreamDefaultReadValueResult<T>
 type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
-type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
-type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+type ReadableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"pipe", "pipe">
 class RedisClient (bun-types/redis.d.ts)
-  append: (key: KeyLike, value: KeyLike) => Promise<number>
-  bitcount: (key: KeyLike) => Promise<number>
-  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
-  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
-  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
-  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
-  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  append: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  bitcount: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  bitfield: (key: Bun.RedisClient.KeyLike, ...operations: Array<number | string>) => Promise<Array<null | number>>
+  bitop: { (operation: "NOT" | "not", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  bitpos: (key: Bun.RedisClient.KeyLike, bit: 0 | 1, ...options: Array<number | string>) => Promise<number>
+  blmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<null | string>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, timeout: number) => Promise<null | string>
   bufferedAmount [readonly]: number
-  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  client: (...args: Array<string | number>) => Promise<any>
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  client: (...args: Array<number | string>) => Promise<any>
   close: () => void
-  command: (...args: Array<string | number>) => Promise<any>
-  config: (...args: Array<string | number>) => Promise<any>
+  command: (...args: Array<number | string>) => Promise<any>
+  config: (...args: Array<number | string>) => Promise<any>
   connect: () => Promise<void>
   connected [readonly]: boolean
-  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  copy: { (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike): Promise<number>; (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, replace: "REPLACE"): Promise<number> }
   dbsize: () => Promise<number>
-  debug: (...args: Array<string | number>) => Promise<any>
-  decr: (key: KeyLike) => Promise<number>
-  decrby: (key: KeyLike, decrement: number) => Promise<number>
-  del: (...keys: Array<KeyLike>) => Promise<number>
-  dump: (key: KeyLike) => Promise<string | null>
-  duplicate: () => Promise<RedisClient>
+  debug: (...args: Array<number | string>) => Promise<any>
+  decr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  decrby: (key: Bun.RedisClient.KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  dump: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  duplicate: () => Promise<Bun.RedisClient>
   echo: (message: string) => Promise<string>
-  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  exists: (key: KeyLike) => Promise<boolean>
-  expire: (key: KeyLike, seconds: number) => Promise<number>
-  expireat: (key: KeyLike, timestamp: number) => Promise<number>
-  expiretime: (key: KeyLike) => Promise<number>
-  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  exists: (key: Bun.RedisClient.KeyLike) => Promise<boolean>
+  expire: (key: Bun.RedisClient.KeyLike, seconds: number) => Promise<number>
+  expireat: (key: Bun.RedisClient.KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
   flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
   flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
-  function: (...args: Array<KeyLike>) => Promise<any>
-  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
-  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
-  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
-  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
-  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
-  get: (key: KeyLike) => Promise<string | null>
-  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
-  getbit: (key: KeyLike, offset: number) => Promise<number>
-  getdel: (key: KeyLike) => Promise<string | null>
-  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
-  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
-  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
-  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
-  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
-  hgetall: (key: KeyLike) => Promise<Record<string, string>>
-  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
-  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
-  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
-  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
-  hkeys: (key: KeyLike) => Promise<Array<string>>
-  hlen: (key: KeyLike) => Promise<number>
-  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
-  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
-  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
-  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
-  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
-  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
-  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
-  hstrlen: (key: KeyLike, field: string) => Promise<number>
-  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hvals: (key: KeyLike) => Promise<Array<string>>
-  incr: (key: KeyLike) => Promise<number>
-  incrby: (key: KeyLike, increment: number) => Promise<number>
-  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  function: (...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  geoadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  geodist: { (key: Bun.RedisClient.KeyLike, member1: string, member2: string): Promise<null | string>; (key: Bun.RedisClient.KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<null | string> }
+  geohash: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<null | string>>
+  geopos: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<unknown>>
+  geosearchstore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  get: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getBuffer: (key: Bun.RedisClient.KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: Bun.RedisClient.KeyLike, offset: number) => Promise<number>
+  getdel: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getex: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST"): Promise<null | string> }
+  getrange: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hdel: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  hexists: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hexpire: { (key: Bun.RedisClient.KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hget: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hgetall: (key: Bun.RedisClient.KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  hgetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>> }
+  hincrby: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  hlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  hmget: { (key: Bun.RedisClient.KeyLike, ...fields: Array<string>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, fields: Array<string>): Promise<Array<null | string>> }
+  hmset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<"OK"> }
+  hpersist: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: Bun.RedisClient.KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpttl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: Bun.RedisClient.KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<number>; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetnx: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hstrlen: (key: Bun.RedisClient.KeyLike, field: string) => Promise<number>
+  httl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hvals: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  incr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  incrby: (key: Bun.RedisClient.KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: Bun.RedisClient.KeyLike, increment: number | string) => Promise<string>
   info: (...sections: Array<string>) => Promise<string>
   keys: (pattern: string) => Promise<Array<string>>
   lastsave: () => Promise<number>
-  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
-  lindex: (key: KeyLike, index: number) => Promise<string | null>
-  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
-  llen: (key: KeyLike) => Promise<number>
-  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
-  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
-  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
-  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
-  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
-  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
-  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
-  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
-  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
-  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
-  onclose: ((this: RedisClient, error: Error) => void) | null
-  onconnect: ((this: RedisClient) => void) | null
-  persist: (key: KeyLike) => Promise<number>
-  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
-  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
-  pexpiretime: (key: KeyLike) => Promise<number>
-  pfadd: (key: KeyLike, element: string) => Promise<number>
-  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
-  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
-  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
-  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
-  pttl: (key: KeyLike) => Promise<number>
+  lcs: (key1: Bun.RedisClient.KeyLike, key2: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<any>
+  lindex: (key: Bun.RedisClient.KeyLike, index: number) => Promise<null | string>
+  linsert: (key: Bun.RedisClient.KeyLike, position: "AFTER" | "BEFORE", pivot: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike) => Promise<number>
+  llen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  lmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<null | string>
+  lmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<Array<number> | null | number>
+  lpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  lpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  lrange: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: Bun.RedisClient.KeyLike, count: number, element: Bun.RedisClient.KeyLike) => Promise<number>
+  lset: (key: Bun.RedisClient.KeyLike, index: number, element: Bun.RedisClient.KeyLike) => Promise<string>
+  ltrim: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  mset: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  onclose: ((this: Bun.RedisClient, error: Error) => void) | null
+  onconnect: ((this: Bun.RedisClient) => void) | null
+  persist: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pexpire: (key: Bun.RedisClient.KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: Bun.RedisClient.KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pfadd: (key: Bun.RedisClient.KeyLike, element: string) => Promise<number>
+  pfcount: (key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  pfmerge: (destkey: Bun.RedisClient.KeyLike, ...sourcekeys: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: Bun.RedisClient.KeyLike): Promise<string> }
+  psetex: (key: Bun.RedisClient.KeyLike, milliseconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  pttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
   publish: (channel: string, message: string) => Promise<number>
-  randomkey: () => Promise<string | null>
-  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
-  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
-  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
-  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
-  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
-  scard: (key: KeyLike) => Promise<number>
+  randomkey: () => Promise<null | string>
+  rename: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<"OK">
+  renamenx: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<number>
+  rpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike) => Promise<null | string>
+  rpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  rpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sadd: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<number | string>): Promise<[string, Array<string>]> }
+  scard: (key: Bun.RedisClient.KeyLike) => Promise<number>
   script: (...args: Array<string>) => Promise<any>
-  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sdiff: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   send: (command: string, args: Array<string>) => Promise<any>
-  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
-  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
-  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
-  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
-  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
-  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
-  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
-  sismember: (key: KeyLike, member: string) => Promise<boolean>
-  smembers: (key: KeyLike) => Promise<Array<string>>
-  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
-  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
-  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
-  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  spublish: (channel: KeyLike, message: string) => Promise<number>
-  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
-  strlen: (key: KeyLike) => Promise<number>
-  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
-  substr: (key: KeyLike, start: number, end: number) => Promise<string>
-  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  set: { (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, nx: "NX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, xx: "XX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, get: "GET"): Promise<null | string>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...options: Array<string>): Promise<null | string> }
+  setbit: (key: Bun.RedisClient.KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: Bun.RedisClient.KeyLike, seconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  setnx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  setrange: (key: Bun.RedisClient.KeyLike, offset: number, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sinter: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: Bun.RedisClient.KeyLike, ...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<number>
+  sinterstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  sismember: (key: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  smembers: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  smismember: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  smove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  sort: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<null | string> | number>
+  spop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: Bun.RedisClient.KeyLike, message: string) => Promise<number>
+  srandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...args: Array<number | string>) => Promise<[string, Array<string>]>
+  strlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<number>; (channels: Array<string>, listener: Bun.RedisClient.StringPubSubListener): Promise<number> }
+  substr: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   time: () => Promise<[string, string]>
-  touch: (...keys: Array<KeyLike>) => Promise<number>
-  ttl: (key: KeyLike) => Promise<number>
-  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
-  unlink: (...keys: Array<KeyLike>) => Promise<number>
-  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  touch: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  ttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  type: (key: Bun.RedisClient.KeyLike) => Promise<"hash" | "list" | "none" | "set" | "stream" | "string" | "zset">
+  unlink: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
   wait: (numreplicas: number, timeout: number) => Promise<number>
-  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
-  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
-  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
-  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
-  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
-  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xlen: (key: KeyLike) => Promise<number>
-  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
-  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xread: (...args: Array<string | number>) => Promise<any>
-  xreadgroup: (...args: Array<string | number>) => Promise<any>
-  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
-  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
-  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  zcard: (key: KeyLike) => Promise<number>
-  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
-  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
-  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
-  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
-  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
-  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
-  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
-  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
-  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
-  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
-  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
-  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
-  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
-  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
-  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
-  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
-  zscore: (key: KeyLike, member: string) => Promise<number | null>
-  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  xack: (key: Bun.RedisClient.KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<null | string>
+  xautoclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<number | string>) => Promise<any>
+  xclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<number | string>) => Promise<any>
+  xdel: (key: Bun.RedisClient.KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  xpending: (key: Bun.RedisClient.KeyLike, group: string, ...args: Array<number | string>) => Promise<any>
+  xrange: (key: Bun.RedisClient.KeyLike, start: string, end: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<number | string>) => Promise<any>
+  xreadgroup: (...args: Array<number | string>) => Promise<any>
+  xrevrange: (key: Bun.RedisClient.KeyLike, end: string, start: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: Bun.RedisClient.KeyLike, lastId: string, ...options: Array<number | string>) => Promise<"OK">
+  xtrim: (key: Bun.RedisClient.KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<number | string>) => Promise<number>
+  zadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  zcard: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  zcount: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: Bun.RedisClient.KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zincrby: (key: Bun.RedisClient.KeyLike, increment: number, member: Bun.RedisClient.KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<number>; (numkeys: number, ...args: Array<Bun.RedisClient.KeyLike | number>): Promise<number> }
+  zinterstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
+  zlexcount: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | number>>
+  zpopmax: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null>; (key: Bun.RedisClient.KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: Bun.RedisClient.KeyLike, min: string, max: string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangebyscore: { (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangestore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zremrangebylex: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: Bun.RedisClient.KeyLike, start: number, stop: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: Bun.RedisClient.KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrevrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: Bun.RedisClient.KeyLike, member: string) => Promise<null | number>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zunionstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
   [static]
-    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
-    prototype: RedisClient
-  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+    construct new (url?: string | undefined, options?: Bun.RedisOptions | undefined): Bun.RedisClient
+    prototype: Bun.RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = Blob | Bun.ArrayBufferView<ArrayBufferLike> | string
   type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
 interface RedisOptions (bun-types/redis.d.ts)
   autoReconnect [?]: boolean | undefined
@@ -1037,34 +1062,34 @@ interface RedisOptions (bun-types/redis.d.ts)
   enableOfflineQueue [?]: boolean | undefined
   idleTimeout [?]: number | undefined
   maxRetries [?]: number | undefined
-  tls [?]: TLSOptions | boolean | undefined
+  tls [?]: Bun.TLSOptions | boolean | undefined
 type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
 interface ReservedSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
   [Symbol.dispose]: () => void
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
   release: () => void
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 interface ResourceUsage (bun-types/bun.d.ts)
   contextSwitches: { voluntary: number; involuntary: number; }
   cpuTime: { user: number; system: number; total: number; }
@@ -1075,27 +1100,27 @@ interface ResourceUsage (bun-types/bun.d.ts)
   signalCount: number
   swapCount: number
 class S3Client (bun-types/s3.d.ts)
-  delete: (path: string, options?: S3Options | undefined) => Promise<void>
-  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
-  file: (path: string, options?: S3Options | undefined) => S3File
-  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
-  size: (path: string, options?: S3Options | undefined) => Promise<number>
-  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
-  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  delete: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+  list: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+  presign: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+  unlink: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  write: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
   [static]
-    construct new (options?: S3Options | undefined): S3Client
-    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
-    file [static]: (path: string, options?: S3Options | undefined) => S3File
-    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
-    prototype: S3Client
-    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
-    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+    construct new (options?: Bun.S3Options | undefined): Bun.S3Client
+    delete [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+    list [static]: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+    presign [static]: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+    prototype: Bun.S3Client
+    size [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+    unlink [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
 interface S3File (bun-types/s3.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bucket [? readonly]: string | undefined
@@ -1103,20 +1128,20 @@ interface S3File (bun-types/s3.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   name [? readonly]: string | undefined
-  presign: (options?: S3FilePresignOptions | undefined) => string
+  presign: (options?: Bun.S3FilePresignOptions | undefined) => string
   readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
-  stat: () => Promise<S3Stats>
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.S3File; (begin?: number | undefined, contentType?: string | undefined): Bun.S3File; (contentType?: string | undefined): Bun.S3File }
+  stat: () => Promise<Bun.S3Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
-  writer: (options?: S3Options | undefined) => NetworkSink
+  write: (data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
+  writer: (options?: Bun.S3Options | undefined) => Bun.NetworkSink
 interface S3FilePresignOptions (bun-types/s3.d.ts)
   accessKeyId [?]: string | undefined
   acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
@@ -1182,89 +1207,89 @@ interface S3Stats (bun-types/s3.d.ts)
   size: number
   type: string
 class SHA1 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA1
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA1
   [static]
-    construct new (): SHA1
+    construct new (): Bun.SHA1
     byteLength [readonly static]: 20
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA1
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA1
 class SHA224 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA224
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA224
   [static]
-    construct new (): SHA224
+    construct new (): Bun.SHA224
     byteLength [readonly static]: 28
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA224
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA224
 class SHA256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA256
   [static]
-    construct new (): SHA256
+    construct new (): Bun.SHA256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA256
 class SHA384 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA384
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA384
   [static]
-    construct new (): SHA384
+    construct new (): Bun.SHA384
     byteLength [readonly static]: 48
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA384
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA384
 class SHA512 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512
   [static]
-    construct new (): SHA512
+    construct new (): Bun.SHA512
     byteLength [readonly static]: 64
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512
 class SHA512_256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512_256
   [static]
-    construct new (): SHA512_256
+    construct new (): Bun.SHA512_256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512_256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512_256
 class SQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   [static]
-    construct new (connectionString: URL | string): SQL
-    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
-    construct new (options?: Options | undefined): SQL
-    MySQLError: typeof MySQLError
-    PostgresError: typeof PostgresError
-    SQLError: typeof SQLError
-    SQLiteError: typeof SQLiteError
-    prototype: SQL
+    construct new (connectionString: URL | string): Bun.SQL
+    construct new (connectionString: URL | string, options: Omit<Bun.SQL.PostgresOrMySQLOptions, "filename" | "url"> | Omit<Bun.SQL.SQLiteOptions, "filename" | "url">): Bun.SQL
+    construct new (options?: Bun.SQL.Options | undefined): Bun.SQL
+    MySQLError: typeof Bun.SQL.MySQLError
+    PostgresError: typeof Bun.SQL.PostgresError
+    SQLError: typeof Bun.SQL.SQLError
+    SQLiteError: typeof Bun.SQL.SQLiteError
+    prototype: Bun.SQL
   type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
-  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
-  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => Bun.MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? Bun.SQL.AwaitPromisesArray<T> : Awaited<T>
   interface SQL.Helper<T> (bun-types/sql.d.ts)
     columns [readonly]: Array<keyof T>
     value [readonly]: Array<T>
@@ -1281,13 +1306,13 @@ class SQL (bun-types/sql.d.ts)
     sqlState [? readonly]: string | undefined
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): Bun.SQL.MySQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: MySQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.MySQLError
       stackTraceLimit: number
-  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  type SQL.Options (bun-types/sql.d.ts) = Bun.SQL.PostgresOrMySQLOptions | Bun.SQL.SQLiteOptions
   class SQL.PostgresError (bun-types/sql.d.ts)
     cause [?]: unknown
     code [readonly]: string
@@ -1311,11 +1336,11 @@ class SQL (bun-types/sql.d.ts)
     table [? readonly]: string | undefined
     where [? readonly]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): Bun.SQL.PostgresError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: PostgresError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.PostgresError
       stackTraceLimit: number
   interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
     adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
@@ -1323,7 +1348,7 @@ class SQL (bun-types/sql.d.ts)
     bigint [?]: boolean | undefined
     connectTimeout [?]: number | undefined
     connect_timeout [?]: number | undefined
-    connection [?]: Record<string, string | number | boolean> | undefined
+    connection [?]: Record<string, boolean | number | string> | undefined
     connectionTimeout [?]: number | undefined
     connection_timeout [?]: number | undefined
     database [?]: string | undefined
@@ -1337,39 +1362,39 @@ class SQL (bun-types/sql.d.ts)
     max_lifetime [?]: number | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
-    pass [?]: (() => MaybePromise<string>) | string | undefined
-    password [?]: (() => MaybePromise<string>) | string | undefined
+    pass [?]: (() => Bun.MaybePromise<string>) | string | undefined
+    password [?]: (() => Bun.MaybePromise<string>) | string | undefined
     path [?]: string | undefined
     port [?]: number | string | undefined
     prepare [?]: boolean | undefined
-    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
-    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
     url [?]: URL | string | undefined
     user [?]: string | undefined
     username [?]: string | undefined
   interface SQL.Query<T> (bun-types/sql.d.ts)
     [Symbol.toStringTag] [readonly]: string
     active: boolean
-    cancel: () => Query<T>
+    cancel: () => Bun.SQL.Query<T>
     cancelled: boolean
     catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
-    execute: () => Query<T>
+    execute: () => Bun.SQL.Query<T>
     finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
-    raw: () => Query<T>
-    simple: () => Query<T>
+    raw: () => Bun.SQL.Query<T>
+    simple: () => Bun.SQL.Query<T>
     then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    values: () => Query<T>
+    values: () => Bun.SQL.Query<T>
   class SQL.SQLError (bun-types/sql.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string): SQLError
+      construct new (message: string): Bun.SQL.SQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLError
       stackTraceLimit: number
   class SQL.SQLiteError (bun-types/sql.d.ts)
     byteOffset [? readonly]: number | undefined
@@ -1380,55 +1405,55 @@ class SQL (bun-types/sql.d.ts)
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): Bun.SQL.SQLiteError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLiteError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLiteError
       stackTraceLimit: number
   interface SQL.SQLiteOptions (bun-types/sql.d.ts)
     adapter [?]: "sqlite" | undefined
     create [?]: boolean | undefined
-    filename [?]: ":memory:" | URL | string & {} | undefined
+    filename [?]: ":memory:" | (string & {}) | URL | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
     readonly [?]: boolean | undefined
     readwrite [?]: boolean | undefined
     safeIntegers [?]: boolean | undefined
     strict [?]: boolean | undefined
-  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SQLArrayParameter (bun-types/sql.d.ts)
-  arrayType: ArrayType
+  arrayType: Bun.ArrayType
   serializedValues: string
-type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
-type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
-type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+type SQLOptions (bun-types/deprecated.d.ts) = Bun.SQL.Options
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Bun.SQL.Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SavepointSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 namespace Security (bun-types/security.d.ts)
   interface Security.Advisory (bun-types/security.d.ts)
     description: null | string
@@ -1441,29 +1466,29 @@ namespace Security (bun-types/security.d.ts)
     tarball: string
     version: string
   interface Security.Scanner (bun-types/security.d.ts)
-    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    scan: (info: { packages: Array<Bun.Security.Package>; }) => Promise<Array<Bun.Security.Advisory>>
     version: "1"
 namespace Serve (bun-types/serve.d.ts)
-  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = Bun.BunFile | Bun.HTMLBundle | Bun.Serve.DirectoryRouteOptions | Response | false
   interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
   type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
   interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
     dir: string
     statCache [?]: boolean | undefined
-  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
-  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
-  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
-  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
-  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & Bun.Serve.ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes?: Bun.Serve.Routes<WebSocketData, R> | undefined; } | { fetch?(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes: Bun.Serve.Routes<WebSocketData, R>; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = Bun.Serve.FetchOrRoutesWithWebSocket<WebSocketData, R>
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => Bun.MaybePromise<Res>
   interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
-    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | (string & {}) | undefined
     http1 [?]: boolean | undefined
     http2 [?]: boolean | undefined
     http3 [?]: boolean | undefined
@@ -1473,18 +1498,18 @@ namespace Serve (bun-types/serve.d.ts)
     maxRequestBodySize [?]: number | undefined
     port [?]: number | string | undefined
     reusePort [?]: boolean | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
-  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
-  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
-  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = Bun.Serve.Options<WebSocketData, R>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined>>>; }
   interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
     unix [?]: string | undefined
-type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = Bun.ServeOptions<T, R>
 interface Server<WebSocketData> (bun-types/serve.d.ts)
   [Symbol.dispose]: () => void
   closeIdleConnections: () => number
@@ -1496,41 +1521,41 @@ interface Server<WebSocketData> (bun-types/serve.d.ts)
   pendingWebSockets [readonly]: number
   port [readonly]: number | undefined
   protocol [readonly]: "http" | "https" | null
-  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  publish: (topic: string, data: ArrayBuffer | Blob | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, compress?: boolean | undefined) => number
   ref: () => void
-  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
-  requestIP: (request: Request) => SocketAddress | null
+  reload: <R extends string>(options: Bun.Serve.Options<WebSocketData, R>) => Bun.Server<WebSocketData>
+  requestIP: (request: Request) => Bun.SocketAddress | null
   stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
   subscriberCount: (topic: string) => number
   timeout: (request: Request, seconds: number) => void
   unref: () => void
-  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: Bun.HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: Bun.HeadersInit | undefined; data: WebSocketData; }]) => boolean
   url [readonly]: URL
 interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
   binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
   close: (code?: number | undefined, reason?: string | undefined) => void
-  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  cork: <T = unknown>(callback: (ws: Bun.ServerWebSocket<T>) => T) => T
   data: T
   getBufferedAmount: () => number
   isSubscribed: (topic: string) => boolean
-  ping: (data?: Blob | BufferSource | string | undefined) => number
-  pong: (data?: Blob | BufferSource | string | undefined) => number
-  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  ping: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  pong: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   publishText: (topic: string, data: string, compress?: boolean | undefined) => number
-  readyState [readonly]: WebSocketReadyState
+  readyState [readonly]: Bun.WebSocketReadyState
   remoteAddress [readonly]: string
-  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  send: (data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   sendText: (data: string, compress?: boolean | undefined) => number
   subscribe: (topic: string) => boolean
   subscriptions [readonly]: Array<string>
   terminate: () => void
   unsubscribe: (topic: string) => boolean
 type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
-type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellExpression (bun-types/shell.d.ts) = Array<Bun.ShellExpression> | BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | Blob | Bun.BunFile | Bun.Subprocess<Bun.SpawnOptions.Writable, Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | ReadableStream<any> | ReadableStream<any> | Request | Response | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | null | number | string | undefined | { raw: string; } | { toString(): string; }
 type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
-type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+type SignalsListener (bun-types/bun.d.ts) = (signal: NodeJS.Signals) => void
 interface SliceAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   ellipsis [?]: string | undefined
@@ -1542,8 +1567,8 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   close: () => void
   data: Data
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1560,14 +1585,14 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1577,154 +1602,154 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface SocketAddress (bun-types/bun.d.ts)
   address: string
   family: "IPv4" | "IPv6"
   port: number
-interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
-  binaryType [?]: keyof BinaryTypeList | undefined
-  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
-  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
-  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
-  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof Bun.BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof Bun.BinaryTypeList | undefined
+  close [?]: ((socket: Bun.Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Bun.Socket<Data>, data: Bun.BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Bun.Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
 interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
+  socket: Bun.SocketHandler<Data, "buffer">
 namespace Spawn (bun-types/bun.d.ts)
-  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
-  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
-  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
-  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
-  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  type Spawn.OptionsObject<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = Bun.SpawnOptions.BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | null | number | undefined
+  type Spawn.ReadableToIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | Bun.BunFile | Bun.ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     lazy [?]: boolean | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
-    terminal [?]: Terminal | TerminalOptions | undefined
+    terminal [?]: Bun.Terminal | Bun.TerminalOptions | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.SpawnSyncOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
-  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
-  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | null | number | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = Bun.FileSink | number | undefined
+  type Spawn.WritableToIO<X extends Bun.SpawnOptions.Writable> (bun-types/bun.d.ts) = X extends "pipe" ? Bun.FileSink : X extends number | Bun.BunFile | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
 SpawnOptions -> Spawn
 type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
-type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type StringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | string
 interface StringWidthOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   countAnsiEscapeCodes [?]: boolean | undefined
   perCodePoint [?]: boolean | undefined
 interface StructuredSerializeOptions (bun-types/bun.d.ts)
-  transfer [?]: Array<Transferable> | undefined
-interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  transfer [?]: Array<Bun.Transferable> | undefined
+interface Subprocess<In extends Bun.SpawnOptions.Writable = Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => PromiseLike<void>
   disconnect: () => void
   exitCode [readonly]: null | number
   exited [readonly]: Promise<number>
-  kill: (exitCode?: Signals | number | undefined) => void
+  kill: (exitCode?: NodeJS.Signals | number | undefined) => void
   killed [readonly]: boolean
   pid [readonly]: number
-  readable [readonly]: ReadableToIO<Out>
+  readable [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
   ref: () => void
-  resourceUsage: () => ResourceUsage | undefined
+  resourceUsage: () => Bun.ResourceUsage | undefined
   send: (message: any) => void
-  signalCode [readonly]: Signals | null
-  stderr [readonly]: ReadableToIO<Err>
-  stdin [readonly]: WritableToIO<In>
+  signalCode [readonly]: NodeJS.Signals | null
+  stderr [readonly]: Bun.SpawnOptions.ReadableToIO<Err>
+  stdin [readonly]: Bun.SpawnOptions.WritableToIO<In>
   stdio [readonly]: [null, null, null, ...(number | null)[]]
-  stdout [readonly]: ReadableToIO<Out>
-  terminal [readonly]: Terminal | undefined
+  stdout [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
+  terminal [readonly]: Bun.Terminal | undefined
   unref: () => void
-type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
-interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha256" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "sha384" | "sha512" | "sha512-224" | "sha512-256" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   exitCode: number
   exitedDueToMaxBuffer [?]: boolean | undefined
   exitedDueToTimeout [?]: boolean | undefined
   pid: number
-  resourceUsage: ResourceUsage
+  resourceUsage: Bun.ResourceUsage
   signalCode [?]: string | undefined
-  stderr: ReadableToSyncIO<Err>
-  stdout: ReadableToSyncIO<Out>
+  stderr: Bun.SpawnOptions.ReadableToSyncIO<Err>
+  stdout: Bun.SpawnOptions.ReadableToSyncIO<Out>
   success: boolean
 interface SystemError (bun-types/bun.d.ts)
   cause [?]: unknown
@@ -1743,8 +1768,8 @@ interface TCPSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1761,14 +1786,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1778,14 +1803,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
@@ -1794,36 +1819,36 @@ interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   ipv6Only [?]: boolean | undefined
   port: number
   reusePort [?]: boolean | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   exclusive [?]: boolean | undefined
   hostname: string
   port: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   hostname [readonly]: string
   port [readonly]: number
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -1839,8 +1864,8 @@ interface TLSSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1857,14 +1882,14 @@ interface TLSSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1874,27 +1899,27 @@ interface TLSSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls: TLSOptions | boolean
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls: Bun.TLSOptions | boolean
 namespace TOML (bun-types/bun.d.ts)
   function TOML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): object
   function TOML.stringify (bun-types/bun.d.ts)
     call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
 interface TSConfig (bun-types/bun.d.ts)
   compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
   extends [?]: string | undefined
-type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+type Target (bun-types/bun.d.ts) = "browser" | "bun" | "node"
 class Terminal (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => Promise<void>
   close: () => void
@@ -1907,43 +1932,43 @@ class Terminal (bun-types/bun.d.ts)
   resize: (cols: number, rows: number) => void
   setRawMode: (enabled: boolean) => void
   unref: () => void
-  write: (data: BufferSource | string) => number
+  write: (data: Bun.BufferSource | string) => number
   [static]
-    construct new (options: TerminalOptions): Terminal
-    prototype: Terminal
+    construct new (options: Bun.TerminalOptions): Bun.Terminal
+    prototype: Bun.Terminal
 interface TerminalOptions (bun-types/bun.d.ts)
   cols [?]: number | undefined
-  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
-  drain [?]: ((terminal: Terminal) => void) | undefined
-  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  data [?]: ((terminal: Bun.Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Bun.Terminal) => void) | undefined
+  exit [?]: ((terminal: Bun.Terminal, exitCode: number, signal: null | string) => void) | undefined
   name [?]: string | undefined
   rows [?]: number | undefined
 type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
 interface TransactionSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  savepoint: { <T>(name: string, fn: Bun.SQL.SavepointContextCallback<T>): Promise<T>; <T>(fn: Bun.SQL.SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
 interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
   call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
@@ -1952,13 +1977,13 @@ interface TransformerStartCallback<O> (bun-types/bun.d.ts)
 interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
   call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
 class Transpiler (bun-types/bun.d.ts)
-  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
-  scanImports: (code: StringOrBuffer) => Array<Import>
-  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
-  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  scan: (code: Bun.StringOrBuffer) => { exports: Array<string>; imports: Array<Bun.Import>; }
+  scanImports: (code: Bun.StringOrBuffer) => Array<Bun.Import>
+  transform: (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: Bun.StringOrBuffer, loader: Bun.JavaScriptLoader, ctx: object): string; (code: Bun.StringOrBuffer, ctx: object): string; (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined): string }
   [static]
-    construct new (options?: TranspilerOptions | undefined): Transpiler
-    prototype: Transpiler
+    construct new (options?: Bun.TranspilerOptions | undefined): Bun.Transpiler
+    prototype: Bun.Transpiler
 interface TranspilerOptions (bun-types/bun.d.ts)
   allowBunRuntime [?]: boolean | undefined
   autoImportJSX [?]: boolean | undefined
@@ -1967,23 +1992,23 @@ interface TranspilerOptions (bun-types/bun.d.ts)
   exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
   inline [?]: boolean | undefined
   jsxOptimizationInline [?]: boolean | undefined
-  loader [?]: JavaScriptLoader | undefined
+  loader [?]: Bun.JavaScriptLoader | undefined
   logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
-  macro [?]: MacroMap | undefined
+  macro [?]: Bun.MacroMap | undefined
   minifyWhitespace [?]: boolean | undefined
   replMode [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   treeShaking [?]: boolean | undefined
   trimUnusedImports [?]: boolean | undefined
-  tsconfig [?]: TSConfig | string | undefined
-type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  tsconfig [?]: Bun.TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: Bun.UncaughtExceptionOrigin) => void
 type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
 interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
-  abort [?]: UnderlyingSinkAbortCallback | undefined
-  close [?]: UnderlyingSinkCloseCallback | undefined
-  start [?]: UnderlyingSinkStartCallback | undefined
+  abort [?]: Bun.UnderlyingSinkAbortCallback | undefined
+  close [?]: Bun.UnderlyingSinkCloseCallback | undefined
+  start [?]: Bun.UnderlyingSinkStartCallback | undefined
   type [?]: "bytes" | "default" | undefined
-  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+  write [?]: Bun.UnderlyingSinkWriteCallback<W> | undefined
 interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
@@ -1993,30 +2018,30 @@ interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
 interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
   call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
 interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
-  pull [?]: UnderlyingSourcePullCallback<R> | undefined
-  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
+  pull [?]: Bun.UnderlyingSourcePullCallback<R> | undefined
+  start [?]: Bun.UnderlyingSourceStartCallback<R> | undefined
   type [?]: undefined
 interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+  call (controller: Bun.ReadableStreamController<R>): PromiseLike<void> | void
 interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): any
+  call (controller: Bun.ReadableStreamController<R>): any
 type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
 interface UnixSocketListener<Data> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unix [readonly]: string
   unref: () => void
 interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
   unix: string
 type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
 namespace WebAssembly (bun-types/wasm.d.ts)
@@ -2025,19 +2050,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     message: string
     name: string
     stack [?]: string | undefined
-  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
-  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.Global<keyof Bun.WebAssembly.ValueTypeMap> | Bun.WebAssembly.Memory | Bun.WebAssembly.Table | Function
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ExportValue; }
+  interface WebAssembly.Global<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
-  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
-  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.ExportValue | number
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ModuleImports; }
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2052,13 +2077,13 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
-  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ImportValue; }
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2070,11 +2095,11 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     length [readonly]: number
     set: (index: number, value?: any) => void
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
-  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof Bun.WebAssembly.ValueTypeMap
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
     anyfunc: Function
     externref: any
@@ -2084,70 +2109,70 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
 interface WebSocket (bun-types/bun.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
-type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+type WebSocketCompressor (bun-types/serve.d.ts) = "128KB" | "16KB" | "256KB" | "32KB" | "3KB" | "4KB" | "64KB" | "8KB" | "dedicated" | "disable" | "shared"
 interface WebSocketEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: Event
-  message: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
   open: Event
 interface WebSocketHandler<T> (bun-types/serve.d.ts)
   backpressureLimit [?]: number | undefined
-  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  close [?]: ((ws: Bun.ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
   closeOnBackpressureLimit [?]: boolean | undefined
   data [?]: T | undefined
-  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  drain [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
   idleTimeout [?]: number | undefined
   maxPayloadLength [?]: number | undefined
-  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
-  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
-  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
-  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
-  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  message: (ws: Bun.ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | Bun.WebSocketCompressor | undefined; decompress?: boolean | Bun.WebSocketCompressor | undefined; }
+  ping [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
   publishToSelf [?]: boolean | undefined
   sendPings [?]: boolean | undefined
-type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptions (bun-types/bun.d.ts) = Bun.WebSocketOptions
 type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
 type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
-type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocol?: string | undefined; } | { protocols?: string | Array<string> | undefined; }
 type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
-type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: Bun.TLSOptions | undefined; }
 type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
 class WebView (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => void
   [Symbol.dispose]: () => void
-  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: BunMessageEvent<T>) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: Bun.BunMessageEvent<T>) => void, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   back: () => Promise<void>
   cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
-  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  click: { (x: number, y: number, options?: Bun.WebView.ClickOptions | undefined): Promise<void>; (selector: string, options?: Bun.WebView.ClickSelectorOptions | undefined): Promise<void> }
   close: () => void
   dispatchEvent: (event: Event) => boolean
   evaluate: <T = unknown>(script: string) => Promise<T>
@@ -2156,66 +2181,66 @@ class WebView (bun-types/bun.d.ts)
   navigate: (url: string) => Promise<void>
   onNavigated: ((url: string, title: string) => void) | null
   onNavigationFailed: ((error: Error) => void) | null
-  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  press: (key: (string & {}) | Bun.WebView.VirtualKey, options?: Bun.WebView.PressOptions | undefined) => Promise<void>
   reload: () => Promise<void>
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   resize: (width: number, height: number) => Promise<void>
   screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
   scroll: (dx: number, dy: number) => Promise<void>
-  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  scrollTo: (selector: string, options?: Bun.WebView.ScrollToOptions | undefined) => Promise<void>
   title [readonly]: string
   type: (text: string) => Promise<void>
   url [readonly]: string
   [static]
-    construct new (options?: ConstructorOptions | undefined): WebView
+    construct new (options?: Bun.WebView.ConstructorOptions | undefined): Bun.WebView
     closeAll [static]: () => void
-    prototype: WebView
-  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+    prototype: Bun.WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "chrome" | "webkit" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
   interface WebView.ClickOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
     timeout [?]: number | undefined
-  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = ((type: string, ...args: Array<unknown>) => void) | Console
   interface WebView.ConstructorOptions (bun-types/bun.d.ts)
-    backend [?]: Backend | undefined
-    console [?]: ConsoleCapture | undefined
+    backend [?]: Bun.WebView.Backend | undefined
+    console [?]: Bun.WebView.ConsoleCapture | undefined
     dataStore [?]: "ephemeral" | undefined | { directory: string; }
     headless [?]: boolean | undefined
     height [?]: number | undefined
     url [?]: string | undefined
     width [?]: number | undefined
-  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  type WebView.Modifier (bun-types/bun.d.ts) = "Alt" | "Control" | "Meta" | "Shift"
   interface WebView.PressOptions (bun-types/bun.d.ts)
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ScrollToOptions (bun-types/bun.d.ts)
     block [?]: "center" | "end" | "nearest" | "start" | undefined
     timeout [?]: number | undefined
-  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "Backspace" | "Delete" | "End" | "Enter" | "Escape" | "Home" | "PageDown" | "PageUp" | "Space" | "Tab"
 interface WhichOptions (bun-types/bun.d.ts)
   PATH [?]: string | undefined
   cwd [?]: string | undefined
 interface Worker (bun-types/bun.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
 interface WorkerEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: ErrorEvent
-  message: BunMessageEvent<any>
-  messageerror: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
+  messageerror: Bun.BunMessageEvent<any>
   open: Event
 interface WorkerOptions (bun-types/bun.d.ts)
   argv [?]: Array<any> | undefined
@@ -2225,44 +2250,44 @@ interface WorkerOptions (bun-types/bun.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
 interface WrapAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   hard [?]: boolean | undefined
   trim [?]: boolean | undefined
   wordWrap [?]: boolean | undefined
-type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+type WritableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", any, any>
 namespace XML (bun-types/bun.d.ts)
   interface XML.Comment (bun-types/bun.d.ts)
     comment: string
   interface XML.Document (bun-types/bun.d.ts)
-    index [string]: Value
+    index [string]: Bun.XML.Value
   interface XML.Element (bun-types/bun.d.ts)
-    index [string]: Array<Value> | Value
+    index [string]: Array<Bun.XML.Value> | Bun.XML.Value
   interface XML.Node (bun-types/bun.d.ts)
     attributes: Record<string, string>
-    children: Array<string | Comment | Node | ProcessingInstruction>
+    children: Array<Bun.XML.Comment | Bun.XML.Node | Bun.XML.ProcessingInstruction | string>
     name: string
   interface XML.NodeInput (bun-types/bun.d.ts)
-    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
-    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    attributes [?]: null | undefined | { [name: string]: Bun.XML.Scalar | null | undefined; }
+    children [?]: Array<Bun.XML.Comment | Bun.XML.NodeInput | Bun.XML.ProcessingInstruction | Bun.XML.Scalar | null | undefined> | null | undefined
     name: string
   interface XML.ParseOptions (bun-types/bun.d.ts)
     compact [?]: boolean | undefined
   interface XML.ProcessingInstruction (bun-types/bun.d.ts)
     data: string
     target: string
-  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
-  type XML.Value (bun-types/bun.d.ts) = string | Element
+  type XML.Scalar (bun-types/bun.d.ts) = Date | bigint | boolean | number | string
+  type XML.Value (bun-types/bun.d.ts) = Bun.XML.Element | string
   function XML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: (Bun.XML.ParseOptions & { compact?: true | undefined; }) | undefined): Bun.XML.Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options: Bun.XML.ParseOptions & { compact: false; }): Bun.XML.Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.XML.ParseOptions | undefined): Bun.XML.Document | Bun.XML.Node
   function XML.stringify (bun-types/bun.d.ts)
-    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: Bun.XML.Document | Bun.XML.NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
     call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
-type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = Blob | Bun.BufferSource | FormData | URLSearchParams | string
 namespace YAML (bun-types/bun.d.ts)
   function YAML.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -2294,9 +2319,9 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     timeStamp [readonly]: number
     type [readonly]: string
   interface __internal.BunEventTarget (bun-types/globals.d.ts)
-    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
     dispatchEvent: (event: Event) => boolean
-    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+    removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
     [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
     append [readonly]: (name: string, value: string) => void
@@ -2324,7 +2349,7 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     destination [readonly]: RequestDestination
     duplex [readonly]: "half"
     formData [readonly]: () => Promise<FormData>
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     integrity [readonly]: string
     json [readonly]: () => Promise<unknown>
     keepalive [readonly]: boolean
@@ -2345,7 +2370,7 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
     clone: () => Response
     formData [readonly]: () => Promise<FormData>
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     json [readonly]: () => Promise<unknown>
     ok [readonly]: boolean
     redirected [readonly]: boolean
@@ -2355,16 +2380,16 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     textStream: () => ReadableStream<string>
     type [readonly]: ResponseType
     url [readonly]: string
-  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Bun.__internal.Merge<T, Exclude<Else, T>> : never
   type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
   type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
   type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = false
   type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = BroadcastChannel
-  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = BunEvent
-  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = BunEventTarget
-  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = WebSocket
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = Bun.__internal.BunEvent
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = Bun.__internal.BunEventTarget
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = Bun.WebSocket
   type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = EventSource
-  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = SubtleCrypto
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = webcrypto.SubtleCrypto
   type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = MessagePort
   type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = ReadableStream<T>
   type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = CompressionStream
@@ -2385,48 +2410,48 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
   type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = ReadableStreamBYOBRequest
   type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = Headers
   type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = Request
-  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: BodyInit | null | undefined; headers?: HeadersInit | undefined; }
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: Bun.BodyInit | null | undefined; headers?: Bun.HeadersInit | undefined; }
   type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = Response
   type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = ResponseInit
   type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = Performance
-  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Worker
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Bun.Worker
   type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
   type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
-  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
-  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = webcrypto.CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = webcrypto.CryptoKeyPair
   type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = Otherwise
   type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
-  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Bun.__internal.Without<A, B> | Bun.__internal.Without<B, A>
 function allocUnsafe (bun-types/bun.d.ts)
   call (size: number): Uint8Array<ArrayBuffer>
 var argv (bun-types/bun.d.ts): Array<string>
 function build (bun-types/bun.d.ts)
-  call (config: BuildConfig): Promise<BuildOutput>
+  call (config: Bun.BuildConfig): Promise<Bun.BuildOutput>
 function color (bun-types/bun.d.ts)
-  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
-  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
-  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
-  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
-  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
-  call (input: ColorInput, outputFormat: "number"): null | number
+  call (input: Bun.ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: Bun.ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: Bun.ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: Bun.ColorInput, outputFormat: "number"): null | number
 function concatArrayBuffers (bun-types/bun.d.ts)
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
 function connect (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: Bun.TCPSocketConnectOptions<Data>): Promise<Bun.Socket<Data>>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Promise<Bun.Socket<Data>>
 var cron (bun-types/bun.d.ts)
-  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
-  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
-  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  call (schedule: Bun.CronWithAutocomplete, handler: (this: Bun.CronJob) => unknown, options?: Bun.CronOptions | undefined): Bun.CronJob
+  call (path: string, schedule: Bun.CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: Bun.CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: Bun.CronOptions | undefined) => Date | null
   remove: (title: string) => Promise<void>
 function deepEquals (bun-types/bun.d.ts)
   call (a: any, b: any, strict?: boolean | undefined): boolean
 function deepMatch (bun-types/bun.d.ts)
   call (subset: unknown, a: unknown): boolean
 function deflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 namespace dns (bun-types/bun.d.ts)
   var dns.ADDRCONFIG (bun-types/bun.d.ts): number
   var dns.ALL (bun-types/bun.d.ts): number
@@ -2434,50 +2459,50 @@ namespace dns (bun-types/bun.d.ts)
   function dns.getCacheStats (bun-types/bun.d.ts)
     call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
   function dns.lookup (bun-types/bun.d.ts)
-    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<Bun.DNSLookup>>
   function dns.prefetch (bun-types/bun.d.ts)
     call (hostname: string, port?: number | undefined): void
 var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
 var enableANSIColors (bun-types/bun.d.ts): boolean
-var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+var env (bun-types/bun.d.ts): Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
 function escapeHTML (bun-types/bun.d.ts)
   call (input: boolean | number | object | string): string
 var fetch (bun-types/bun.d.ts): typeof fetch
 function file (bun-types/bun.d.ts)
-  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
-  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
-  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+  call (path: URL | string, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): Bun.BunFile
 function fileURLToPath (bun-types/bun.d.ts)
   call (url: URL | string): string
 function gc (bun-types/bun.d.ts)
   call (force?: boolean | undefined): void
 function generateHeapSnapshot (bun-types/bun.d.ts)
-  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format?: "jsc" | undefined): Bun.HeapSnapshot
   call (format: "v8"): string
   call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
 function gunzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function gzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
-var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | number | undefined) => bigint | number) & Bun.Hash
 function indexOfLine (bun-types/bun.d.ts)
-  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+  call (buffer: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
 function inflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function inspect (bun-types/bun.d.ts)
-  call (arg: any, options?: BunInspectOptions | undefined): string
-  custom: typeof custom
+  call (arg: any, options?: Bun.BunInspectOptions | undefined): string
+  custom: typeof inspect.custom
   table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
 namespace inspect (bun-types/bun.d.ts)
-  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  var inspect.custom (bun-types/bun.d.ts): typeof inspect.custom
   function inspect.table (bun-types/bun.d.ts)
     call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
     call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
 var isMainThread (bun-types/bun.d.ts): boolean
 var isStandaloneExecutable (bun-types/bun.d.ts): boolean
 function listen (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+  call <Data = undefined>(options: Bun.TCPSocketListenOptions<Data>): Bun.TCPSocketListener<Data>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Bun.UnixSocketListener<Data>
 var main (bun-types/bun.d.ts): string
 namespace markdown (bun-types/bun.d.ts)
   interface markdown.AnsiTheme (bun-types/bun.d.ts)
@@ -2498,37 +2523,37 @@ namespace markdown (bun-types/bun.d.ts)
   interface markdown.CodeBlockProps (bun-types/bun.d.ts)
     children: Array<unknown>
     language [?]: string | undefined
-  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = ((props: P) => any) | (new (props: P) => any) | string
   interface markdown.ComponentOverrides (bun-types/bun.d.ts)
-    a [?]: Component<LinkProps> | undefined
-    blockquote [?]: Component<ChildrenProps> | undefined
-    br [?]: Component<{}> | undefined
-    code [?]: Component<ChildrenProps> | undefined
-    del [?]: Component<ChildrenProps> | undefined
-    em [?]: Component<ChildrenProps> | undefined
-    h1 [?]: Component<HeadingProps> | undefined
-    h2 [?]: Component<HeadingProps> | undefined
-    h3 [?]: Component<HeadingProps> | undefined
-    h4 [?]: Component<HeadingProps> | undefined
-    h5 [?]: Component<HeadingProps> | undefined
-    h6 [?]: Component<HeadingProps> | undefined
-    hr [?]: Component<{}> | undefined
-    html [?]: Component<ChildrenProps> | undefined
-    img [?]: Component<ImageProps> | undefined
-    li [?]: Component<ListItemProps> | undefined
-    math [?]: Component<ChildrenProps> | undefined
-    ol [?]: Component<OrderedListProps> | undefined
-    p [?]: Component<ChildrenProps> | undefined
-    pre [?]: Component<CodeBlockProps> | undefined
-    strong [?]: Component<ChildrenProps> | undefined
-    table [?]: Component<ChildrenProps> | undefined
-    tbody [?]: Component<ChildrenProps> | undefined
-    td [?]: Component<CellProps> | undefined
-    th [?]: Component<CellProps> | undefined
-    thead [?]: Component<ChildrenProps> | undefined
-    tr [?]: Component<ChildrenProps> | undefined
-    u [?]: Component<ChildrenProps> | undefined
-    ul [?]: Component<ChildrenProps> | undefined
+    a [?]: Bun.markdown.Component<Bun.markdown.LinkProps> | undefined
+    blockquote [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    br [?]: Bun.markdown.Component<{}> | undefined
+    code [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    del [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    em [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    h1 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h2 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h3 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h4 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h5 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h6 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    hr [?]: Bun.markdown.Component<{}> | undefined
+    html [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    img [?]: Bun.markdown.Component<Bun.markdown.ImageProps> | undefined
+    li [?]: Bun.markdown.Component<Bun.markdown.ListItemProps> | undefined
+    math [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ol [?]: Bun.markdown.Component<Bun.markdown.OrderedListProps> | undefined
+    p [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    pre [?]: Bun.markdown.Component<Bun.markdown.CodeBlockProps> | undefined
+    strong [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    table [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tbody [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    td [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    th [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    thead [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tr [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    u [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ul [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
   interface markdown.HeadingMeta (bun-types/bun.d.ts)
     id [?]: string | undefined
     level: number
@@ -2600,45 +2625,45 @@ namespace markdown (bun-types/bun.d.ts)
     wikiLinks [?]: boolean | undefined
   interface markdown.RenderCallbacks (bun-types/bun.d.ts)
     blockquote [?]: ((children: string) => null | string | undefined) | undefined
-    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: Bun.markdown.CodeBlockMeta | undefined) => null | string | undefined) | undefined
     codespan [?]: ((children: string) => null | string | undefined) | undefined
     emphasis [?]: ((children: string) => null | string | undefined) | undefined
-    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: Bun.markdown.HeadingMeta) => null | string | undefined) | undefined
     hr [?]: ((children: string) => null | string | undefined) | undefined
     html [?]: ((children: string) => null | string | undefined) | undefined
-    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
-    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
-    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
-    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: Bun.markdown.ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: Bun.markdown.LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: Bun.markdown.ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: Bun.markdown.ListItemMeta) => null | string | undefined) | undefined
     paragraph [?]: ((children: string) => null | string | undefined) | undefined
     strikethrough [?]: ((children: string) => null | string | undefined) | undefined
     strong [?]: ((children: string) => null | string | undefined) | undefined
     table [?]: ((children: string) => null | string | undefined) | undefined
     tbody [?]: ((children: string) => null | string | undefined) | undefined
-    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     text [?]: ((text: string) => null | string | undefined) | undefined
-    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     thead [?]: ((children: string) => null | string | undefined) | undefined
     tr [?]: ((children: string) => null | string | undefined) | undefined
   function markdown.ansi (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, theme?: Bun.markdown.AnsiTheme | undefined): string
   function markdown.html (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.markdown.Options | undefined): string
   function markdown.react (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, components?: Bun.markdown.ComponentOverrides | undefined, options?: Bun.markdown.ReactOptions | undefined): unknown
   function markdown.render (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, callbacks?: Bun.markdown.RenderCallbacks | undefined, options?: Bun.markdown.Options | undefined): string
 function mmap (bun-types/bun.d.ts)
-  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+  call (path: Bun.PathLike, opts?: Bun.MMapOptions | undefined): Uint8Array<ArrayBuffer>
 function nanoseconds (bun-types/bun.d.ts)
   call (): number
 function openInEditor (bun-types/bun.d.ts)
-  call (path: string, options?: EditorOptions | undefined): void
+  call (path: string, options?: Bun.EditorOptions | undefined): void
 var password (bun-types/bun.d.ts)
-  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
-  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
-  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
-  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+  hash: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => string
+  verify: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
 function pathToFileURL (bun-types/bun.d.ts)
   call (path: string): URL
 function peek (bun-types/bun.d.ts)
@@ -2647,49 +2672,49 @@ function peek (bun-types/bun.d.ts)
 namespace peek (bun-types/bun.d.ts)
   function peek.status (bun-types/bun.d.ts)
     call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
-var plugin (bun-types/bun.d.ts): BunRegisterPlugin
-var postgres (bun-types/sql.d.ts): SQL
+var plugin (bun-types/bun.d.ts): Bun.BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): Bun.SQL
 function randomUUIDv5 (bun-types/bun.d.ts)
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
 function randomUUIDv7 (bun-types/bun.d.ts)
   call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
   call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
 function readableStreamToArray (bun-types/bun.d.ts)
   call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
 function readableStreamToArrayBuffer (bun-types/bun.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
 function readableStreamToBlob (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<Blob>
 function readableStreamToBytes (bun-types/deprecated.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
 function readableStreamToFormData (bun-types/bun.d.ts)
-  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+  call (stream: ReadableStream<BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
 function readableStreamToJSON (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<any>
 function readableStreamToText (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<string>
-var redis (bun-types/redis.d.ts): RedisClient
+var redis (bun-types/redis.d.ts): Bun.RedisClient
 function resolve (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): Promise<string>
 function resolveSync (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): string
 var revision (bun-types/bun.d.ts): string
-var s3 (bun-types/s3.d.ts): S3Client
+var s3 (bun-types/s3.d.ts): Bun.S3Client
 var secrets (bun-types/bun.d.ts)
   delete: (options: { service: string; name: string; }) => Promise<boolean>
-  get: (options: { service: string; name: string; }) => Promise<string | null>
+  get: (options: { service: string; name: string; }) => Promise<null | string>
   set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
 namespace semver (bun-types/bun.d.ts)
   function semver.order (bun-types/bun.d.ts)
-    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+    call (v1: Bun.StringLike, v2: Bun.StringLike): -1 | 0 | 1
   function semver.satisfies (bun-types/bun.d.ts)
-    call (version: StringLike, range: StringLike): boolean
+    call (version: Bun.StringLike, range: Bun.StringLike): boolean
 function serve (bun-types/serve.d.ts)
-  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+  call <WebSocketData = undefined, R extends string = never>(options: Bun.Serve.Options<WebSocketData, R>): Bun.Server<WebSocketData>
 function sha (bun-types/bun.d.ts)
-  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
-  call (input: StringOrBuffer, encoding: DigestEncoding): string
+  call (input: Bun.StringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>
+  call (input: Bun.StringOrBuffer, encoding: Bun.DigestEncoding): string
 function shrink (bun-types/bun.d.ts)
   call (): void
 function sleep (bun-types/bun.d.ts)
@@ -2697,27 +2722,27 @@ function sleep (bun-types/bun.d.ts)
 function sleepSync (bun-types/bun.d.ts)
   call (ms: number): void
 function sliceAnsi (bun-types/bun.d.ts)
-  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: Bun.SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
 function spawn (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(options: Bun.SpawnOptions.SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Bun.Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnOptions<In, Out, Err> | undefined): Bun.Subprocess<In, Out, Err>
 function spawnSync (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
-var sql (bun-types/sql.d.ts): SQL
-var stderr (bun-types/bun.d.ts): BunFile
-var stdin (bun-types/bun.d.ts): BunFile
-var stdout (bun-types/bun.d.ts): BunFile
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(options: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): Bun.SyncSubprocess<Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> | undefined): Bun.SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): Bun.SQL
+var stderr (bun-types/bun.d.ts): Bun.BunFile
+var stdin (bun-types/bun.d.ts): Bun.BunFile
+var stdout (bun-types/bun.d.ts): Bun.BunFile
 function stringWidth (bun-types/bun.d.ts)
-  call (input: string, options?: StringWidthOptions | undefined): number
+  call (input: string, options?: Bun.StringWidthOptions | undefined): number
 function stripANSI (bun-types/bun.d.ts)
   call (input: string): string
 namespace udp (bun-types/bun.d.ts)
   interface udp.BaseUDPSocket (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2731,17 +2756,17 @@ namespace udp (bun-types/bun.d.ts)
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     connect: { hostname: string; port: number; }
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
-  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    socket [?]: Bun.udp.ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2749,29 +2774,29 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
-    remoteAddress [readonly]: SocketAddress
-    send: (data: Data) => boolean
-    sendMany: (packets: ReadonlyArray<Data>) => number
+    reload: (handler: Bun.udp.ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: Bun.SocketAddress
+    send: (data: Bun.udp.Data) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string
   interface udp.ReceiveFlags (bun-types/bun.d.ts)
     ipv6: boolean
     truncated: boolean
-  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.Socket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2779,27 +2804,27 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: SocketHandler<DataBinaryType>) => void
-    send: (data: Data, port: number, address: string) => boolean
-    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    reload: (handler: Bun.udp.SocketHandler<DataBinaryType>) => void
+    send: (data: Bun.udp.Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data | number>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.SocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.Socket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: SocketHandler<DataBinaryType> | undefined
+    socket [?]: Bun.udp.SocketHandler<DataBinaryType> | undefined
 function udpSocket (bun-types/bun.d.ts)
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.SocketOptions<DataBinaryType>): Promise<Bun.udp.Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.ConnectSocketOptions<DataBinaryType>): Promise<Bun.udp.ConnectedSocket<DataBinaryType>>
 namespace unsafe (bun-types/bun.d.ts)
   function unsafe.arrayBufferToString (bun-types/bun.d.ts)
     call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
@@ -2813,23 +2838,23 @@ namespace unsafe (bun-types/bun.d.ts)
 var version (bun-types/bun.d.ts): string
 var version_with_sha (bun-types/bun.d.ts): string
 function which (bun-types/bun.d.ts)
-  call (command: string, options?: WhichOptions | undefined): null | string
+  call (command: string, options?: Bun.WhichOptions | undefined): null | string
 function wrapAnsi (bun-types/bun.d.ts)
-  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+  call (input: string, columns: number, options?: Bun.WrapAnsiOptions | undefined): string
 function write (bun-types/bun.d.ts)
-  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile | Bun.PathLike | Bun.S3File, input: Array<Bun.BlobPart> | ArrayBufferLike | Blob | Bun.Archive | NodeJS.TypedArray<ArrayBufferLike> | ReadableStream<any> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
 function zstdCompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
 function zstdCompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
 function zstdDecompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
 function zstdDecompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
 
 # module "bun:bundle"
 interface Registry (bun-types/bundle.d.ts)
@@ -2928,17 +2953,17 @@ interface FFITypeToArgsType (bun-types/ffi.d.ts)
   1: number
   10: number
   11: boolean
-  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  12: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null
   13: undefined
-  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  14: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null | string
   15: bigint | number
   16: bigint | number
   17: JSCallback | Pointer
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2960,8 +2985,8 @@ interface FFITypeToReturnsType (bun-types/ffi.d.ts)
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2983,13 +3008,13 @@ type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
 type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
 type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
 function cc (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | Bun.BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
 function dlopen (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(name: Bun.BunFile | URL | string, symbols: Fns): Library<Fns>
 function linkSymbols (bun-types/ffi.d.ts)
   call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
 function ptr (bun-types/ffi.d.ts)
-  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
 namespace read (bun-types/ffi.d.ts)
   function read.f32 (bun-types/ffi.d.ts)
     call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
@@ -3062,7 +3087,7 @@ interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
 function callerSourceOrigin (bun-types/jsc.d.ts)
   call (): null | string
 function deserialize (bun-types/jsc.d.ts)
-  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>): any
 function drainMicrotasks (bun-types/jsc.d.ts)
   call (): void
 function edenGC (bun-types/jsc.d.ts)
@@ -3138,7 +3163,7 @@ class Database (bun-types/sqlite.d.ts)
   [static]
     construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
     MAX_QUERY_CACHE_SIZE [static]: number
-    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    deserialize [static]: { (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
     open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
     prototype: Database
     setCustomSQLite [static]: (path: string) => boolean
@@ -3148,7 +3173,7 @@ interface DatabaseOptions (bun-types/sqlite.d.ts)
   readwrite [?]: boolean | undefined
   safeIntegers [?]: boolean | undefined
   strict [?]: boolean | undefined
-type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+type SQLQueryBindings (bun-types/sqlite.d.ts) = NodeJS.TypedArray<ArrayBufferLike> | Record<string, NodeJS.TypedArray<ArrayBufferLike> | bigint | boolean | null | number | string> | bigint | boolean | null | number | string
 class SQLiteError (bun-types/sqlite.d.ts)
   byteOffset [readonly]: number
   cause [?]: unknown
@@ -3163,7 +3188,7 @@ class SQLiteError (bun-types/sqlite.d.ts)
     construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
     captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
     isError: (value: unknown) => value is Error
-    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
     prototype: SQLiteError
     stackTraceLimit: number
 class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
@@ -3172,8 +3197,8 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   all: (...params: ParamsType) => Array<ReturnType>
   as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
   columnNames [readonly]: Array<string>
-  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
-  declaredTypes [readonly]: Array<string | null>
+  columnTypes [readonly]: Array<"BLOB" | "FLOAT" | "INTEGER" | "NULL" | "TEXT" | null>
+  declaredTypes [readonly]: Array<null | string>
   finalize: () => void
   get: (...params: ParamsType) => ReturnType | null
   iterate: (...params: ParamsType) => IterableIterator<ReturnType>
@@ -3182,7 +3207,7 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
   run: (...params: ParamsType) => Changes
   toString: () => string
-  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  values: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | bigint | boolean | number | string>>
   [static]
     construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
     prototype: Statement<any, any>
@@ -3259,7 +3284,7 @@ var native (bun-types/sqlite.d.ts): any
 # module "bun:test"
 type AsymmetricMatcher (bun-types/test.d.ts) = any
 interface AsymmetricMatchers (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3267,7 +3292,7 @@ interface AsymmetricMatchers (bun-types/test.d.ts)
   stringContaining: (str: String | string) => any
   stringMatching: (regex: RegExp | String | string) => any
 interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3293,7 +3318,7 @@ interface Expect (bun-types/test.d.ts)
   call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
   call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
   call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   assertions: (neededAssertions: number) => void
@@ -3360,13 +3385,13 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3380,7 +3405,7 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3446,13 +3471,13 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3466,7 +3491,7 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3483,9 +3508,9 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toThrowError: (expected?: unknown) => void
   toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
   toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
-type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
 interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
-  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  call (label: string, fn: (...args: __internal.IsTuple<T> extends true ? [...table: __internal.Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
   concurrent: Test<T>
   concurrentIf: (condition: boolean) => Test<T>
   each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
@@ -3521,23 +3546,23 @@ var expectTypeOf (bun-types/test.d.ts)
   call <Actual>(): PositiveExpectTypeOf<Actual>
 var it (bun-types/test.d.ts): Test<[]>
 namespace jest (bun-types/test.d.ts)
-  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
-  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
-  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
-  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
-  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
-  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
-  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = JestMock.Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | JestMock.ClassLike> (bun-types/test.d.ts) = T extends JestMock.ClassLike ? JestMock.SpiedClass<T> : T extends JestMock.FunctionLike ? JestMock.SpiedFunction<T> : never
+  type jest.SpiedClass<T extends JestMock.ClassLike> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<(arg: T) => void>
   function jest.advanceTimersByTime (bun-types/test.d.ts)
-    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.clearAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.clearAllTimers (bun-types/test.d.ts)
     call (): void
   function jest.fn (bun-types/test.d.ts)
-    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): jest.Mock<T>
   function jest.getTimerCount (bun-types/test.d.ts)
     call (): number
   function jest.isFakeTimers (bun-types/test.d.ts)
@@ -3547,19 +3572,19 @@ namespace jest (bun-types/test.d.ts)
   function jest.restoreAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.runAllTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.runOnlyPendingTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.setSystemTime (bun-types/test.d.ts)
     call (now?: Date | number | undefined): void
   function jest.setTimeout (bun-types/test.d.ts)
     call (milliseconds: number): void
   function jest.spyOn (bun-types/test.d.ts)
-    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): jest.Mock<Extract<T[K], (...args: Array<any>) => any>>
   function jest.useFakeTimers (bun-types/test.d.ts)
-    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.useRealTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var mock (bun-types/test.d.ts)
   call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
   clearAllMocks: () => void
@@ -3575,24 +3600,118 @@ function spyOn (bun-types/test.d.ts)
   call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
 test -> it
 var vi (bun-types/test.d.ts)
-  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   clearAllMocks: () => void
   clearAllTimers: () => void
-  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => jest.Mock<T>
   getTimerCount: () => number
   isFakeTimers: () => boolean
   mock: (id: string, factory: () => any) => Promise<void> | void
   resetAllMocks: () => void
   restoreAllMocks: () => void
-  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
-  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var xdescribe (bun-types/test.d.ts): Describe<[]>
 var xit (bun-types/test.d.ts): Test<[]>
 xtest -> xit
+
+# module "node:fs/promises"
+function exists (bun-types/overrides.d.ts)
+  call (path: Bun.PathLike): Promise<boolean>
+
+# module "node:tls"
+interface BunConnectionOptions (bun-types/overrides.d.ts)
+  ALPNCallback [?]: ((arg: { servername: string; protocols: Array<string>; }) => string | undefined) | undefined
+  ALPNProtocols [?]: NodeJS.ArrayBufferView<ArrayBufferLike> | ReadonlyArray<string> | undefined
+  SNICallback [?]: ((servername: string, cb: (err: Error | null, ctx?: SecureContext | undefined) => void) => void) | undefined
+  allowPartialTrustChain [?]: boolean | undefined
+  ca [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  cert [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientCertEngine [?]: string | undefined
+  crl [?]: Array<Buffer<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | string | undefined
+  dhparam [?]: Buffer<ArrayBufferLike> | string | undefined
+  ecdhCurve [?]: string | undefined
+  enableTrace [?]: boolean | undefined
+  honorCipherOrder [?]: boolean | undefined
+  host [?]: string | undefined
+  key [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | KeyObject | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  lookup [?]: LookupFunction | undefined
+  maxVersion [?]: SecureVersion | undefined
+  minDHSize [?]: number | undefined
+  minVersion [?]: SecureVersion | undefined
+  passphrase [?]: string | undefined
+  path [?]: string | undefined
+  pfx [?]: Array<Buffer<ArrayBufferLike> | PxfObject | string> | Buffer<ArrayBufferLike> | string | undefined
+  port [?]: number | undefined
+  privateKeyEngine [?]: string | undefined
+  privateKeyIdentifier [?]: string | undefined
+  pskCallback [?]: ((hint: null | string) => PSKCallbackNegotation | null) | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  requestOCSP [?]: boolean | undefined
+  secureContext [?]: SecureContext | undefined
+  secureOptions [?]: number | undefined
+  secureProtocol [?]: string | undefined
+  servername [?]: string | undefined
+  session [?]: Buffer<ArrayBufferLike> | undefined
+  sessionIdContext [?]: string | undefined
+  sessionTimeout [?]: number | undefined
+  sigalgs [?]: string | undefined
+  socket [?]: Stream.Duplex | undefined
+  ticketKeys [?]: Buffer<ArrayBufferLike> | undefined
+  timeout [?]: number | undefined
+function connect (@types/node/tls.d.ts, bun-types/overrides.d.ts)
+  call (options: ConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, host?: string | undefined, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (options: BunConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+
+# module "stream/web"
+interface ReadableStream<R = any> (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  construct new (underlyingSource: UnderlyingByteSource, strategy?: undefined | { highWaterMark?: number | undefined; }): ReadableStream<NodeJS.NonSharedUint8Array>
+  construct new <R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  from: <R = any>(iterable: AsyncIterable<R> | Iterable<R>) => ReadableStream<R>
+  prototype: ReadableStream<any>
+
+# module "url"
+interface URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  construct new (init?: Array<Array<string>> | Record<string, string> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
 
 # globals
 interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
@@ -3603,11 +3722,11 @@ var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/glo
   prototype: AbortController
 interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
   aborted [readonly]: boolean
-  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
   dispatchEvent: (event: Event) => boolean
   onabort: ((this: AbortSignal, ev: Event) => any) | null
   reason [readonly]: any
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   throwIfAborted: () => void
 var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
   construct new (): AbortSignal
@@ -3650,14 +3769,14 @@ interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   size [readonly]: number
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
 var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
-  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  construct new (blobParts?: Array<Bun.BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
   prototype: Blob
 interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   type [?]: string | undefined
@@ -3686,25 +3805,25 @@ class BuildMessage (bun-types/globals.d.ts)
     prototype: BuildMessage
 Bun -> module "bun"
 interface BunFetchRequestInit (bun-types/globals.d.ts)
-  body [?]: BodyInit | null | undefined
+  body [?]: Bun.BodyInit | null | undefined
   cache [?]: RequestCache | undefined
   compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
   credentials [?]: RequestCredentials | undefined
   decompress [?]: boolean | undefined
   dispatcher [?]: Dispatcher | undefined
   duplex [?]: "half" | undefined
-  headers [?]: HeadersInit | undefined
+  headers [?]: Bun.HeadersInit | undefined
   integrity [?]: string | undefined
   keepalive [?]: boolean | undefined
   maxRedirects [?]: number | undefined
   method [?]: string | undefined
   mode [?]: RequestMode | undefined
   protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
-  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: Bun.HeadersInit | undefined; }
   redirect [?]: RequestRedirect | undefined
   referrer [?]: string | undefined
   referrerPolicy [?]: ReferrerPolicy | undefined
-  s3 [?]: S3Options | undefined
+  s3 [?]: Bun.S3Options | undefined
   signal [?]: AbortSignal | null | undefined
   timeout [?]: boolean | number | undefined
   tls [?]: BunFetchRequestInitTLS | undefined
@@ -3712,17 +3831,17 @@ interface BunFetchRequestInit (bun-types/globals.d.ts)
   verbose [?]: boolean | undefined
   window [?]: null | undefined
 interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -3758,16 +3877,16 @@ interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts
   type [readonly]: string
   wasClean [readonly]: boolean
 var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  construct new (type: string, eventInitDict?: Bun.CloseEventInit | undefined): CloseEvent
   prototype: CloseEvent
 interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
-  writable [readonly]: WritableStream<BufferSource>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
+  construct new (format: Bun.CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
   prototype: CompressionStream
 interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
-  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  Console [readonly]: { new (stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
   [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
   assert: (condition?: boolean | undefined, ...data: Array<any>) => void
   clear: () => void
@@ -3791,14 +3910,14 @@ interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
   timeStamp: (label?: string | undefined) => void
   trace: (...data: Array<any>) => void
   warn: (...data: Array<any>) => void
-  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+  write: (...data: Array<ArrayBuffer | ArrayBufferView<ArrayBufferLike> | string>) => number
 interface ConsoleOptions (bun-types/globals.d.ts)
   colorMode [?]: "auto" | boolean | undefined
   groupIndentation [?]: number | undefined
   ignoreErrors [?]: boolean | undefined
   inspectOptions [?]: InspectOptions | undefined
-  stderr [?]: Writable | undefined
-  stdout: Writable
+  stderr [?]: Stream.Writable | undefined
+  stdout: Stream.Writable
 interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   highWaterMark [readonly]: number
   size [readonly]: QueuingStrategySize<any>
@@ -3809,21 +3928,21 @@ interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   getRandomValues: <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T) => T
   randomUUID: () => `${string}-${string}-${string}-${string}-${string}`
   subtle [readonly]: SubtleCrypto
-  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+  timingSafeEqual: (a: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>) => boolean
 var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): Crypto
   prototype: Crypto
 interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
-  algorithm [readonly]: KeyAlgorithm
+  algorithm [readonly]: webcrypto.KeyAlgorithm
   extractable [readonly]: boolean
-  type [readonly]: KeyType
-  usages [readonly]: Array<KeyUsage>
+  type [readonly]: webcrypto.KeyType
+  usages [readonly]: Array<webcrypto.KeyUsage>
 var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): CryptoKey
   prototype: CryptoKey
 interface CryptoKeyPair (bun-types/globals.d.ts)
-  privateKey: CryptoKey
-  publicKey: CryptoKey
+  privateKey: webcrypto.CryptoKey
+  publicKey: webcrypto.CryptoKey
 interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -3845,7 +3964,7 @@ interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/d
   timeStamp [readonly]: number
   type [readonly]: string
 var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
-  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  construct new <T>(type: string, eventInitDict?: Bun.CustomEventInit<T> | undefined): CustomEvent<T>
   prototype: CustomEvent<any>
 interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
   ABORT_ERR [readonly]: 20
@@ -3907,10 +4026,10 @@ var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecate
   WRONG_DOCUMENT_ERR [readonly]: 4
   prototype: DOMException
 interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
-  writable [readonly]: WritableStream<BufferSource>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
+  construct new (format: Bun.CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
   prototype: DecompressionStream
 interface Dict<T> (bun-types/globals.d.ts)
   index [string]: T | undefined
@@ -3937,7 +4056,7 @@ interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, li
   construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
   captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
   isError: (value: unknown) => value is Error
-  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
   prototype [readonly]: Error
   stackTraceLimit: number
 interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
@@ -3964,7 +4083,7 @@ interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts
   timeStamp [readonly]: number
   type [readonly]: string
 var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  construct new (type: string, eventInitDict?: Bun.ErrorEventInit | undefined): ErrorEvent
   prototype: ErrorEvent
 interface ErrorOptions (bun-types/globals.d.ts, lib.es2022.error.d.ts)
   cause [?]: unknown
@@ -3987,7 +4106,7 @@ interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
   timeStamp [readonly]: number
   type [readonly]: string
 var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  construct new (type: string, eventInitDict?: Bun.EventInit | undefined): Event
   AT_TARGET [readonly]: 2
   BUBBLING_PHASE [readonly]: 3
   CAPTURING_PHASE [readonly]: 1
@@ -4021,9 +4140,9 @@ var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
 interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   withCredentials [?]: boolean | undefined
 interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
-  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
   dispatchEvent: (event: Event) => boolean
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
 var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
   construct new (): EventTarget
   prototype: EventTarget
@@ -4053,7 +4172,7 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified [readonly]: number
   name [readonly]: string
@@ -4062,15 +4181,15 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   text: () => Promise<string>
   type [readonly]: string
 var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
-  construct new (parts: Array<BlobPart>, name: string, options?: BlobPropertyBag & { lastModified?: number | Date | undefined; } | undefined): File
+  construct new (parts: Array<Bun.BlobPart>, name: string, options?: (BlobPropertyBag & { lastModified?: number | Date | undefined; }) | undefined): File
   prototype: File
 interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
   delete: (name: string) => void
   entries: () => IterableIterator<[string, string]>
-  forEach: (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
-  get: (name: string) => FormDataEntryValue | null
-  getAll: (name: string) => Array<FormDataEntryValue>
+  forEach: (callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
+  get: (name: string) => Bun.FormDataEntryValue | null
+  getAll: (name: string) => Array<Bun.FormDataEntryValue>
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
   set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
@@ -4079,19 +4198,19 @@ var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   construct new (): FormData
   prototype: FormData
 class HTMLRewriter (bun-types/html-rewriter.d.ts)
-  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
-  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
-  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  on: (selector: string, handlers: HTMLRewriterTypes.HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: Bun.BufferSource): ArrayBuffer }
   [static]
     construct new (): HTMLRewriter
     prototype: HTMLRewriter
 namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Comment
-    before: (content: string, options?: ContentOptions | undefined) => Comment
-    remove: () => Comment
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    remove: () => HTMLRewriterTypes.Comment
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
     text: string
   type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
   interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
@@ -4099,52 +4218,52 @@ namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
     name [readonly]: null | string
     publicId [readonly]: null | string
-    remove: () => Doctype
+    remove: () => HTMLRewriterTypes.Doctype
     removed [readonly]: boolean
     systemId [readonly]: null | string
   interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
-    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.DocumentEnd
   interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Element
-    append: (content: string, options?: ContentOptions | undefined) => Element
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     attributes [readonly]: IterableIterator<[string, string]>
-    before: (content: string, options?: ContentOptions | undefined) => Element
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     canHaveContent [readonly]: boolean
     getAttribute: (name: string) => null | string
     hasAttribute: (name: string) => boolean
     namespaceURI [readonly]: string
-    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
-    prepend: (content: string, options?: ContentOptions | undefined) => Element
-    remove: () => Element
-    removeAndKeepContent: () => Element
-    removeAttribute: (name: string) => Element
+    onEndTag: (handler: (tag: HTMLRewriterTypes.EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    remove: () => HTMLRewriterTypes.Element
+    removeAndKeepContent: () => HTMLRewriterTypes.Element
+    removeAttribute: (name: string) => HTMLRewriterTypes.Element
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Element
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     selfClosing [readonly]: boolean
-    setAttribute: (name: string, value: string) => Element
-    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    setAttribute: (name: string, value: string) => HTMLRewriterTypes.Element
+    setInnerContent: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     tagName: string
   interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => EndTag
-    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
     name: string
-    remove: () => EndTag
+    remove: () => HTMLRewriterTypes.EndTag
   interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
-    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: HTMLRewriterTypes.Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: HTMLRewriterTypes.DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    element [?]: ((element: Element) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: HTMLRewriterTypes.Element) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Text
-    before: (content: string, options?: ContentOptions | undefined) => Text
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     lastInTextNode [readonly]: boolean
-    remove: () => Text
+    remove: () => HTMLRewriterTypes.Text
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Text
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     text [readonly]: string
 interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
@@ -4162,18 +4281,18 @@ interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
   values [readonly]: () => SpecIterableIterator<string>
 var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (init?: HeadersInit | undefined): Headers
+  construct new (init?: Bun.HeadersInit | undefined): Headers
   prototype: Headers
 interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.es5.d.ts)
   dir [readonly]: string
   dirname: string
-  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  env [readonly]: Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
   file [readonly]: string
   filename: string
-  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: Bun.HMREvent, callback: () => void): void; off(event: Bun.HMREvent, callback: () => void): void; }
   main: boolean
   path [readonly]: string
-  require: Require
+  require: NodeJS.Require
   resolve: (specifier: string, parent?: URL | string | undefined) => string
   resolveSync: (moduleId: string, parent?: string | undefined) => string
   url: string
@@ -4214,7 +4333,7 @@ interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/g
   timeStamp [readonly]: number
   type [readonly]: string
 var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<any>
+  construct new <T>(type: string, eventInitDict?: Bun.MessageEventInit<T> | undefined): MessageEvent<any>
   prototype: MessageEvent<any>
 interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
   addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
@@ -4254,148 +4373,14 @@ var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
   construct new (): Navigator
   prototype: Navigator
 namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
-  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
-  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
-  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.asyncDispose]: () => PromiseLike<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
-    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
-    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
-  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
-  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
-  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
-  interface NodeJS.CallSite (@types/node/globals.d.ts)
-    getColumnNumber: () => null | number
-    getEnclosingColumnNumber: () => null | number
-    getEnclosingLineNumber: () => null | number
-    getEvalOrigin: () => string | undefined
-    getFileName: () => null | string
-    getFunction: () => Function | undefined
-    getFunctionName: () => null | string
-    getLineNumber: () => null | number
-    getMethodName: () => null | string
-    getPosition: () => number
-    getPromiseIndex: () => null | number
-    getScriptHash: () => string
-    getScriptNameOrSourceURL: () => null | string
-    getThis: () => unknown
-    getTypeName: () => null | string
-    isAsync: () => boolean
-    isConstructor: () => boolean
-    isEval: () => boolean
-    isNative: () => boolean
-    isPromiseAll: () => boolean
-    isToplevel: () => boolean
-  interface NodeJS.CpuUsage (@types/node/process.d.ts)
-    system: number
-    user: number
-  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined
-  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
-  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
-    code [?]: string | undefined
-    ctor [?]: Function | undefined
-    detail [?]: string | undefined
-    type [?]: string | undefined
-  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
-    cause [?]: unknown
-    code [?]: string | undefined
-    errno [?]: number | undefined
-    message: string
-    name: string
-    path [?]: string | undefined
-    stack [?]: string | undefined
-    syscall [?]: string | undefined
-  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
-    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
-    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    setMaxListeners: (n: number) => EventEmitter<T>
-  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
-  interface NodeJS.GCFunction (@types/node/globals.d.ts)
-    call (minor?: boolean | undefined): void
-    call (options: GCOptions & { execution: "async"; }): Promise<void>
-    call (options: GCOptions): void
-  interface NodeJS.GCOptions (@types/node/globals.d.ts)
-    execution [?]: "async" | "sync" | undefined
-    filename [?]: string | undefined
-    flavor [?]: "last-resort" | "regular" | undefined
-    type [?]: "major" | "major-snapshot" | "minor" | undefined
-  interface NodeJS.HRTime (@types/node/process.d.ts)
-    call (time?: [number, number] | undefined): [number, number]
-    bigint: () => bigint
-  interface NodeJS.Immediate (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    _onImmediate: (...args: Array<any>) => void
-    hasRef: () => boolean
-    ref: () => Immediate
-    unref: () => Immediate
-  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
-    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
-    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
-  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
-    arrayBuffers: number
-    external: number
-    heapTotal: number
-    heapUsed: number
-    rss: number
-  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
-    call (): MemoryUsage
-    rss: () => number
-  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
-  interface NodeJS.Module (@types/node/module.d.ts)
-    children: Array<Module>
-    exports: any
-    filename: string
-    id: string
-    isPreloading: boolean
-    loaded: boolean
-    parent: Module | null | undefined
-    path: string
-    paths: Array<string>
-    require: (id: string) => any
-  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
-  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
-  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
-  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
-  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
-  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
-  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
-  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
-  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
-  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
-  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
   interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
     [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
     _exiting: boolean
     abort: () => never
-    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
     allowedNodeEnvironmentFlags: ReadonlySet<string>
-    arch [readonly]: Architecture
+    arch [readonly]: NodeJS.Architecture
     argv: Array<string>
     argv0: string
     assert: (value: unknown, message?: Error | string | undefined) => asserts value
@@ -4404,24 +4389,24 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     browser: boolean
     channel [?]: Control | undefined
     chdir: (directory: string) => void
-    config [readonly]: ProcessConfig
+    config [readonly]: NodeJS.ProcessConfig
     connected: boolean
     constrainedMemory: () => number
-    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     cwd: () => string
     debugPort: number
     disconnect [?]: (() => void) | undefined
     dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
     emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
-    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
-    env: ProcessEnv
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: NodeJS.EmitWarningOptions | undefined): void }
+    env: NodeJS.ProcessEnv
     eventNames: () => Array<string | symbol>
     execArgv: Array<string>
     execPath: string
-    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: NodeJS.ProcessEnv | undefined) => never) | undefined
     exit: (code?: null | number | string | undefined) => never
     exitCode: null | number | string | undefined
-    features [readonly]: ProcessFeatures
+    features [readonly]: NodeJS.ProcessFeatures
     finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
     getActiveResourcesInfo: () => Array<string>
     getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
@@ -4432,48 +4417,48 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     getgroups [?]: (() => Array<number>) | undefined
     getuid [?]: (() => number) | undefined
     hasUncaughtExceptionCaptureCallback: () => boolean
-    hrtime: HRTime
+    hrtime: NodeJS.HRTime
     isBun: true
     kill: (pid: number, signal?: number | string | undefined) => true
     listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
     listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     loadEnvFile: (path?: PathLike | undefined) => void
-    mainModule [?]: Module | undefined
-    memoryUsage: MemoryUsageFn
+    mainModule [?]: NodeJS.Module | undefined
+    memoryUsage: NodeJS.MemoryUsageFn
     nextTick: (callback: Function, ...args: Array<any>) => void
     noDeprecation [?]: boolean | undefined
-    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    permission: ProcessPermission
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    permission: NodeJS.ProcessPermission
     pid [readonly]: number
-    platform [readonly]: Platform
+    platform [readonly]: NodeJS.Platform
     ppid [readonly]: number
-    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     reallyExit: (code?: number | undefined) => never
     ref: (maybeRefable: any) => void
-    release [readonly]: ProcessRelease
-    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
-    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    report: ProcessReport
-    resourceUsage: () => ResourceUsage
+    release [readonly]: NodeJS.ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): NodeJS.Process; (eventName?: string | symbol | undefined): NodeJS.Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    report: NodeJS.ProcessReport
+    resourceUsage: () => NodeJS.ResourceUsage
     revision: string
     send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
-    setMaxListeners: (n: number) => Process
+    setMaxListeners: (n: number) => NodeJS.Process
     setSourceMapsEnabled: (value: boolean) => void
     setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
     setegid [?]: ((id: number | string) => void) | undefined
     seteuid [?]: ((id: number | string) => void) | undefined
     setgid [?]: ((id: number | string) => void) | undefined
-    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<number | string>) => void) | undefined
     setuid [?]: ((id: number | string) => void) | undefined
     sourceMapsEnabled [readonly]: boolean
-    stderr: WriteStream & { fd: 2; }
-    stdin: ReadStream & { fd: 0; }
-    stdout: WriteStream & { fd: 1; }
-    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    stderr: NodeJS.WriteStream & { fd: 2; }
+    stdin: NodeJS.ReadStream & { fd: 0; }
+    stdout: NodeJS.WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     throwDeprecation: boolean
     title: string
     traceDeprecation: boolean
@@ -4482,45 +4467,11 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     unref: (maybeRefable: any) => void
     uptime: () => number
     version [readonly]: string
-    versions [readonly]: ProcessVersions
-  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
-    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
-    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+    versions [readonly]: NodeJS.ProcessVersions
   interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     NODE_ENV [?]: string | undefined
     TZ [?]: string | undefined
-  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
-    cached_builtins [readonly]: boolean
-    debug [readonly]: boolean
-    inspector [readonly]: boolean
-    ipv6 [readonly]: boolean
-    require_module [readonly]: boolean
-    tls [readonly]: boolean
-    tls_alpn [readonly]: boolean
-    tls_ocsp [readonly]: boolean
-    tls_sni [readonly]: boolean
-    typescript [readonly]: "strip" | false
-    uv [readonly]: boolean
-  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
-    has: (scope: string, reference?: string | undefined) => boolean
-  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
-    headersUrl [?]: string | undefined
-    libUrl [?]: string | undefined
-    lts [?]: string | undefined
-    name: string
-    sourceUrl [?]: string | undefined
-  interface NodeJS.ProcessReport (@types/node/process.d.ts)
-    compact: boolean
-    directory: string
-    excludeEnv: boolean
-    filename: string
-    getReport: (err?: Error | undefined) => object
-    reportOnFatalError: boolean
-    reportOnSignal: boolean
-    reportOnUncaughtException: boolean
-    signal: Signals
-    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
   interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     ares: string
@@ -4532,404 +4483,14 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     uv: string
     v8: string
     zlib: string
-  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined [readonly]
-  interface NodeJS.ReadStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    closed [readonly]: boolean
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    destroy: (error?: Error | undefined) => ReadStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    isPaused: () => boolean
-    isRaw: boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    pause: () => ReadStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => ReadStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
-    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    resetAndDestroy: () => ReadStream
-    resume: () => ReadStream
-    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
-    setMaxListeners: (n: number) => ReadStream
-    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
-    setRawMode: (mode: boolean) => ReadStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
-    setTypeOfService: (tos: number) => ReadStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => ReadStream
-    unref: () => ReadStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => ReadStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    pause: () => ReadWriteStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    resume: () => ReadWriteStream
-    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
-    setMaxListeners: (n: number) => ReadWriteStream
-    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadWriteStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    pause: () => ReadableStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    resume: () => ReadableStream
-    setEncoding: (encoding: BufferEncoding) => ReadableStream
-    setMaxListeners: (n: number) => ReadableStream
-    unpipe: (destination?: WritableStream | undefined) => ReadableStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadableStream
-  interface NodeJS.RefCounted (@types/node/globals.d.ts)
-    ref: () => RefCounted
-    unref: () => RefCounted
-  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
-  interface NodeJS.Require (@types/node/module.d.ts)
-    call (id: string): any
-    cache: Dict<Module>
-    extensions: RequireExtensions
-    main: Module | undefined
-    resolve: RequireResolve
-  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
-    index [string]: ((module: Module, filename: string) => any) | undefined
-    .js: (module: Module, filename: string) => any
-    .json: (module: Module, filename: string) => any
-    .node: (module: Module, filename: string) => any
-  interface NodeJS.RequireResolve (@types/node/module.d.ts)
-    call (request: string, options?: RequireResolveOptions | undefined): string
-    paths: (request: string) => Array<string> | null
-  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
-    paths [?]: Array<string> | undefined
-  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
-    fsRead: number
-    fsWrite: number
-    involuntaryContextSwitches: number
-    ipcReceived: number
-    ipcSent: number
-    majorPageFault: number
-    maxRSS: number
-    minorPageFault: number
-    sharedMemorySize: number
-    signalsCount: number
-    swappedOut: number
-    systemCPUTime: number
-    unsharedDataSize: number
-    unsharedStackSize: number
-    userCPUTime: number
-    voluntaryContextSwitches: number
-  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
-  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
-  interface NodeJS.Socket (@types/node/process.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    isTTY [?]: true | undefined
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    pause: () => Socket
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    resume: () => Socket
-    setEncoding: (encoding: BufferEncoding) => Socket
-    setMaxListeners: (n: number) => Socket
-    unpipe: (destination?: WritableStream | undefined) => Socket
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => Socket
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.Timeout (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.toPrimitive]: () => number
-    _onTimeout: (...args: Array<any>) => void
-    close: () => Timeout
-    hasRef: () => boolean
-    ref: () => Timeout
-    refresh: () => Timeout
-    unref: () => Timeout
-  interface NodeJS.Timer (@types/node/timers.d.ts)
-    [Symbol.toPrimitive]: () => number
-    hasRef: () => boolean
-    ref: () => Timer
-    refresh: () => Timer
-    unref: () => Timer
-  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
-  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
-  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
-  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
-  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
-  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
-  interface NodeJS.WritableStream (@types/node/stream.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    setMaxListeners: (n: number) => WritableStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.WriteStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
-    clearScreenDown: (callback?: (() => void) | undefined) => boolean
-    closed [readonly]: boolean
-    columns: number
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
-    destroy: (error?: Error | undefined) => WriteStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
-    getColorDepth: (env?: object | undefined) => number
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    getWindowSize: () => [number, number]
-    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
-    isPaused: () => boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
-    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    pause: () => WriteStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => WriteStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
-    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    resetAndDestroy: () => WriteStream
-    resume: () => WriteStream
-    rows: number
-    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
-    setMaxListeners: (n: number) => WriteStream
-    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
-    setTypeOfService: (tos: number) => WriteStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => WriteStream
-    unref: () => WriteStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => WriteStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
 interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
-  children: Array<Module>
+  children: Array<NodeJS.Module>
   exports: any
   filename: string
   id: string
   isPreloading: boolean
   loaded: boolean
-  parent: Module | null | undefined
+  parent: NodeJS.Module | null | undefined
   path: string
   paths: Array<string>
   require: (id: string) => any
@@ -5038,11 +4599,11 @@ interface Position (bun-types/globals.d.ts)
 interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts)
   construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
   [Symbol.species] [readonly]: PromiseConstructor
-  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
   prototype [readonly]: Promise<any>
-  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
   reject: <T = never>(reason?: any) => Promise<T>
   resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
   try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
@@ -5060,7 +4621,7 @@ interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bu
   byobRequest [readonly]: ReadableStreamBYOBRequest | null
   close: () => void
   desiredSize [readonly]: null | number
-  enqueue: (chunk: NonSharedArrayBufferView) => void
+  enqueue: (chunk: NodeJS.NonSharedArrayBufferView) => void
   error: (e?: any) => void
 var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableByteStreamController
@@ -5079,21 +4640,21 @@ interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-typ
   text: () => Promise<string>
   values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
 var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
-  construct new <R = any>(underlyingSource?: DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: Bun.UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: Bun.DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
   prototype: ReadableStream<any>
 interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
-  read: <T extends NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  read: <T extends NodeJS.NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
   releaseLock: () => void
 var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableStreamBYOBReader
   prototype: ReadableStreamBYOBReader
 interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   respond: (bytesWritten: number) => void
-  respondWithNewView: (view: NonSharedArrayBufferView) => void
-  view [readonly]: NonSharedArrayBufferView | null
+  respondWithNewView: (view: NodeJS.NonSharedArrayBufferView) => void
+  view [readonly]: NodeJS.NonSharedArrayBufferView | null
 var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableStreamBYOBRequest
   prototype: ReadableStreamBYOBRequest
@@ -5114,8 +4675,8 @@ interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
 interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
-  read: () => Promise<ReadableStreamDefaultReadResult<R>>
-  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  read: () => Promise<Bun.ReadableStreamDefaultReadResult<R>>
+  readMany: () => Bun.ReadableStreamDefaultReadManyResult<R> | Promise<Bun.ReadableStreamDefaultReadManyResult<R>>
   releaseLock: () => void
 var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
@@ -5125,7 +4686,7 @@ interface ReadableStreamDirectController (bun-types/globals.d.ts)
   end: () => Promise<number> | number
   flush: (wait?: boolean | undefined) => Promise<number> | number
   start: () => void
-  write: (data: BufferSource | string) => Promise<number> | number
+  write: (data: Bun.BufferSource | string) => Promise<number> | number
 interface ReadableStreamGenericReader (bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
@@ -5173,7 +4734,7 @@ interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   destination [readonly]: RequestDestination
   duplex [readonly]: "half"
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   integrity [readonly]: string
   json [readonly]: () => Promise<unknown>
   keepalive [readonly]: boolean
@@ -5192,12 +4753,12 @@ var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   construct new (requestInfo: Request, init?: RequestInit | undefined): Request
   prototype: Request
 interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  body [?]: BodyInit | null | undefined
+  body [?]: Bun.BodyInit | null | undefined
   cache [?]: RequestCache | undefined
   credentials [?]: RequestCredentials | undefined
   dispatcher [?]: Dispatcher | undefined
   duplex [?]: "half" | undefined
-  headers [?]: HeadersInit | undefined
+  headers [?]: Bun.HeadersInit | undefined
   integrity [?]: string | undefined
   keepalive [?]: boolean | undefined
   method [?]: string | undefined
@@ -5229,7 +4790,7 @@ interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
   clone: () => Response
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   json [readonly]: () => Promise<unknown>
   ok [readonly]: boolean
   redirected [readonly]: boolean
@@ -5240,7 +4801,7 @@ interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   type [readonly]: ResponseType
   url [readonly]: string
 var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  construct new (body?: Bun.BodyInit | null | undefined, init?: ResponseInit | undefined): Response
   error: () => Response
   json: (body?: any, init?: ResponseInit | number | undefined) => Response
   redirect: { (url: string, status?: number | undefined): Response; (url: string, init?: ResponseInit | undefined): Response }
@@ -5266,53 +4827,53 @@ interface StreamPipeOptions (bun-types/globals.d.ts)
   preventClose [?]: boolean | undefined
   signal [?]: AbortSignal | undefined
 interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
-  decapsulateBits: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource) => Promise<ArrayBuffer>
-  decapsulateKey: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<CryptoKey>
-  decrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  deriveBits: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
-  deriveKey: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>) => Promise<CryptoKey>
-  digest: (algorithm: AlgorithmIdentifier | CShakeParams | KangarooTwelveParams | TurboShakeParams, data: BufferSource) => Promise<ArrayBuffer>
-  encapsulateBits: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey) => Promise<EncapsulatedBits>
-  encapsulateKey: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<EncapsulatedKey>
-  encrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
-  generateKey: { (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | KmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
-  getPublicKey: (key: CryptoKey, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
-  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey> }
-  sign: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  unwrapKey: (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
-  verify: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
-  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+  decapsulateBits: (decapsulationAlgorithm: webcrypto.AlgorithmIdentifier, decapsulationKey: webcrypto.CryptoKey, ciphertext: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  decapsulateKey: (decapsulationAlgorithm: webcrypto.AlgorithmIdentifier, decapsulationKey: webcrypto.CryptoKey, ciphertext: NodeJS.BufferSource, sharedKeyAlgorithm: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, usages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  decrypt: (algorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.Argon2Params | webcrypto.EcdhKeyDeriveParams | webcrypto.HkdfParams | webcrypto.Pbkdf2Params, baseKey: webcrypto.CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.Argon2Params | webcrypto.EcdhKeyDeriveParams | webcrypto.HkdfParams | webcrypto.Pbkdf2Params, baseKey: webcrypto.CryptoKey, derivedKeyType: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  digest: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.CShakeParams | webcrypto.KangarooTwelveParams | webcrypto.TurboShakeParams, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  encapsulateBits: (encapsulationAlgorithm: webcrypto.AlgorithmIdentifier, encapsulationKey: webcrypto.CryptoKey) => Promise<webcrypto.EncapsulatedBits>
+  encapsulateKey: (encapsulationAlgorithm: webcrypto.AlgorithmIdentifier, encapsulationKey: webcrypto.CryptoKey, sharedKeyAlgorithm: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, usages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.EncapsulatedKey>
+  encrypt: (algorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: webcrypto.CryptoKey): Promise<webcrypto.JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: webcrypto.CryptoKey): Promise<ArrayBuffer>; (format: webcrypto.KeyFormat, key: webcrypto.CryptoKey): Promise<ArrayBuffer | webcrypto.JsonWebKey> }
+  generateKey: { (algorithm: webcrypto.EcKeyGenParams | webcrypto.RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKeyPair>; (algorithm: webcrypto.AesKeyGenParams | webcrypto.HmacKeyGenParams | webcrypto.KmacKeyGenParams | webcrypto.Pbkdf2Params, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey>; (algorithm: webcrypto.AlgorithmIdentifier, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey | webcrypto.CryptoKeyPair> }
+  getPublicKey: (key: webcrypto.CryptoKey, keyUsages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  importKey: { (format: "jwk", keyData: webcrypto.JsonWebKey, algorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: NodeJS.BufferSource, algorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey> }
+  sign: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.ContextParams | webcrypto.EcdsaParams | webcrypto.KmacParams | webcrypto.RsaPssParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: (format: webcrypto.KeyFormat, wrappedKey: NodeJS.BufferSource, unwrappingKey: webcrypto.CryptoKey, unwrapAlgorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, unwrappedKeyAlgorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  verify: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.ContextParams | webcrypto.EcdsaParams | webcrypto.KmacParams | webcrypto.RsaPssParams, key: webcrypto.CryptoKey, signature: NodeJS.BufferSource, data: NodeJS.BufferSource) => Promise<boolean>
+  wrapKey: (format: webcrypto.KeyFormat, key: webcrypto.CryptoKey, wrappingKey: webcrypto.CryptoKey, wrapAlgorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams) => Promise<ArrayBuffer>
 var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): SubtleCrypto
   prototype: SubtleCrypto
 interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  decode: (input?: NodeJS.AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
   encoding [readonly]: string
   fatal [readonly]: boolean
   ignoreBOM [readonly]: boolean
 var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
+  construct new (encoding?: Bun.Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
   prototype: TextDecoder
 interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   encoding [readonly]: string
   fatal [readonly]: boolean
   ignoreBOM [readonly]: boolean
   readable [readonly]: ReadableStream<string>
-  writable [readonly]: WritableStream<BufferSource>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): TextDecoderStream
   prototype: TextDecoderStream
 interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  encode: (input?: string | undefined) => NonSharedUint8Array
-  encodeInto: (src?: string | undefined, dest?: BufferSource | undefined) => TextEncoderEncodeIntoResult
+  encode: (input?: string | undefined) => NodeJS.NonSharedUint8Array
+  encodeInto: (src?: string | undefined, dest?: Bun.BufferSource | undefined) => TextEncoderEncodeIntoResult
   encoding [readonly]: string
 var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
+  construct new (encoding?: Bun.Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
   prototype: TextEncoder
 interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   encoding [readonly]: string
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
   writable [readonly]: WritableStream<string>
 var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): TextEncoderStream
@@ -5338,10 +4899,10 @@ var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-
   construct new (): TransformStreamDefaultController<any>
   prototype: TransformStreamDefaultController<any>
 interface Transformer<I = any, O = any> (bun-types/globals.d.ts)
-  flush [?]: TransformerFlushCallback<O> | undefined
+  flush [?]: Bun.TransformerFlushCallback<O> | undefined
   readableType [?]: undefined
-  start [?]: TransformerStartCallback<O> | undefined
-  transform [?]: TransformerTransformCallback<I, O> | undefined
+  start [?]: Bun.TransformerStartCallback<O> | undefined
+  transform [?]: Bun.TransformerTransformCallback<I, O> | undefined
   writableType [?]: undefined
 interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
   hash: string
@@ -5380,7 +4941,7 @@ interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d
   toJSON: () => Record<string, string>
   values: () => URLSearchParamsIterator<string>
 var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
-  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, string | ReadonlyArray<string>> | URLSearchParams | string | undefined): URLSearchParams
+  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, ReadonlyArray<string> | string> | URLSearchParams | string | undefined): URLSearchParams
   prototype: URLSearchParams
 interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es5.d.ts)
   index [number]: number
@@ -5418,7 +4979,7 @@ interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bu
   subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
   toBase64: (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }) => string
   toHex: () => string
-  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: Intl.NumberFormatOptions | undefined): string }
   toString: () => string
   valueOf: () => Uint8Array<TArrayBuffer>
   values: () => ArrayIterator<number>
@@ -5444,54 +5005,54 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     name: string
     stack [?]: string | undefined
   var WebAssembly.CompileError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): CompileError
-    construct new (message?: string | undefined): CompileError
-    prototype: CompileError
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
+    call (message?: string | undefined): WebAssembly.CompileError
+    construct new (message?: string | undefined): WebAssembly.CompileError
+    prototype: WebAssembly.CompileError
+  interface WebAssembly.Global<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
   var WebAssembly.Global (bun-types/wasm.d.ts)
-    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
-    prototype: Global<keyof ValueTypeMap>
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    construct new <T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap>(descriptor: WebAssembly.GlobalDescriptor<T>, v?: WebAssembly.ValueTypeMap[T] | undefined): WebAssembly.Global<T>
+    prototype: WebAssembly.Global<keyof WebAssembly.ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   var WebAssembly.Instance (bun-types/wasm.d.ts)
-    construct new (module: Module, importObject?: Imports | undefined): Instance
-    prototype: Instance
+    construct new (module: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): WebAssembly.Instance
+    prototype: WebAssembly.Instance
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.LinkError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): LinkError
-    construct new (message?: string | undefined): LinkError
-    prototype: LinkError
+    call (message?: string | undefined): WebAssembly.LinkError
+    construct new (message?: string | undefined): WebAssembly.LinkError
+    prototype: WebAssembly.LinkError
   interface WebAssembly.Memory (bun-types/wasm.d.ts)
     buffer [readonly]: ArrayBuffer
     grow: (delta: number) => number
   var WebAssembly.Memory (bun-types/wasm.d.ts)
-    construct new (descriptor: MemoryDescriptor): Memory
-    prototype: Memory
+    construct new (descriptor: WebAssembly.MemoryDescriptor): WebAssembly.Memory
+    prototype: WebAssembly.Memory
   interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
     initial: number
     maximum [?]: number | undefined
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   var WebAssembly.Module (bun-types/wasm.d.ts)
-    construct new (bytes: BufferSource): Module
-    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
-    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
-    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
-    prototype: Module
+    construct new (bytes: Bun.BufferSource): WebAssembly.Module
+    customSections: (moduleObject: WebAssembly.Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleExportDescriptor>
+    imports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleImportDescriptor>
+    prototype: WebAssembly.Module
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
@@ -5500,19 +5061,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     name: string
     stack [?]: string | undefined
   var WebAssembly.RuntimeError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): RuntimeError
-    construct new (message?: string | undefined): RuntimeError
-    prototype: RuntimeError
+    call (message?: string | undefined): WebAssembly.RuntimeError
+    construct new (message?: string | undefined): WebAssembly.RuntimeError
+    prototype: WebAssembly.RuntimeError
   interface WebAssembly.Table (bun-types/wasm.d.ts)
     get: (index: number) => any
     grow: (delta: number, value?: any) => number
     length [readonly]: number
     set: (index: number, value?: any) => void
   var WebAssembly.Table (bun-types/wasm.d.ts)
-    construct new (descriptor: TableDescriptor, value?: any): Table
-    prototype: Table
+    construct new (descriptor: WebAssembly.TableDescriptor, value?: any): WebAssembly.Table
+    prototype: WebAssembly.Table
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
@@ -5524,48 +5085,48 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
   function WebAssembly.compile (bun-types/wasm.d.ts)
-    call (bytes: BufferSource): Promise<Module>
+    call (bytes: Bun.BufferSource): Promise<WebAssembly.Module>
   function WebAssembly.compileStreaming (bun-types/wasm.d.ts)
-    call (source: PromiseLike<Response> | Response): Promise<Module>
+    call (source: PromiseLike<Response> | Response): Promise<WebAssembly.Module>
   function WebAssembly.instantiate (bun-types/wasm.d.ts)
-    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+    call (bytes: Bun.BufferSource, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (moduleObject: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.Instance>
   function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts)
-    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
   function WebAssembly.validate (bun-types/wasm.d.ts)
-    call (bytes: BufferSource): boolean
+    call (bytes: Bun.BufferSource): boolean
 interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
 var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (url: URL | string, options?: WebSocketOptions | undefined): WebSocket
+  construct new (url: URL | string, options?: Bun.WebSocketOptions | undefined): WebSocket
   construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
@@ -5573,19 +5134,19 @@ var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   OPEN [readonly]: 1
   prototype: WebSocket
 interface Worker (bun-types/globals.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
 var Worker (bun-types/globals.d.ts)
-  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  construct new (scriptURL: URL | string, options?: Bun.WorkerOptions | undefined): Worker
   data: any
   prototype: Worker
 interface WorkerOptions (bun-types/globals.d.ts)
@@ -5596,14 +5157,14 @@ interface WorkerOptions (bun-types/globals.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   abort: (reason?: any) => Promise<void>
   close: () => Promise<void>
   getWriter: () => WritableStreamDefaultWriter<W>
   locked [readonly]: boolean
 var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  construct new <W = any>(underlyingSink?: Bun.UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
   prototype: WritableStream<any>
 interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   error: (e?: any) => void
@@ -5623,18 +5184,18 @@ var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types
   prototype: WritableStreamDefaultWriter<any>
 function addEventListener (bun-types/globals.d.ts)
   call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
 function alert (bun-types/globals.d.ts)
   call (message?: string | undefined): void
 function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (immediate: Immediate | undefined): void
+  call (immediate: NodeJS.Immediate | undefined): void
 function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function confirm (bun-types/globals.d.ts)
   call (message?: string | undefined): boolean
 var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts): Console
@@ -5652,35 +5213,31 @@ var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts): 
 var onmessage (bun-types/index.d.ts): never
 var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts): Performance
 function postMessage (bun-types/globals.d.ts)
-  call (message: any, transfer?: Array<Transferable> | undefined): void
+  call (message: any, transfer?: Array<Bun.Transferable> | undefined): void
 function prompt (bun-types/globals.d.ts)
   call (message?: string | undefined, _default?: string | undefined): null | string
 function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (callback: (...args: Array<any>) => void): void
   call (callback: () => void): void
 function removeEventListener (bun-types/globals.d.ts)
-  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void
 function reportError (bun-types/globals.d.ts)
   call (error: any): void
-var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): NodeJS.Require
 function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  call (handler: Bun.TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Immediate
   __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
 function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
   __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
-  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T>(value: T, options?: Bun.StructuredSerializeOptions | undefined): T
   call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/es2022.txt
+++ b/test/integration/bun-types/inventory/es2022.txt
@@ -1,0 +1,5686 @@
+# bun-types inventory: preset es2022
+# lib: lib.es2022.d.ts
+# typescript: 6.0.2
+# @types/node: 26.2.0
+# undici-types: 8.3.0
+
+# module "*.html"
+
+# module "*.json5"
+
+# module "*.jsonc"
+
+# module "*.toml"
+
+# module "*.txt"
+
+# module "*.xml"
+
+# module "*.yaml"
+
+# module "*.yml"
+
+# module "*/bun.lock"
+
+# module "bun"
+type $ (bun-types/shell.d.ts) = typeof $
+function $ (bun-types/shell.d.ts)
+  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
+  Shell: new () => typeof $
+  ShellError: typeof ShellError
+  ShellPromise: typeof ShellPromise
+  braces: (pattern: string) => Array<string>
+  cwd: (newCwd?: string | undefined) => typeof $
+  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  escape: (input: string) => string
+  nothrow: () => typeof $
+  throws: (shouldThrow: boolean) => typeof $
+namespace $ (bun-types/shell.d.ts)
+  var $.Shell (bun-types/shell.d.ts)
+    construct new (): typeof $
+  class $.ShellError (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    cause [?]: unknown
+    exitCode [readonly]: number
+    json: () => any
+    message: string
+    name: string
+    stack [?]: string | undefined
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+    [static]
+      construct new (message?: string | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: ShellError
+      stackTraceLimit: number
+  interface $.ShellOutput (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    exitCode [readonly]: number
+    json: () => any
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+  class $.ShellPromise (bun-types/shell.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    arrayBuffer: () => Promise<ArrayBuffer>
+    blob: () => Promise<Blob>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
+    cwd: (newCwd: string) => ShellPromise
+    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    json: () => Promise<any>
+    lines: () => AsyncIterable<string>
+    nothrow: () => ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    stdin: WritableStream<any>
+    text: (encoding?: BufferEncoding | undefined) => Promise<string>
+    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => ShellPromise
+    [static]
+      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      [Symbol.species] [readonly]: PromiseConstructor
+      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+      prototype: ShellPromise
+      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      reject: <T = never>(reason?: any) => Promise<T>
+      resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+      try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
+      withResolvers: <T>() => { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; }
+  function $.braces (bun-types/shell.d.ts)
+    call (pattern: string): Array<string>
+  function $.cwd (bun-types/shell.d.ts)
+    call (newCwd?: string | undefined): typeof $
+  function $.env (bun-types/shell.d.ts)
+    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+  function $.escape (bun-types/shell.d.ts)
+    call (input: string): string
+  function $.nothrow (bun-types/shell.d.ts)
+    call (): typeof $
+  function $.throws (bun-types/shell.d.ts)
+    call (shouldThrow: boolean): typeof $
+interface AbstractWorker (bun-types/bun.d.ts)
+  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+interface AbstractWorkerEventMap (bun-types/bun.d.ts)
+  error: ErrorEvent
+interface AddEventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc" | "ppc64" | "s390" | "s390x" | "x64"
+class Archive (bun-types/bun.d.ts)
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
+  [static]
+    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
+    prototype: Archive
+    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
+interface ArchiveExtractOptions (bun-types/bun.d.ts)
+  glob [?]: ReadonlyArray<string> | string | undefined
+type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+interface ArchiveOptions (bun-types/bun.d.ts)
+  compress [?]: "gzip" | undefined
+  level [?]: number | undefined
+class ArrayBufferSink (bun-types/bun.d.ts)
+  end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
+  flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
+  start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  [static]
+    construct new (): ArrayBufferSink
+    prototype: ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
+type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+interface BinaryTypeList (bun-types/bun.d.ts)
+  arraybuffer: ArrayBuffer
+  buffer: Buffer<ArrayBufferLike>
+  uint8array: Uint8Array<ArrayBuffer>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
+type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+namespace Build (bun-types/bun.d.ts)
+  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
+  type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
+interface BuildArtifact (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  hash: null | string
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
+  loader: Loader
+  path: string
+  size [readonly]: number
+  sourcemap: BuildArtifact | null
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+interface BuildConfig (bun-types/bun.d.ts)
+  allowUnresolved [?]: Array<string> | undefined
+  banner [?]: string | undefined
+  bytecode [?]: boolean | undefined
+  bytecodeDepth [?]: number | undefined
+  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  conditions [?]: Array<string> | string | undefined
+  define [?]: Record<string, string> | undefined
+  deprecatedNamespaceObjectSetters [?]: boolean | undefined
+  drop [?]: Array<string> | undefined
+  emitDCEAnnotations [?]: boolean | undefined
+  entrypoints: Array<string>
+  env [?]: "disable" | "inline" | `${string}*` | undefined
+  external [?]: Array<string> | undefined
+  features [?]: Array<string> | undefined
+  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  footer [?]: string | undefined
+  format [?]: "cjs" | "esm" | "iife" | undefined
+  ignoreDCEAnnotations [?]: boolean | undefined
+  jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
+  loader [?]: undefined | { [x: string]: Loader; }
+  metafile [?]: boolean | undefined
+  minChunkSize [?]: number | undefined
+  minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
+  modulePreload [?]: boolean | undefined
+  naming [?]: string | undefined | { chunk?: string | undefined; entry?: string | undefined; asset?: string | undefined; }
+  optimizeImports [?]: Array<string> | undefined
+  outdir [?]: string | undefined
+  packages [?]: "bundle" | "external" | undefined
+  plugins [?]: Array<BunPlugin> | undefined
+  publicPath [?]: string | undefined
+  reactCompiler [?]: boolean | undefined
+  reactCompilerOutputMode [?]: "client" | "ssr" | undefined
+  reactFastRefresh [?]: boolean | undefined
+  root [?]: string | undefined
+  sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
+  splitRequire [?]: boolean | undefined
+  splitting [?]: boolean | undefined
+  target [?]: Target | undefined
+  throw [?]: boolean | undefined
+  treeShaking [?]: boolean | undefined
+  tsconfig [?]: string | undefined
+interface BuildMetafile (bun-types/bun.d.ts)
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+interface BuildOutput (bun-types/bun.d.ts)
+  logs: Array<BuildMessage | ResolveMessage>
+  metafile [?]: BuildMetafile | undefined
+  outputs: Array<BuildArtifact>
+  success: boolean
+interface BunFile (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface BunInspectOptions (bun-types/bun.d.ts)
+  colors [?]: boolean | undefined
+  compact [?]: boolean | undefined
+  depth [?]: number | undefined
+  sorted [?]: boolean | undefined
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+interface BunPlugin (bun-types/bun.d.ts)
+  name: string
+  setup: (build: PluginBuilder) => Promise<void> | void
+  target [?]: Target | undefined
+interface BunRegisterPlugin (bun-types/bun.d.ts)
+  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  clearAll: () => void
+interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  cache [readonly]: RequestCache
+  clone: () => BunRequest<T>
+  cookies [readonly]: CookieMap
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  duplex [readonly]: "half"
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  integrity [readonly]: string
+  json [readonly]: () => Promise<unknown>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+namespace CSRF (bun-types/bun.d.ts)
+  function CSRF.generate (bun-types/bun.d.ts)
+    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+  function CSRF.verify (bun-types/bun.d.ts)
+    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
+interface CSRFGenerateOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  expiresIn [?]: number | undefined
+  sessionId [?]: string | undefined
+interface CSRFVerifyOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  maxAge [?]: number | undefined
+  secret [?]: string | undefined
+  sessionId [?]: string | undefined
+interface CloseEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  code [?]: number | undefined
+  composed [?]: boolean | undefined
+  reason [?]: string | undefined
+  wasClean [?]: boolean | undefined
+type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+interface CompileBuildOptions (bun-types/bun.d.ts)
+  assets [?]: Array<string> | undefined
+  autoloadBunfig [?]: boolean | undefined
+  autoloadDotenv [?]: boolean | undefined
+  autoloadPackageJson [?]: boolean | undefined
+  autoloadTsconfig [?]: boolean | undefined
+  execArgv [?]: Array<string> | undefined
+  executablePath [?]: string | undefined
+  outfile [?]: string | undefined
+  target [?]: CompileTarget | undefined
+  windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
+type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+class Cookie (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | undefined
+  httpOnly: boolean
+  isExpired: () => boolean
+  maxAge [?]: number | undefined
+  name [readonly]: string
+  partitioned: boolean
+  path: string
+  sameSite: CookieSameSite
+  secure: boolean
+  serialize: () => string
+  toJSON: () => CookieInit
+  toString: () => string
+  value: string
+  [static]
+    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
+    construct new (cookieString: string): Cookie
+    construct new (cookieObject?: CookieInit | undefined): Cookie
+    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
+    parse [static]: (cookieString: string) => Cookie
+    prototype: Cookie
+interface CookieInit (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | number | string | undefined
+  httpOnly [?]: boolean | undefined
+  maxAge [?]: number | undefined
+  name [?]: string | undefined
+  partitioned [?]: boolean | undefined
+  path [?]: string | undefined
+  sameSite [?]: CookieSameSite | undefined
+  secure [?]: boolean | undefined
+  value [?]: string | undefined
+class CookieMap (bun-types/bun.d.ts)
+  [Symbol.iterator]: () => IterableIterator<[string, string]>
+  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  get: (name: string) => null | string
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  size [readonly]: number
+  toJSON: () => Record<string, string>
+  toSetCookieHeaders: () => Array<string>
+  values: () => IterableIterator<string>
+  [static]
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
+    prototype: CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
+  domain [?]: null | string | undefined
+  name: string
+  path [?]: string | undefined
+interface CookieStoreGetOptions (bun-types/bun.d.ts)
+  name [?]: string | undefined
+  url [?]: string | undefined
+interface CronController (bun-types/bun.d.ts)
+  cron [readonly]: string
+  scheduledTime [readonly]: number
+  type [readonly]: "scheduled"
+interface CronJob (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  cron [readonly]: string
+  ref: () => CronJob
+  stop: () => CronJob
+  unref: () => CronJob
+interface CronOptions (bun-types/bun.d.ts)
+  tz [?]: string | undefined
+type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+class CryptoHashInterface<T> (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => T
+  [static]
+    construct new <T>(): CryptoHashInterface<T>
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHashInterface<any>
+class CryptoHasher (bun-types/bun.d.ts)
+  algorithm [readonly]: SupportedCryptoAlgorithms
+  byteLength [readonly]: number
+  copy: () => CryptoHasher
+  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
+  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  [static]
+    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
+    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHasher
+interface CustomEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  detail [?]: T | undefined
+interface DNSLookup (bun-types/bun.d.ts)
+  address: string
+  family: 4 | 6
+  ttl: number
+type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
+  type: "direct"
+type DisconnectListener (bun-types/bun.d.ts) = () => void
+interface EditorOptions (bun-types/bun.d.ts)
+  column [?]: number | undefined
+  editor [?]: "subl" | "vscode" | undefined
+  line [?]: number | undefined
+type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+interface Env (bun-types/bun.d.ts)
+  NODE_ENV [?]: string | undefined
+  TZ [?]: string | undefined
+interface ErrorEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  colno [?]: number | undefined
+  composed [?]: boolean | undefined
+  error [?]: any
+  filename [?]: string | undefined
+  lineno [?]: number | undefined
+  message [?]: string | undefined
+interface ErrorLike (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+interface EventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+interface EventListener (bun-types/bun.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (bun-types/bun.d.ts)
+  handleEvent: (object: Event) => void
+interface EventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+interface EventMap (bun-types/bun.d.ts)
+  fetch: FetchEvent
+  message: BunMessageEvent<any>
+  messageerror: BunMessageEvent<any>
+interface EventSource (bun-types/bun.d.ts)
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: Event) => any) | null
+  onmessage: ((this: EventSource, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: number
+  ref: () => void
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => void
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+interface EventSourceEventMap (bun-types/bun.d.ts)
+  error: Event
+  message: BunMessageEvent<any>
+  open: Event
+type ExitListener (bun-types/bun.d.ts) = (code: number) => void
+type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
+interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  fd: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface FetchEvent (bun-types/bun.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface FileBlob (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface FileSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+class FileSystemRouter (bun-types/bun.d.ts)
+  assetPrefix [readonly]: string
+  match: (input: Request | Response | string) => MatchedRoute | null
+  origin [readonly]: string
+  reload: () => void
+  routes [readonly]: Record<string, string>
+  style [readonly]: string
+  [static]
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
+    prototype: FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+interface GenericTransformStream (bun-types/bun.d.ts)
+  readable [readonly]: ReadableStream<any>
+  writable [readonly]: WritableStream<any>
+class Glob (bun-types/bun.d.ts)
+  match: (str: string) => boolean
+  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  [static]
+    construct new (pattern: string): Glob
+    prototype: Glob
+interface GlobScanOptions (bun-types/bun.d.ts)
+  absolute [?]: boolean | undefined
+  cwd [?]: string | undefined
+  dot [?]: boolean | undefined
+  followSymlinks [?]: boolean | undefined
+  onlyFiles [?]: boolean | undefined
+  throwErrorOnBrokenSymlink [?]: boolean | undefined
+type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
+type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+interface HTMLBundle (bun-types/bun.d.ts)
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  index: string
+interface Hash (bun-types/bun.d.ts)
+  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Record<string, string | ReadonlyArray<string>> | Headers
+interface HeapSnapshot (bun-types/bun.d.ts)
+  edgeNames: Array<string>
+  edgeTypes: Array<string>
+  edges: Array<number>
+  nodeClassNames: Array<string>
+  nodes: Array<number>
+  type: string
+  version: number
+class Image (bun-types/bun.d.ts)
+  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  blob: () => Promise<Blob>
+  buffer: () => Promise<Buffer<ArrayBufferLike>>
+  bytes: () => Promise<Uint8Array<ArrayBufferLike>>
+  dataurl: () => Promise<string>
+  flip: () => Image
+  flop: () => Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  height [readonly]: number
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
+  metadata: () => Promise<Metadata>
+  modulate: (options: ModulateOptions) => Image
+  placeholder: (as?: "dataurl" | undefined) => Promise<string>
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
+  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
+  rotate: (degrees: number) => Image
+  toBase64: () => Promise<string>
+  toBuffer: () => Promise<Buffer<ArrayBufferLike>>
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  width [readonly]: number
+  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  [static]
+    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    backend [static]: "bun" | "system"
+    clipboardChangeCount [static]: () => number
+    fromClipboard [static]: () => Image | null
+    hasClipboardImage [static]: () => boolean
+    prototype: Image
+  interface Image.ConstructorOptions (bun-types/bun.d.ts)
+    autoOrient [?]: boolean | undefined
+    maxPixels [?]: number | undefined
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
+  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  interface Image.Metadata (bun-types/bun.d.ts)
+    format: Format
+    height: number
+    width: number
+  interface Image.ModulateOptions (bun-types/bun.d.ts)
+    brightness [?]: number | undefined
+    saturation [?]: number | undefined
+  interface Image.ResizeOptions (bun-types/bun.d.ts)
+    filter [?]: Filter | undefined
+    fit [?]: "fill" | "inside" | undefined
+    withoutEnlargement [?]: boolean | undefined
+  var Image.backend (bun-types/bun.d.ts): "bun" | "system"
+interface Import (bun-types/bun.d.ts)
+  kind: ImportKind
+  path: string
+type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+namespace JSON5 (bun-types/bun.d.ts)
+  function JSON5.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function JSON5.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+namespace JSONC (bun-types/bun.d.ts)
+  function JSONC.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+namespace JSONL (bun-types/bun.d.ts)
+  interface JSONL.ParseChunkResult (bun-types/bun.d.ts)
+    done: boolean
+    error: SyntaxError | null
+    read: number
+    values: Array<unknown>
+  function JSONL.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+  function JSONL.parseChunk (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
+interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
+  level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "libdeflate" | undefined
+type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+class MD4 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD4
+  [static]
+    construct new (): MD4
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD4
+class MD5 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD5
+  [static]
+    construct new (): MD5
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD5
+interface MMapOptions (bun-types/bun.d.ts)
+  offset [?]: number | undefined
+  shared [?]: boolean | undefined
+  size [?]: number | undefined
+  sync [?]: boolean | undefined
+type MacroMap (bun-types/bun.d.ts) = { [x: string]: Record<string, string>; }
+interface MatchedRoute (bun-types/bun.d.ts)
+  filePath [readonly]: string
+  kind [readonly]: "catch-all" | "dynamic" | "exact" | "optional-catch-all"
+  name [readonly]: string
+  params [readonly]: Record<string, string>
+  pathname [readonly]: string
+  query [readonly]: Record<string, string>
+  src [readonly]: string
+type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
+type MessageEvent<T = any> (bun-types/bun.d.ts) = BunMessageEvent<T>
+interface MessageEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  data [?]: T | undefined
+  lastEventId [?]: string | undefined
+  origin [?]: string | undefined
+  source [?]: null | undefined
+type MessageEventSource (bun-types/bun.d.ts) = undefined
+type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+interface NetworkSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  stat: () => Promise<Stats>
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
+type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+interface OnLoadArgs (bun-types/bun.d.ts)
+  defer: () => Promise<void>
+  loader: Loader
+  namespace: string
+  path: string
+type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+interface OnLoadResultObject (bun-types/bun.d.ts)
+  exports: Record<string, unknown>
+  loader: "object"
+interface OnLoadResultSourceCode (bun-types/bun.d.ts)
+  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Loader | undefined
+interface OnResolveArgs (bun-types/bun.d.ts)
+  importer: string
+  kind: ImportKind
+  namespace: string
+  path: string
+  resolveDir: string
+type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+interface OnResolveResult (bun-types/bun.d.ts)
+  external [?]: boolean | undefined
+  namespace [?]: string | undefined
+  path: string
+type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
+namespace Password (bun-types/bun.d.ts)
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  interface Password.Argon2Algorithm (bun-types/bun.d.ts)
+    algorithm: "argon2d" | "argon2i" | "argon2id"
+    memoryCost [?]: number | undefined
+    timeCost [?]: number | undefined
+  interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
+    algorithm: "bcrypt"
+    cost [?]: number | undefined
+type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
+type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+interface PluginBuilder (bun-types/bun.d.ts)
+  config: BuildConfig & { plugins: Array<BunPlugin>; }
+  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
+  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
+  onEnd: (callback: OnEndCallback) => PluginBuilder
+  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
+  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
+  onStart: (callback: OnStartCallback) => PluginBuilder
+interface PluginConstraints (bun-types/bun.d.ts)
+  filter: RegExp
+  namespace [?]: string | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
+interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
+  done: boolean
+  size: number
+  value: Array<T>
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
+type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+class RedisClient (bun-types/redis.d.ts)
+  append: (key: KeyLike, value: KeyLike) => Promise<number>
+  bitcount: (key: KeyLike) => Promise<number>
+  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
+  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
+  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
+  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  bufferedAmount [readonly]: number
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  client: (...args: Array<string | number>) => Promise<any>
+  close: () => void
+  command: (...args: Array<string | number>) => Promise<any>
+  config: (...args: Array<string | number>) => Promise<any>
+  connect: () => Promise<void>
+  connected [readonly]: boolean
+  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  dbsize: () => Promise<number>
+  debug: (...args: Array<string | number>) => Promise<any>
+  decr: (key: KeyLike) => Promise<number>
+  decrby: (key: KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<KeyLike>) => Promise<number>
+  dump: (key: KeyLike) => Promise<string | null>
+  duplicate: () => Promise<RedisClient>
+  echo: (message: string) => Promise<string>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  exists: (key: KeyLike) => Promise<boolean>
+  expire: (key: KeyLike, seconds: number) => Promise<number>
+  expireat: (key: KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  function: (...args: Array<KeyLike>) => Promise<any>
+  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
+  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
+  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
+  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
+  get: (key: KeyLike) => Promise<string | null>
+  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: KeyLike, offset: number) => Promise<number>
+  getdel: (key: KeyLike) => Promise<string | null>
+  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
+  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
+  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
+  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
+  hgetall: (key: KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
+  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
+  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: KeyLike) => Promise<Array<string>>
+  hlen: (key: KeyLike) => Promise<number>
+  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
+  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
+  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
+  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
+  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
+  hstrlen: (key: KeyLike, field: string) => Promise<number>
+  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hvals: (key: KeyLike) => Promise<Array<string>>
+  incr: (key: KeyLike) => Promise<number>
+  incrby: (key: KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  info: (...sections: Array<string>) => Promise<string>
+  keys: (pattern: string) => Promise<Array<string>>
+  lastsave: () => Promise<number>
+  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
+  lindex: (key: KeyLike, index: number) => Promise<string | null>
+  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
+  llen: (key: KeyLike) => Promise<number>
+  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
+  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
+  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
+  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
+  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
+  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
+  onclose: ((this: RedisClient, error: Error) => void) | null
+  onconnect: ((this: RedisClient) => void) | null
+  persist: (key: KeyLike) => Promise<number>
+  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: KeyLike) => Promise<number>
+  pfadd: (key: KeyLike, element: string) => Promise<number>
+  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
+  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
+  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
+  pttl: (key: KeyLike) => Promise<number>
+  publish: (channel: string, message: string) => Promise<number>
+  randomkey: () => Promise<string | null>
+  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
+  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
+  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
+  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
+  scard: (key: KeyLike) => Promise<number>
+  script: (...args: Array<string>) => Promise<any>
+  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  send: (command: string, args: Array<string>) => Promise<any>
+  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
+  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
+  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
+  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
+  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
+  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sismember: (key: KeyLike, member: string) => Promise<boolean>
+  smembers: (key: KeyLike) => Promise<Array<string>>
+  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
+  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
+  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
+  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: KeyLike, message: string) => Promise<number>
+  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
+  strlen: (key: KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
+  substr: (key: KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  time: () => Promise<[string, string]>
+  touch: (...keys: Array<KeyLike>) => Promise<number>
+  ttl: (key: KeyLike) => Promise<number>
+  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
+  unlink: (...keys: Array<KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  wait: (numreplicas: number, timeout: number) => Promise<number>
+  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
+  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
+  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
+  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xlen: (key: KeyLike) => Promise<number>
+  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
+  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<string | number>) => Promise<any>
+  xreadgroup: (...args: Array<string | number>) => Promise<any>
+  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
+  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
+  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  zcard: (key: KeyLike) => Promise<number>
+  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
+  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
+  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
+  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
+  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: KeyLike, member: string) => Promise<number | null>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  [static]
+    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
+    prototype: RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+  type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
+interface RedisOptions (bun-types/redis.d.ts)
+  autoReconnect [?]: boolean | undefined
+  connectionTimeout [?]: number | undefined
+  enableAutoPipelining [?]: boolean | undefined
+  enableOfflineQueue [?]: boolean | undefined
+  idleTimeout [?]: number | undefined
+  maxRetries [?]: number | undefined
+  tls [?]: TLSOptions | boolean | undefined
+type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
+interface ReservedSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  [Symbol.dispose]: () => void
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  release: () => void
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+interface ResourceUsage (bun-types/bun.d.ts)
+  contextSwitches: { voluntary: number; involuntary: number; }
+  cpuTime: { user: number; system: number; total: number; }
+  maxRSS: number
+  messages: { sent: number; received: number; }
+  ops: { in: number; out: number; }
+  shmSize: number
+  signalCount: number
+  swapCount: number
+class S3Client (bun-types/s3.d.ts)
+  delete: (path: string, options?: S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: S3Options | undefined) => S3File
+  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
+  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  [static]
+    construct new (options?: S3Options | undefined): S3Client
+    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: S3Options | undefined) => S3File
+    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
+    prototype: S3Client
+    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+interface S3File (bun-types/s3.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bucket [? readonly]: string | undefined
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  name [? readonly]: string | undefined
+  presign: (options?: S3FilePresignOptions | undefined) => string
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
+  stat: () => Promise<S3Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  writer: (options?: S3Options | undefined) => NetworkSink
+interface S3FilePresignOptions (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endpoint [?]: string | undefined
+  expiresIn [?]: number | undefined
+  highWaterMark [?]: number | undefined
+  method [?]: "DELETE" | "GET" | "HEAD" | "POST" | "PUT" | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3ListObjectsOptions (bun-types/s3.d.ts)
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  fetchOwner [?]: boolean | undefined
+  maxKeys [?]: number | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3ListObjectsResponse (bun-types/s3.d.ts)
+  commonPrefixes [?]: Array<{ prefix: string; }> | undefined
+  contents [?]: Array<{ checksumAlgorithm?: "CRC32" | "CRC32C" | "SHA1" | "SHA256" | "CRC64NVME" | undefined; checksumType?: "COMPOSITE" | "FULL_OBJECT" | undefined; eTag?: string | undefined; key: string; lastModified?: string | undefined; owner?: { id?: string | undefined; displayName?: string | undefined; } | undefined; restoreStatus?: { isRestoreInProgress?: boolean | undefined; restoreExpiryDate?: string | undefined; } | undefined; size?: number | undefined; storageClass?: "STANDARD" | "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD_IA" | undefined; }> | undefined
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  isTruncated [?]: boolean | undefined
+  keyCount [?]: number | undefined
+  maxKeys [?]: number | undefined
+  name [?]: string | undefined
+  nextContinuationToken [?]: string | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3Options (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endpoint [?]: string | undefined
+  highWaterMark [?]: number | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3Stats (bun-types/s3.d.ts)
+  etag: string
+  lastModified: Date
+  size: number
+  type: string
+class SHA1 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA1
+  [static]
+    construct new (): SHA1
+    byteLength [readonly static]: 20
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA1
+class SHA224 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA224
+  [static]
+    construct new (): SHA224
+    byteLength [readonly static]: 28
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA224
+class SHA256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA256
+  [static]
+    construct new (): SHA256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA256
+class SHA384 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA384
+  [static]
+    construct new (): SHA384
+    byteLength [readonly static]: 48
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA384
+class SHA512 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512
+  [static]
+    construct new (): SHA512
+    byteLength [readonly static]: 64
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512
+class SHA512_256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  [static]
+    construct new (): SHA512_256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512_256
+class SQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  [static]
+    construct new (connectionString: URL | string): SQL
+    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
+    construct new (options?: Options | undefined): SQL
+    MySQLError: typeof MySQLError
+    PostgresError: typeof PostgresError
+    SQLError: typeof SQLError
+    SQLiteError: typeof SQLiteError
+    prototype: SQL
+  type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  interface SQL.Helper<T> (bun-types/sql.d.ts)
+    columns [readonly]: Array<keyof T>
+    value [readonly]: Array<T>
+  interface SQL.ListenSubscription (bun-types/sql.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    channel [readonly]: string
+    unlisten: () => Promise<void>
+  class SQL.MySQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    errno [? readonly]: number | undefined
+    message: string
+    name: string
+    sqlState [? readonly]: string | undefined
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: MySQLError
+      stackTraceLimit: number
+  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  class SQL.PostgresError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    column [? readonly]: string | undefined
+    constraint [? readonly]: string | undefined
+    dataType [? readonly]: string | undefined
+    detail [? readonly]: string | undefined
+    errno [? readonly]: string | undefined
+    file [? readonly]: string | undefined
+    hint [? readonly]: string | undefined
+    internalPosition [? readonly]: string | undefined
+    internalQuery [? readonly]: string | undefined
+    line [? readonly]: string | undefined
+    message: string
+    name: string
+    position [? readonly]: string | undefined
+    routine [? readonly]: string | undefined
+    schema [? readonly]: string | undefined
+    severity [? readonly]: string | undefined
+    stack [?]: string | undefined
+    table [? readonly]: string | undefined
+    where [? readonly]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: PostgresError
+      stackTraceLimit: number
+  interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
+    adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
+    allowPublicKeyRetrieval [?]: boolean | undefined
+    bigint [?]: boolean | undefined
+    connectTimeout [?]: number | undefined
+    connect_timeout [?]: number | undefined
+    connection [?]: Record<string, string | number | boolean> | undefined
+    connectionTimeout [?]: number | undefined
+    connection_timeout [?]: number | undefined
+    database [?]: string | undefined
+    db [?]: string | undefined
+    host [?]: string | undefined
+    hostname [?]: string | undefined
+    idleTimeout [?]: number | undefined
+    idle_timeout [?]: number | undefined
+    max [?]: number | undefined
+    maxLifetime [?]: number | undefined
+    max_lifetime [?]: number | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    pass [?]: (() => MaybePromise<string>) | string | undefined
+    password [?]: (() => MaybePromise<string>) | string | undefined
+    path [?]: string | undefined
+    port [?]: number | string | undefined
+    prepare [?]: boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    url [?]: URL | string | undefined
+    user [?]: string | undefined
+    username [?]: string | undefined
+  interface SQL.Query<T> (bun-types/sql.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    active: boolean
+    cancel: () => Query<T>
+    cancelled: boolean
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
+    execute: () => Query<T>
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
+    raw: () => Query<T>
+    simple: () => Query<T>
+    then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    values: () => Query<T>
+  class SQL.SQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string): SQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLError
+      stackTraceLimit: number
+  class SQL.SQLiteError (bun-types/sql.d.ts)
+    byteOffset [? readonly]: number | undefined
+    cause [?]: unknown
+    code [readonly]: string
+    errno [readonly]: number
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLiteError
+      stackTraceLimit: number
+  interface SQL.SQLiteOptions (bun-types/sql.d.ts)
+    adapter [?]: "sqlite" | undefined
+    create [?]: boolean | undefined
+    filename [?]: ":memory:" | URL | string & {} | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    readonly [?]: boolean | undefined
+    readwrite [?]: boolean | undefined
+    safeIntegers [?]: boolean | undefined
+    strict [?]: boolean | undefined
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SQLArrayParameter (bun-types/sql.d.ts)
+  arrayType: ArrayType
+  serializedValues: string
+type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SavepointSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+namespace Security (bun-types/security.d.ts)
+  interface Security.Advisory (bun-types/security.d.ts)
+    description: null | string
+    level: "fatal" | "warn"
+    package: string
+    url: null | string
+  interface Security.Package (bun-types/security.d.ts)
+    name: string
+    requestedRange: string
+    tarball: string
+    version: string
+  interface Security.Scanner (bun-types/security.d.ts)
+    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    version: "1"
+namespace Serve (bun-types/serve.d.ts)
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
+  interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
+    dir: string
+    statCache [?]: boolean | undefined
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    http1 [?]: boolean | undefined
+    http2 [?]: boolean | undefined
+    http3 [?]: boolean | undefined
+    id [?]: null | string | undefined
+    idleTimeout [?]: number | undefined
+    ipv6Only [?]: boolean | undefined
+    maxRequestBodySize [?]: number | undefined
+    port [?]: number | string | undefined
+    reusePort [?]: boolean | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+  interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    unix [?]: string | undefined
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+interface Server<WebSocketData> (bun-types/serve.d.ts)
+  [Symbol.dispose]: () => void
+  closeIdleConnections: () => number
+  development [readonly]: boolean
+  fetch: (request: Request | string) => Promise<Response> | Response
+  hostname [readonly]: string | undefined
+  id [readonly]: string
+  pendingRequests [readonly]: number
+  pendingWebSockets [readonly]: number
+  port [readonly]: number | undefined
+  protocol [readonly]: "http" | "https" | null
+  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  ref: () => void
+  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
+  requestIP: (request: Request) => SocketAddress | null
+  stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
+  subscriberCount: (topic: string) => number
+  timeout: (request: Request, seconds: number) => void
+  unref: () => void
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  url [readonly]: URL
+interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
+  binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  data: T
+  getBufferedAmount: () => number
+  isSubscribed: (topic: string) => boolean
+  ping: (data?: Blob | BufferSource | string | undefined) => number
+  pong: (data?: Blob | BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  publishText: (topic: string, data: string, compress?: boolean | undefined) => number
+  readyState [readonly]: WebSocketReadyState
+  remoteAddress [readonly]: string
+  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  sendText: (data: string, compress?: boolean | undefined) => number
+  subscribe: (topic: string) => boolean
+  subscriptions [readonly]: Array<string>
+  terminate: () => void
+  unsubscribe: (topic: string) => boolean
+type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
+type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
+type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+interface SliceAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  ellipsis [?]: string | undefined
+interface Socket<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: Data
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface SocketAddress (bun-types/bun.d.ts)
+  address: string
+  family: "IPv4" | "IPv6"
+  port: number
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof BinaryTypeList | undefined
+  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+namespace Spawn (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
+  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    lazy [?]: boolean | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    terminal [?]: Terminal | TerminalOptions | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
+  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+SpawnOptions -> Spawn
+type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
+type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+interface StringWidthOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  countAnsiEscapeCodes [?]: boolean | undefined
+  perCodePoint [?]: boolean | undefined
+interface StructuredSerializeOptions (bun-types/bun.d.ts)
+  transfer [?]: Array<Transferable> | undefined
+interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  disconnect: () => void
+  exitCode [readonly]: null | number
+  exited [readonly]: Promise<number>
+  kill: (exitCode?: Signals | number | undefined) => void
+  killed [readonly]: boolean
+  pid [readonly]: number
+  readable [readonly]: ReadableToIO<Out>
+  ref: () => void
+  resourceUsage: () => ResourceUsage | undefined
+  send: (message: any) => void
+  signalCode [readonly]: Signals | null
+  stderr [readonly]: ReadableToIO<Err>
+  stdin [readonly]: WritableToIO<In>
+  stdio [readonly]: [null, null, null, ...(number | null)[]]
+  stdout [readonly]: ReadableToIO<Out>
+  terminal [readonly]: Terminal | undefined
+  unref: () => void
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  exitCode: number
+  exitedDueToMaxBuffer [?]: boolean | undefined
+  exitedDueToTimeout [?]: boolean | undefined
+  pid: number
+  resourceUsage: ResourceUsage
+  signalCode [?]: string | undefined
+  stderr: ReadableToSyncIO<Err>
+  stdout: ReadableToSyncIO<Out>
+  success: boolean
+interface SystemError (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface TCPSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  ipv6Only [?]: boolean | undefined
+  port: number
+  reusePort [?]: boolean | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  port: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  hostname [readonly]: string
+  port [readonly]: number
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface TLSSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls: TLSOptions | boolean
+namespace TOML (bun-types/bun.d.ts)
+  function TOML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+  function TOML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+interface TSConfig (bun-types/bun.d.ts)
+  compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
+  extends [?]: string | undefined
+type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+class Terminal (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => Promise<void>
+  close: () => void
+  closed [readonly]: boolean
+  controlFlags: number
+  inputFlags: number
+  localFlags: number
+  outputFlags: number
+  ref: () => void
+  resize: (cols: number, rows: number) => void
+  setRawMode: (enabled: boolean) => void
+  unref: () => void
+  write: (data: BufferSource | string) => number
+  [static]
+    construct new (options: TerminalOptions): Terminal
+    prototype: Terminal
+interface TerminalOptions (bun-types/bun.d.ts)
+  cols [?]: number | undefined
+  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Terminal) => void) | undefined
+  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  name [?]: string | undefined
+  rows [?]: number | undefined
+type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
+interface TransactionSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
+interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+interface TransformerStartCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): any
+interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
+  call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+class Transpiler (bun-types/bun.d.ts)
+  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
+  scanImports: (code: StringOrBuffer) => Array<Import>
+  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  [static]
+    construct new (options?: TranspilerOptions | undefined): Transpiler
+    prototype: Transpiler
+interface TranspilerOptions (bun-types/bun.d.ts)
+  allowBunRuntime [?]: boolean | undefined
+  autoImportJSX [?]: boolean | undefined
+  deadCodeElimination [?]: boolean | undefined
+  define [?]: Record<string, string> | undefined
+  exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
+  inline [?]: boolean | undefined
+  jsxOptimizationInline [?]: boolean | undefined
+  loader [?]: JavaScriptLoader | undefined
+  logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
+  macro [?]: MacroMap | undefined
+  minifyWhitespace [?]: boolean | undefined
+  replMode [?]: boolean | undefined
+  target [?]: Target | undefined
+  treeShaking [?]: boolean | undefined
+  trimUnusedImports [?]: boolean | undefined
+  tsconfig [?]: TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
+interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
+  abort [?]: UnderlyingSinkAbortCallback | undefined
+  close [?]: UnderlyingSinkCloseCallback | undefined
+  start [?]: UnderlyingSinkStartCallback | undefined
+  type [?]: "bytes" | "default" | undefined
+  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
+  call (): PromiseLike<void> | void
+interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
+  call (controller: WritableStreamDefaultController): any
+interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
+  call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
+interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull [?]: UnderlyingSourcePullCallback<R> | undefined
+  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  type [?]: undefined
+interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): any
+type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+interface UnixSocketListener<Data> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unix [readonly]: string
+  unref: () => void
+interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+  unix: string
+type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+interface WebSocket (bun-types/bun.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+interface WebSocketEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: Event
+  message: BunMessageEvent<any>
+  open: Event
+interface WebSocketHandler<T> (bun-types/serve.d.ts)
+  backpressureLimit [?]: number | undefined
+  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  closeOnBackpressureLimit [?]: boolean | undefined
+  data [?]: T | undefined
+  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  idleTimeout [?]: number | undefined
+  maxPayloadLength [?]: number | undefined
+  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
+  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  publishToSelf [?]: boolean | undefined
+  sendPings [?]: boolean | undefined
+type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
+type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
+class WebView (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => void
+  [Symbol.dispose]: () => void
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: BunMessageEvent<T>) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  back: () => Promise<void>
+  cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
+  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  evaluate: <T = unknown>(script: string) => Promise<T>
+  forward: () => Promise<void>
+  loading [readonly]: boolean
+  navigate: (url: string) => Promise<void>
+  onNavigated: ((url: string, title: string) => void) | null
+  onNavigationFailed: ((error: Error) => void) | null
+  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  reload: () => Promise<void>
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  resize: (width: number, height: number) => Promise<void>
+  screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
+  scroll: (dx: number, dy: number) => Promise<void>
+  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  title [readonly]: string
+  type: (text: string) => Promise<void>
+  url [readonly]: string
+  [static]
+    construct new (options?: ConstructorOptions | undefined): WebView
+    closeAll [static]: () => void
+    prototype: WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+  interface WebView.ClickOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+    timeout [?]: number | undefined
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  interface WebView.ConstructorOptions (bun-types/bun.d.ts)
+    backend [?]: Backend | undefined
+    console [?]: ConsoleCapture | undefined
+    dataStore [?]: "ephemeral" | undefined | { directory: string; }
+    headless [?]: boolean | undefined
+    height [?]: number | undefined
+    url [?]: string | undefined
+    width [?]: number | undefined
+  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  interface WebView.PressOptions (bun-types/bun.d.ts)
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ScrollToOptions (bun-types/bun.d.ts)
+    block [?]: "center" | "end" | "nearest" | "start" | undefined
+    timeout [?]: number | undefined
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+interface WhichOptions (bun-types/bun.d.ts)
+  PATH [?]: string | undefined
+  cwd [?]: string | undefined
+interface Worker (bun-types/bun.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+interface WorkerEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: ErrorEvent
+  message: BunMessageEvent<any>
+  messageerror: BunMessageEvent<any>
+  open: Event
+interface WorkerOptions (bun-types/bun.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
+interface WrapAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  hard [?]: boolean | undefined
+  trim [?]: boolean | undefined
+  wordWrap [?]: boolean | undefined
+type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+namespace XML (bun-types/bun.d.ts)
+  interface XML.Comment (bun-types/bun.d.ts)
+    comment: string
+  interface XML.Document (bun-types/bun.d.ts)
+    index [string]: Value
+  interface XML.Element (bun-types/bun.d.ts)
+    index [string]: Array<Value> | Value
+  interface XML.Node (bun-types/bun.d.ts)
+    attributes: Record<string, string>
+    children: Array<string | Comment | Node | ProcessingInstruction>
+    name: string
+  interface XML.NodeInput (bun-types/bun.d.ts)
+    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
+    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    name: string
+  interface XML.ParseOptions (bun-types/bun.d.ts)
+    compact [?]: boolean | undefined
+  interface XML.ProcessingInstruction (bun-types/bun.d.ts)
+    data: string
+    target: string
+  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
+  type XML.Value (bun-types/bun.d.ts) = string | Element
+  function XML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+  function XML.stringify (bun-types/bun.d.ts)
+    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+namespace YAML (bun-types/bun.d.ts)
+  function YAML.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function YAML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string
+interface ZlibCompressionOptions (bun-types/bun.d.ts)
+  level [?]: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "zlib" | undefined
+  memLevel [?]: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  strategy [?]: number | undefined
+  windowBits [?]: -10 | -11 | -12 | -13 | -14 | -15 | -9 | 10 | 11 | 12 | 13 | 14 | 15 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 9 | undefined
+namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/globals.d.ts)
+  interface __internal.BunEvent (bun-types/globals.d.ts)
+    bubbles [readonly]: boolean
+    cancelBubble: boolean
+    cancelable [readonly]: boolean
+    composed [readonly]: boolean
+    composedPath: () => [(EventTarget | undefined)?]
+    currentTarget [readonly]: EventTarget | null
+    defaultPrevented [readonly]: boolean
+    eventPhase [readonly]: number
+    isTrusted [readonly]: boolean
+    preventDefault: () => void
+    returnValue: boolean
+    srcElement [readonly]: EventTarget | null
+    stopImmediatePropagation: () => void
+    stopPropagation: () => void
+    target [readonly]: EventTarget | null
+    timeStamp [readonly]: number
+    type [readonly]: string
+  interface __internal.BunEventTarget (bun-types/globals.d.ts)
+    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    dispatchEvent: (event: Event) => boolean
+    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
+    [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
+    append [readonly]: (name: string, value: string) => void
+    count [readonly]: number
+    delete [readonly]: (name: string) => void
+    entries [readonly]: () => SpecIterableIterator<[string, string]>
+    forEach [readonly]: (callbackfn: (value: string, key: string, iterable: Headers) => void, thisArg?: unknown) => void
+    get [readonly]: (name: string) => null | string
+    getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+    getSetCookie [readonly]: () => Array<string>
+    has [readonly]: (name: string) => boolean
+    keys [readonly]: () => SpecIterableIterator<string>
+    set [readonly]: (name: string, value: string) => void
+    toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+    values [readonly]: () => SpecIterableIterator<string>
+  interface __internal.BunRequestOverride (bun-types/fetch.d.ts)
+    arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+    blob [readonly]: () => Promise<Blob>
+    body [readonly]: ReadableStream<any> | null
+    bodyUsed [readonly]: boolean
+    bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+    cache [readonly]: RequestCache
+    clone: () => Request
+    credentials [readonly]: RequestCredentials
+    destination [readonly]: RequestDestination
+    duplex [readonly]: "half"
+    formData [readonly]: () => Promise<FormData>
+    headers: BunHeadersOverride
+    integrity [readonly]: string
+    json [readonly]: () => Promise<unknown>
+    keepalive [readonly]: boolean
+    method [readonly]: string
+    mode [readonly]: RequestMode
+    redirect [readonly]: RequestRedirect
+    referrer [readonly]: string
+    referrerPolicy [readonly]: ReferrerPolicy
+    signal [readonly]: AbortSignal
+    text [readonly]: () => Promise<string>
+    textStream: () => ReadableStream<string>
+    url [readonly]: string
+  interface __internal.BunResponseOverride (bun-types/fetch.d.ts)
+    arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+    blob [readonly]: () => Promise<Blob>
+    body [readonly]: ReadableStream<any> | null
+    bodyUsed [readonly]: boolean
+    bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+    clone: () => Response
+    formData [readonly]: () => Promise<FormData>
+    headers: BunHeadersOverride
+    json [readonly]: () => Promise<unknown>
+    ok [readonly]: boolean
+    redirected [readonly]: boolean
+    status [readonly]: number
+    statusText [readonly]: string
+    text [readonly]: () => Promise<string>
+    textStream: () => ReadableStream<string>
+    type [readonly]: ResponseType
+    url [readonly]: string
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
+  type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
+  type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = false
+  type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = BroadcastChannel
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = BunEvent
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = BunEventTarget
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = WebSocket
+  type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = EventSource
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = SubtleCrypto
+  type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = MessagePort
+  type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = ReadableStream<T>
+  type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = CompressionStream
+  type __internal.LibEmptyOrNodeStreamWebDecompressionStream (bun-types/globals.d.ts) = DecompressionStream
+  type __internal.LibEmptyOrNodeStreamWebTextDecoderStream (bun-types/globals.d.ts) = TextDecoderStream
+  type __internal.LibEmptyOrNodeStreamWebTextEncoderStream (bun-types/globals.d.ts) = TextEncoderStream
+  type __internal.LibEmptyOrNodeUtilTextDecoder (bun-types/globals.d.ts) = TextDecoder
+  type __internal.LibEmptyOrNodeUtilTextEncoder (bun-types/globals.d.ts) = TextEncoder
+  type __internal.LibEmptyOrNodeWritableStream<T> (bun-types/globals.d.ts) = WritableStream<T>
+  type __internal.LibEmptyOrPerformanceEntry (bun-types/globals.d.ts) = PerformanceEntry
+  type __internal.LibEmptyOrPerformanceMark (bun-types/globals.d.ts) = PerformanceMark
+  type __internal.LibEmptyOrPerformanceMeasure (bun-types/globals.d.ts) = PerformanceMeasure
+  type __internal.LibEmptyOrPerformanceObserver (bun-types/globals.d.ts) = PerformanceObserver
+  type __internal.LibEmptyOrPerformanceObserverEntryList (bun-types/globals.d.ts) = PerformanceObserverEntryList
+  type __internal.LibEmptyOrPerformanceResourceTiming (bun-types/globals.d.ts) = PerformanceResourceTiming
+  type __internal.LibEmptyOrReadableByteStreamController (bun-types/globals.d.ts) = ReadableByteStreamController
+  type __internal.LibEmptyOrReadableStreamBYOBReader (bun-types/globals.d.ts) = ReadableStreamBYOBReader
+  type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = ReadableStreamBYOBRequest
+  type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = Headers
+  type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = Request
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: BodyInit | null | undefined; headers?: HeadersInit | undefined; }
+  type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = Response
+  type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = ResponseInit
+  type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = Performance
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Worker
+  type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
+  type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = Otherwise
+  type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+function allocUnsafe (bun-types/bun.d.ts)
+  call (size: number): Uint8Array<ArrayBuffer>
+var argv (bun-types/bun.d.ts): Array<string>
+function build (bun-types/bun.d.ts)
+  call (config: BuildConfig): Promise<BuildOutput>
+function color (bun-types/bun.d.ts)
+  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: ColorInput, outputFormat: "number"): null | number
+function concatArrayBuffers (bun-types/bun.d.ts)
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+function connect (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+var cron (bun-types/bun.d.ts)
+  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
+  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  remove: (title: string) => Promise<void>
+function deepEquals (bun-types/bun.d.ts)
+  call (a: any, b: any, strict?: boolean | undefined): boolean
+function deepMatch (bun-types/bun.d.ts)
+  call (subset: unknown, a: unknown): boolean
+function deflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+namespace dns (bun-types/bun.d.ts)
+  var dns.ADDRCONFIG (bun-types/bun.d.ts): number
+  var dns.ALL (bun-types/bun.d.ts): number
+  var dns.V4MAPPED (bun-types/bun.d.ts): number
+  function dns.getCacheStats (bun-types/bun.d.ts)
+    call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
+  function dns.lookup (bun-types/bun.d.ts)
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+  function dns.prefetch (bun-types/bun.d.ts)
+    call (hostname: string, port?: number | undefined): void
+var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
+var enableANSIColors (bun-types/bun.d.ts): boolean
+var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+function escapeHTML (bun-types/bun.d.ts)
+  call (input: boolean | number | object | string): string
+var fetch (bun-types/bun.d.ts): typeof fetch
+function file (bun-types/bun.d.ts)
+  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+function fileURLToPath (bun-types/bun.d.ts)
+  call (url: URL | string): string
+function gc (bun-types/bun.d.ts)
+  call (force?: boolean | undefined): void
+function generateHeapSnapshot (bun-types/bun.d.ts)
+  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format: "v8"): string
+  call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
+function gunzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function gzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+function indexOfLine (bun-types/bun.d.ts)
+  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+function inflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function inspect (bun-types/bun.d.ts)
+  call (arg: any, options?: BunInspectOptions | undefined): string
+  custom: typeof custom
+  table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
+namespace inspect (bun-types/bun.d.ts)
+  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  function inspect.table (bun-types/bun.d.ts)
+    call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
+    call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
+var isMainThread (bun-types/bun.d.ts): boolean
+var isStandaloneExecutable (bun-types/bun.d.ts): boolean
+function listen (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+var main (bun-types/bun.d.ts): string
+namespace markdown (bun-types/bun.d.ts)
+  interface markdown.AnsiTheme (bun-types/bun.d.ts)
+    colors [?]: boolean | undefined
+    columns [?]: number | undefined
+    hyperlinks [?]: boolean | undefined
+    kittyGraphics [?]: boolean | undefined
+    light [?]: boolean | undefined
+  interface markdown.CellMeta (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+  interface markdown.CellProps (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+    children: Array<unknown>
+  interface markdown.ChildrenProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+  interface markdown.CodeBlockMeta (bun-types/bun.d.ts)
+    language [?]: string | undefined
+  interface markdown.CodeBlockProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    language [?]: string | undefined
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  interface markdown.ComponentOverrides (bun-types/bun.d.ts)
+    a [?]: Component<LinkProps> | undefined
+    blockquote [?]: Component<ChildrenProps> | undefined
+    br [?]: Component<{}> | undefined
+    code [?]: Component<ChildrenProps> | undefined
+    del [?]: Component<ChildrenProps> | undefined
+    em [?]: Component<ChildrenProps> | undefined
+    h1 [?]: Component<HeadingProps> | undefined
+    h2 [?]: Component<HeadingProps> | undefined
+    h3 [?]: Component<HeadingProps> | undefined
+    h4 [?]: Component<HeadingProps> | undefined
+    h5 [?]: Component<HeadingProps> | undefined
+    h6 [?]: Component<HeadingProps> | undefined
+    hr [?]: Component<{}> | undefined
+    html [?]: Component<ChildrenProps> | undefined
+    img [?]: Component<ImageProps> | undefined
+    li [?]: Component<ListItemProps> | undefined
+    math [?]: Component<ChildrenProps> | undefined
+    ol [?]: Component<OrderedListProps> | undefined
+    p [?]: Component<ChildrenProps> | undefined
+    pre [?]: Component<CodeBlockProps> | undefined
+    strong [?]: Component<ChildrenProps> | undefined
+    table [?]: Component<ChildrenProps> | undefined
+    tbody [?]: Component<ChildrenProps> | undefined
+    td [?]: Component<CellProps> | undefined
+    th [?]: Component<CellProps> | undefined
+    thead [?]: Component<ChildrenProps> | undefined
+    tr [?]: Component<ChildrenProps> | undefined
+    u [?]: Component<ChildrenProps> | undefined
+    ul [?]: Component<ChildrenProps> | undefined
+  interface markdown.HeadingMeta (bun-types/bun.d.ts)
+    id [?]: string | undefined
+    level: number
+  interface markdown.HeadingProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    id [?]: string | undefined
+  interface markdown.ImageMeta (bun-types/bun.d.ts)
+    src: string
+    title [?]: string | undefined
+  interface markdown.ImageProps (bun-types/bun.d.ts)
+    alt [?]: string | undefined
+    src: string
+    title [?]: string | undefined
+  interface markdown.LinkMeta (bun-types/bun.d.ts)
+    href: string
+    title [?]: string | undefined
+  interface markdown.LinkProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    href: string
+    title [?]: string | undefined
+  interface markdown.ListItemMeta (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    depth: number
+    index: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.ListItemProps (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    children: Array<unknown>
+  interface markdown.ListMeta (bun-types/bun.d.ts)
+    depth: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.Options (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.OrderedListProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    start: number
+  interface markdown.ReactOptions (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    reactVersion [?]: 18 | 19 | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.RenderCallbacks (bun-types/bun.d.ts)
+    blockquote [?]: ((children: string) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    codespan [?]: ((children: string) => null | string | undefined) | undefined
+    emphasis [?]: ((children: string) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    hr [?]: ((children: string) => null | string | undefined) | undefined
+    html [?]: ((children: string) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    paragraph [?]: ((children: string) => null | string | undefined) | undefined
+    strikethrough [?]: ((children: string) => null | string | undefined) | undefined
+    strong [?]: ((children: string) => null | string | undefined) | undefined
+    table [?]: ((children: string) => null | string | undefined) | undefined
+    tbody [?]: ((children: string) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    text [?]: ((text: string) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    thead [?]: ((children: string) => null | string | undefined) | undefined
+    tr [?]: ((children: string) => null | string | undefined) | undefined
+  function markdown.ansi (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+  function markdown.html (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+  function markdown.react (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+  function markdown.render (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+function mmap (bun-types/bun.d.ts)
+  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+function nanoseconds (bun-types/bun.d.ts)
+  call (): number
+function openInEditor (bun-types/bun.d.ts)
+  call (path: string, options?: EditorOptions | undefined): void
+var password (bun-types/bun.d.ts)
+  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
+  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+function pathToFileURL (bun-types/bun.d.ts)
+  call (path: string): URL
+function peek (bun-types/bun.d.ts)
+  call <T = undefined>(promise: Promise<T> | T): Promise<T> | T
+  status: <T = undefined>(promise: Promise<T> | T) => "fulfilled" | "pending" | "rejected"
+namespace peek (bun-types/bun.d.ts)
+  function peek.status (bun-types/bun.d.ts)
+    call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
+var plugin (bun-types/bun.d.ts): BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): SQL
+function randomUUIDv5 (bun-types/bun.d.ts)
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+function randomUUIDv7 (bun-types/bun.d.ts)
+  call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
+  call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
+function readableStreamToArray (bun-types/bun.d.ts)
+  call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
+function readableStreamToArrayBuffer (bun-types/bun.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+function readableStreamToBlob (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<Blob>
+function readableStreamToBytes (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+function readableStreamToFormData (bun-types/bun.d.ts)
+  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+function readableStreamToJSON (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<any>
+function readableStreamToText (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<string>
+var redis (bun-types/redis.d.ts): RedisClient
+function resolve (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): Promise<string>
+function resolveSync (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): string
+var revision (bun-types/bun.d.ts): string
+var s3 (bun-types/s3.d.ts): S3Client
+var secrets (bun-types/bun.d.ts)
+  delete: (options: { service: string; name: string; }) => Promise<boolean>
+  get: (options: { service: string; name: string; }) => Promise<string | null>
+  set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
+namespace semver (bun-types/bun.d.ts)
+  function semver.order (bun-types/bun.d.ts)
+    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+  function semver.satisfies (bun-types/bun.d.ts)
+    call (version: StringLike, range: StringLike): boolean
+function serve (bun-types/serve.d.ts)
+  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+function sha (bun-types/bun.d.ts)
+  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
+  call (input: StringOrBuffer, encoding: DigestEncoding): string
+function shrink (bun-types/bun.d.ts)
+  call (): void
+function sleep (bun-types/bun.d.ts)
+  call (ms: Date | number): Promise<void>
+function sleepSync (bun-types/bun.d.ts)
+  call (ms: number): void
+function sliceAnsi (bun-types/bun.d.ts)
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+function spawn (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+function spawnSync (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): SQL
+var stderr (bun-types/bun.d.ts): BunFile
+var stdin (bun-types/bun.d.ts): BunFile
+var stdout (bun-types/bun.d.ts): BunFile
+function stringWidth (bun-types/bun.d.ts)
+  call (input: string, options?: StringWidthOptions | undefined): number
+function stripANSI (bun-types/bun.d.ts)
+  call (input: string): string
+namespace udp (bun-types/bun.d.ts)
+  interface udp.BaseUDPSocket (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    connect: { hostname: string; port: number; }
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: SocketAddress
+    send: (data: Data) => boolean
+    sendMany: (packets: ReadonlyArray<Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ReceiveFlags (bun-types/bun.d.ts)
+    ipv6: boolean
+    truncated: boolean
+  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: SocketHandler<DataBinaryType>) => void
+    send: (data: Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: SocketHandler<DataBinaryType> | undefined
+function udpSocket (bun-types/bun.d.ts)
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+namespace unsafe (bun-types/bun.d.ts)
+  function unsafe.arrayBufferToString (bun-types/bun.d.ts)
+    call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
+    call (buffer: Uint16Array<ArrayBufferLike>): string
+  function unsafe.gcAggressionLevel (bun-types/bun.d.ts)
+    call (level?: 0 | 1 | 2 | undefined): 0 | 1 | 2
+  function unsafe.memoryFootprint (bun-types/bun.d.ts)
+    call (): number | undefined
+  function unsafe.mimallocDump (bun-types/bun.d.ts)
+    call (): void
+var version (bun-types/bun.d.ts): string
+var version_with_sha (bun-types/bun.d.ts): string
+function which (bun-types/bun.d.ts)
+  call (command: string, options?: WhichOptions | undefined): null | string
+function wrapAnsi (bun-types/bun.d.ts)
+  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+function write (bun-types/bun.d.ts)
+  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+function zstdCompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+function zstdCompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+function zstdDecompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+function zstdDecompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+
+# module "bun:bundle"
+interface Registry (bun-types/bundle.d.ts)
+function feature (bun-types/bundle.d.ts)
+  call (flag: string): boolean
+
+# module "bun:ffi"
+function CFunction (bun-types/ffi.d.ts)
+  call (fn: FFIFunction & { ptr: number | bigint | Pointer; }): CallableFunction & { close(): void; }
+type CString (bun-types/ffi.d.ts) = string
+var CString (bun-types/ffi.d.ts): CStringConstructor
+interface CStringConstructor (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+  construct new (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts) = { [K in keyof Fns]: { (...args: Fns[K]["args"] extends infer A extends ReadonlyArray<FFITypeOrString> ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>]; } : [unknown] extends [Fns[K]["args"]] ? [] : never): [unknown] extends [Fns[K]["returns"]] ? undefined : FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>]; __ffi_function_callable: typeof FFIFunctionCallableSymbol; }; }
+interface FFIFunction (bun-types/ffi.d.ts)
+  args [? readonly]: ReadonlyArray<FFITypeOrString> | undefined
+  ptr [? readonly]: Pointer | bigint | undefined
+  returns [? readonly]: FFITypeOrString | undefined
+  threadsafe [? readonly]: boolean | undefined
+var FFIFunctionCallableSymbol (bun-types/ffi.d.ts): typeof FFIFunctionCallableSymbol
+enum FFIType (bun-types/ffi.d.ts)
+  char = FFIType.char
+  int8_t = FFIType.int8_t
+  i8 = FFIType.int8_t
+  uint8_t = FFIType.uint8_t
+  u8 = FFIType.uint8_t
+  int16_t = FFIType.int16_t
+  i16 = FFIType.int16_t
+  uint16_t = FFIType.uint16_t
+  u16 = FFIType.uint16_t
+  int32_t = FFIType.int32_t
+  i32 = FFIType.int32_t
+  int = FFIType.int32_t
+  uint32_t = FFIType.uint32_t
+  u32 = FFIType.uint32_t
+  int64_t = FFIType.int64_t
+  i64 = FFIType.int64_t
+  uint64_t = FFIType.uint64_t
+  u64 = FFIType.uint64_t
+  double = FFIType.double
+  f64 = FFIType.double
+  float = FFIType.float
+  f32 = FFIType.float
+  bool = FFIType.bool
+  ptr = FFIType.ptr
+  pointer = FFIType.ptr
+  void = FFIType.void
+  cstring = FFIType.cstring
+  i64_fast = FFIType.i64_fast
+  u64_fast = FFIType.u64_fast
+  function = FFIType.function
+  napi_env = FFIType.napi_env
+  napi_value = FFIType.napi_value
+  buffer = FFIType.buffer
+  buffer_length = FFIType.buffer_length
+type FFITypeOrString (bun-types/ffi.d.ts) = FFIType | keyof FFITypeStringToType
+interface FFITypeStringToType (bun-types/ffi.d.ts)
+  bool: FFIType.bool
+  buffer: FFIType.buffer
+  buffer_bytelength: FFIType.buffer_length
+  buffer_length: FFIType.buffer_length
+  callback: FFIType.ptr
+  char: FFIType.char
+  cstring: FFIType.cstring
+  double: FFIType.double
+  f32: FFIType.float
+  f64: FFIType.double
+  float: FFIType.float
+  function: FFIType.ptr
+  i16: FFIType.int16_t
+  i32: FFIType.int32_t
+  i64: FFIType.int64_t
+  i8: FFIType.int8_t
+  int: FFIType.int32_t
+  int16_t: FFIType.int16_t
+  int32_t: FFIType.int32_t
+  int64_t: FFIType.int64_t
+  int8_t: FFIType.int8_t
+  napi_env: FFIType.napi_env
+  napi_value: FFIType.napi_value
+  pointer: FFIType.ptr
+  ptr: FFIType.ptr
+  u16: FFIType.uint16_t
+  u32: FFIType.uint32_t
+  u64: FFIType.uint64_t
+  u8: FFIType.uint8_t
+  uint16_t: FFIType.uint16_t
+  uint32_t: FFIType.uint32_t
+  uint64_t: FFIType.uint64_t
+  uint8_t: FFIType.uint8_t
+  usize: FFIType.uint64_t
+  void: FFIType.void
+interface FFITypeToArgsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  13: undefined
+  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  15: bigint | number
+  16: bigint | number
+  17: JSCallback | Pointer
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint | number
+  8: bigint | number
+  9: number
+interface FFITypeToReturnsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | bigint | null
+  13: undefined
+  14: null | string
+  15: bigint | number
+  16: bigint | number
+  17: Pointer | bigint | null
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint
+  8: bigint
+  9: number
+class JSCallback (bun-types/ffi.d.ts)
+  close: () => void
+  ptr [readonly]: Pointer | null
+  threadsafe [readonly]: boolean
+  [static]
+    construct new (callback: (...args: Array<any>) => any, definition: FFIFunction): JSCallback
+    prototype: JSCallback
+interface Library<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts)
+  close: () => void
+  symbols: ConvertFns<Fns>
+type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
+type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
+type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
+function cc (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+function dlopen (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+function linkSymbols (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
+function ptr (bun-types/ffi.d.ts)
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+namespace read (bun-types/ffi.d.ts)
+  function read.f32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.f64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.i8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.intptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.ptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.u8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+var suffix (bun-types/ffi.d.ts): string
+function toArrayBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): ArrayBuffer
+function toBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): Buffer<ArrayBufferLike>
+function viewSource (bun-types/ffi.d.ts)
+  call (symbols: Readonly<Record<string, FFIFunction>>, is_callback?: false | undefined): Array<string>
+  call (callback: FFIFunction, is_callback: true): string
+
+# module "bun:jsc"
+interface HeapStats (bun-types/jsc.d.ts)
+  extraMemorySize: number
+  globalObjectCount: number
+  heapCapacity: number
+  heapSize: number
+  objectCount: number
+  objectTypeCounts: Record<string, number>
+  protectedGlobalObjectCount: number
+  protectedObjectCount: number
+  protectedObjectTypeCounts: Record<string, number>
+interface MemoryUsage (bun-types/jsc.d.ts)
+  current: number
+  currentCommit: number
+  pageFaults: number
+  peak: number
+  peakCommit: number
+interface SamplingProfile (bun-types/jsc.d.ts)
+  bytecodes: string
+  functions: string
+  stackTraces: SamplingProfileStackTraces
+interface SamplingProfileStackFrame (bun-types/jsc.d.ts)
+  category: string
+  column: number
+  flags: number
+  inliner [?]: undefined | { name: string; location: string; line: number; column: number; category: string; }
+  line: number
+  location: string
+  name: string
+  sourceID: number
+  sourceURL [?]: string | undefined
+interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
+  interval: number
+  sources: Array<{ sourceID: number; url?: string | undefined; sourceURL?: string | undefined; sourceMappingURL?: string | undefined; }>
+  traces: Array<{ timestamp: number; frames: Array<SamplingProfileStackFrame>; }>
+function callerSourceOrigin (bun-types/jsc.d.ts)
+  call (): null | string
+function deserialize (bun-types/jsc.d.ts)
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+function drainMicrotasks (bun-types/jsc.d.ts)
+  call (): void
+function edenGC (bun-types/jsc.d.ts)
+  call (): number
+function estimateShallowMemoryUsageOf (bun-types/jsc.d.ts)
+  call (value: CallableFunction | bigint | object | string | symbol): number
+function fullGC (bun-types/jsc.d.ts)
+  call (): number
+function gcAndSweep (bun-types/jsc.d.ts)
+  call (): number
+function getProtectedObjects (bun-types/jsc.d.ts)
+  call (): Array<any>
+function getRandomSeed (bun-types/jsc.d.ts)
+  call (): number
+function heapSize (bun-types/jsc.d.ts)
+  call (): number
+function heapStats (bun-types/jsc.d.ts)
+  call (): HeapStats
+function isRope (bun-types/jsc.d.ts)
+  call (input: string): boolean
+function jscDescribe (bun-types/jsc.d.ts)
+  call (value: any): string
+function jscDescribeArray (bun-types/jsc.d.ts)
+  call (array: Array<any>): string
+function memoryUsage (bun-types/jsc.d.ts)
+  call (): MemoryUsage
+function noFTL (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function noOSRExitFuzzing (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function numberOfDFGCompiles (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function optimizeNextInvocation (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function profile (bun-types/jsc.d.ts)
+  call <T extends (...args: Array<any>) => any>(callback: T, sampleInterval?: number | undefined, ...args: Parameters<T>): ReturnType<T> extends Promise<infer U> ? Promise<SamplingProfile> : SamplingProfile
+function releaseWeakRefs (bun-types/jsc.d.ts)
+  call (): void
+function reoptimizationRetryCount (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function serialize (bun-types/jsc.d.ts)
+  call (value: any, options?: undefined | { binaryType?: "arraybuffer" | undefined; }): SharedArrayBuffer
+  call (value: any, options?: undefined | { binaryType: "nodebuffer"; }): Buffer<ArrayBufferLike>
+function setRandomSeed (bun-types/jsc.d.ts)
+  call (value: number): void
+function setTimeZone (bun-types/jsc.d.ts)
+  call (timeZone: string): string
+function startRemoteDebugger (bun-types/jsc.d.ts)
+  call (host?: string | undefined, port?: number | undefined): void
+function startSamplingProfiler (bun-types/jsc.d.ts)
+  call (optionalDirectory?: string | undefined, sampleInterval?: number | undefined): void
+function totalCompileTime (bun-types/jsc.d.ts)
+  call (): number
+
+# module "bun:sqlite"
+interface Changes (bun-types/sqlite.d.ts)
+  changes: number
+  lastInsertRowid: bigint | number
+class Database (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  close: (throwOnError?: boolean | undefined) => void
+  exec: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  fileControl: { (op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number; (zDbName: string, op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number }
+  filename [readonly]: string
+  handle [readonly]: number
+  inTransaction: boolean
+  loadExtension: (extension: string, entryPoint?: string | undefined) => void
+  prepare: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string, params?: ParamsType | undefined) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  query: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  run: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  serialize: (name?: string | undefined) => Buffer<ArrayBufferLike>
+  transaction: <A extends Array<any>, T>(insideTransaction: (...args: A) => T) => { (...args: A): T; deferred: (...args: A) => T; immediate: (...args: A) => T; exclusive: (...args: A) => T; }
+  [static]
+    construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
+    MAX_QUERY_CACHE_SIZE [static]: number
+    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
+    prototype: Database
+    setCustomSQLite [static]: (path: string) => boolean
+interface DatabaseOptions (bun-types/sqlite.d.ts)
+  create [?]: boolean | undefined
+  readonly [?]: boolean | undefined
+  readwrite [?]: boolean | undefined
+  safeIntegers [?]: boolean | undefined
+  strict [?]: boolean | undefined
+type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+class SQLiteError (bun-types/sqlite.d.ts)
+  byteOffset [readonly]: number
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno: number
+  message: string
+  name [readonly]: "SQLiteError"
+  stack [?]: string | undefined
+  [static]
+    construct new (message?: string | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+    isError: (value: unknown) => value is Error
+    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prototype: SQLiteError
+    stackTraceLimit: number
+class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  [Symbol.iterator]: () => IterableIterator<ReturnType>
+  all: (...params: ParamsType) => Array<ReturnType>
+  as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
+  columnNames [readonly]: Array<string>
+  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
+  declaredTypes [readonly]: Array<string | null>
+  finalize: () => void
+  get: (...params: ParamsType) => ReturnType | null
+  iterate: (...params: ParamsType) => IterableIterator<ReturnType>
+  native [readonly]: any
+  paramsCount [readonly]: number
+  raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
+  run: (...params: ParamsType) => Changes
+  toString: () => string
+  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  [static]
+    construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
+    prototype: Statement<any, any>
+namespace constants (bun-types/sqlite.d.ts)
+  var constants.SQLITE_FCNTL_BEGIN_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_BUSYHANDLER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CHUNK_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_DONE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_START (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKSM_FILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_PHASETWO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_DATA_VERSION (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_EXTERNAL_READER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_FILE_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_GET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_HAS_MOVED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_JOURNAL_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LAST_ERRNO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCKSTATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCK_TIMEOUT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_MMAP_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PDB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PERSIST_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_POWERSAFE_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PRAGMA (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RBU (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESERVE_BYTES (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESET_CACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_HINT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_LIMIT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC_OMITTED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TEMPFILENAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TRACE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFSNAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFS_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WAL_BLOCK (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_AV_RETRY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_GET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_SET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ZIPVFS (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_AUTOPROXY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_CREATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_DELETEONCLOSE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXCLUSIVE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXRESCODE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_FULLMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MEMORY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOFOLLOW (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_PRIVATECACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READONLY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SHAREDCACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUBJOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUPER_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TRANSIENT_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_URI (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NORMALIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NO_VTAB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_PERSISTENT (bun-types/sqlite.d.ts): number
+default -> Database
+var native (bun-types/sqlite.d.ts): any
+
+# module "bun:test"
+type AsymmetricMatcher (bun-types/test.d.ts) = any
+interface AsymmetricMatchers (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+type CustomMatcher<E, P extends Array<any>> (bun-types/test.d.ts) = (this: MatcherContext, expected: E, ...matcherArguments: P) => MatcherResult | Promise<MatcherResult>
+type CustomMatchersDetected (bun-types/test.d.ts) = Omit<Matchers<unknown>, keyof MatchersBuiltin<unknown>> & Omit<AsymmetricMatchers, keyof AsymmetricMatchersBuiltin>
+interface Describe<T extends ReadonlyArray<any>> (bun-types/test.d.ts)
+  call (fn: () => void): void
+  call (label: DescribeLabel, fn: (...args: T) => void): void
+  concurrent: Describe<T>
+  each: { <T extends readonly [any, ...any[]]>(table: ReadonlyArray<T>): Describe<[...T]>; <T extends Array<any>>(table: ReadonlyArray<T>): Describe<[...T]>; <T>(table: Array<T>): Describe<[T]> }
+  if: (condition: boolean) => Describe<T>
+  only: Describe<T>
+  serial: Describe<T>
+  skip: Describe<T>
+  skipIf: (condition: boolean) => Describe<T>
+  todo: Describe<T>
+  todoIf: (condition: boolean) => Describe<T>
+type EqualsFunction (bun-types/test.d.ts) = (a: unknown, b: unknown) => boolean
+interface Expect (bun-types/test.d.ts)
+  call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
+  call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
+  call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  assertions: (neededAssertions: number) => void
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  extend: <M>(matchers: ExpectExtendMatchers<M>) => void
+  hasAssertions: () => void
+  not: ExpectNot
+  objectContaining: (obj: object) => any
+  rejectsTo: AsymmetricMatchers
+  resolvesTo: AsymmetricMatchers
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+  unreachable: (msg?: Error | string | undefined) => never
+type ExpectExtendMatchers<M> (bun-types/test.d.ts) = { [k in keyof M]: k extends never ? CustomMatcher<unknown, Parameters<CustomMatchersDetected[k]>> : CustomMatcher<unknown, Array<any>>; }
+interface MatcherResult (bun-types/test.d.ts)
+  message [?]: (() => string) | string | undefined
+  pass: boolean
+interface Matchers<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
+  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  concurrent: Test<T>
+  concurrentIf: (condition: boolean) => Test<T>
+  each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
+  failing: Test<T>
+  failingIf: (condition: boolean) => Test<T>
+  if: (condition: boolean) => Test<T>
+  only: Test<T>
+  serial: Test<T>
+  serialIf: (condition: boolean) => Test<T>
+  skip: Test<T>
+  skipIf: (condition: boolean) => Test<T>
+  todo: Test<T>
+  todoIf: (condition: boolean) => Test<T>
+interface TestOptions (bun-types/test.d.ts)
+  repeats [?]: number | undefined
+  retry [?]: number | undefined
+  timeout [?]: number | undefined
+type Tester (bun-types/test.d.ts) = (this: TesterContext, a: any, b: any, customTesters: Array<Tester>) => boolean | undefined
+interface TesterContext (bun-types/test.d.ts)
+  equals: EqualsFunction
+function afterAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function afterEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+var describe (bun-types/test.d.ts): Describe<[]>
+var expect (bun-types/test.d.ts): Expect
+var expectTypeOf (bun-types/test.d.ts)
+  call <Actual>(actual: Actual): PositiveExpectTypeOf<Actual>
+  call <Actual>(): PositiveExpectTypeOf<Actual>
+var it (bun-types/test.d.ts): Test<[]>
+namespace jest (bun-types/test.d.ts)
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
+  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  function jest.advanceTimersByTime (bun-types/test.d.ts)
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.clearAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.clearAllTimers (bun-types/test.d.ts)
+    call (): void
+  function jest.fn (bun-types/test.d.ts)
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+  function jest.getTimerCount (bun-types/test.d.ts)
+    call (): number
+  function jest.isFakeTimers (bun-types/test.d.ts)
+    call (): boolean
+  function jest.resetAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.restoreAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.runAllTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.runOnlyPendingTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.setSystemTime (bun-types/test.d.ts)
+    call (now?: Date | number | undefined): void
+  function jest.setTimeout (bun-types/test.d.ts)
+    call (milliseconds: number): void
+  function jest.spyOn (bun-types/test.d.ts)
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+  function jest.useFakeTimers (bun-types/test.d.ts)
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.useRealTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var mock (bun-types/test.d.ts)
+  call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
+  clearAllMocks: () => void
+  module: (id: string, factory: () => any) => Promise<void> | void
+  restore: () => void
+function onTestFinished (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function setDefaultTimeout (bun-types/test.d.ts)
+  call (milliseconds: number): void
+function setSystemTime (bun-types/test.d.ts)
+  call (now?: Date | number | undefined): ThisType<void>
+function spyOn (bun-types/test.d.ts)
+  call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+test -> it
+var vi (bun-types/test.d.ts)
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  clearAllMocks: () => void
+  clearAllTimers: () => void
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  getTimerCount: () => number
+  isFakeTimers: () => boolean
+  mock: (id: string, factory: () => any) => Promise<void> | void
+  resetAllMocks: () => void
+  restoreAllMocks: () => void
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var xdescribe (bun-types/test.d.ts): Describe<[]>
+var xit (bun-types/test.d.ts): Test<[]>
+xtest -> xit
+
+# globals
+interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => void
+  signal [readonly]: AbortSignal
+var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  construct new (): AbortController
+  prototype: AbortController
+interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  aborted [readonly]: boolean
+  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  onabort: ((this: AbortSignal, ev: Event) => any) | null
+  reason [readonly]: any
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  throwIfAborted: () => void
+var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  construct new (): AbortSignal
+  abort: (reason?: any) => AbortSignal
+  any: (signals: Array<AbortSignal>) => AbortSignal
+  prototype: AbortSignal
+  timeout: (ms: number) => AbortSignal
+interface AddEventListenerOptions (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  [Symbol.toStringTag] [readonly]: "ArrayBuffer"
+  byteLength [readonly]: number
+  resize: (byteLength: number) => ArrayBuffer
+  slice: { (begin?: number | undefined, end?: number | undefined): ArrayBuffer; (begin: number, end?: number | undefined): ArrayBuffer }
+var ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts): ArrayBufferConstructor
+interface ArrayBufferConstructor (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2017.arraybuffer.d.ts, lib.es5.d.ts)
+  construct new (byteLength: number): ArrayBuffer
+  construct new (): ArrayBuffer
+  construct new (byteLength: number, options: { maxByteLength?: number | undefined; }): ArrayBuffer
+  [Symbol.species] [readonly]: ArrayBufferConstructor
+  isView: (arg: any) => arg is ArrayBufferView<ArrayBufferLike>
+  prototype [readonly]: ArrayBuffer
+interface ArrayConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  call (arrayLength?: number | undefined): Array<any>
+  call <T>(arrayLength: number): Array<T>
+  call <T>(...items: Array<T>): Array<T>
+  construct new (arrayLength?: number | undefined): Array<any>
+  construct new <T>(arrayLength: number): Array<T>
+  construct new <T>(...items: Array<T>): Array<T>
+  [Symbol.species] [readonly]: ArrayConstructor
+  from: { <T>(arrayLike: ArrayLike<T>): Array<T>; <T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>; <T>(iterable: ArrayLike<T> | Iterable<T>): Array<T>; <T, U>(iterable: ArrayLike<T> | Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U> }
+  fromAsync: { <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
+  isArray: (arg: any) => arg is any[]
+  of: <T>(...items: Array<T>) => Array<T>
+  prototype [readonly]: Array<any>
+interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  size [readonly]: number
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
+interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  type [?]: string | undefined
+interface BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (ev: BroadcastChannelEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  name [readonly]: string
+  onmessage: ((ev: MessageEvent<any>) => void) | null
+  onmessageerror: ((ev: MessageEvent<any>) => void) | null
+  postMessage: (message: any) => void
+  ref: () => BroadcastChannel
+  removeEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (ev: BroadcastChannelEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => BroadcastChannel
+var BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (name: string): BroadcastChannel
+  prototype: BroadcastChannel
+var BuildError (bun-types/deprecated.d.ts): typeof BuildMessage
+class BuildMessage (bun-types/globals.d.ts)
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "BuildMessage"
+  position [readonly]: Position | null
+  [static]
+    construct new (): BuildMessage
+    prototype: BuildMessage
+Bun -> module "bun"
+interface BunFetchRequestInit (bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
+  credentials [?]: RequestCredentials | undefined
+  decompress [?]: boolean | undefined
+  dispatcher [?]: Dispatcher | undefined
+  duplex [?]: "half" | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  maxRedirects [?]: number | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  s3 [?]: S3Options | undefined
+  signal [?]: AbortSignal | null | undefined
+  timeout [?]: boolean | number | undefined
+  tls [?]: BunFetchRequestInitTLS | undefined
+  unix [?]: string | undefined
+  verbose [?]: boolean | undefined
+  window [?]: null | undefined
+interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<ArrayBufferView<ArrayBufferLike>>
+var ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (init: QueuingStrategyInit): ByteLengthQueuingStrategy
+  prototype: ByteLengthQueuingStrategy
+interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  code [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  reason [readonly]: string
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  wasClean [readonly]: boolean
+var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  prototype: CloseEvent
+interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<BufferSource>
+var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
+  prototype: CompressionStream
+interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
+  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
+  assert: (condition?: boolean | undefined, ...data: Array<any>) => void
+  clear: () => void
+  count: (label?: string | undefined) => void
+  countReset: (label?: string | undefined) => void
+  debug: (...data: Array<any>) => void
+  dir: (item?: any, options?: any) => void
+  dirxml: (...data: Array<any>) => void
+  error: (...data: Array<any>) => void
+  group: (...data: Array<any>) => void
+  groupCollapsed: (...data: Array<any>) => void
+  groupEnd: () => void
+  info: (...data: Array<any>) => void
+  log: (...data: Array<any>) => void
+  profile: (label?: string | undefined) => void
+  profileEnd: (label?: string | undefined) => void
+  table: (tabularData?: any, properties?: Array<string> | undefined) => void
+  time: (label?: string | undefined) => void
+  timeEnd: (label?: string | undefined) => void
+  timeLog: (label?: string | undefined, ...data: Array<any>) => void
+  timeStamp: (label?: string | undefined) => void
+  trace: (...data: Array<any>) => void
+  warn: (...data: Array<any>) => void
+  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+interface ConsoleOptions (bun-types/globals.d.ts)
+  colorMode [?]: "auto" | boolean | undefined
+  groupIndentation [?]: number | undefined
+  ignoreErrors [?]: boolean | undefined
+  inspectOptions [?]: InspectOptions | undefined
+  stderr [?]: Writable | undefined
+  stdout: Writable
+interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<any>
+var CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (init: QueuingStrategyInit): CountQueuingStrategy
+  prototype: CountQueuingStrategy
+interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  getRandomValues: <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T) => T
+  randomUUID: () => `${string}-${string}-${string}-${string}-${string}`
+  subtle [readonly]: SubtleCrypto
+  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): Crypto
+  prototype: Crypto
+interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  algorithm [readonly]: KeyAlgorithm
+  extractable [readonly]: boolean
+  type [readonly]: KeyType
+  usages [readonly]: Array<KeyUsage>
+var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): CryptoKey
+  prototype: CryptoKey
+interface CryptoKeyPair (bun-types/globals.d.ts)
+  privateKey: CryptoKey
+  publicKey: CryptoKey
+interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  detail [readonly]: T
+  eventPhase [readonly]: number
+  initCustomEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, detail?: T | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  prototype: CustomEvent<any>
+interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  cause [?]: unknown
+  code [readonly]: number
+  message [readonly]: string
+  name [readonly]: string
+  stack [?]: string | undefined
+var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  construct new (message?: string | undefined, name?: string | undefined): DOMException
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  prototype: DOMException
+interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<BufferSource>
+var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
+  prototype: DecompressionStream
+interface Dict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined
+interface ErrnoException (bun-types/globals.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts)
+  cause [?]: unknown
+  message: string
+  name: string
+  stack [?]: string | undefined
+var Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts): ErrorConstructor
+interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts)
+  call (message?: string | undefined): Error
+  call (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+  isError: (value: unknown) => value is Error
+  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prototype [readonly]: Error
+  stackTraceLimit: number
+interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  colno [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  error [readonly]: any
+  eventPhase [readonly]: number
+  filename [readonly]: string
+  isTrusted [readonly]: boolean
+  lineno [readonly]: number
+  message [readonly]: string
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  prototype: ErrorEvent
+interface ErrorOptions (bun-types/globals.d.ts, lib.es2022.error.d.ts)
+  cause [?]: unknown
+interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  prototype: Event
+interface EventListener (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  handleEvent: (object: Event) => void
+interface EventMap (bun-types/globals.d.ts)
+  fetch: FetchEvent
+  message: MessageEvent<any>
+  messageerror: MessageEvent<any>
+interface EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: ErrorEvent) => any) | null
+  onmessage: ((this: EventSource, ev: MessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: 0 | 1 | 2
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (): EventSource
+  prototype: EventSource
+interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  withCredentials [?]: boolean | undefined
+interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  construct new (): EventTarget
+  prototype: EventTarget
+interface FetchEvent (bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified [readonly]: number
+  name [readonly]: string
+  size [readonly]: number
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  construct new (parts: Array<BlobPart>, name: string, options?: BlobPropertyBag & { lastModified?: number | Date | undefined; } | undefined): File
+  prototype: File
+interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  delete: (name: string) => void
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
+  get: (name: string) => FormDataEntryValue | null
+  getAll: (name: string) => Array<FormDataEntryValue>
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  values: () => IterableIterator<string>
+var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (): FormData
+  prototype: FormData
+class HTMLRewriter (bun-types/html-rewriter.d.ts)
+  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  [static]
+    construct new (): HTMLRewriter
+    prototype: HTMLRewriter
+namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
+  interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Comment
+    before: (content: string, options?: ContentOptions | undefined) => Comment
+    remove: () => Comment
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    text: string
+  type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
+  interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
+    html [?]: boolean | undefined
+  interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
+    name [readonly]: null | string
+    publicId [readonly]: null | string
+    remove: () => Doctype
+    removed [readonly]: boolean
+    systemId [readonly]: null | string
+  interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
+    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+  interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Element
+    append: (content: string, options?: ContentOptions | undefined) => Element
+    attributes [readonly]: IterableIterator<[string, string]>
+    before: (content: string, options?: ContentOptions | undefined) => Element
+    canHaveContent [readonly]: boolean
+    getAttribute: (name: string) => null | string
+    hasAttribute: (name: string) => boolean
+    namespaceURI [readonly]: string
+    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: ContentOptions | undefined) => Element
+    remove: () => Element
+    removeAndKeepContent: () => Element
+    removeAttribute: (name: string) => Element
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Element
+    selfClosing [readonly]: boolean
+    setAttribute: (name: string, value: string) => Element
+    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    tagName: string
+  interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => EndTag
+    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    name: string
+    remove: () => EndTag
+  interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: Element) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Text
+    before: (content: string, options?: ContentOptions | undefined) => Text
+    lastInTextNode [readonly]: boolean
+    remove: () => Text
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Text
+    text [readonly]: string
+interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
+  append [readonly]: (name: string, value: string) => void
+  count [readonly]: number
+  delete [readonly]: (name: string) => void
+  entries [readonly]: () => SpecIterableIterator<[string, string]>
+  forEach [readonly]: (callbackfn: (value: string, key: string, iterable: Headers) => void, thisArg?: unknown) => void
+  get [readonly]: (name: string) => null | string
+  getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+  getSetCookie [readonly]: () => Array<string>
+  has [readonly]: (name: string) => boolean
+  keys [readonly]: () => SpecIterableIterator<string>
+  set [readonly]: (name: string, value: string) => void
+  toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+  values [readonly]: () => SpecIterableIterator<string>
+var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (init?: HeadersInit | undefined): Headers
+  prototype: Headers
+interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.es5.d.ts)
+  dir [readonly]: string
+  dirname: string
+  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  file [readonly]: string
+  filename: string
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  main: boolean
+  path [readonly]: string
+  require: Require
+  resolve: (specifier: string, parent?: URL | string | undefined) => string
+  resolveSync: (moduleId: string, parent?: string | undefined) => string
+  url: string
+interface ImportMetaEnv (bun-types/globals.d.ts)
+  index [string]: string | undefined
+var Loader (bun-types/globals.d.ts)
+  dependencyKeysIfEvaluated: (specifier: string) => Array<string>
+  registry: Map<string, { key: string; state: number; fetch: Promise<any>; instantiate: Promise<any>; satisfy: Promise<any>; dependencies: Array<any>; module: { dependenciesMap: Map<string, any>; }; linkError?: any; linkSucceeded: boolean; evaluated: boolean; then?: any; isAsync: boolean; }>
+  resolve: (specifier: string, referrer: string) => string
+interface MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  port1 [readonly]: MessagePort
+  port2 [readonly]: MessagePort
+var MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (): MessageChannel
+  prototype: MessageChannel
+interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<any>
+  prototype: MessageEvent<any>
+interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addListener: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  emit: { (event: "close", ev: Event): boolean; (event: "message", value: any): boolean; (event: "messageerror", error: Error): boolean; (event: string, arg: any): boolean }
+  eventNames: () => Array<string>
+  getMaxListeners: () => number
+  hasRef: () => boolean
+  listenerCount: (type: string) => number
+  off: { (event: "close", listener: (ev: Event) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "message", listener: (value: any) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions | undefined): MessagePort; (event: string, listener: (arg: any) => void, options?: EventListenerOptions | undefined): MessagePort }
+  on: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  once: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  onclose: ((ev: Event) => void) | null
+  onmessage: ((ev: MessageEvent<any>) => void) | null
+  onmessageerror: ((ev: MessageEvent<any>) => void) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeAllListeners: (type?: string | undefined) => MessagePort
+  removeEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeListener: { (event: "close", listener: (ev: Event) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "message", listener: (value: any) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions | undefined): MessagePort; (event: string, listener: (arg: any) => void, options?: EventListenerOptions | undefined): MessagePort }
+  setMaxListeners: (n: number) => void
+  start: () => void
+  unref: () => void
+var MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (): MessagePort
+  prototype: MessagePort
+interface Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
+  hardwareConcurrency [readonly]: number
+  language [readonly]: string
+  languages [readonly]: ReadonlyArray<string>
+  locks [readonly]: LockManager
+  platform [readonly]: "Linux x86_64" | "MacIntel" | "Win32"
+  userAgent [readonly]: string
+var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
+  construct new (): Navigator
+  prototype: Navigator
+namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
+  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
+    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
+    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
+  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
+  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
+  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
+  interface NodeJS.CallSite (@types/node/globals.d.ts)
+    getColumnNumber: () => null | number
+    getEnclosingColumnNumber: () => null | number
+    getEnclosingLineNumber: () => null | number
+    getEvalOrigin: () => string | undefined
+    getFileName: () => null | string
+    getFunction: () => Function | undefined
+    getFunctionName: () => null | string
+    getLineNumber: () => null | number
+    getMethodName: () => null | string
+    getPosition: () => number
+    getPromiseIndex: () => null | number
+    getScriptHash: () => string
+    getScriptNameOrSourceURL: () => null | string
+    getThis: () => unknown
+    getTypeName: () => null | string
+    isAsync: () => boolean
+    isConstructor: () => boolean
+    isEval: () => boolean
+    isNative: () => boolean
+    isPromiseAll: () => boolean
+    isToplevel: () => boolean
+  interface NodeJS.CpuUsage (@types/node/process.d.ts)
+    system: number
+    user: number
+  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined
+  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
+  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
+    code [?]: string | undefined
+    ctor [?]: Function | undefined
+    detail [?]: string | undefined
+    type [?]: string | undefined
+  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
+    cause [?]: unknown
+    code [?]: string | undefined
+    errno [?]: number | undefined
+    message: string
+    name: string
+    path [?]: string | undefined
+    stack [?]: string | undefined
+    syscall [?]: string | undefined
+  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
+    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
+    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    setMaxListeners: (n: number) => EventEmitter<T>
+  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
+  interface NodeJS.GCFunction (@types/node/globals.d.ts)
+    call (minor?: boolean | undefined): void
+    call (options: GCOptions & { execution: "async"; }): Promise<void>
+    call (options: GCOptions): void
+  interface NodeJS.GCOptions (@types/node/globals.d.ts)
+    execution [?]: "async" | "sync" | undefined
+    filename [?]: string | undefined
+    flavor [?]: "last-resort" | "regular" | undefined
+    type [?]: "major" | "major-snapshot" | "minor" | undefined
+  interface NodeJS.HRTime (@types/node/process.d.ts)
+    call (time?: [number, number] | undefined): [number, number]
+    bigint: () => bigint
+  interface NodeJS.Immediate (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    _onImmediate: (...args: Array<any>) => void
+    hasRef: () => boolean
+    ref: () => Immediate
+    unref: () => Immediate
+  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
+    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
+    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
+  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
+    arrayBuffers: number
+    external: number
+    heapTotal: number
+    heapUsed: number
+    rss: number
+  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
+    call (): MemoryUsage
+    rss: () => number
+  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
+  interface NodeJS.Module (@types/node/module.d.ts)
+    children: Array<Module>
+    exports: any
+    filename: string
+    id: string
+    isPreloading: boolean
+    loaded: boolean
+    parent: Module | null | undefined
+    path: string
+    paths: Array<string>
+    require: (id: string) => any
+  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
+  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
+  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
+  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
+  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
+  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
+  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
+  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
+  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
+  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
+  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+  interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    _exiting: boolean
+    abort: () => never
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
+    allowedNodeEnvironmentFlags: ReadonlySet<string>
+    arch [readonly]: Architecture
+    argv: Array<string>
+    argv0: string
+    assert: (value: unknown, message?: Error | string | undefined) => asserts value
+    availableMemory: () => number
+    binding: { (m: "constants"): { os: typeof constants; fs: typeof constants; crypto: typeof constants; zlib: typeof constants; trace: { TRACE_EVENT_PHASE_BEGIN: number; TRACE_EVENT_PHASE_END: number; TRACE_EVENT_PHASE_COMPLETE: number; TRACE_EVENT_PHASE_INSTANT: number; TRACE_EVENT_PHASE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_ASYNC_STEP_INTO: number; TRACE_EVENT_PHASE_ASYNC_STEP_PAST: number; TRACE_EVENT_PHASE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_INSTANT: number; TRACE_EVENT_PHASE_FLOW_BEGIN: number; TRACE_EVENT_PHASE_FLOW_STEP: number; TRACE_EVENT_PHASE_FLOW_END: number; TRACE_EVENT_PHASE_METADATA: number; TRACE_EVENT_PHASE_COUNTER: number; TRACE_EVENT_PHASE_SAMPLE: number; TRACE_EVENT_PHASE_CREATE_OBJECT: number; TRACE_EVENT_PHASE_SNAPSHOT_OBJECT: number; TRACE_EVENT_PHASE_DELETE_OBJECT: number; TRACE_EVENT_PHASE_MEMORY_DUMP: number; TRACE_EVENT_PHASE_MARK: number; TRACE_EVENT_PHASE_CLOCK_SYNC: number; TRACE_EVENT_PHASE_ENTER_CONTEXT: number; TRACE_EVENT_PHASE_LEAVE_CONTEXT: number; TRACE_EVENT_PHASE_LINK_IDS: number; }; }; (m: "uv"): { errname(code: number): string; UV_E2BIG: number; UV_EACCES: number; UV_EADDRINUSE: number; UV_EADDRNOTAVAIL: number; UV_EAFNOSUPPORT: number; UV_EAGAIN: number; UV_EAI_ADDRFAMILY: number; UV_EAI_AGAIN: number; UV_EAI_BADFLAGS: number; UV_EAI_BADHINTS: number; UV_EAI_CANCELED: number; UV_EAI_FAIL: number; UV_EAI_FAMILY: number; UV_EAI_MEMORY: number; UV_EAI_NODATA: number; UV_EAI_NONAME: number; UV_EAI_OVERFLOW: number; UV_EAI_PROTOCOL: number; UV_EAI_SERVICE: number; UV_EAI_SOCKTYPE: number; UV_EALREADY: number; UV_EBADF: number; UV_EBUSY: number; UV_ECANCELED: number; UV_ECHARSET: number; UV_ECONNABORTED: number; UV_ECONNREFUSED: number; UV_ECONNRESET: number; UV_EDESTADDRREQ: number; UV_EEXIST: number; UV_EFAULT: number; UV_EFBIG: number; UV_EHOSTUNREACH: number; UV_EINTR: number; UV_EINVAL: number; UV_EIO: number; UV_EISCONN: number; UV_EISDIR: number; UV_ELOOP: number; UV_EMFILE: number; UV_EMSGSIZE: number; UV_ENAMETOOLONG: number; UV_ENETDOWN: number; UV_ENETUNREACH: number; UV_ENFILE: number; UV_ENOBUFS: number; UV_ENODEV: number; UV_ENOENT: number; UV_ENOMEM: number; UV_ENONET: number; UV_ENOPROTOOPT: number; UV_ENOSPC: number; UV_ENOSYS: number; UV_ENOTCONN: number; UV_ENOTDIR: number; UV_ENOTEMPTY: number; UV_ENOTSOCK: number; UV_ENOTSUP: number; UV_EOVERFLOW: number; UV_EPERM: number; UV_EPIPE: number; UV_EPROTO: number; UV_EPROTONOSUPPORT: number; UV_EPROTOTYPE: number; UV_ERANGE: number; UV_EROFS: number; UV_ESHUTDOWN: number; UV_ESPIPE: number; UV_ESRCH: number; UV_ETIMEDOUT: number; UV_ETXTBSY: number; UV_EXDEV: number; UV_UNKNOWN: number; UV_EOF: number; UV_ENXIO: number; UV_EMLINK: number; UV_EHOSTDOWN: number; UV_EREMOTEIO: number; UV_ENOTTY: number; UV_EFTYPE: number; UV_EILSEQ: number; UV_ESOCKTNOSUPPORT: number; UV_ENODATA: number; UV_EUNATCH: number; }; (m: "http_parser"): { methods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "QUERY"]; allMethods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "PRI", "DESCRIBE", "ANNOUNCE", "SETUP", "PLAY", "PAUSE", "TEARDOWN", "GET_PARAMETER", "SET_PARAMETER", "REDIRECT", "RECORD", "FLUSH", "QUERY"]; HTTPParser: unknown; ConnectionsList: unknown; }; (m: string): object }
+    browser: boolean
+    channel [?]: Control | undefined
+    chdir: (directory: string) => void
+    config [readonly]: ProcessConfig
+    connected: boolean
+    constrainedMemory: () => number
+    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cwd: () => string
+    debugPort: number
+    disconnect [?]: (() => void) | undefined
+    dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
+    emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
+    env: ProcessEnv
+    eventNames: () => Array<string | symbol>
+    execArgv: Array<string>
+    execPath: string
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    exit: (code?: null | number | string | undefined) => never
+    exitCode: null | number | string | undefined
+    features [readonly]: ProcessFeatures
+    finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
+    getActiveResourcesInfo: () => Array<string>
+    getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
+    getMaxListeners: () => number
+    getegid [?]: (() => number) | undefined
+    geteuid [?]: (() => number) | undefined
+    getgid [?]: (() => number) | undefined
+    getgroups [?]: (() => Array<number>) | undefined
+    getuid [?]: (() => number) | undefined
+    hasUncaughtExceptionCaptureCallback: () => boolean
+    hrtime: HRTime
+    isBun: true
+    kill: (pid: number, signal?: number | string | undefined) => true
+    listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    loadEnvFile: (path?: PathLike | undefined) => void
+    mainModule [?]: Module | undefined
+    memoryUsage: MemoryUsageFn
+    nextTick: (callback: Function, ...args: Array<any>) => void
+    noDeprecation [?]: boolean | undefined
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    permission: ProcessPermission
+    pid [readonly]: number
+    platform [readonly]: Platform
+    ppid [readonly]: number
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    reallyExit: (code?: number | undefined) => never
+    ref: (maybeRefable: any) => void
+    release [readonly]: ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    report: ProcessReport
+    resourceUsage: () => ResourceUsage
+    revision: string
+    send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
+    setMaxListeners: (n: number) => Process
+    setSourceMapsEnabled: (value: boolean) => void
+    setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
+    setegid [?]: ((id: number | string) => void) | undefined
+    seteuid [?]: ((id: number | string) => void) | undefined
+    setgid [?]: ((id: number | string) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setuid [?]: ((id: number | string) => void) | undefined
+    sourceMapsEnabled [readonly]: boolean
+    stderr: WriteStream & { fd: 2; }
+    stdin: ReadStream & { fd: 0; }
+    stdout: WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    throwDeprecation: boolean
+    title: string
+    traceDeprecation: boolean
+    traceProcessWarnings: boolean
+    umask: { (): number; (mask: number | string): number }
+    unref: (maybeRefable: any) => void
+    uptime: () => number
+    version [readonly]: string
+    versions [readonly]: ProcessVersions
+  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
+    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
+    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+  interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    NODE_ENV [?]: string | undefined
+    TZ [?]: string | undefined
+  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
+    cached_builtins [readonly]: boolean
+    debug [readonly]: boolean
+    inspector [readonly]: boolean
+    ipv6 [readonly]: boolean
+    require_module [readonly]: boolean
+    tls [readonly]: boolean
+    tls_alpn [readonly]: boolean
+    tls_ocsp [readonly]: boolean
+    tls_sni [readonly]: boolean
+    typescript [readonly]: "strip" | false
+    uv [readonly]: boolean
+  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
+    has: (scope: string, reference?: string | undefined) => boolean
+  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
+    headersUrl [?]: string | undefined
+    libUrl [?]: string | undefined
+    lts [?]: string | undefined
+    name: string
+    sourceUrl [?]: string | undefined
+  interface NodeJS.ProcessReport (@types/node/process.d.ts)
+    compact: boolean
+    directory: string
+    excludeEnv: boolean
+    filename: string
+    getReport: (err?: Error | undefined) => object
+    reportOnFatalError: boolean
+    reportOnSignal: boolean
+    reportOnUncaughtException: boolean
+    signal: Signals
+    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
+  interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    ares: string
+    bun: string
+    http_parser: string
+    modules: string
+    node: string
+    openssl: string
+    uv: string
+    v8: string
+    zlib: string
+  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined [readonly]
+  interface NodeJS.ReadStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    closed [readonly]: boolean
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    destroy: (error?: Error | undefined) => ReadStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    isPaused: () => boolean
+    isRaw: boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    pause: () => ReadStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => ReadStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
+    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    resetAndDestroy: () => ReadStream
+    resume: () => ReadStream
+    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
+    setMaxListeners: (n: number) => ReadStream
+    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
+    setRawMode: (mode: boolean) => ReadStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
+    setTypeOfService: (tos: number) => ReadStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => ReadStream
+    unref: () => ReadStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => ReadStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    pause: () => ReadWriteStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    resume: () => ReadWriteStream
+    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
+    setMaxListeners: (n: number) => ReadWriteStream
+    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadWriteStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    pause: () => ReadableStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    resume: () => ReadableStream
+    setEncoding: (encoding: BufferEncoding) => ReadableStream
+    setMaxListeners: (n: number) => ReadableStream
+    unpipe: (destination?: WritableStream | undefined) => ReadableStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadableStream
+  interface NodeJS.RefCounted (@types/node/globals.d.ts)
+    ref: () => RefCounted
+    unref: () => RefCounted
+  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
+  interface NodeJS.Require (@types/node/module.d.ts)
+    call (id: string): any
+    cache: Dict<Module>
+    extensions: RequireExtensions
+    main: Module | undefined
+    resolve: RequireResolve
+  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
+    index [string]: ((module: Module, filename: string) => any) | undefined
+    .js: (module: Module, filename: string) => any
+    .json: (module: Module, filename: string) => any
+    .node: (module: Module, filename: string) => any
+  interface NodeJS.RequireResolve (@types/node/module.d.ts)
+    call (request: string, options?: RequireResolveOptions | undefined): string
+    paths: (request: string) => Array<string> | null
+  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
+    paths [?]: Array<string> | undefined
+  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
+    fsRead: number
+    fsWrite: number
+    involuntaryContextSwitches: number
+    ipcReceived: number
+    ipcSent: number
+    majorPageFault: number
+    maxRSS: number
+    minorPageFault: number
+    sharedMemorySize: number
+    signalsCount: number
+    swappedOut: number
+    systemCPUTime: number
+    unsharedDataSize: number
+    unsharedStackSize: number
+    userCPUTime: number
+    voluntaryContextSwitches: number
+  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
+  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
+  interface NodeJS.Socket (@types/node/process.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    isTTY [?]: true | undefined
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    pause: () => Socket
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    resume: () => Socket
+    setEncoding: (encoding: BufferEncoding) => Socket
+    setMaxListeners: (n: number) => Socket
+    unpipe: (destination?: WritableStream | undefined) => Socket
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => Socket
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.Timeout (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.toPrimitive]: () => number
+    _onTimeout: (...args: Array<any>) => void
+    close: () => Timeout
+    hasRef: () => boolean
+    ref: () => Timeout
+    refresh: () => Timeout
+    unref: () => Timeout
+  interface NodeJS.Timer (@types/node/timers.d.ts)
+    [Symbol.toPrimitive]: () => number
+    hasRef: () => boolean
+    ref: () => Timer
+    refresh: () => Timer
+    unref: () => Timer
+  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
+  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
+  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
+  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
+  interface NodeJS.WritableStream (@types/node/stream.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    setMaxListeners: (n: number) => WritableStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.WriteStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
+    clearScreenDown: (callback?: (() => void) | undefined) => boolean
+    closed [readonly]: boolean
+    columns: number
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
+    destroy: (error?: Error | undefined) => WriteStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
+    getColorDepth: (env?: object | undefined) => number
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    getWindowSize: () => [number, number]
+    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
+    isPaused: () => boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
+    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    pause: () => WriteStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => WriteStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
+    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    resetAndDestroy: () => WriteStream
+    resume: () => WriteStream
+    rows: number
+    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
+    setMaxListeners: (n: number) => WriteStream
+    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
+    setTypeOfService: (tos: number) => WriteStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => WriteStream
+    unref: () => WriteStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => WriteStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
+  children: Array<Module>
+  exports: any
+  filename: string
+  id: string
+  isPreloading: boolean
+  loaded: boolean
+  parent: Module | null | undefined
+  path: string
+  paths: Array<string>
+  require: (id: string) => any
+interface Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (ev: PerformanceEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  clearMarks: (markName?: string | undefined) => void
+  clearMeasures: (measureName?: string | undefined) => void
+  clearResourceTimings: (resourceTimingName?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  eventLoopUtilization: (utilization1?: EventLoopUtilization | undefined, utilization2?: EventLoopUtilization | undefined) => EventLoopUtilization
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: EntryType | undefined) => PerformanceEntryList
+  getEntriesByType: (type: EntryType) => PerformanceEntryList
+  mark: (markName: string, markOptions?: PerformanceMarkOptions | undefined) => PerformanceMark
+  markResourceTiming: (timingInfo: FetchTimingInfo, requestedUrl: string, initiatorType: string, global: unknown, cacheMode: string, bodyInfo: unknown, responseStatus: number, deliveryType?: string | undefined) => PerformanceResourceTiming
+  measure: { (measureName: string, startMark?: string | undefined, endMark?: string | undefined): PerformanceMeasure; (measureName: string, options: PerformanceMeasureOptions, endMark?: string | undefined): PerformanceMeasure }
+  nodeTiming [readonly]: PerformanceNodeTiming
+  now: () => number
+  onresourcetimingbufferfull: ((ev: Event) => void) | null
+  removeEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (ev: PerformanceEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  setResourceTimingBufferSize: (maxSize: number) => void
+  timeOrigin [readonly]: number
+  timerify: <T extends (...args: Array<any>) => any>(fn: T, options?: TimerifyOptions | undefined) => T
+  toJSON: () => any
+var Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): Performance
+  prototype: Performance
+interface PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  duration [readonly]: number
+  entryType [readonly]: EntryType
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceEntry
+  prototype: PerformanceEntry
+interface PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: "mark"
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceMark
+  prototype: PerformanceMark
+interface PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: "measure"
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceMeasure
+  prototype: PerformanceMeasure
+interface PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  disconnect: () => void
+  observe: (options: PerformanceObserverInit) => void
+  takeRecords: () => PerformanceEntryList
+var PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceObserver
+  prototype: PerformanceObserver
+interface PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: EntryType | undefined) => PerformanceEntryList
+  getEntriesByType: (type: EntryType) => PerformanceEntryList
+var PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceObserverEntryList
+  prototype: PerformanceObserverEntryList
+interface PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  connectEnd [readonly]: number
+  connectStart [readonly]: number
+  decodedBodySize [readonly]: number
+  domainLookupEnd [readonly]: number
+  domainLookupStart [readonly]: number
+  duration [readonly]: number
+  encodedBodySize [readonly]: number
+  entryType [readonly]: "resource"
+  fetchStart [readonly]: number
+  initiatorType [readonly]: string
+  name [readonly]: string
+  nextHopProtocol [readonly]: string
+  redirectEnd [readonly]: number
+  redirectStart [readonly]: number
+  requestStart [readonly]: number
+  responseEnd [readonly]: number
+  responseStart [readonly]: number
+  responseStatus [readonly]: number
+  secureConnectionStart [readonly]: number
+  startTime [readonly]: number
+  toJSON: () => any
+  transferSize [readonly]: number
+  workerStart [readonly]: number
+var PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceResourceTiming
+  prototype: PerformanceResourceTiming
+interface Position (bun-types/globals.d.ts)
+  column: number
+  file: string
+  length: number
+  line: number
+  lineText: string
+  namespace: string
+  offset: number
+interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts)
+  construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
+  [Symbol.species] [readonly]: PromiseConstructor
+  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  prototype [readonly]: Promise<any>
+  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  reject: <T = never>(reason?: any) => Promise<T>
+  resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+  try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
+  withResolvers: <T>() => { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; }
+interface QueuingStrategy<T = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [?]: number | undefined
+  size [?]: QueuingStrategySize<T> | undefined
+interface QueuingStrategyInit (bun-types/globals.d.ts)
+  highWaterMark: number
+interface QueuingStrategySize<T = any> (bun-types/globals.d.ts)
+  call (chunk?: T | undefined): number
+interface ReadOnlyDict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined [readonly]
+interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  byobRequest [readonly]: ReadableStreamBYOBRequest | null
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk: NonSharedArrayBufferView) => void
+  error: (e?: any) => void
+var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableByteStreamController
+  prototype: ReadableByteStreamController
+interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  prototype: ReadableStream<any>
+interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+  read: <T extends NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  releaseLock: () => void
+var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamBYOBReader
+  prototype: ReadableStreamBYOBReader
+interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  respond: (bytesWritten: number) => void
+  respondWithNewView: (view: NonSharedArrayBufferView) => void
+  view [readonly]: NonSharedArrayBufferView | null
+var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamBYOBRequest
+  prototype: ReadableStreamBYOBRequest
+interface ReadableStreamDefaultController<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk?: R | undefined) => void
+  error: (e?: any) => void
+var ReadableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamDefaultController<any>
+  prototype: ReadableStreamDefaultController<any>
+interface ReadableStreamDefaultReadDoneResult (bun-types/globals.d.ts)
+  done: true
+  value [?]: undefined
+interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
+  done: false
+  value: T
+interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+  read: () => Promise<ReadableStreamDefaultReadResult<R>>
+  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  releaseLock: () => void
+var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
+  prototype: ReadableStreamDefaultReader<any>
+interface ReadableStreamDirectController (bun-types/globals.d.ts)
+  close: (error?: Error | undefined) => void
+  end: () => Promise<number> | number
+  flush: (wait?: boolean | undefined) => Promise<number> | number
+  start: () => void
+  write: (data: BufferSource | string) => Promise<number> | number
+interface ReadableStreamGenericReader (bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+interface ReadableWritablePair<R = any, W = any> (bun-types/globals.d.ts)
+  readable: ReadableStream<R>
+  writable: WritableStream<W>
+interface RegExpConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  call (pattern: RegExp | string): RegExp
+  call (pattern: string, flags?: string | undefined): RegExp
+  call (pattern: RegExp | string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string): RegExp
+  construct new (pattern: string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string, flags?: string | undefined): RegExp
+  $&: string
+  $': string
+  $+: string
+  $1: string
+  $2: string
+  $3: string
+  $4: string
+  $5: string
+  $6: string
+  $7: string
+  $8: string
+  $9: string
+  $_: string
+  $`: string
+  [Symbol.species] [readonly]: RegExpConstructor
+  escape: (string: string) => string
+  input: string
+  lastMatch: string
+  lastParen: string
+  leftContext: string
+  prototype [readonly]: RegExp
+  rightContext: string
+interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  cache [readonly]: RequestCache
+  clone: () => Request
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  duplex [readonly]: "half"
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  integrity [readonly]: string
+  json [readonly]: () => Promise<unknown>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (requestInfo: string, init?: RequestInit | undefined): Request
+  construct new (requestInfo: RequestInit & { url: string; }): Request
+  construct new (requestInfo: Request, init?: RequestInit | undefined): Request
+  prototype: Request
+interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  credentials [?]: RequestCredentials | undefined
+  dispatcher [?]: Dispatcher | undefined
+  duplex [?]: "half" | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  signal [?]: AbortSignal | null | undefined
+  window [?]: null | undefined
+var ResolveError (bun-types/deprecated.d.ts): typeof ResolveMessage
+class ResolveMessage (bun-types/globals.d.ts)
+  code [readonly]: string
+  importKind [readonly]: "at" | "at_conditional" | "dynamic" | "entry_point" | "import" | "internal" | "require" | "require_resolve" | "stmt" | "url"
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "ResolveMessage"
+  position [readonly]: Position | null
+  referrer [readonly]: string
+  specifier [readonly]: string
+  toString: () => string
+  [static]
+    construct new (): ResolveMessage
+    prototype: ResolveMessage
+interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  clone: () => Response
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  json [readonly]: () => Promise<unknown>
+  ok [readonly]: boolean
+  redirected [readonly]: boolean
+  status [readonly]: number
+  statusText [readonly]: string
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  type [readonly]: ResponseType
+  url [readonly]: string
+var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  error: () => Response
+  json: (body?: any, init?: ResponseInit | number | undefined) => Response
+  redirect: { (url: string, status?: number | undefined): Response; (url: string, init?: ResponseInit | undefined): Response }
+interface ResponseInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  headers [? readonly]: HeadersInit | undefined
+  status [? readonly]: number | undefined
+  statusText [? readonly]: string | undefined
+interface ShadowRealm (bun-types/globals.d.ts)
+  evaluate: (sourceText: string) => any
+  importValue: (specifier: string, bindingName: string) => Promise<any>
+var ShadowRealm (bun-types/globals.d.ts)
+  construct new (): ShadowRealm
+  prototype: ShadowRealm
+interface SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts)
+  [Symbol.toStringTag] [readonly]: "SharedArrayBuffer"
+  byteLength [readonly]: number
+  grow: (size: number) => SharedArrayBuffer
+  slice: (begin?: number | undefined, end?: number | undefined) => SharedArrayBuffer
+var SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts): SharedArrayBufferConstructor
+interface StreamPipeOptions (bun-types/globals.d.ts)
+  preventAbort [?]: boolean | undefined
+  preventCancel [?]: boolean | undefined
+  preventClose [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  decapsulateBits: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource) => Promise<ArrayBuffer>
+  decapsulateKey: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<CryptoKey>
+  decrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>) => Promise<CryptoKey>
+  digest: (algorithm: AlgorithmIdentifier | CShakeParams | KangarooTwelveParams | TurboShakeParams, data: BufferSource) => Promise<ArrayBuffer>
+  encapsulateBits: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey) => Promise<EncapsulatedBits>
+  encapsulateKey: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<EncapsulatedKey>
+  encrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
+  generateKey: { (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | KmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
+  getPublicKey: (key: CryptoKey, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
+  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey> }
+  sign: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
+  verify: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
+  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): SubtleCrypto
+  prototype: SubtleCrypto
+interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
+  prototype: TextDecoder
+interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+  readable [readonly]: ReadableStream<string>
+  writable [readonly]: WritableStream<BufferSource>
+var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TextDecoderStream
+  prototype: TextDecoderStream
+interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  encode: (input?: string | undefined) => NonSharedUint8Array
+  encodeInto: (src?: string | undefined, dest?: BufferSource | undefined) => TextEncoderEncodeIntoResult
+  encoding [readonly]: string
+var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
+  prototype: TextEncoder
+interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  encoding [readonly]: string
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<string>
+var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TextEncoderStream
+  prototype: TextEncoderStream
+interface Timer (bun-types/globals.d.ts)
+  [Symbol.toPrimitive]: () => number
+  hasRef: () => boolean
+  ref: () => Timer
+  refresh: () => Timer
+  unref: () => Timer
+interface TransformStream<I = any, O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<O>
+  writable [readonly]: WritableStream<I>
+var TransformStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <I = any, O = any>(transformer?: Transformer<I, O> | undefined, writableStrategy?: QueuingStrategy<I> | undefined, readableStrategy?: QueuingStrategy<O> | undefined): TransformStream<I, O>
+  prototype: TransformStream<any, any>
+interface TransformStreamDefaultController<O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  desiredSize [readonly]: null | number
+  enqueue: (chunk?: O | undefined) => void
+  error: (reason?: any) => void
+  terminate: () => void
+var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TransformStreamDefaultController<any>
+  prototype: TransformStreamDefaultController<any>
+interface Transformer<I = any, O = any> (bun-types/globals.d.ts)
+  flush [?]: TransformerFlushCallback<O> | undefined
+  readableType [?]: undefined
+  start [?]: TransformerStartCallback<O> | undefined
+  transform [?]: TransformerTransformCallback<I, O> | undefined
+  writableType [?]: undefined
+interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  hash: string
+  host: string
+  hostname: string
+  href: string
+  origin [readonly]: string
+  password: string
+  pathname: string
+  port: string
+  protocol: string
+  search: string
+  searchParams [readonly]: URLSearchParams
+  toJSON: () => string
+  username: string
+var URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  construct new (url: URL | string, base?: URL | string | undefined): URL
+  canParse: (url: string, base?: string | undefined) => boolean
+  createObjectURL: (object: Blob) => `blob:${string}`
+  parse: (url: string, base?: string | undefined) => URL | null
+  prototype: URL
+  revokeObjectURL: (url: string) => void
+interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, string | ReadonlyArray<string>> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es5.d.ts)
+  index [number]: number
+  BYTES_PER_ELEMENT [readonly]: number
+  [Symbol.iterator]: () => ArrayIterator<number>
+  [Symbol.toStringTag] [readonly]: "Uint8Array"
+  at: (index: number) => number | undefined
+  buffer [readonly]: TArrayBuffer
+  byteLength [readonly]: number
+  byteOffset [readonly]: number
+  copyWithin: (target: number, start: number, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  entries: () => ArrayIterator<[number, number]>
+  every: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  fill: (value: number, start?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  filter: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => any, thisArg?: any) => Uint8Array<ArrayBuffer>
+  find: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number | undefined
+  findIndex: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number
+  forEach: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => void, thisArg?: any) => void
+  includes: (searchElement: number, fromIndex?: number | undefined) => boolean
+  indexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  join: (separator?: string | undefined) => string
+  keys: () => ArrayIterator<number>
+  lastIndexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  length [readonly]: number
+  map: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => number, thisArg?: any) => Uint8Array<ArrayBuffer>
+  reduce: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reduceRight: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reverse: () => Uint8Array<TArrayBuffer>
+  set: (array: ArrayLike<number>, offset?: number | undefined) => void
+  setFromBase64: (base64: string, offset?: number | undefined) => { read: number; written: number; }
+  setFromHex: (hex: string) => { read: number; written: number; }
+  slice: (start?: number | undefined, end?: number | undefined) => Uint8Array<ArrayBuffer>
+  some: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  sort: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<TArrayBuffer>
+  subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  toBase64: (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }) => string
+  toHex: () => string
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toString: () => string
+  valueOf: () => Uint8Array<TArrayBuffer>
+  values: () => ArrayIterator<number>
+var Uint8Array (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es5.d.ts): Uint8ArrayConstructor
+interface Uint8ArrayConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2017.typedarrays.d.ts, lib.es5.d.ts)
+  construct new (length: number): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<TArrayBuffer>
+  construct new (buffer: ArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayBuffer | ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new (elements: Iterable<number>): Uint8Array<ArrayBuffer>
+  construct new (): Uint8Array<ArrayBuffer>
+  BYTES_PER_ELEMENT [readonly]: number
+  from: { (arrayLike: ArrayLike<number>): Uint8Array<ArrayBuffer>; <T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array<ArrayBuffer>; (elements: Iterable<number>): Uint8Array<ArrayBuffer>; <T>(elements: Iterable<T>, mapfn?: ((v: T, k: number) => number) | undefined, thisArg?: any): Uint8Array<ArrayBuffer> }
+  fromBase64: (base64: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }) => Uint8Array<ArrayBuffer>
+  fromHex: (hex: string) => Uint8Array<ArrayBuffer>
+  of: (...items: Array<number>) => Uint8Array<ArrayBuffer>
+  prototype [readonly]: Uint8Array<ArrayBufferLike>
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.CompileError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): CompileError
+    construct new (message?: string | undefined): CompileError
+    prototype: CompileError
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  var WebAssembly.Global (bun-types/wasm.d.ts)
+    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
+    prototype: Global<keyof ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  var WebAssembly.Instance (bun-types/wasm.d.ts)
+    construct new (module: Module, importObject?: Imports | undefined): Instance
+    prototype: Instance
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.LinkError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): LinkError
+    construct new (message?: string | undefined): LinkError
+    prototype: LinkError
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  var WebAssembly.Memory (bun-types/wasm.d.ts)
+    construct new (descriptor: MemoryDescriptor): Memory
+    prototype: Memory
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  var WebAssembly.Module (bun-types/wasm.d.ts)
+    construct new (bytes: BufferSource): Module
+    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
+    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
+    prototype: Module
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): RuntimeError
+    construct new (message?: string | undefined): RuntimeError
+    prototype: RuntimeError
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  var WebAssembly.Table (bun-types/wasm.d.ts)
+    construct new (descriptor: TableDescriptor, value?: any): Table
+    prototype: Table
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+  function WebAssembly.compile (bun-types/wasm.d.ts)
+    call (bytes: BufferSource): Promise<Module>
+  function WebAssembly.compileStreaming (bun-types/wasm.d.ts)
+    call (source: PromiseLike<Response> | Response): Promise<Module>
+  function WebAssembly.instantiate (bun-types/wasm.d.ts)
+    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+  function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts)
+    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+  function WebAssembly.validate (bun-types/wasm.d.ts)
+    call (bytes: BufferSource): boolean
+interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (url: URL | string, options?: WebSocketOptions | undefined): WebSocket
+  construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  prototype: WebSocket
+interface Worker (bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+var Worker (bun-types/globals.d.ts)
+  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  data: any
+  prototype: Worker
+interface WorkerOptions (bun-types/globals.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  getWriter: () => WritableStreamDefaultWriter<W>
+  locked [readonly]: boolean
+var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  prototype: WritableStream<any>
+interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  error: (e?: any) => void
+var WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): WritableStreamDefaultController
+  prototype: WritableStreamDefaultController
+interface WritableStreamDefaultWriter<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  closed [readonly]: Promise<void>
+  desiredSize [readonly]: null | number
+  ready [readonly]: Promise<void>
+  releaseLock: () => void
+  write: (chunk?: W | undefined) => Promise<void>
+var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>
+  prototype: WritableStreamDefaultWriter<any>
+function addEventListener (bun-types/globals.d.ts)
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+function alert (bun-types/globals.d.ts)
+  call (message?: string | undefined): void
+function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (immediate: Immediate | undefined): void
+function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function confirm (bun-types/globals.d.ts)
+  call (message?: string | undefined): boolean
+var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts): Console
+var crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts): Crypto
+var exports (@types/node/module.d.ts, bun-types/globals.d.ts): any
+function fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  call (input: Request | URL | string, init?: BunFetchRequestInit | undefined): Promise<Response>
+  call (input: Request | URL | string, init?: RequestInit | undefined): Promise<Response>
+  preconnect: (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }) => void
+namespace fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  function fetch.preconnect (bun-types/globals.d.ts)
+    call (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }): void
+var module (@types/node/module.d.ts, bun-types/globals.d.ts): NodeModule
+var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts): Navigator
+var onmessage (bun-types/index.d.ts): never
+var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts): Performance
+function postMessage (bun-types/globals.d.ts)
+  call (message: any, transfer?: Array<Transferable> | undefined): void
+function prompt (bun-types/globals.d.ts)
+  call (message?: string | undefined, _default?: string | undefined): null | string
+function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (callback: (...args: Array<any>) => void): void
+  call (callback: () => void): void
+function removeEventListener (bun-types/globals.d.ts)
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+function reportError (bun-types/globals.d.ts)
+  call (error: any): void
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/esnext-dom.txt
+++ b/test/integration/bun-types/inventory/esnext-dom.txt
@@ -5,39 +5,64 @@
 # undici-types: 8.3.0
 
 # module "*.html"
+export = Bun.HTMLBundle
 
 # module "*.json5"
+export = any
 
 # module "*.jsonc"
+export = any
 
 # module "*.toml"
+export = any
 
 # module "*.txt"
+export = string
 
 # module "*.xml"
+export = Bun.XML.Document
 
 # module "*.yaml"
+export = any
 
 # module "*.yml"
+export = any
 
 # module "*/bun.lock"
+export = Bun.BunLockFile
+
+# module "buffer"
+interface Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<NodeJS.NonSharedUint8Array>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
+  json: () => Promise<any>
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<NodeJS.NonSharedUint8Array>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
 
 # module "bun"
-type $ (bun-types/shell.d.ts) = typeof $
+type $ (bun-types/shell.d.ts) = typeof Bun.$
 function $ (bun-types/shell.d.ts)
-  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
-  Shell: new () => typeof $
-  ShellError: typeof ShellError
-  ShellPromise: typeof ShellPromise
+  call (strings: TemplateStringsArray, ...expressions: Array<Bun.ShellExpression>): Bun.$.ShellPromise
+  Shell: new () => typeof Bun.$
+  ShellError: typeof Bun.$.ShellError
+  ShellPromise: typeof Bun.$.ShellPromise
   braces: (pattern: string) => Array<string>
-  cwd: (newCwd?: string | undefined) => typeof $
-  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  cwd: (newCwd?: string | undefined) => typeof Bun.$
+  env: (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => typeof Bun.$
   escape: (input: string) => string
-  nothrow: () => typeof $
-  throws: (shouldThrow: boolean) => typeof $
+  nothrow: () => typeof Bun.$
+  throws: (shouldThrow: boolean) => typeof Bun.$
 namespace $ (bun-types/shell.d.ts)
   var $.Shell (bun-types/shell.d.ts)
-    construct new (): typeof $
+    construct new (): typeof Bun.$
   class $.ShellError (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
     blob: () => Blob
@@ -52,13 +77,13 @@ namespace $ (bun-types/shell.d.ts)
     stdout [readonly]: Buffer<ArrayBufferLike>
     text: (encoding?: BufferEncoding | undefined) => string
     [static]
-      construct new (message?: string | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: ShellError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.$.ShellError
       stackTraceLimit: number
   interface $.ShellOutput (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
@@ -73,26 +98,26 @@ namespace $ (bun-types/shell.d.ts)
     [Symbol.toStringTag] [readonly]: string
     arrayBuffer: () => Promise<ArrayBuffer>
     blob: () => Promise<Blob>
-    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
-    cwd: (newCwd: string) => ShellPromise
-    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
-    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<Bun.$.ShellOutput | TResult>
+    cwd: (newCwd: string) => Bun.$.ShellPromise
+    env: (newEnv: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => Bun.$.ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<Bun.$.ShellOutput>
     json: () => Promise<any>
     lines: () => AsyncIterable<string>
-    nothrow: () => ShellPromise
-    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    nothrow: () => Bun.$.ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => Bun.$.ShellPromise
     stdin: WritableStream<any>
     text: (encoding?: BufferEncoding | undefined) => Promise<string>
-    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    throws: (shouldThrow: boolean) => ShellPromise
+    then: <TResult1 = Bun.$.ShellOutput, TResult2 = never>(onfulfilled?: ((value: Bun.$.ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => Bun.$.ShellPromise
     [static]
-      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      construct new (executor: (resolve: (value: Bun.$.ShellOutput | PromiseLike<Bun.$.ShellOutput>) => void, reject: (reason?: any) => void) => void): Bun.$.ShellPromise
       [Symbol.species] [readonly]: PromiseConstructor
-      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
-      prototype: ShellPromise
-      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
+      prototype: Bun.$.ShellPromise
+      race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
       reject: <T = never>(reason?: any) => Promise<T>
       resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
       try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
@@ -100,19 +125,19 @@ namespace $ (bun-types/shell.d.ts)
   function $.braces (bun-types/shell.d.ts)
     call (pattern: string): Array<string>
   function $.cwd (bun-types/shell.d.ts)
-    call (newCwd?: string | undefined): typeof $
+    call (newCwd?: string | undefined): typeof Bun.$
   function $.env (bun-types/shell.d.ts)
-    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+    call (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined): typeof Bun.$
   function $.escape (bun-types/shell.d.ts)
     call (input: string): string
   function $.nothrow (bun-types/shell.d.ts)
-    call (): typeof $
+    call (): typeof Bun.$
   function $.throws (bun-types/shell.d.ts)
-    call (shouldThrow: boolean): typeof $
+    call (shouldThrow: boolean): typeof Bun.$
 interface AbstractWorker (bun-types/bun.d.ts)
-  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
 interface AbstractWorkerEventMap (bun-types/bun.d.ts)
   error: ErrorEvent
 interface AddEventListenerOptions (bun-types/bun.d.ts)
@@ -124,16 +149,16 @@ type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips
 class Archive (bun-types/bun.d.ts)
   blob: () => Promise<Blob>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
-  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  extract: (path: string, options?: Bun.ArchiveExtractOptions | undefined) => Promise<number>
   files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
   [static]
-    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
-    prototype: Archive
-    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+    construct new (data: Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined): Bun.Archive
+    prototype: Bun.Archive
+    write [static]: (path: string, data: Bun.Archive | Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined) => Promise<void>
 type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
 interface ArchiveExtractOptions (bun-types/bun.d.ts)
   glob [?]: ReadonlyArray<string> | string | undefined
-type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+type ArchiveInput (bun-types/bun.d.ts) = ArrayBufferLike | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Record<string, Bun.BlobPart>
 interface ArchiveOptions (bun-types/bun.d.ts)
   compress [?]: "gzip" | undefined
   level [?]: number | undefined
@@ -141,25 +166,25 @@ class ArrayBufferSink (bun-types/bun.d.ts)
   end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
   flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
   start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
   [static]
-    construct new (): ArrayBufferSink
-    prototype: ArrayBufferSink
-type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+    construct new (): Bun.ArrayBufferSink
+    prototype: Bun.ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = DataView<TArrayBuffer> | NodeJS.TypedArray<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "ACLITEM" | "BIGINT" | "BIT" | "BOOLEAN" | "BOX" | "BYTEA" | "CHAR" | "CID" | "CIDR" | "CIRCLE" | "DATE" | "DOUBLE PRECISION" | "INET" | "INT" | "INT2VECTOR" | "INTEGER" | "INTERVAL" | "JSON" | "JSONB" | "JSONPATH" | "LINE" | "LSEG" | "MACADDR" | "MACADDR8" | "MONEY" | "NAME" | "NUMERIC" | "OID" | "PATH" | "PG_DATABASE" | "POINT" | "POLYGON" | "REAL" | "SMALLINT" | "TEXT" | "TID" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "TIMETZ" | "VARBIT" | "VARCHAR" | "XID" | "XML" | (string & {})
 type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
-type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+type BinaryType (bun-types/bun.d.ts) = keyof Bun.BinaryTypeList
 interface BinaryTypeList (bun-types/bun.d.ts)
   arraybuffer: ArrayBuffer
   buffer: Buffer<ArrayBufferLike>
   uint8array: Uint8Array<ArrayBuffer>
-type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
-type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
-type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
-type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string
+type BlobPart (bun-types/bun.d.ts) = Blob | Bun.BufferSource | string
+type BodyInit (bun-types/fetch.d.ts) = (() => AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any>) | AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any> | AsyncIterable<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string> | Bun.Image | Bun.XMLHttpRequestBodyInit | ReadableStream<any>
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
 namespace Build (bun-types/bun.d.ts)
-  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
-  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Architecture (bun-types/bun.d.ts) = "aarch64" | "arm64" | "x64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-aarch64" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-darwin-arm64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-linux-aarch64" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-modern" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-linux-aarch64-musl" | "bun-linux-arm64" | "bun-linux-arm64-baseline" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-glibc" | "bun-linux-arm64-modern" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-arm64-musl" | "bun-linux-x64" | "bun-linux-x64-baseline" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-modern" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-x64-musl" | "bun-windows-aarch64" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
   type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
   type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
 interface BuildArtifact (bun-types/bun.d.ts)
@@ -167,14 +192,14 @@ interface BuildArtifact (bun-types/bun.d.ts)
   bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
   formData: () => Promise<FormData>
   hash: null | string
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
-  loader: Loader
+  loader: Bun.Loader
   path: string
   size [readonly]: number
   slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
-  sourcemap: BuildArtifact | null
+  sourcemap: Bun.BuildArtifact | null
   stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
@@ -183,7 +208,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   banner [?]: string | undefined
   bytecode [?]: boolean | undefined
   bytecodeDepth [?]: number | undefined
-  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  compile [?]: Bun.Build.CompileTarget | Bun.CompileBuildOptions | boolean | undefined
   conditions [?]: Array<string> | string | undefined
   define [?]: Record<string, string> | undefined
   deprecatedNamespaceObjectSetters [?]: boolean | undefined
@@ -193,12 +218,12 @@ interface BuildConfig (bun-types/bun.d.ts)
   env [?]: "disable" | "inline" | `${string}*` | undefined
   external [?]: Array<string> | undefined
   features [?]: Array<string> | undefined
-  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  files [?]: Record<string, ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string> | undefined
   footer [?]: string | undefined
   format [?]: "cjs" | "esm" | "iife" | undefined
   ignoreDCEAnnotations [?]: boolean | undefined
   jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
-  loader [?]: undefined | { [x: string]: Loader; }
+  loader [?]: undefined | { [x: string]: Bun.Loader; }
   metafile [?]: boolean | undefined
   minChunkSize [?]: number | undefined
   minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
@@ -207,7 +232,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   optimizeImports [?]: Array<string> | undefined
   outdir [?]: string | undefined
   packages [?]: "bundle" | "external" | undefined
-  plugins [?]: Array<BunPlugin> | undefined
+  plugins [?]: Array<Bun.BunPlugin> | undefined
   publicPath [?]: string | undefined
   reactCompiler [?]: boolean | undefined
   reactCompilerOutputMode [?]: "client" | "ssr" | undefined
@@ -216,17 +241,17 @@ interface BuildConfig (bun-types/bun.d.ts)
   sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
   splitRequire [?]: boolean | undefined
   splitting [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   throw [?]: boolean | undefined
   treeShaking [?]: boolean | undefined
   tsconfig [?]: string | undefined
 interface BuildMetafile (bun-types/bun.d.ts)
-  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
-  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: Bun.ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: Bun.ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
 interface BuildOutput (bun-types/bun.d.ts)
   logs: Array<BuildMessage | ResolveMessage>
-  metafile [?]: BuildMetafile | undefined
-  outputs: Array<BuildArtifact>
+  metafile [?]: Bun.BuildMetafile | undefined
+  outputs: Array<Bun.BuildArtifact>
   success: boolean
 interface BunFile (bun-types/bun.d.ts)
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
@@ -234,29 +259,29 @@ interface BunFile (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface BunInspectOptions (bun-types/bun.d.ts)
   colors [?]: boolean | undefined
   compact [?]: boolean | undefined
   depth [?]: number | undefined
   sorted [?]: boolean | undefined
-type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: Bun.BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: Bun.BunLockFilePackageArray; }; }
 type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
-type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
-type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
-type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, info: Bun.BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Bun.BunLockFilePackageInfo] | [pkg: string, info: Pick<Bun.BunLockFileBasePackageInfo, "bin" | "binDir">] | [pkg: string, registry: string, info: Bun.BunLockFilePackageInfo, integrity: string] | [pkg: string]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
 interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
   AT_TARGET [readonly]: 2
   BUBBLING_PHASE [readonly]: 3
@@ -288,10 +313,10 @@ interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.t
   type [readonly]: string
 interface BunPlugin (bun-types/bun.d.ts)
   name: string
-  setup: (build: PluginBuilder) => Promise<void> | void
-  target [?]: Target | undefined
+  setup: (build: Bun.PluginBuilder) => Promise<void> | void
+  target [?]: Bun.Target | undefined
 interface BunRegisterPlugin (bun-types/bun.d.ts)
-  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  call <T extends Bun.BunPlugin>(options: T): ReturnType<T["setup"]>
   clearAll: () => void
 interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
@@ -300,8 +325,8 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   bodyUsed [readonly]: boolean
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   cache [readonly]: RequestCache
-  clone: () => BunRequest<T>
-  cookies [readonly]: CookieMap
+  clone: () => Bun.BunRequest<T>
+  cookies [readonly]: Bun.CookieMap
   credentials [readonly]: RequestCredentials
   destination [readonly]: RequestDestination
   formData: () => Promise<FormData>
@@ -311,7 +336,7 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   keepalive [readonly]: boolean
   method [readonly]: string
   mode [readonly]: RequestMode
-  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  params [readonly]: { [Key in keyof Bun.Serve.ExtractRouteParams<T>]: Bun.Serve.ExtractRouteParams<T>[Key]; }
   redirect [readonly]: RequestRedirect
   referrer [readonly]: string
   referrerPolicy [readonly]: ReferrerPolicy
@@ -321,17 +346,17 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   url [readonly]: string
 namespace CSRF (bun-types/bun.d.ts)
   function CSRF.generate (bun-types/bun.d.ts)
-    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+    call (secret?: string | undefined, options?: Bun.CSRFGenerateOptions | undefined): string
   function CSRF.verify (bun-types/bun.d.ts)
-    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+    call (token: string, options?: Bun.CSRFVerifyOptions | undefined): boolean
 type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
 interface CSRFGenerateOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   expiresIn [?]: number | undefined
   sessionId [?]: string | undefined
 interface CSRFVerifyOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   maxAge [?]: number | undefined
   secret [?]: string | undefined
@@ -343,7 +368,7 @@ interface CloseEventInit (bun-types/bun.d.ts)
   composed [?]: boolean | undefined
   reason [?]: string | undefined
   wasClean [?]: boolean | undefined
-type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+type ColorInput (bun-types/bun.d.ts) = Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | [number, number, number, number] | [number, number, number] | number | string | { r: number; g: number; b: number; a?: number | undefined; } | { toString(): string; }
 interface CompileBuildOptions (bun-types/bun.d.ts)
   assets [?]: Array<string> | undefined
   autoloadBunfig [?]: boolean | undefined
@@ -353,9 +378,9 @@ interface CompileBuildOptions (bun-types/bun.d.ts)
   execArgv [?]: Array<string> | undefined
   executablePath [?]: string | undefined
   outfile [?]: string | undefined
-  target [?]: CompileTarget | undefined
+  target [?]: Bun.Build.CompileTarget | undefined
   windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
-type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+type CompressionFormat (bun-types/bun.d.ts) = "brotli" | "deflate" | "deflate-raw" | "gzip" | "zstd"
 class Cookie (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | undefined
@@ -365,19 +390,19 @@ class Cookie (bun-types/bun.d.ts)
   name [readonly]: string
   partitioned: boolean
   path: string
-  sameSite: CookieSameSite
+  sameSite: Bun.CookieSameSite
   secure: boolean
   serialize: () => string
-  toJSON: () => CookieInit
+  toJSON: () => Bun.CookieInit
   toString: () => string
   value: string
   [static]
-    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
-    construct new (cookieString: string): Cookie
-    construct new (cookieObject?: CookieInit | undefined): Cookie
-    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
-    parse [static]: (cookieString: string) => Cookie
-    prototype: Cookie
+    construct new (name: string, value: string, options?: Bun.CookieInit | undefined): Bun.Cookie
+    construct new (cookieString: string): Bun.Cookie
+    construct new (cookieObject?: Bun.CookieInit | undefined): Bun.Cookie
+    from [static]: (name: string, value: string, options?: Bun.CookieInit | undefined) => Bun.Cookie
+    parse [static]: (cookieString: string) => Bun.Cookie
+    prototype: Bun.Cookie
 interface CookieInit (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | number | string | undefined
@@ -386,26 +411,26 @@ interface CookieInit (bun-types/bun.d.ts)
   name [?]: string | undefined
   partitioned [?]: boolean | undefined
   path [?]: string | undefined
-  sameSite [?]: CookieSameSite | undefined
+  sameSite [?]: Bun.CookieSameSite | undefined
   secure [?]: boolean | undefined
   value [?]: string | undefined
 class CookieMap (bun-types/bun.d.ts)
   [Symbol.iterator]: () => IterableIterator<[string, string]>
-  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  delete: { (name: string): void; (options: Bun.CookieStoreDeleteOptions): void; (name: string, options: Omit<Bun.CookieStoreDeleteOptions, "name">): void }
   entries: () => IterableIterator<[string, string]>
-  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  forEach: (callback: (value: string, key: string, map: Bun.CookieMap) => void) => void
   get: (name: string) => null | string
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
-  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  set: { (name: string, value: string, options?: Bun.CookieInit | undefined): void; (options: Bun.CookieInit): void }
   size [readonly]: number
   toJSON: () => Record<string, string>
   toSetCookieHeaders: () => Array<string>
   values: () => IterableIterator<string>
   [static]
-    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
-    prototype: CookieMap
-type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): Bun.CookieMap
+    prototype: Bun.CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "lax" | "none" | "strict"
 interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
   domain [?]: null | string | undefined
   name: string
@@ -420,30 +445,30 @@ interface CronController (bun-types/bun.d.ts)
 interface CronJob (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   cron [readonly]: string
-  ref: () => CronJob
-  stop: () => CronJob
-  unref: () => CronJob
+  ref: () => Bun.CronJob
+  stop: () => Bun.CronJob
+  unref: () => Bun.CronJob
 interface CronOptions (bun-types/bun.d.ts)
   tz [?]: string | undefined
-type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+type CronWithAutocomplete (bun-types/bun.d.ts) = "@annually" | "@daily" | "@hourly" | "@midnight" | "@monthly" | "@weekly" | "@yearly" | (string & {}) | `${string} ${string} ${string} ${string} ${string}`
 class CryptoHashInterface<T> (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => T
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => T
   [static]
-    construct new <T>(): CryptoHashInterface<T>
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHashInterface<any>
+    construct new <T>(): Bun.CryptoHashInterface<T>
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHashInterface<any>
 class CryptoHasher (bun-types/bun.d.ts)
-  algorithm [readonly]: SupportedCryptoAlgorithms
+  algorithm [readonly]: Bun.SupportedCryptoAlgorithms
   byteLength [readonly]: number
-  copy: () => CryptoHasher
-  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
-  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  copy: () => Bun.CryptoHasher
+  digest: { (encoding: Bun.DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (input: Bun.BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => Bun.CryptoHasher
   [static]
-    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
-    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
-    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHasher
+    construct new (algorithm: Bun.SupportedCryptoAlgorithms, hmacKey?: NodeJS.TypedArray<ArrayBufferLike> | string | undefined): Bun.CryptoHasher
+    algorithms [readonly static]: Array<Bun.SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHasher
 interface CustomEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -454,9 +479,9 @@ interface DNSLookup (bun-types/bun.d.ts)
   family: 4 | 6
   ttl: number
 type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
-type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "base64" | "base64url" | "hex" | "latin1" | "ucs2" | "utf16le" | "utf8"
 interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
   pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
   type: "direct"
 type DisconnectListener (bun-types/bun.d.ts) = () => void
@@ -464,7 +489,7 @@ interface EditorOptions (bun-types/bun.d.ts)
   column [?]: number | undefined
   editor [?]: "subl" | "vscode" | undefined
   line [?]: number | undefined
-type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+type Encoding (bun-types/bun.d.ts) = "866" | "ansi_x3.4-1968" | "arabic" | "ascii" | "asmo-708" | "big5" | "big5-hkscs" | "chinese" | "cn-big5" | "cp1250" | "cp1251" | "cp1252" | "cp1253" | "cp1254" | "cp1255" | "cp1256" | "cp1257" | "cp1258" | "cp819" | "cp866" | "csbig5" | "cseuckr" | "cseucpkdfmtjapanese" | "csgb2312" | "csibm866" | "csiso2022jp" | "csiso58gb231280" | "csiso88596e" | "csiso88596i" | "csiso88598e" | "csiso88598i" | "csisolatin1" | "csisolatin2" | "csisolatin3" | "csisolatin4" | "csisolatin5" | "csisolatin6" | "csisolatin9" | "csisolatinarabic" | "csisolatincyrillic" | "csisolatingreek" | "csisolatinhebrew" | "cskoi8r" | "csksc56011987" | "csmacintosh" | "csshiftjis" | "csunicode" | "cyrillic" | "dos-874" | "ecma-114" | "ecma-118" | "elot_928" | "euc-jp" | "euc-kr" | "gb18030" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "greek" | "greek8" | "hebrew" | "ibm819" | "ibm866" | "iso-10646-ucs-2" | "iso-2022-jp" | "iso-8859-1" | "iso-8859-10" | "iso-8859-11" | "iso-8859-13" | "iso-8859-14" | "iso-8859-15" | "iso-8859-16" | "iso-8859-2" | "iso-8859-3" | "iso-8859-4" | "iso-8859-5" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-8859-7" | "iso-8859-8" | "iso-8859-8-e" | "iso-8859-8-i" | "iso-8859-9" | "iso-ir-100" | "iso-ir-101" | "iso-ir-109" | "iso-ir-110" | "iso-ir-126" | "iso-ir-127" | "iso-ir-138" | "iso-ir-144" | "iso-ir-148" | "iso-ir-149" | "iso-ir-157" | "iso-ir-58" | "iso8859-1" | "iso8859-10" | "iso8859-11" | "iso8859-13" | "iso8859-14" | "iso8859-15" | "iso8859-2" | "iso8859-3" | "iso8859-4" | "iso8859-5" | "iso8859-6" | "iso8859-7" | "iso8859-8" | "iso8859-9" | "iso88591" | "iso885910" | "iso885911" | "iso885913" | "iso885914" | "iso885915" | "iso88592" | "iso88593" | "iso88594" | "iso88595" | "iso88596" | "iso88597" | "iso88598" | "iso88599" | "iso_8859-1" | "iso_8859-15" | "iso_8859-1:1987" | "iso_8859-2" | "iso_8859-2:1987" | "iso_8859-3" | "iso_8859-3:1988" | "iso_8859-4" | "iso_8859-4:1988" | "iso_8859-5" | "iso_8859-5:1988" | "iso_8859-6" | "iso_8859-6:1987" | "iso_8859-7" | "iso_8859-7:1987" | "iso_8859-8" | "iso_8859-8:1988" | "iso_8859-9" | "iso_8859-9:1989" | "koi" | "koi8" | "koi8-r" | "koi8-ru" | "koi8-u" | "koi8_r" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "l1" | "l2" | "l3" | "l4" | "l5" | "l6" | "l9" | "latin1" | "latin2" | "latin3" | "latin4" | "latin5" | "latin6" | "logical" | "mac" | "macintosh" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "sun_eu_greek" | "tis-620" | "ucs-2" | "unicode" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "unicodefeff" | "unicodefffe" | "us-ascii" | "utf-16" | "utf-16be" | "utf-16le" | "utf-8" | "utf8" | "visual" | "windows-1250" | "windows-1251" | "windows-1252" | "windows-1253" | "windows-1254" | "windows-1255" | "windows-1256" | "windows-1257" | "windows-1258" | "windows-31j" | "windows-874" | "windows-949" | "x-cp1250" | "x-cp1251" | "x-cp1252" | "x-cp1253" | "x-cp1254" | "x-cp1255" | "x-cp1256" | "x-cp1257" | "x-cp1258" | "x-euc-jp" | "x-gbk" | "x-mac-cyrillic" | "x-mac-roman" | "x-mac-ukrainian" | "x-sjis" | "x-unicode20utf8" | "x-user-defined" | "x-x-big5"
 interface Env (bun-types/bun.d.ts)
   NODE_ENV [?]: string | undefined
   TZ [?]: string | undefined
@@ -485,7 +510,7 @@ interface ErrorLike (bun-types/bun.d.ts)
   name: string
   stack [?]: string | undefined
   syscall [?]: string | undefined
-type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+type Errorlike (bun-types/deprecated.d.ts) = Bun.ErrorLike
 interface EventInit (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -496,25 +521,25 @@ interface EventListenerObject (bun-types/bun.d.ts)
   handleEvent: (object: Event) => void
 interface EventListenerOptions (bun-types/bun.d.ts)
   capture [?]: boolean | undefined
-type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = Bun.EventListener | Bun.EventListenerObject
 interface EventMap (bun-types/bun.d.ts)
-  fetch: FetchEvent
+  fetch: Bun.FetchEvent
   message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
   messageerror: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
 interface EventSource (bun-types/bun.d.ts)
-  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): Bun.EventSource
   CLOSED [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
-  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   close: () => void
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: EventSource, ev: Event) => any) | null
-  onmessage: ((this: EventSource, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  onopen: ((this: EventSource, ev: Event) => any) | null
+  onerror: ((this: Bun.EventSource, ev: Event) => any) | null
+  onmessage: ((this: Bun.EventSource, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: Bun.EventSource, ev: Event) => any) | null
   readyState [readonly]: number
   ref: () => void
-  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   unref: () => void
   url [readonly]: string
   withCredentials [readonly]: boolean
@@ -528,8 +553,8 @@ interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   fd: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface FetchEvent (bun-types/bun.d.ts)
   AT_TARGET [readonly]: 2
   BUBBLING_PHASE [readonly]: 3
@@ -563,47 +588,47 @@ interface FileBlob (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface FileSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
   ref: () => void
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
 class FileSystemRouter (bun-types/bun.d.ts)
   assetPrefix [readonly]: string
-  match: (input: Request | Response | string) => MatchedRoute | null
+  match: (input: Request | Response | string) => Bun.MatchedRoute | null
   origin [readonly]: string
   reload: () => void
   routes [readonly]: Record<string, string>
   style [readonly]: string
   [static]
-    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
-    prototype: FileSystemRouter
-type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): Bun.FileSystemRouter
+    prototype: Bun.FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = File | string
 interface GenericTransformStream (bun-types/bun.d.ts)
   readable [readonly]: ReadableStream<any>
   writable [readonly]: WritableStream<any>
 class Glob (bun-types/bun.d.ts)
   match: (str: string) => boolean
-  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
-  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  scan: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => IterableIterator<string>
   [static]
-    construct new (pattern: string): Glob
-    prototype: Glob
+    construct new (pattern: string): Bun.Glob
+    prototype: Bun.Glob
 interface GlobScanOptions (bun-types/bun.d.ts)
   absolute [?]: boolean | undefined
   cwd [?]: string | undefined
@@ -611,25 +636,25 @@ interface GlobScanOptions (bun-types/bun.d.ts)
   followSymlinks [?]: boolean | undefined
   onlyFiles [?]: boolean | undefined
   throwErrorOnBrokenSymlink [?]: boolean | undefined
-type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
-type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+type HMREvent (bun-types/devserver.d.ts) = "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:beforeUpdate" | "bun:error" | "bun:invalidate" | "bun:ws:connect" | "bun:ws:disconnect" | (string & {})
+type HMREventNames (bun-types/devserver.d.ts) = "afterUpdate" | "beforeFullReload" | "beforePrune" | "beforeUpdate" | "error" | "invalidate" | "ws:connect" | "ws:disconnect"
 interface HTMLBundle (bun-types/bun.d.ts)
-  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Bun.Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
   index: string
 interface Hash (bun-types/bun.d.ts)
-  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-type HeadersInit (bun-types/fetch.d.ts) = Headers | Array<Array<string>> | Record<string, string | ReadonlyArray<string>>
+  adler32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Headers | Record<string, ReadonlyArray<string> | string>
 interface HeapSnapshot (bun-types/bun.d.ts)
   edgeNames: Array<string>
   edgeTypes: Array<string>
@@ -639,56 +664,56 @@ interface HeapSnapshot (bun-types/bun.d.ts)
   type: string
   version: number
 class Image (bun-types/bun.d.ts)
-  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  avif: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   blob: () => Promise<Blob>
   buffer: () => Promise<Buffer<ArrayBufferLike>>
   bytes: () => Promise<Uint8Array<ArrayBufferLike>>
   dataurl: () => Promise<string>
-  flip: () => Image
-  flop: () => Image
-  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  flip: () => Bun.Image
+  flop: () => Bun.Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   height [readonly]: number
-  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
-  metadata: () => Promise<Metadata>
-  modulate: (options: ModulateOptions) => Image
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Bun.Image
+  metadata: () => Promise<Bun.Image.Metadata>
+  modulate: (options: Bun.Image.ModulateOptions) => Bun.Image
   placeholder: (as?: "dataurl" | undefined) => Promise<string>
-  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
-  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
-  rotate: (degrees: number) => Image
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Bun.Image
+  resize: (width: number, height?: number | undefined, options?: Bun.Image.ResizeOptions | undefined) => Bun.Image
+  rotate: (degrees: number) => Bun.Image
   toBase64: () => Promise<string>
   toBuffer: () => Promise<Buffer<ArrayBufferLike>>
-  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Bun.Image
   width [readonly]: number
-  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  write: (dest: Bun.BunFile | Bun.PathLike | Bun.S3File | number) => Promise<number>
   [static]
-    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    construct new (input: ArrayBuffer | Blob | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.Image.ConstructorOptions | undefined): Bun.Image
     backend [static]: "bun" | "system"
     clipboardChangeCount [static]: () => number
-    fromClipboard [static]: () => Image | null
+    fromClipboard [static]: () => Bun.Image | null
     hasClipboardImage [static]: () => boolean
-    prototype: Image
+    prototype: Bun.Image
   interface Image.ConstructorOptions (bun-types/bun.d.ts)
     autoOrient [?]: boolean | undefined
     maxPixels [?]: number | undefined
-  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
-  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
-  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "bilinear" | "box" | "cubic" | "lanczos2" | "lanczos3" | "linear" | "mitchell" | "mks2013" | "mks2021" | "nearest"
+  type Image.Format (bun-types/bun.d.ts) = "avif" | "bmp" | "gif" | "heic" | "jpeg" | "png" | "tiff" | "webp"
   interface Image.Metadata (bun-types/bun.d.ts)
-    format: Format
+    format: Bun.Image.Format
     height: number
     width: number
   interface Image.ModulateOptions (bun-types/bun.d.ts)
     brightness [?]: number | undefined
     saturation [?]: number | undefined
   interface Image.ResizeOptions (bun-types/bun.d.ts)
-    filter [?]: Filter | undefined
+    filter [?]: Bun.Image.Filter | undefined
     fit [?]: "fill" | "inside" | undefined
     withoutEnlargement [?]: boolean | undefined
   var Image.backend (bun-types/bun.d.ts): "bun" | "system"
 interface Import (bun-types/bun.d.ts)
-  kind: ImportKind
+  kind: Bun.ImportKind
   path: string
-type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+type ImportKind (bun-types/bun.d.ts) = "dynamic-import" | "entry-point-build" | "entry-point-run" | "import-rule" | "import-statement" | "internal" | "require-call" | "require-resolve" | "url-token"
 namespace JSON5 (bun-types/bun.d.ts)
   function JSON5.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -704,30 +729,30 @@ namespace JSONL (bun-types/bun.d.ts)
     read: number
     values: Array<unknown>
   function JSONL.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Array<unknown>
   function JSONL.parseChunk (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): Bun.JSONL.ParseChunkResult
 type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
 interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
   level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
   library [?]: "libdeflate" | undefined
-type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+type Loader (bun-types/bun.d.ts) = "css" | "file" | "html" | "js" | "json" | "jsonc" | "jsx" | "napi" | "text" | "toml" | "ts" | "tsx" | "wasm" | "xml" | "yaml"
 class MD4 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD4
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD4
   [static]
-    construct new (): MD4
+    construct new (): Bun.MD4
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD4
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD4
 class MD5 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD5
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD5
   [static]
-    construct new (): MD5
+    construct new (): Bun.MD5
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD5
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD5
 interface MMapOptions (bun-types/bun.d.ts)
   offset [?]: number | undefined
   shared [?]: boolean | undefined
@@ -742,7 +767,7 @@ interface MatchedRoute (bun-types/bun.d.ts)
   pathname [readonly]: string
   query [readonly]: Record<string, string>
   src [readonly]: string
-type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
+type MaybePromise<T> (bun-types/bun.d.ts) = Promise<T> | T
 type MessageEvent<T = any> (bun-types/bun.d.ts) = { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
 interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
@@ -754,8 +779,8 @@ interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   source [?]: null | undefined
 type MessageEventSource (bun-types/bun.d.ts) = undefined
 type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
-type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
-type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: Bun.MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "reject" | "resolve"
 interface NetworkSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
@@ -763,38 +788,38 @@ interface NetworkSink (bun-types/s3.d.ts)
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   stat: () => Promise<Stats>
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
-type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
-type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
 type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
-type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+type OnEndCallback (bun-types/bun.d.ts) = (result: Bun.BuildOutput) => void | Promise<void>
 interface OnLoadArgs (bun-types/bun.d.ts)
   defer: () => Promise<void>
-  loader: Loader
+  loader: Bun.Loader
   namespace: string
   path: string
-type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
-type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+type OnLoadCallback (bun-types/bun.d.ts) = (args: Bun.OnLoadArgs) => Bun.OnLoadResult | Promise<Bun.OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = Bun.OnLoadResultObject | Bun.OnLoadResultSourceCode | undefined | void
 interface OnLoadResultObject (bun-types/bun.d.ts)
   exports: Record<string, unknown>
   loader: "object"
 interface OnLoadResultSourceCode (bun-types/bun.d.ts)
-  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
-  loader [?]: Loader | undefined
+  contents: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Bun.Loader | undefined
 interface OnResolveArgs (bun-types/bun.d.ts)
   importer: string
-  kind: ImportKind
+  kind: Bun.ImportKind
   namespace: string
   path: string
   resolveDir: string
-type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+type OnResolveCallback (bun-types/bun.d.ts) = (args: Bun.OnResolveArgs) => Bun.OnResolveResult | Promise<Bun.OnResolveResult | null | undefined> | null | undefined
 interface OnResolveResult (bun-types/bun.d.ts)
   external [?]: boolean | undefined
   namespace [?]: string | undefined
   path: string
 type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
 namespace Password (bun-types/bun.d.ts)
-  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "argon2d" | "argon2i" | "argon2id" | "bcrypt"
   interface Password.Argon2Algorithm (bun-types/bun.d.ts)
     algorithm: "argon2d" | "argon2i" | "argon2id"
     memoryCost [?]: number | undefined
@@ -802,243 +827,243 @@ namespace Password (bun-types/bun.d.ts)
   interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
     algorithm: "bcrypt"
     cost [?]: number | undefined
-type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
-type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
-type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+type PathLike (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | URL | string
+type PipedSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "cygwin" | "darwin" | "freebsd" | "haiku" | "linux" | "netbsd" | "openbsd" | "sunos" | "win32"
 interface PluginBuilder (bun-types/bun.d.ts)
-  config: BuildConfig & { plugins: Array<BunPlugin>; }
-  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
-  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
-  onEnd: (callback: OnEndCallback) => PluginBuilder
-  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
-  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
-  onStart: (callback: OnStartCallback) => PluginBuilder
+  config: Bun.BuildConfig & { plugins: Array<Bun.BunPlugin>; }
+  module: (specifier: string, callback: () => Bun.OnLoadResult | Promise<Bun.OnLoadResult>) => Bun.PluginBuilder
+  onBeforeParse: (constraints: Bun.PluginConstraints, callback: Bun.OnBeforeParseCallback) => Bun.PluginBuilder
+  onEnd: (callback: Bun.OnEndCallback) => Bun.PluginBuilder
+  onLoad: (constraints: Bun.PluginConstraints, callback: Bun.OnLoadCallback) => Bun.PluginBuilder
+  onResolve: (constraints: Bun.PluginConstraints, callback: Bun.OnResolveCallback) => Bun.PluginBuilder
+  onStart: (callback: Bun.OnStartCallback) => Bun.PluginBuilder
 interface PluginConstraints (bun-types/bun.d.ts)
   filter: RegExp
   namespace [?]: string | undefined
-type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined
 type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
 interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
   done: boolean
   size: number
   value: Array<T>
-type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadDoneResult | ReadableStreamDefaultReadValueResult<T>
 type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
-type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
-type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+type ReadableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"pipe", "pipe">
 class RedisClient (bun-types/redis.d.ts)
-  append: (key: KeyLike, value: KeyLike) => Promise<number>
-  bitcount: (key: KeyLike) => Promise<number>
-  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
-  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
-  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
-  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
-  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  append: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  bitcount: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  bitfield: (key: Bun.RedisClient.KeyLike, ...operations: Array<number | string>) => Promise<Array<null | number>>
+  bitop: { (operation: "NOT" | "not", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  bitpos: (key: Bun.RedisClient.KeyLike, bit: 0 | 1, ...options: Array<number | string>) => Promise<number>
+  blmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<null | string>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, timeout: number) => Promise<null | string>
   bufferedAmount [readonly]: number
-  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  client: (...args: Array<string | number>) => Promise<any>
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  client: (...args: Array<number | string>) => Promise<any>
   close: () => void
-  command: (...args: Array<string | number>) => Promise<any>
-  config: (...args: Array<string | number>) => Promise<any>
+  command: (...args: Array<number | string>) => Promise<any>
+  config: (...args: Array<number | string>) => Promise<any>
   connect: () => Promise<void>
   connected [readonly]: boolean
-  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  copy: { (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike): Promise<number>; (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, replace: "REPLACE"): Promise<number> }
   dbsize: () => Promise<number>
-  debug: (...args: Array<string | number>) => Promise<any>
-  decr: (key: KeyLike) => Promise<number>
-  decrby: (key: KeyLike, decrement: number) => Promise<number>
-  del: (...keys: Array<KeyLike>) => Promise<number>
-  dump: (key: KeyLike) => Promise<string | null>
-  duplicate: () => Promise<RedisClient>
+  debug: (...args: Array<number | string>) => Promise<any>
+  decr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  decrby: (key: Bun.RedisClient.KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  dump: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  duplicate: () => Promise<Bun.RedisClient>
   echo: (message: string) => Promise<string>
-  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  exists: (key: KeyLike) => Promise<boolean>
-  expire: (key: KeyLike, seconds: number) => Promise<number>
-  expireat: (key: KeyLike, timestamp: number) => Promise<number>
-  expiretime: (key: KeyLike) => Promise<number>
-  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  exists: (key: Bun.RedisClient.KeyLike) => Promise<boolean>
+  expire: (key: Bun.RedisClient.KeyLike, seconds: number) => Promise<number>
+  expireat: (key: Bun.RedisClient.KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
   flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
   flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
-  function: (...args: Array<KeyLike>) => Promise<any>
-  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
-  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
-  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
-  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
-  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
-  get: (key: KeyLike) => Promise<string | null>
-  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
-  getbit: (key: KeyLike, offset: number) => Promise<number>
-  getdel: (key: KeyLike) => Promise<string | null>
-  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
-  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
-  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
-  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
-  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
-  hgetall: (key: KeyLike) => Promise<Record<string, string>>
-  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
-  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
-  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
-  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
-  hkeys: (key: KeyLike) => Promise<Array<string>>
-  hlen: (key: KeyLike) => Promise<number>
-  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
-  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
-  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
-  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
-  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
-  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
-  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
-  hstrlen: (key: KeyLike, field: string) => Promise<number>
-  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hvals: (key: KeyLike) => Promise<Array<string>>
-  incr: (key: KeyLike) => Promise<number>
-  incrby: (key: KeyLike, increment: number) => Promise<number>
-  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  function: (...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  geoadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  geodist: { (key: Bun.RedisClient.KeyLike, member1: string, member2: string): Promise<null | string>; (key: Bun.RedisClient.KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<null | string> }
+  geohash: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<null | string>>
+  geopos: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<unknown>>
+  geosearchstore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  get: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getBuffer: (key: Bun.RedisClient.KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: Bun.RedisClient.KeyLike, offset: number) => Promise<number>
+  getdel: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getex: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST"): Promise<null | string> }
+  getrange: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hdel: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  hexists: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hexpire: { (key: Bun.RedisClient.KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hget: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hgetall: (key: Bun.RedisClient.KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  hgetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>> }
+  hincrby: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  hlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  hmget: { (key: Bun.RedisClient.KeyLike, ...fields: Array<string>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, fields: Array<string>): Promise<Array<null | string>> }
+  hmset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<"OK"> }
+  hpersist: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: Bun.RedisClient.KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpttl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: Bun.RedisClient.KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<number>; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetnx: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hstrlen: (key: Bun.RedisClient.KeyLike, field: string) => Promise<number>
+  httl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hvals: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  incr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  incrby: (key: Bun.RedisClient.KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: Bun.RedisClient.KeyLike, increment: number | string) => Promise<string>
   info: (...sections: Array<string>) => Promise<string>
   keys: (pattern: string) => Promise<Array<string>>
   lastsave: () => Promise<number>
-  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
-  lindex: (key: KeyLike, index: number) => Promise<string | null>
-  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
-  llen: (key: KeyLike) => Promise<number>
-  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
-  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
-  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
-  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
-  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
-  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
-  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
-  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
-  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
-  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
-  onclose: ((this: RedisClient, error: Error) => void) | null
-  onconnect: ((this: RedisClient) => void) | null
-  persist: (key: KeyLike) => Promise<number>
-  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
-  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
-  pexpiretime: (key: KeyLike) => Promise<number>
-  pfadd: (key: KeyLike, element: string) => Promise<number>
-  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
-  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
-  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
-  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
-  pttl: (key: KeyLike) => Promise<number>
+  lcs: (key1: Bun.RedisClient.KeyLike, key2: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<any>
+  lindex: (key: Bun.RedisClient.KeyLike, index: number) => Promise<null | string>
+  linsert: (key: Bun.RedisClient.KeyLike, position: "AFTER" | "BEFORE", pivot: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike) => Promise<number>
+  llen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  lmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<null | string>
+  lmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<Array<number> | null | number>
+  lpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  lpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  lrange: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: Bun.RedisClient.KeyLike, count: number, element: Bun.RedisClient.KeyLike) => Promise<number>
+  lset: (key: Bun.RedisClient.KeyLike, index: number, element: Bun.RedisClient.KeyLike) => Promise<string>
+  ltrim: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  mset: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  onclose: ((this: Bun.RedisClient, error: Error) => void) | null
+  onconnect: ((this: Bun.RedisClient) => void) | null
+  persist: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pexpire: (key: Bun.RedisClient.KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: Bun.RedisClient.KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pfadd: (key: Bun.RedisClient.KeyLike, element: string) => Promise<number>
+  pfcount: (key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  pfmerge: (destkey: Bun.RedisClient.KeyLike, ...sourcekeys: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: Bun.RedisClient.KeyLike): Promise<string> }
+  psetex: (key: Bun.RedisClient.KeyLike, milliseconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  pttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
   publish: (channel: string, message: string) => Promise<number>
-  randomkey: () => Promise<string | null>
-  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
-  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
-  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
-  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
-  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
-  scard: (key: KeyLike) => Promise<number>
+  randomkey: () => Promise<null | string>
+  rename: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<"OK">
+  renamenx: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<number>
+  rpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike) => Promise<null | string>
+  rpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  rpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sadd: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<number | string>): Promise<[string, Array<string>]> }
+  scard: (key: Bun.RedisClient.KeyLike) => Promise<number>
   script: (...args: Array<string>) => Promise<any>
-  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sdiff: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   send: (command: string, args: Array<string>) => Promise<any>
-  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
-  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
-  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
-  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
-  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
-  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
-  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
-  sismember: (key: KeyLike, member: string) => Promise<boolean>
-  smembers: (key: KeyLike) => Promise<Array<string>>
-  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
-  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
-  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
-  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  spublish: (channel: KeyLike, message: string) => Promise<number>
-  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
-  strlen: (key: KeyLike) => Promise<number>
-  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
-  substr: (key: KeyLike, start: number, end: number) => Promise<string>
-  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  set: { (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, nx: "NX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, xx: "XX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, get: "GET"): Promise<null | string>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...options: Array<string>): Promise<null | string> }
+  setbit: (key: Bun.RedisClient.KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: Bun.RedisClient.KeyLike, seconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  setnx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  setrange: (key: Bun.RedisClient.KeyLike, offset: number, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sinter: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: Bun.RedisClient.KeyLike, ...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<number>
+  sinterstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  sismember: (key: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  smembers: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  smismember: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  smove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  sort: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<null | string> | number>
+  spop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: Bun.RedisClient.KeyLike, message: string) => Promise<number>
+  srandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...args: Array<number | string>) => Promise<[string, Array<string>]>
+  strlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<number>; (channels: Array<string>, listener: Bun.RedisClient.StringPubSubListener): Promise<number> }
+  substr: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   time: () => Promise<[string, string]>
-  touch: (...keys: Array<KeyLike>) => Promise<number>
-  ttl: (key: KeyLike) => Promise<number>
-  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
-  unlink: (...keys: Array<KeyLike>) => Promise<number>
-  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  touch: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  ttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  type: (key: Bun.RedisClient.KeyLike) => Promise<"hash" | "list" | "none" | "set" | "stream" | "string" | "zset">
+  unlink: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
   wait: (numreplicas: number, timeout: number) => Promise<number>
-  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
-  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
-  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
-  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
-  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
-  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xlen: (key: KeyLike) => Promise<number>
-  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
-  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xread: (...args: Array<string | number>) => Promise<any>
-  xreadgroup: (...args: Array<string | number>) => Promise<any>
-  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
-  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
-  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  zcard: (key: KeyLike) => Promise<number>
-  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
-  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
-  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
-  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
-  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
-  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
-  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
-  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
-  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
-  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
-  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
-  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
-  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
-  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
-  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
-  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
-  zscore: (key: KeyLike, member: string) => Promise<number | null>
-  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  xack: (key: Bun.RedisClient.KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<null | string>
+  xautoclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<number | string>) => Promise<any>
+  xclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<number | string>) => Promise<any>
+  xdel: (key: Bun.RedisClient.KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  xpending: (key: Bun.RedisClient.KeyLike, group: string, ...args: Array<number | string>) => Promise<any>
+  xrange: (key: Bun.RedisClient.KeyLike, start: string, end: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<number | string>) => Promise<any>
+  xreadgroup: (...args: Array<number | string>) => Promise<any>
+  xrevrange: (key: Bun.RedisClient.KeyLike, end: string, start: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: Bun.RedisClient.KeyLike, lastId: string, ...options: Array<number | string>) => Promise<"OK">
+  xtrim: (key: Bun.RedisClient.KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<number | string>) => Promise<number>
+  zadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  zcard: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  zcount: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: Bun.RedisClient.KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zincrby: (key: Bun.RedisClient.KeyLike, increment: number, member: Bun.RedisClient.KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<number>; (numkeys: number, ...args: Array<Bun.RedisClient.KeyLike | number>): Promise<number> }
+  zinterstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
+  zlexcount: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | number>>
+  zpopmax: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null>; (key: Bun.RedisClient.KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: Bun.RedisClient.KeyLike, min: string, max: string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangebyscore: { (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangestore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zremrangebylex: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: Bun.RedisClient.KeyLike, start: number, stop: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: Bun.RedisClient.KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrevrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: Bun.RedisClient.KeyLike, member: string) => Promise<null | number>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zunionstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
   [static]
-    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
-    prototype: RedisClient
-  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+    construct new (url?: string | undefined, options?: Bun.RedisOptions | undefined): Bun.RedisClient
+    prototype: Bun.RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = Blob | Bun.ArrayBufferView<ArrayBufferLike> | string
   type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
 interface RedisOptions (bun-types/redis.d.ts)
   autoReconnect [?]: boolean | undefined
@@ -1047,34 +1072,34 @@ interface RedisOptions (bun-types/redis.d.ts)
   enableOfflineQueue [?]: boolean | undefined
   idleTimeout [?]: number | undefined
   maxRetries [?]: number | undefined
-  tls [?]: TLSOptions | boolean | undefined
+  tls [?]: Bun.TLSOptions | boolean | undefined
 type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
 interface ReservedSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
   [Symbol.dispose]: () => void
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
   release: () => void
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 interface ResourceUsage (bun-types/bun.d.ts)
   contextSwitches: { voluntary: number; involuntary: number; }
   cpuTime: { user: number; system: number; total: number; }
@@ -1085,27 +1110,27 @@ interface ResourceUsage (bun-types/bun.d.ts)
   signalCount: number
   swapCount: number
 class S3Client (bun-types/s3.d.ts)
-  delete: (path: string, options?: S3Options | undefined) => Promise<void>
-  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
-  file: (path: string, options?: S3Options | undefined) => S3File
-  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
-  size: (path: string, options?: S3Options | undefined) => Promise<number>
-  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
-  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  delete: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+  list: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+  presign: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+  unlink: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  write: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
   [static]
-    construct new (options?: S3Options | undefined): S3Client
-    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
-    file [static]: (path: string, options?: S3Options | undefined) => S3File
-    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
-    prototype: S3Client
-    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
-    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+    construct new (options?: Bun.S3Options | undefined): Bun.S3Client
+    delete [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+    list [static]: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+    presign [static]: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+    prototype: Bun.S3Client
+    size [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+    unlink [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
 interface S3File (bun-types/s3.d.ts)
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
   bucket [? readonly]: string | undefined
@@ -1113,20 +1138,20 @@ interface S3File (bun-types/s3.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   name [? readonly]: string | undefined
-  presign: (options?: S3FilePresignOptions | undefined) => string
+  presign: (options?: Bun.S3FilePresignOptions | undefined) => string
   readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
-  stat: () => Promise<S3Stats>
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.S3File; (begin?: number | undefined, contentType?: string | undefined): Bun.S3File; (contentType?: string | undefined): Bun.S3File }
+  stat: () => Promise<Bun.S3Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: { (): Promise<string>; (): Promise<string> }
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
-  writer: (options?: S3Options | undefined) => NetworkSink
+  write: (data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
+  writer: (options?: Bun.S3Options | undefined) => Bun.NetworkSink
 interface S3FilePresignOptions (bun-types/s3.d.ts)
   accessKeyId [?]: string | undefined
   acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
@@ -1194,89 +1219,89 @@ interface S3Stats (bun-types/s3.d.ts)
   size: number
   type: string
 class SHA1 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA1
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA1
   [static]
-    construct new (): SHA1
+    construct new (): Bun.SHA1
     byteLength [readonly static]: 20
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA1
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA1
 class SHA224 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA224
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA224
   [static]
-    construct new (): SHA224
+    construct new (): Bun.SHA224
     byteLength [readonly static]: 28
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA224
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA224
 class SHA256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA256
   [static]
-    construct new (): SHA256
+    construct new (): Bun.SHA256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA256
 class SHA384 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA384
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA384
   [static]
-    construct new (): SHA384
+    construct new (): Bun.SHA384
     byteLength [readonly static]: 48
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA384
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA384
 class SHA512 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512
   [static]
-    construct new (): SHA512
+    construct new (): Bun.SHA512
     byteLength [readonly static]: 64
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512
 class SHA512_256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512_256
   [static]
-    construct new (): SHA512_256
+    construct new (): Bun.SHA512_256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512_256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512_256
 class SQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   [static]
-    construct new (connectionString: URL | string): SQL
-    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
-    construct new (options?: Options | undefined): SQL
-    MySQLError: typeof MySQLError
-    PostgresError: typeof PostgresError
-    SQLError: typeof SQLError
-    SQLiteError: typeof SQLiteError
-    prototype: SQL
+    construct new (connectionString: URL | string): Bun.SQL
+    construct new (connectionString: URL | string, options: Omit<Bun.SQL.PostgresOrMySQLOptions, "filename" | "url"> | Omit<Bun.SQL.SQLiteOptions, "filename" | "url">): Bun.SQL
+    construct new (options?: Bun.SQL.Options | undefined): Bun.SQL
+    MySQLError: typeof Bun.SQL.MySQLError
+    PostgresError: typeof Bun.SQL.PostgresError
+    SQLError: typeof Bun.SQL.SQLError
+    SQLiteError: typeof Bun.SQL.SQLiteError
+    prototype: Bun.SQL
   type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
-  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
-  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => Bun.MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? Bun.SQL.AwaitPromisesArray<T> : Awaited<T>
   interface SQL.Helper<T> (bun-types/sql.d.ts)
     columns [readonly]: Array<keyof T>
     value [readonly]: Array<T>
@@ -1293,13 +1318,13 @@ class SQL (bun-types/sql.d.ts)
     sqlState [? readonly]: string | undefined
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): Bun.SQL.MySQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: MySQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.MySQLError
       stackTraceLimit: number
-  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  type SQL.Options (bun-types/sql.d.ts) = Bun.SQL.PostgresOrMySQLOptions | Bun.SQL.SQLiteOptions
   class SQL.PostgresError (bun-types/sql.d.ts)
     cause [?]: unknown
     code [readonly]: string
@@ -1323,11 +1348,11 @@ class SQL (bun-types/sql.d.ts)
     table [? readonly]: string | undefined
     where [? readonly]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): Bun.SQL.PostgresError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: PostgresError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.PostgresError
       stackTraceLimit: number
   interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
     adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
@@ -1335,7 +1360,7 @@ class SQL (bun-types/sql.d.ts)
     bigint [?]: boolean | undefined
     connectTimeout [?]: number | undefined
     connect_timeout [?]: number | undefined
-    connection [?]: Record<string, string | number | boolean> | undefined
+    connection [?]: Record<string, boolean | number | string> | undefined
     connectionTimeout [?]: number | undefined
     connection_timeout [?]: number | undefined
     database [?]: string | undefined
@@ -1349,39 +1374,39 @@ class SQL (bun-types/sql.d.ts)
     max_lifetime [?]: number | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
-    pass [?]: (() => MaybePromise<string>) | string | undefined
-    password [?]: (() => MaybePromise<string>) | string | undefined
+    pass [?]: (() => Bun.MaybePromise<string>) | string | undefined
+    password [?]: (() => Bun.MaybePromise<string>) | string | undefined
     path [?]: string | undefined
     port [?]: number | string | undefined
     prepare [?]: boolean | undefined
-    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
-    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
     url [?]: URL | string | undefined
     user [?]: string | undefined
     username [?]: string | undefined
   interface SQL.Query<T> (bun-types/sql.d.ts)
     [Symbol.toStringTag] [readonly]: string
     active: boolean
-    cancel: () => Query<T>
+    cancel: () => Bun.SQL.Query<T>
     cancelled: boolean
     catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
-    execute: () => Query<T>
+    execute: () => Bun.SQL.Query<T>
     finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
-    raw: () => Query<T>
-    simple: () => Query<T>
+    raw: () => Bun.SQL.Query<T>
+    simple: () => Bun.SQL.Query<T>
     then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    values: () => Query<T>
+    values: () => Bun.SQL.Query<T>
   class SQL.SQLError (bun-types/sql.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string): SQLError
+      construct new (message: string): Bun.SQL.SQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLError
       stackTraceLimit: number
   class SQL.SQLiteError (bun-types/sql.d.ts)
     byteOffset [? readonly]: number | undefined
@@ -1392,55 +1417,55 @@ class SQL (bun-types/sql.d.ts)
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): Bun.SQL.SQLiteError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLiteError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLiteError
       stackTraceLimit: number
   interface SQL.SQLiteOptions (bun-types/sql.d.ts)
     adapter [?]: "sqlite" | undefined
     create [?]: boolean | undefined
-    filename [?]: ":memory:" | URL | string & {} | undefined
+    filename [?]: ":memory:" | (string & {}) | URL | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
     readonly [?]: boolean | undefined
     readwrite [?]: boolean | undefined
     safeIntegers [?]: boolean | undefined
     strict [?]: boolean | undefined
-  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SQLArrayParameter (bun-types/sql.d.ts)
-  arrayType: ArrayType
+  arrayType: Bun.ArrayType
   serializedValues: string
-type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
-type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
-type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+type SQLOptions (bun-types/deprecated.d.ts) = Bun.SQL.Options
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Bun.SQL.Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SavepointSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 namespace Security (bun-types/security.d.ts)
   interface Security.Advisory (bun-types/security.d.ts)
     description: null | string
@@ -1453,29 +1478,29 @@ namespace Security (bun-types/security.d.ts)
     tarball: string
     version: string
   interface Security.Scanner (bun-types/security.d.ts)
-    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    scan: (info: { packages: Array<Bun.Security.Package>; }) => Promise<Array<Bun.Security.Advisory>>
     version: "1"
 namespace Serve (bun-types/serve.d.ts)
-  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = Bun.BunFile | Bun.HTMLBundle | Bun.Serve.DirectoryRouteOptions | Response | false
   interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
   type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
   interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
     dir: string
     statCache [?]: boolean | undefined
-  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
-  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
-  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
-  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
-  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & Bun.Serve.ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes?: Bun.Serve.Routes<WebSocketData, R> | undefined; } | { fetch?(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes: Bun.Serve.Routes<WebSocketData, R>; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = Bun.Serve.FetchOrRoutesWithWebSocket<WebSocketData, R>
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => Bun.MaybePromise<Res>
   interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
-    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | (string & {}) | undefined
     http1 [?]: boolean | undefined
     http2 [?]: boolean | undefined
     http3 [?]: boolean | undefined
@@ -1485,18 +1510,18 @@ namespace Serve (bun-types/serve.d.ts)
     maxRequestBodySize [?]: number | undefined
     port [?]: number | string | undefined
     reusePort [?]: boolean | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
-  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
-  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
-  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = Bun.Serve.Options<WebSocketData, R>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined>>>; }
   interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
     unix [?]: string | undefined
-type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = Bun.ServeOptions<T, R>
 interface Server<WebSocketData> (bun-types/serve.d.ts)
   [Symbol.dispose]: () => void
   closeIdleConnections: () => number
@@ -1508,41 +1533,41 @@ interface Server<WebSocketData> (bun-types/serve.d.ts)
   pendingWebSockets [readonly]: number
   port [readonly]: number | undefined
   protocol [readonly]: "http" | "https" | null
-  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  publish: (topic: string, data: ArrayBuffer | Blob | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, compress?: boolean | undefined) => number
   ref: () => void
-  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
-  requestIP: (request: Request) => SocketAddress | null
+  reload: <R extends string>(options: Bun.Serve.Options<WebSocketData, R>) => Bun.Server<WebSocketData>
+  requestIP: (request: Request) => Bun.SocketAddress | null
   stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
   subscriberCount: (topic: string) => number
   timeout: (request: Request, seconds: number) => void
   unref: () => void
-  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: Bun.HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: Bun.HeadersInit | undefined; data: WebSocketData; }]) => boolean
   url [readonly]: URL
 interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
   binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
   close: (code?: number | undefined, reason?: string | undefined) => void
-  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  cork: <T = unknown>(callback: (ws: Bun.ServerWebSocket<T>) => T) => T
   data: T
   getBufferedAmount: () => number
   isSubscribed: (topic: string) => boolean
-  ping: (data?: Blob | BufferSource | string | undefined) => number
-  pong: (data?: Blob | BufferSource | string | undefined) => number
-  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  ping: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  pong: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   publishText: (topic: string, data: string, compress?: boolean | undefined) => number
-  readyState [readonly]: WebSocketReadyState
+  readyState [readonly]: Bun.WebSocketReadyState
   remoteAddress [readonly]: string
-  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  send: (data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   sendText: (data: string, compress?: boolean | undefined) => number
   subscribe: (topic: string) => boolean
   subscriptions [readonly]: Array<string>
   terminate: () => void
   unsubscribe: (topic: string) => boolean
 type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
-type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellExpression (bun-types/shell.d.ts) = Array<Bun.ShellExpression> | BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | Blob | Bun.BunFile | Bun.Subprocess<Bun.SpawnOptions.Writable, Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | ReadableStream<any> | ReadableStream<any> | Request | Response | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | null | number | string | undefined | { raw: string; } | { toString(): string; }
 type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
-type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+type SignalsListener (bun-types/bun.d.ts) = (signal: NodeJS.Signals) => void
 interface SliceAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   ellipsis [?]: string | undefined
@@ -1554,8 +1579,8 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   close: () => void
   data: Data
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1572,14 +1597,14 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1589,154 +1614,154 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface SocketAddress (bun-types/bun.d.ts)
   address: string
   family: "IPv4" | "IPv6"
   port: number
-interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
-  binaryType [?]: keyof BinaryTypeList | undefined
-  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
-  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
-  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
-  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof Bun.BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof Bun.BinaryTypeList | undefined
+  close [?]: ((socket: Bun.Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Bun.Socket<Data>, data: Bun.BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Bun.Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
 interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
+  socket: Bun.SocketHandler<Data, "buffer">
 namespace Spawn (bun-types/bun.d.ts)
-  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
-  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
-  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
-  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
-  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  type Spawn.OptionsObject<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = Bun.SpawnOptions.BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | null | number | undefined
+  type Spawn.ReadableToIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | Bun.BunFile | Bun.ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     lazy [?]: boolean | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
-    terminal [?]: Terminal | TerminalOptions | undefined
+    terminal [?]: Bun.Terminal | Bun.TerminalOptions | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.SpawnSyncOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
-  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
-  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | null | number | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = Bun.FileSink | number | undefined
+  type Spawn.WritableToIO<X extends Bun.SpawnOptions.Writable> (bun-types/bun.d.ts) = X extends "pipe" ? Bun.FileSink : X extends number | Bun.BunFile | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
 SpawnOptions -> Spawn
 type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
-type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type StringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | string
 interface StringWidthOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   countAnsiEscapeCodes [?]: boolean | undefined
   perCodePoint [?]: boolean | undefined
 interface StructuredSerializeOptions (bun-types/bun.d.ts)
-  transfer [?]: Array<Transferable> | undefined
-interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  transfer [?]: Array<Bun.Transferable> | undefined
+interface Subprocess<In extends Bun.SpawnOptions.Writable = Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => PromiseLike<void>
   disconnect: () => void
   exitCode [readonly]: null | number
   exited [readonly]: Promise<number>
-  kill: (exitCode?: Signals | number | undefined) => void
+  kill: (exitCode?: NodeJS.Signals | number | undefined) => void
   killed [readonly]: boolean
   pid [readonly]: number
-  readable [readonly]: ReadableToIO<Out>
+  readable [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
   ref: () => void
-  resourceUsage: () => ResourceUsage | undefined
+  resourceUsage: () => Bun.ResourceUsage | undefined
   send: (message: any) => void
-  signalCode [readonly]: Signals | null
-  stderr [readonly]: ReadableToIO<Err>
-  stdin [readonly]: WritableToIO<In>
+  signalCode [readonly]: NodeJS.Signals | null
+  stderr [readonly]: Bun.SpawnOptions.ReadableToIO<Err>
+  stdin [readonly]: Bun.SpawnOptions.WritableToIO<In>
   stdio [readonly]: [null, null, null, ...(number | null)[]]
-  stdout [readonly]: ReadableToIO<Out>
-  terminal [readonly]: Terminal | undefined
+  stdout [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
+  terminal [readonly]: Bun.Terminal | undefined
   unref: () => void
-type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
-interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha256" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "sha384" | "sha512" | "sha512-224" | "sha512-256" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   exitCode: number
   exitedDueToMaxBuffer [?]: boolean | undefined
   exitedDueToTimeout [?]: boolean | undefined
   pid: number
-  resourceUsage: ResourceUsage
+  resourceUsage: Bun.ResourceUsage
   signalCode [?]: string | undefined
-  stderr: ReadableToSyncIO<Err>
-  stdout: ReadableToSyncIO<Out>
+  stderr: Bun.SpawnOptions.ReadableToSyncIO<Err>
+  stdout: Bun.SpawnOptions.ReadableToSyncIO<Out>
   success: boolean
 interface SystemError (bun-types/bun.d.ts)
   cause [?]: unknown
@@ -1755,8 +1780,8 @@ interface TCPSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1773,14 +1798,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1790,14 +1815,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
@@ -1806,36 +1831,36 @@ interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   ipv6Only [?]: boolean | undefined
   port: number
   reusePort [?]: boolean | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   exclusive [?]: boolean | undefined
   hostname: string
   port: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   hostname [readonly]: string
   port [readonly]: number
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -1851,8 +1876,8 @@ interface TLSSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1869,14 +1894,14 @@ interface TLSSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1886,27 +1911,27 @@ interface TLSSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls: TLSOptions | boolean
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls: Bun.TLSOptions | boolean
 namespace TOML (bun-types/bun.d.ts)
   function TOML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): object
   function TOML.stringify (bun-types/bun.d.ts)
     call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
 interface TSConfig (bun-types/bun.d.ts)
   compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
   extends [?]: string | undefined
-type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+type Target (bun-types/bun.d.ts) = "browser" | "bun" | "node"
 class Terminal (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => Promise<void>
   close: () => void
@@ -1919,43 +1944,43 @@ class Terminal (bun-types/bun.d.ts)
   resize: (cols: number, rows: number) => void
   setRawMode: (enabled: boolean) => void
   unref: () => void
-  write: (data: BufferSource | string) => number
+  write: (data: Bun.BufferSource | string) => number
   [static]
-    construct new (options: TerminalOptions): Terminal
-    prototype: Terminal
+    construct new (options: Bun.TerminalOptions): Bun.Terminal
+    prototype: Bun.Terminal
 interface TerminalOptions (bun-types/bun.d.ts)
   cols [?]: number | undefined
-  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
-  drain [?]: ((terminal: Terminal) => void) | undefined
-  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  data [?]: ((terminal: Bun.Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Bun.Terminal) => void) | undefined
+  exit [?]: ((terminal: Bun.Terminal, exitCode: number, signal: null | string) => void) | undefined
   name [?]: string | undefined
   rows [?]: number | undefined
 type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
 interface TransactionSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  savepoint: { <T>(name: string, fn: Bun.SQL.SavepointContextCallback<T>): Promise<T>; <T>(fn: Bun.SQL.SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
 interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
   call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
@@ -1964,13 +1989,13 @@ interface TransformerStartCallback<O> (bun-types/bun.d.ts)
 interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
   call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
 class Transpiler (bun-types/bun.d.ts)
-  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
-  scanImports: (code: StringOrBuffer) => Array<Import>
-  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
-  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  scan: (code: Bun.StringOrBuffer) => { exports: Array<string>; imports: Array<Bun.Import>; }
+  scanImports: (code: Bun.StringOrBuffer) => Array<Bun.Import>
+  transform: (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: Bun.StringOrBuffer, loader: Bun.JavaScriptLoader, ctx: object): string; (code: Bun.StringOrBuffer, ctx: object): string; (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined): string }
   [static]
-    construct new (options?: TranspilerOptions | undefined): Transpiler
-    prototype: Transpiler
+    construct new (options?: Bun.TranspilerOptions | undefined): Bun.Transpiler
+    prototype: Bun.Transpiler
 interface TranspilerOptions (bun-types/bun.d.ts)
   allowBunRuntime [?]: boolean | undefined
   autoImportJSX [?]: boolean | undefined
@@ -1979,23 +2004,23 @@ interface TranspilerOptions (bun-types/bun.d.ts)
   exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
   inline [?]: boolean | undefined
   jsxOptimizationInline [?]: boolean | undefined
-  loader [?]: JavaScriptLoader | undefined
+  loader [?]: Bun.JavaScriptLoader | undefined
   logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
-  macro [?]: MacroMap | undefined
+  macro [?]: Bun.MacroMap | undefined
   minifyWhitespace [?]: boolean | undefined
   replMode [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   treeShaking [?]: boolean | undefined
   trimUnusedImports [?]: boolean | undefined
-  tsconfig [?]: TSConfig | string | undefined
-type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  tsconfig [?]: Bun.TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: Bun.UncaughtExceptionOrigin) => void
 type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
 interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
-  abort [?]: UnderlyingSinkAbortCallback | undefined
-  close [?]: UnderlyingSinkCloseCallback | undefined
-  start [?]: UnderlyingSinkStartCallback | undefined
+  abort [?]: Bun.UnderlyingSinkAbortCallback | undefined
+  close [?]: Bun.UnderlyingSinkCloseCallback | undefined
+  start [?]: Bun.UnderlyingSinkStartCallback | undefined
   type [?]: "bytes" | "default" | undefined
-  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+  write [?]: Bun.UnderlyingSinkWriteCallback<W> | undefined
 interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
@@ -2005,30 +2030,30 @@ interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
 interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
   call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
 interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
-  pull [?]: UnderlyingSourcePullCallback<R> | undefined
-  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
+  pull [?]: Bun.UnderlyingSourcePullCallback<R> | undefined
+  start [?]: Bun.UnderlyingSourceStartCallback<R> | undefined
   type [?]: undefined
 interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+  call (controller: Bun.ReadableStreamController<R>): PromiseLike<void> | void
 interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): any
+  call (controller: Bun.ReadableStreamController<R>): any
 type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
 interface UnixSocketListener<Data> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unix [readonly]: string
   unref: () => void
 interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
   unix: string
 type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
 namespace WebAssembly (bun-types/wasm.d.ts)
@@ -2037,19 +2062,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     message: string
     name: string
     stack [?]: string | undefined
-  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
-  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.Global<keyof Bun.WebAssembly.ValueTypeMap> | Bun.WebAssembly.Memory | Bun.WebAssembly.Table | Function
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ExportValue; }
+  interface WebAssembly.Global<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
-  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
-  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.ExportValue | number
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ModuleImports; }
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2064,13 +2089,13 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
-  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ImportValue; }
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2082,11 +2107,11 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     length [readonly]: number
     set: (index: number, value?: any) => void
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
-  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof Bun.WebAssembly.ValueTypeMap
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
     anyfunc: Function
     externref: any
@@ -2096,36 +2121,36 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
 interface WebSocket (bun-types/bun.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
-type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+type WebSocketCompressor (bun-types/serve.d.ts) = "128KB" | "16KB" | "256KB" | "32KB" | "3KB" | "4KB" | "64KB" | "8KB" | "dedicated" | "disable" | "shared"
 interface WebSocketEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: Event
@@ -2133,33 +2158,33 @@ interface WebSocketEventMap (bun-types/bun.d.ts)
   open: Event
 interface WebSocketHandler<T> (bun-types/serve.d.ts)
   backpressureLimit [?]: number | undefined
-  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  close [?]: ((ws: Bun.ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
   closeOnBackpressureLimit [?]: boolean | undefined
   data [?]: T | undefined
-  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  drain [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
   idleTimeout [?]: number | undefined
   maxPayloadLength [?]: number | undefined
-  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
-  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
-  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
-  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
-  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  message: (ws: Bun.ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | Bun.WebSocketCompressor | undefined; decompress?: boolean | Bun.WebSocketCompressor | undefined; }
+  ping [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
   publishToSelf [?]: boolean | undefined
   sendPings [?]: boolean | undefined
-type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptions (bun-types/bun.d.ts) = Bun.WebSocketOptions
 type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
 type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
-type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocol?: string | undefined; } | { protocols?: string | Array<string> | undefined; }
 type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
-type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: Bun.TLSOptions | undefined; }
 type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
 class WebView (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => void
   [Symbol.dispose]: () => void
-  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => void, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   back: () => Promise<void>
   cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
-  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  click: { (x: number, y: number, options?: Bun.WebView.ClickOptions | undefined): Promise<void>; (selector: string, options?: Bun.WebView.ClickSelectorOptions | undefined): Promise<void> }
   close: () => void
   dispatchEvent: (event: Event) => boolean
   evaluate: <T = unknown>(script: string) => Promise<T>
@@ -2168,58 +2193,58 @@ class WebView (bun-types/bun.d.ts)
   navigate: (url: string) => Promise<void>
   onNavigated: ((url: string, title: string) => void) | null
   onNavigationFailed: ((error: Error) => void) | null
-  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  press: (key: (string & {}) | Bun.WebView.VirtualKey, options?: Bun.WebView.PressOptions | undefined) => Promise<void>
   reload: () => Promise<void>
   removeEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean | undefined) => void
   resize: (width: number, height: number) => Promise<void>
   screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
   scroll: (dx: number, dy: number) => Promise<void>
-  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  scrollTo: (selector: string, options?: Bun.WebView.ScrollToOptions | undefined) => Promise<void>
   title [readonly]: string
   type: (text: string) => Promise<void>
   url [readonly]: string
   [static]
-    construct new (options?: ConstructorOptions | undefined): WebView
+    construct new (options?: Bun.WebView.ConstructorOptions | undefined): Bun.WebView
     closeAll [static]: () => void
-    prototype: WebView
-  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+    prototype: Bun.WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "chrome" | "webkit" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
   interface WebView.ClickOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
     timeout [?]: number | undefined
-  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = ((type: string, ...args: Array<unknown>) => void) | Console
   interface WebView.ConstructorOptions (bun-types/bun.d.ts)
-    backend [?]: Backend | undefined
-    console [?]: ConsoleCapture | undefined
+    backend [?]: Bun.WebView.Backend | undefined
+    console [?]: Bun.WebView.ConsoleCapture | undefined
     dataStore [?]: "ephemeral" | undefined | { directory: string; }
     headless [?]: boolean | undefined
     height [?]: number | undefined
     url [?]: string | undefined
     width [?]: number | undefined
-  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  type WebView.Modifier (bun-types/bun.d.ts) = "Alt" | "Control" | "Meta" | "Shift"
   interface WebView.PressOptions (bun-types/bun.d.ts)
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ScrollToOptions (bun-types/bun.d.ts)
     block [?]: "center" | "end" | "nearest" | "start" | undefined
     timeout [?]: number | undefined
-  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "Backspace" | "Delete" | "End" | "Enter" | "Escape" | "Home" | "PageDown" | "PageUp" | "Space" | "Tab"
 interface WhichOptions (bun-types/bun.d.ts)
   PATH [?]: string | undefined
   cwd [?]: string | undefined
 interface Worker (bun-types/bun.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  onmessageerror: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
@@ -2237,44 +2262,44 @@ interface WorkerOptions (bun-types/bun.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
 interface WrapAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   hard [?]: boolean | undefined
   trim [?]: boolean | undefined
   wordWrap [?]: boolean | undefined
-type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+type WritableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", any, any>
 namespace XML (bun-types/bun.d.ts)
   interface XML.Comment (bun-types/bun.d.ts)
     comment: string
   interface XML.Document (bun-types/bun.d.ts)
-    index [string]: Value
+    index [string]: Bun.XML.Value
   interface XML.Element (bun-types/bun.d.ts)
-    index [string]: Array<Value> | Value
+    index [string]: Array<Bun.XML.Value> | Bun.XML.Value
   interface XML.Node (bun-types/bun.d.ts)
     attributes: Record<string, string>
-    children: Array<string | Comment | Node | ProcessingInstruction>
+    children: Array<Bun.XML.Comment | Bun.XML.Node | Bun.XML.ProcessingInstruction | string>
     name: string
   interface XML.NodeInput (bun-types/bun.d.ts)
-    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
-    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    attributes [?]: null | undefined | { [name: string]: Bun.XML.Scalar | null | undefined; }
+    children [?]: Array<Bun.XML.Comment | Bun.XML.NodeInput | Bun.XML.ProcessingInstruction | Bun.XML.Scalar | null | undefined> | null | undefined
     name: string
   interface XML.ParseOptions (bun-types/bun.d.ts)
     compact [?]: boolean | undefined
   interface XML.ProcessingInstruction (bun-types/bun.d.ts)
     data: string
     target: string
-  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
-  type XML.Value (bun-types/bun.d.ts) = string | Element
+  type XML.Scalar (bun-types/bun.d.ts) = Date | bigint | boolean | number | string
+  type XML.Value (bun-types/bun.d.ts) = Bun.XML.Element | string
   function XML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: (Bun.XML.ParseOptions & { compact?: true | undefined; }) | undefined): Bun.XML.Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options: Bun.XML.ParseOptions & { compact: false; }): Bun.XML.Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.XML.ParseOptions | undefined): Bun.XML.Document | Bun.XML.Node
   function XML.stringify (bun-types/bun.d.ts)
-    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: Bun.XML.Document | Bun.XML.NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
     call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
-type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = Blob | Bun.BufferSource | FormData | URLSearchParams | string
 namespace YAML (bun-types/bun.d.ts)
   function YAML.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -2306,20 +2331,20 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     timeStamp [readonly]: number
     type [readonly]: string
   interface __internal.BunEventTarget (bun-types/globals.d.ts)
-    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
     dispatchEvent: (event: Event) => boolean
-    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+    removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
     count [readonly]: number
     getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
     toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
   interface __internal.BunRequestOverride (bun-types/fetch.d.ts)
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     textStream: () => ReadableStream<string>
   interface __internal.BunResponseOverride (bun-types/fetch.d.ts)
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     textStream: () => ReadableStream<string>
-  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Bun.__internal.Merge<T, Exclude<Else, T>> : never
   type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
   type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
   type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = true
@@ -2356,41 +2381,41 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
   type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = {}
   type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
   type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
-  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
-  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = webcrypto.CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = webcrypto.CryptoKeyPair
   type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = typeof globalThis extends { [K in GlobalThisKeyName]: infer T; } ? T : Otherwise
   type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
-  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Bun.__internal.Without<A, B> | Bun.__internal.Without<B, A>
 function allocUnsafe (bun-types/bun.d.ts)
   call (size: number): Uint8Array<ArrayBuffer>
 var argv (bun-types/bun.d.ts): Array<string>
 function build (bun-types/bun.d.ts)
-  call (config: BuildConfig): Promise<BuildOutput>
+  call (config: Bun.BuildConfig): Promise<Bun.BuildOutput>
 function color (bun-types/bun.d.ts)
-  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
-  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
-  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
-  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
-  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
-  call (input: ColorInput, outputFormat: "number"): null | number
+  call (input: Bun.ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: Bun.ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: Bun.ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: Bun.ColorInput, outputFormat: "number"): null | number
 function concatArrayBuffers (bun-types/bun.d.ts)
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
 function connect (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: Bun.TCPSocketConnectOptions<Data>): Promise<Bun.Socket<Data>>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Promise<Bun.Socket<Data>>
 var cron (bun-types/bun.d.ts)
-  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
-  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
-  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  call (schedule: Bun.CronWithAutocomplete, handler: (this: Bun.CronJob) => unknown, options?: Bun.CronOptions | undefined): Bun.CronJob
+  call (path: string, schedule: Bun.CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: Bun.CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: Bun.CronOptions | undefined) => Date | null
   remove: (title: string) => Promise<void>
 function deepEquals (bun-types/bun.d.ts)
   call (a: any, b: any, strict?: boolean | undefined): boolean
 function deepMatch (bun-types/bun.d.ts)
   call (subset: unknown, a: unknown): boolean
 function deflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 namespace dns (bun-types/bun.d.ts)
   var dns.ADDRCONFIG (bun-types/bun.d.ts): number
   var dns.ALL (bun-types/bun.d.ts): number
@@ -2398,50 +2423,50 @@ namespace dns (bun-types/bun.d.ts)
   function dns.getCacheStats (bun-types/bun.d.ts)
     call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
   function dns.lookup (bun-types/bun.d.ts)
-    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<Bun.DNSLookup>>
   function dns.prefetch (bun-types/bun.d.ts)
     call (hostname: string, port?: number | undefined): void
 var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
 var enableANSIColors (bun-types/bun.d.ts): boolean
-var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+var env (bun-types/bun.d.ts): Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
 function escapeHTML (bun-types/bun.d.ts)
   call (input: boolean | number | object | string): string
 var fetch (bun-types/bun.d.ts): typeof fetch
 function file (bun-types/bun.d.ts)
-  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
-  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
-  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+  call (path: URL | string, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): Bun.BunFile
 function fileURLToPath (bun-types/bun.d.ts)
   call (url: URL | string): string
 function gc (bun-types/bun.d.ts)
   call (force?: boolean | undefined): void
 function generateHeapSnapshot (bun-types/bun.d.ts)
-  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format?: "jsc" | undefined): Bun.HeapSnapshot
   call (format: "v8"): string
   call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
 function gunzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function gzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
-var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | number | undefined) => bigint | number) & Bun.Hash
 function indexOfLine (bun-types/bun.d.ts)
-  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+  call (buffer: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
 function inflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function inspect (bun-types/bun.d.ts)
-  call (arg: any, options?: BunInspectOptions | undefined): string
-  custom: typeof custom
+  call (arg: any, options?: Bun.BunInspectOptions | undefined): string
+  custom: typeof inspect.custom
   table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
 namespace inspect (bun-types/bun.d.ts)
-  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  var inspect.custom (bun-types/bun.d.ts): typeof inspect.custom
   function inspect.table (bun-types/bun.d.ts)
     call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
     call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
 var isMainThread (bun-types/bun.d.ts): boolean
 var isStandaloneExecutable (bun-types/bun.d.ts): boolean
 function listen (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+  call <Data = undefined>(options: Bun.TCPSocketListenOptions<Data>): Bun.TCPSocketListener<Data>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Bun.UnixSocketListener<Data>
 var main (bun-types/bun.d.ts): string
 namespace markdown (bun-types/bun.d.ts)
   interface markdown.AnsiTheme (bun-types/bun.d.ts)
@@ -2462,37 +2487,37 @@ namespace markdown (bun-types/bun.d.ts)
   interface markdown.CodeBlockProps (bun-types/bun.d.ts)
     children: Array<unknown>
     language [?]: string | undefined
-  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = ((props: P) => any) | (new (props: P) => any) | string
   interface markdown.ComponentOverrides (bun-types/bun.d.ts)
-    a [?]: Component<LinkProps> | undefined
-    blockquote [?]: Component<ChildrenProps> | undefined
-    br [?]: Component<{}> | undefined
-    code [?]: Component<ChildrenProps> | undefined
-    del [?]: Component<ChildrenProps> | undefined
-    em [?]: Component<ChildrenProps> | undefined
-    h1 [?]: Component<HeadingProps> | undefined
-    h2 [?]: Component<HeadingProps> | undefined
-    h3 [?]: Component<HeadingProps> | undefined
-    h4 [?]: Component<HeadingProps> | undefined
-    h5 [?]: Component<HeadingProps> | undefined
-    h6 [?]: Component<HeadingProps> | undefined
-    hr [?]: Component<{}> | undefined
-    html [?]: Component<ChildrenProps> | undefined
-    img [?]: Component<ImageProps> | undefined
-    li [?]: Component<ListItemProps> | undefined
-    math [?]: Component<ChildrenProps> | undefined
-    ol [?]: Component<OrderedListProps> | undefined
-    p [?]: Component<ChildrenProps> | undefined
-    pre [?]: Component<CodeBlockProps> | undefined
-    strong [?]: Component<ChildrenProps> | undefined
-    table [?]: Component<ChildrenProps> | undefined
-    tbody [?]: Component<ChildrenProps> | undefined
-    td [?]: Component<CellProps> | undefined
-    th [?]: Component<CellProps> | undefined
-    thead [?]: Component<ChildrenProps> | undefined
-    tr [?]: Component<ChildrenProps> | undefined
-    u [?]: Component<ChildrenProps> | undefined
-    ul [?]: Component<ChildrenProps> | undefined
+    a [?]: Bun.markdown.Component<Bun.markdown.LinkProps> | undefined
+    blockquote [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    br [?]: Bun.markdown.Component<{}> | undefined
+    code [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    del [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    em [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    h1 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h2 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h3 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h4 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h5 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h6 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    hr [?]: Bun.markdown.Component<{}> | undefined
+    html [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    img [?]: Bun.markdown.Component<Bun.markdown.ImageProps> | undefined
+    li [?]: Bun.markdown.Component<Bun.markdown.ListItemProps> | undefined
+    math [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ol [?]: Bun.markdown.Component<Bun.markdown.OrderedListProps> | undefined
+    p [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    pre [?]: Bun.markdown.Component<Bun.markdown.CodeBlockProps> | undefined
+    strong [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    table [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tbody [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    td [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    th [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    thead [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tr [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    u [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ul [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
   interface markdown.HeadingMeta (bun-types/bun.d.ts)
     id [?]: string | undefined
     level: number
@@ -2564,45 +2589,45 @@ namespace markdown (bun-types/bun.d.ts)
     wikiLinks [?]: boolean | undefined
   interface markdown.RenderCallbacks (bun-types/bun.d.ts)
     blockquote [?]: ((children: string) => null | string | undefined) | undefined
-    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: Bun.markdown.CodeBlockMeta | undefined) => null | string | undefined) | undefined
     codespan [?]: ((children: string) => null | string | undefined) | undefined
     emphasis [?]: ((children: string) => null | string | undefined) | undefined
-    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: Bun.markdown.HeadingMeta) => null | string | undefined) | undefined
     hr [?]: ((children: string) => null | string | undefined) | undefined
     html [?]: ((children: string) => null | string | undefined) | undefined
-    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
-    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
-    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
-    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: Bun.markdown.ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: Bun.markdown.LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: Bun.markdown.ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: Bun.markdown.ListItemMeta) => null | string | undefined) | undefined
     paragraph [?]: ((children: string) => null | string | undefined) | undefined
     strikethrough [?]: ((children: string) => null | string | undefined) | undefined
     strong [?]: ((children: string) => null | string | undefined) | undefined
     table [?]: ((children: string) => null | string | undefined) | undefined
     tbody [?]: ((children: string) => null | string | undefined) | undefined
-    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     text [?]: ((text: string) => null | string | undefined) | undefined
-    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     thead [?]: ((children: string) => null | string | undefined) | undefined
     tr [?]: ((children: string) => null | string | undefined) | undefined
   function markdown.ansi (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, theme?: Bun.markdown.AnsiTheme | undefined): string
   function markdown.html (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.markdown.Options | undefined): string
   function markdown.react (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, components?: Bun.markdown.ComponentOverrides | undefined, options?: Bun.markdown.ReactOptions | undefined): unknown
   function markdown.render (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, callbacks?: Bun.markdown.RenderCallbacks | undefined, options?: Bun.markdown.Options | undefined): string
 function mmap (bun-types/bun.d.ts)
-  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+  call (path: Bun.PathLike, opts?: Bun.MMapOptions | undefined): Uint8Array<ArrayBuffer>
 function nanoseconds (bun-types/bun.d.ts)
   call (): number
 function openInEditor (bun-types/bun.d.ts)
-  call (path: string, options?: EditorOptions | undefined): void
+  call (path: string, options?: Bun.EditorOptions | undefined): void
 var password (bun-types/bun.d.ts)
-  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
-  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
-  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
-  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+  hash: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => string
+  verify: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
 function pathToFileURL (bun-types/bun.d.ts)
   call (path: string): URL
 function peek (bun-types/bun.d.ts)
@@ -2611,49 +2636,49 @@ function peek (bun-types/bun.d.ts)
 namespace peek (bun-types/bun.d.ts)
   function peek.status (bun-types/bun.d.ts)
     call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
-var plugin (bun-types/bun.d.ts): BunRegisterPlugin
-var postgres (bun-types/sql.d.ts): SQL
+var plugin (bun-types/bun.d.ts): Bun.BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): Bun.SQL
 function randomUUIDv5 (bun-types/bun.d.ts)
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
 function randomUUIDv7 (bun-types/bun.d.ts)
   call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
   call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
 function readableStreamToArray (bun-types/bun.d.ts)
   call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
 function readableStreamToArrayBuffer (bun-types/bun.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
 function readableStreamToBlob (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<Blob>
 function readableStreamToBytes (bun-types/deprecated.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
 function readableStreamToFormData (bun-types/bun.d.ts)
-  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+  call (stream: ReadableStream<BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
 function readableStreamToJSON (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<any>
 function readableStreamToText (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<string>
-var redis (bun-types/redis.d.ts): RedisClient
+var redis (bun-types/redis.d.ts): Bun.RedisClient
 function resolve (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): Promise<string>
 function resolveSync (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): string
 var revision (bun-types/bun.d.ts): string
-var s3 (bun-types/s3.d.ts): S3Client
+var s3 (bun-types/s3.d.ts): Bun.S3Client
 var secrets (bun-types/bun.d.ts)
   delete: (options: { service: string; name: string; }) => Promise<boolean>
-  get: (options: { service: string; name: string; }) => Promise<string | null>
+  get: (options: { service: string; name: string; }) => Promise<null | string>
   set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
 namespace semver (bun-types/bun.d.ts)
   function semver.order (bun-types/bun.d.ts)
-    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+    call (v1: Bun.StringLike, v2: Bun.StringLike): -1 | 0 | 1
   function semver.satisfies (bun-types/bun.d.ts)
-    call (version: StringLike, range: StringLike): boolean
+    call (version: Bun.StringLike, range: Bun.StringLike): boolean
 function serve (bun-types/serve.d.ts)
-  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+  call <WebSocketData = undefined, R extends string = never>(options: Bun.Serve.Options<WebSocketData, R>): Bun.Server<WebSocketData>
 function sha (bun-types/bun.d.ts)
-  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
-  call (input: StringOrBuffer, encoding: DigestEncoding): string
+  call (input: Bun.StringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>
+  call (input: Bun.StringOrBuffer, encoding: Bun.DigestEncoding): string
 function shrink (bun-types/bun.d.ts)
   call (): void
 function sleep (bun-types/bun.d.ts)
@@ -2661,27 +2686,27 @@ function sleep (bun-types/bun.d.ts)
 function sleepSync (bun-types/bun.d.ts)
   call (ms: number): void
 function sliceAnsi (bun-types/bun.d.ts)
-  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: Bun.SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
 function spawn (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(options: Bun.SpawnOptions.SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Bun.Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnOptions<In, Out, Err> | undefined): Bun.Subprocess<In, Out, Err>
 function spawnSync (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
-var sql (bun-types/sql.d.ts): SQL
-var stderr (bun-types/bun.d.ts): BunFile
-var stdin (bun-types/bun.d.ts): BunFile
-var stdout (bun-types/bun.d.ts): BunFile
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(options: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): Bun.SyncSubprocess<Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> | undefined): Bun.SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): Bun.SQL
+var stderr (bun-types/bun.d.ts): Bun.BunFile
+var stdin (bun-types/bun.d.ts): Bun.BunFile
+var stdout (bun-types/bun.d.ts): Bun.BunFile
 function stringWidth (bun-types/bun.d.ts)
-  call (input: string, options?: StringWidthOptions | undefined): number
+  call (input: string, options?: Bun.StringWidthOptions | undefined): number
 function stripANSI (bun-types/bun.d.ts)
   call (input: string): string
 namespace udp (bun-types/bun.d.ts)
   interface udp.BaseUDPSocket (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2695,17 +2720,17 @@ namespace udp (bun-types/bun.d.ts)
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     connect: { hostname: string; port: number; }
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
-  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    socket [?]: Bun.udp.ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2713,29 +2738,29 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
-    remoteAddress [readonly]: SocketAddress
-    send: (data: Data) => boolean
-    sendMany: (packets: ReadonlyArray<Data>) => number
+    reload: (handler: Bun.udp.ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: Bun.SocketAddress
+    send: (data: Bun.udp.Data) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string
   interface udp.ReceiveFlags (bun-types/bun.d.ts)
     ipv6: boolean
     truncated: boolean
-  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.Socket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2743,27 +2768,27 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: SocketHandler<DataBinaryType>) => void
-    send: (data: Data, port: number, address: string) => boolean
-    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    reload: (handler: Bun.udp.SocketHandler<DataBinaryType>) => void
+    send: (data: Bun.udp.Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data | number>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.SocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.Socket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: SocketHandler<DataBinaryType> | undefined
+    socket [?]: Bun.udp.SocketHandler<DataBinaryType> | undefined
 function udpSocket (bun-types/bun.d.ts)
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.SocketOptions<DataBinaryType>): Promise<Bun.udp.Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.ConnectSocketOptions<DataBinaryType>): Promise<Bun.udp.ConnectedSocket<DataBinaryType>>
 namespace unsafe (bun-types/bun.d.ts)
   function unsafe.arrayBufferToString (bun-types/bun.d.ts)
     call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
@@ -2777,23 +2802,23 @@ namespace unsafe (bun-types/bun.d.ts)
 var version (bun-types/bun.d.ts): string
 var version_with_sha (bun-types/bun.d.ts): string
 function which (bun-types/bun.d.ts)
-  call (command: string, options?: WhichOptions | undefined): null | string
+  call (command: string, options?: Bun.WhichOptions | undefined): null | string
 function wrapAnsi (bun-types/bun.d.ts)
-  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+  call (input: string, columns: number, options?: Bun.WrapAnsiOptions | undefined): string
 function write (bun-types/bun.d.ts)
-  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile | Bun.PathLike | Bun.S3File, input: Array<Bun.BlobPart> | ArrayBufferLike | Blob | Bun.Archive | NodeJS.TypedArray<ArrayBufferLike> | ReadableStream<any> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
 function zstdCompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
 function zstdCompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
 function zstdDecompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
 function zstdDecompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
 
 # module "bun:bundle"
 interface Registry (bun-types/bundle.d.ts)
@@ -2892,17 +2917,17 @@ interface FFITypeToArgsType (bun-types/ffi.d.ts)
   1: number
   10: number
   11: boolean
-  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  12: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null
   13: undefined
-  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  14: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null | string
   15: bigint | number
   16: bigint | number
   17: JSCallback | Pointer
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2924,8 +2949,8 @@ interface FFITypeToReturnsType (bun-types/ffi.d.ts)
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2947,13 +2972,13 @@ type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
 type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
 type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
 function cc (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | Bun.BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
 function dlopen (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(name: Bun.BunFile | URL | string, symbols: Fns): Library<Fns>
 function linkSymbols (bun-types/ffi.d.ts)
   call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
 function ptr (bun-types/ffi.d.ts)
-  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
 namespace read (bun-types/ffi.d.ts)
   function read.f32 (bun-types/ffi.d.ts)
     call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
@@ -3026,7 +3051,7 @@ interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
 function callerSourceOrigin (bun-types/jsc.d.ts)
   call (): null | string
 function deserialize (bun-types/jsc.d.ts)
-  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>): any
 function drainMicrotasks (bun-types/jsc.d.ts)
   call (): void
 function edenGC (bun-types/jsc.d.ts)
@@ -3102,7 +3127,7 @@ class Database (bun-types/sqlite.d.ts)
   [static]
     construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
     MAX_QUERY_CACHE_SIZE [static]: number
-    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    deserialize [static]: { (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
     open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
     prototype: Database
     setCustomSQLite [static]: (path: string) => boolean
@@ -3112,7 +3137,7 @@ interface DatabaseOptions (bun-types/sqlite.d.ts)
   readwrite [?]: boolean | undefined
   safeIntegers [?]: boolean | undefined
   strict [?]: boolean | undefined
-type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+type SQLQueryBindings (bun-types/sqlite.d.ts) = NodeJS.TypedArray<ArrayBufferLike> | Record<string, NodeJS.TypedArray<ArrayBufferLike> | bigint | boolean | null | number | string> | bigint | boolean | null | number | string
 class SQLiteError (bun-types/sqlite.d.ts)
   byteOffset [readonly]: number
   cause [?]: unknown
@@ -3127,7 +3152,7 @@ class SQLiteError (bun-types/sqlite.d.ts)
     construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
     captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
     isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
     prototype: SQLiteError
     stackTraceLimit: number
 class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
@@ -3136,8 +3161,8 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   all: (...params: ParamsType) => Array<ReturnType>
   as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
   columnNames [readonly]: Array<string>
-  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
-  declaredTypes [readonly]: Array<string | null>
+  columnTypes [readonly]: Array<"BLOB" | "FLOAT" | "INTEGER" | "NULL" | "TEXT" | null>
+  declaredTypes [readonly]: Array<null | string>
   finalize: () => void
   get: (...params: ParamsType) => ReturnType | null
   iterate: (...params: ParamsType) => IterableIterator<ReturnType>
@@ -3146,7 +3171,7 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
   run: (...params: ParamsType) => Changes
   toString: () => string
-  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  values: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | bigint | boolean | number | string>>
   [static]
     construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
     prototype: Statement<any, any>
@@ -3223,7 +3248,7 @@ var native (bun-types/sqlite.d.ts): any
 # module "bun:test"
 type AsymmetricMatcher (bun-types/test.d.ts) = any
 interface AsymmetricMatchers (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3231,7 +3256,7 @@ interface AsymmetricMatchers (bun-types/test.d.ts)
   stringContaining: (str: String | string) => any
   stringMatching: (regex: RegExp | String | string) => any
 interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3257,7 +3282,7 @@ interface Expect (bun-types/test.d.ts)
   call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
   call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
   call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   assertions: (neededAssertions: number) => void
@@ -3324,13 +3349,13 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3344,7 +3369,7 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3410,13 +3435,13 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3430,7 +3455,7 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3447,9 +3472,9 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toThrowError: (expected?: unknown) => void
   toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
   toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
-type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
 interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
-  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  call (label: string, fn: (...args: __internal.IsTuple<T> extends true ? [...table: __internal.Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
   concurrent: Test<T>
   concurrentIf: (condition: boolean) => Test<T>
   each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
@@ -3485,23 +3510,23 @@ var expectTypeOf (bun-types/test.d.ts)
   call <Actual>(): PositiveExpectTypeOf<Actual>
 var it (bun-types/test.d.ts): Test<[]>
 namespace jest (bun-types/test.d.ts)
-  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
-  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
-  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
-  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
-  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
-  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
-  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = JestMock.Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | JestMock.ClassLike> (bun-types/test.d.ts) = T extends JestMock.ClassLike ? JestMock.SpiedClass<T> : T extends JestMock.FunctionLike ? JestMock.SpiedFunction<T> : never
+  type jest.SpiedClass<T extends JestMock.ClassLike> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<(arg: T) => void>
   function jest.advanceTimersByTime (bun-types/test.d.ts)
-    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.clearAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.clearAllTimers (bun-types/test.d.ts)
     call (): void
   function jest.fn (bun-types/test.d.ts)
-    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): jest.Mock<T>
   function jest.getTimerCount (bun-types/test.d.ts)
     call (): number
   function jest.isFakeTimers (bun-types/test.d.ts)
@@ -3511,19 +3536,19 @@ namespace jest (bun-types/test.d.ts)
   function jest.restoreAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.runAllTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.runOnlyPendingTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.setSystemTime (bun-types/test.d.ts)
     call (now?: Date | number | undefined): void
   function jest.setTimeout (bun-types/test.d.ts)
     call (milliseconds: number): void
   function jest.spyOn (bun-types/test.d.ts)
-    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): jest.Mock<Extract<T[K], (...args: Array<any>) => any>>
   function jest.useFakeTimers (bun-types/test.d.ts)
-    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.useRealTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var mock (bun-types/test.d.ts)
   call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
   clearAllMocks: () => void
@@ -3539,24 +3564,118 @@ function spyOn (bun-types/test.d.ts)
   call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
 test -> it
 var vi (bun-types/test.d.ts)
-  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   clearAllMocks: () => void
   clearAllTimers: () => void
-  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => jest.Mock<T>
   getTimerCount: () => number
   isFakeTimers: () => boolean
   mock: (id: string, factory: () => any) => Promise<void> | void
   resetAllMocks: () => void
   restoreAllMocks: () => void
-  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
-  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var xdescribe (bun-types/test.d.ts): Describe<[]>
 var xit (bun-types/test.d.ts): Test<[]>
 xtest -> xit
+
+# module "node:fs/promises"
+function exists (bun-types/overrides.d.ts)
+  call (path: Bun.PathLike): Promise<boolean>
+
+# module "node:tls"
+interface BunConnectionOptions (bun-types/overrides.d.ts)
+  ALPNCallback [?]: ((arg: { servername: string; protocols: Array<string>; }) => string | undefined) | undefined
+  ALPNProtocols [?]: NodeJS.ArrayBufferView<ArrayBufferLike> | ReadonlyArray<string> | undefined
+  SNICallback [?]: ((servername: string, cb: (err: Error | null, ctx?: SecureContext | undefined) => void) => void) | undefined
+  allowPartialTrustChain [?]: boolean | undefined
+  ca [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  cert [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientCertEngine [?]: string | undefined
+  crl [?]: Array<Buffer<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | string | undefined
+  dhparam [?]: Buffer<ArrayBufferLike> | string | undefined
+  ecdhCurve [?]: string | undefined
+  enableTrace [?]: boolean | undefined
+  honorCipherOrder [?]: boolean | undefined
+  host [?]: string | undefined
+  key [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | KeyObject | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  lookup [?]: LookupFunction | undefined
+  maxVersion [?]: SecureVersion | undefined
+  minDHSize [?]: number | undefined
+  minVersion [?]: SecureVersion | undefined
+  passphrase [?]: string | undefined
+  path [?]: string | undefined
+  pfx [?]: Array<Buffer<ArrayBufferLike> | PxfObject | string> | Buffer<ArrayBufferLike> | string | undefined
+  port [?]: number | undefined
+  privateKeyEngine [?]: string | undefined
+  privateKeyIdentifier [?]: string | undefined
+  pskCallback [?]: ((hint: null | string) => PSKCallbackNegotation | null) | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  requestOCSP [?]: boolean | undefined
+  secureContext [?]: SecureContext | undefined
+  secureOptions [?]: number | undefined
+  secureProtocol [?]: string | undefined
+  servername [?]: string | undefined
+  session [?]: Buffer<ArrayBufferLike> | undefined
+  sessionIdContext [?]: string | undefined
+  sessionTimeout [?]: number | undefined
+  sigalgs [?]: string | undefined
+  socket [?]: Stream.Duplex | undefined
+  ticketKeys [?]: Buffer<ArrayBufferLike> | undefined
+  timeout [?]: number | undefined
+function connect (@types/node/tls.d.ts, bun-types/overrides.d.ts)
+  call (options: ConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, host?: string | undefined, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (options: BunConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+
+# module "stream/web"
+interface ReadableStream<R = any> (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  construct new (underlyingSource: UnderlyingByteSource, strategy?: undefined | { highWaterMark?: number | undefined; }): ReadableStream<NodeJS.NonSharedUint8Array>
+  construct new <R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  from: <R = any>(iterable: AsyncIterable<R> | Iterable<R>) => ReadableStream<R>
+  prototype: ReadableStream<any>
+
+# module "url"
+interface URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  construct new (init?: Array<Array<string>> | Record<string, string> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
 
 # globals
 interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
@@ -3612,7 +3731,7 @@ interface ArrayConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es
   construct new <T>(...items: Array<T>): Array<T>
   [Symbol.species] [readonly]: ArrayConstructor
   from: { <T>(arrayLike: ArrayLike<T>): Array<T>; <T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>; <T>(iterable: ArrayLike<T> | Iterable<T>): Array<T>; <T, U>(iterable: ArrayLike<T> | Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U> }
-  fromAsync: { <T>(iterableOrArrayLike: ArrayLike<T | PromiseLike<T>> | AsyncIterable<T> | Iterable<T | PromiseLike<T>>): Promise<Array<T>>; <T, U>(iterableOrArrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Array<Awaited<U>>>; <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
+  fromAsync: { <T>(iterableOrArrayLike: ArrayLike<PromiseLike<T> | T> | AsyncIterable<T> | Iterable<PromiseLike<T> | T>): Promise<Array<T>>; <T, U>(iterableOrArrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Array<Awaited<U>>>; <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
   isArray: (arg: any) => arg is any[]
   of: <T>(...items: Array<T>) => Array<T>
   prototype [readonly]: Array<any>
@@ -3620,7 +3739,7 @@ interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.d
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
   bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   size [readonly]: number
   slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
@@ -3669,11 +3788,11 @@ interface BunFetchRequestInit (bun-types/globals.d.ts)
   mode [?]: RequestMode | undefined
   priority [?]: RequestPriority | undefined
   protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
-  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: Bun.HeadersInit | undefined; }
   redirect [?]: RequestRedirect | undefined
   referrer [?]: string | undefined
   referrerPolicy [?]: ReferrerPolicy | undefined
-  s3 [?]: S3Options | undefined
+  s3 [?]: Bun.S3Options | undefined
   signal [?]: AbortSignal | null | undefined
   timeout [?]: boolean | number | undefined
   tls [?]: BunFetchRequestInitTLS | undefined
@@ -3681,17 +3800,17 @@ interface BunFetchRequestInit (bun-types/globals.d.ts)
   verbose [?]: boolean | undefined
   window [?]: null | undefined
 interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -3741,7 +3860,7 @@ var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d
   construct new (format: CompressionFormat): CompressionStream
   prototype: CompressionStream
 interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
-  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  Console [readonly]: { new (stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
   [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
   assert: { (condition?: boolean | undefined, ...data: Array<any>): void; (condition?: boolean | undefined, ...data: Array<any>): void }
   clear: { (): void; (): void }
@@ -3765,14 +3884,14 @@ interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts,
   timeStamp: { (label?: string | undefined): void; (label?: string | undefined): void }
   trace: { (...data: Array<any>): void; (...data: Array<any>): void }
   warn: { (...data: Array<any>): void; (...data: Array<any>): void }
-  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+  write: (...data: Array<ArrayBuffer | ArrayBufferView<ArrayBufferLike> | string>) => number
 interface ConsoleOptions (bun-types/globals.d.ts)
   colorMode [?]: "auto" | boolean | undefined
   groupIndentation [?]: number | undefined
   ignoreErrors [?]: boolean | undefined
   inspectOptions [?]: InspectOptions | undefined
-  stderr [?]: Writable | undefined
-  stdout: Writable
+  stderr [?]: Stream.Writable | undefined
+  stdout: Stream.Writable
 interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   highWaterMark [readonly]: number
   size [readonly]: QueuingStrategySize<any>
@@ -3783,7 +3902,7 @@ interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, l
   getRandomValues: { <T extends ArrayBufferView<ArrayBuffer>>(array: T): T; <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T): T }
   randomUUID: { (): `${string}-${string}-${string}-${string}-${string}`; (): `${string}-${string}-${string}-${string}-${string}` }
   subtle [readonly]: SubtleCrypto
-  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+  timingSafeEqual: (a: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>) => boolean
 var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   construct new (): Crypto
   prototype: Crypto
@@ -3916,7 +4035,7 @@ interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, li
   construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
   captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
   isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
   prototype [readonly]: Error
   stackTraceLimit: number
 interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
@@ -4051,7 +4170,7 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.d
   arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
   bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified [readonly]: number
   name [readonly]: string
@@ -4069,9 +4188,9 @@ interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, 
   append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
   delete: { (name: string): void; (name: string): void }
   entries: { (): FormDataIterator<[string, FormDataEntryValue]>; (): IterableIterator<[string, string]> }
-  forEach: { (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void; (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void }
-  get: { (name: string): FormDataEntryValue | null; (name: string): FormDataEntryValue | null }
-  getAll: { (name: string): Array<FormDataEntryValue>; (name: string): Array<FormDataEntryValue> }
+  forEach: { (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void; (callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void }
+  get: { (name: string): FormDataEntryValue | null; (name: string): Bun.FormDataEntryValue | null }
+  getAll: { (name: string): Array<FormDataEntryValue>; (name: string): Array<Bun.FormDataEntryValue> }
   has: { (name: string): boolean; (name: string): boolean }
   keys: { (): FormDataIterator<string>; (): IterableIterator<string> }
   set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
@@ -4080,19 +4199,19 @@ var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.do
   construct new (form?: HTMLFormElement | undefined, submitter?: HTMLElement | null | undefined): FormData
   prototype: FormData
 class HTMLRewriter (bun-types/html-rewriter.d.ts)
-  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
-  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
-  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  on: (selector: string, handlers: HTMLRewriterTypes.HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: Bun.BufferSource): ArrayBuffer }
   [static]
     construct new (): HTMLRewriter
     prototype: HTMLRewriter
 namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Comment
-    before: (content: string, options?: ContentOptions | undefined) => Comment
-    remove: () => Comment
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    remove: () => HTMLRewriterTypes.Comment
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
     text: string
   type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
   interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
@@ -4100,52 +4219,52 @@ namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
     name [readonly]: null | string
     publicId [readonly]: null | string
-    remove: () => Doctype
+    remove: () => HTMLRewriterTypes.Doctype
     removed [readonly]: boolean
     systemId [readonly]: null | string
   interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
-    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.DocumentEnd
   interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Element
-    append: (content: string, options?: ContentOptions | undefined) => Element
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     attributes [readonly]: IterableIterator<[string, string]>
-    before: (content: string, options?: ContentOptions | undefined) => Element
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     canHaveContent [readonly]: boolean
     getAttribute: (name: string) => null | string
     hasAttribute: (name: string) => boolean
     namespaceURI [readonly]: string
-    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
-    prepend: (content: string, options?: ContentOptions | undefined) => Element
-    remove: () => Element
-    removeAndKeepContent: () => Element
-    removeAttribute: (name: string) => Element
+    onEndTag: (handler: (tag: HTMLRewriterTypes.EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    remove: () => HTMLRewriterTypes.Element
+    removeAndKeepContent: () => HTMLRewriterTypes.Element
+    removeAttribute: (name: string) => HTMLRewriterTypes.Element
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Element
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     selfClosing [readonly]: boolean
-    setAttribute: (name: string, value: string) => Element
-    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    setAttribute: (name: string, value: string) => HTMLRewriterTypes.Element
+    setInnerContent: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     tagName: string
   interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => EndTag
-    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
     name: string
-    remove: () => EndTag
+    remove: () => HTMLRewriterTypes.EndTag
   interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
-    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: HTMLRewriterTypes.Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: HTMLRewriterTypes.DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    element [?]: ((element: Element) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: HTMLRewriterTypes.Element) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Text
-    before: (content: string, options?: ContentOptions | undefined) => Text
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     lastInTextNode [readonly]: boolean
-    remove: () => Text
+    remove: () => HTMLRewriterTypes.Text
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Text
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     text [readonly]: string
 interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   [Symbol.iterator]: () => HeadersIterator<[string, string]>
@@ -4168,13 +4287,13 @@ var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom
 interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.dom.d.ts, lib.es5.d.ts)
   dir [readonly]: string
   dirname: string
-  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  env [readonly]: Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
   file [readonly]: string
   filename: string
-  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: Bun.HMREvent, callback: () => void): void; off(event: Bun.HMREvent, callback: () => void): void; }
   main: boolean
   path [readonly]: string
-  require: Require
+  require: NodeJS.Require
   resolve: { (specifier: string): string; (specifier: string, parent?: URL | string | undefined): string }
   resolveSync: (moduleId: string, parent?: string | undefined) => string
   url: string
@@ -4286,160 +4405,14 @@ var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, l
   construct new (): Navigator
   prototype: Navigator
 namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
-  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
-  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
-  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.asyncDispose]: () => PromiseLike<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
-    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
-    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
-  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
-  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
-  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
-  interface NodeJS.CallSite (@types/node/globals.d.ts)
-    getColumnNumber: () => null | number
-    getEnclosingColumnNumber: () => null | number
-    getEnclosingLineNumber: () => null | number
-    getEvalOrigin: () => string | undefined
-    getFileName: () => null | string
-    getFunction: () => Function | undefined
-    getFunctionName: () => null | string
-    getLineNumber: () => null | number
-    getMethodName: () => null | string
-    getPosition: () => number
-    getPromiseIndex: () => null | number
-    getScriptHash: () => string
-    getScriptNameOrSourceURL: () => null | string
-    getThis: () => unknown
-    getTypeName: () => null | string
-    isAsync: () => boolean
-    isConstructor: () => boolean
-    isEval: () => boolean
-    isNative: () => boolean
-    isPromiseAll: () => boolean
-    isToplevel: () => boolean
-  interface NodeJS.CpuUsage (@types/node/process.d.ts)
-    system: number
-    user: number
-  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined
-  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
-  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
-    code [?]: string | undefined
-    ctor [?]: Function | undefined
-    detail [?]: string | undefined
-    type [?]: string | undefined
-  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
-    cause [?]: unknown
-    code [?]: string | undefined
-    errno [?]: number | undefined
-    message: string
-    name: string
-    path [?]: string | undefined
-    stack [?]: string | undefined
-    syscall [?]: string | undefined
-  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
-    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
-    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    setMaxListeners: (n: number) => EventEmitter<T>
-  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
-  interface NodeJS.GCFunction (@types/node/globals.d.ts)
-    call (minor?: boolean | undefined): void
-    call (options: GCOptions & { execution: "async"; }): Promise<void>
-    call (options: GCOptions): void
-  interface NodeJS.GCOptions (@types/node/globals.d.ts)
-    execution [?]: "async" | "sync" | undefined
-    filename [?]: string | undefined
-    flavor [?]: "last-resort" | "regular" | undefined
-    type [?]: "major" | "major-snapshot" | "minor" | undefined
-  interface NodeJS.HRTime (@types/node/process.d.ts)
-    call (time?: [number, number] | undefined): [number, number]
-    bigint: () => bigint
-  interface NodeJS.Immediate (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    _onImmediate: (...args: Array<any>) => void
-    hasRef: () => boolean
-    ref: () => Immediate
-    unref: () => Immediate
-  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
-    [Symbol.toStringTag] [readonly]: string
-    drop: (count: number) => IteratorObject<T, undefined, unknown>
-    every: (predicate: (value: T, index: number) => unknown) => boolean
-    filter: { <S>(predicate: (value: T, index: number) => value is S): IteratorObject<S, undefined, unknown>; (predicate: (value: T, index: number) => unknown): IteratorObject<T, undefined, unknown> }
-    find: { <S>(predicate: (value: T, index: number) => value is S): S | undefined; (predicate: (value: T, index: number) => unknown): T | undefined }
-    flatMap: <U>(callback: (value: T, index: number) => Iterable<U, unknown, undefined> | Iterator<U, unknown, undefined>) => IteratorObject<U, undefined, unknown>
-    forEach: (callbackfn: (value: T, index: number) => void) => void
-    map: <U>(callbackfn: (value: T, index: number) => U) => IteratorObject<U, undefined, unknown>
-    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
-    reduce: { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number) => U, initialValue: U): U }
-    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
-    some: (predicate: (value: T, index: number) => unknown) => boolean
-    take: (limit: number) => IteratorObject<T, undefined, unknown>
-    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
-    toArray: () => Array<T>
-  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
-    arrayBuffers: number
-    external: number
-    heapTotal: number
-    heapUsed: number
-    rss: number
-  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
-    call (): MemoryUsage
-    rss: () => number
-  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
-  interface NodeJS.Module (@types/node/module.d.ts)
-    children: Array<Module>
-    exports: any
-    filename: string
-    id: string
-    isPreloading: boolean
-    loaded: boolean
-    parent: Module | null | undefined
-    path: string
-    paths: Array<string>
-    require: (id: string) => any
-  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
-  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
-  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
-  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
-  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
-  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
-  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
-  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
-  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
-  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
-  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
   interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
     [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
     _exiting: boolean
     abort: () => never
-    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
     allowedNodeEnvironmentFlags: ReadonlySet<string>
-    arch [readonly]: Architecture
+    arch [readonly]: NodeJS.Architecture
     argv: Array<string>
     argv0: string
     assert: (value: unknown, message?: Error | string | undefined) => asserts value
@@ -4448,24 +4421,24 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     browser: boolean
     channel [?]: Control | undefined
     chdir: (directory: string) => void
-    config [readonly]: ProcessConfig
+    config [readonly]: NodeJS.ProcessConfig
     connected: boolean
     constrainedMemory: () => number
-    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     cwd: () => string
     debugPort: number
     disconnect [?]: (() => void) | undefined
     dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
     emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
-    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
-    env: ProcessEnv
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: NodeJS.EmitWarningOptions | undefined): void }
+    env: NodeJS.ProcessEnv
     eventNames: () => Array<string | symbol>
     execArgv: Array<string>
     execPath: string
-    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: NodeJS.ProcessEnv | undefined) => never) | undefined
     exit: (code?: null | number | string | undefined) => never
     exitCode: null | number | string | undefined
-    features [readonly]: ProcessFeatures
+    features [readonly]: NodeJS.ProcessFeatures
     finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
     getActiveResourcesInfo: () => Array<string>
     getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
@@ -4476,48 +4449,48 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     getgroups [?]: (() => Array<number>) | undefined
     getuid [?]: (() => number) | undefined
     hasUncaughtExceptionCaptureCallback: () => boolean
-    hrtime: HRTime
+    hrtime: NodeJS.HRTime
     isBun: true
     kill: (pid: number, signal?: number | string | undefined) => true
     listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
     listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     loadEnvFile: (path?: PathLike | undefined) => void
-    mainModule [?]: Module | undefined
-    memoryUsage: MemoryUsageFn
+    mainModule [?]: NodeJS.Module | undefined
+    memoryUsage: NodeJS.MemoryUsageFn
     nextTick: (callback: Function, ...args: Array<any>) => void
     noDeprecation [?]: boolean | undefined
-    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    permission: ProcessPermission
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    permission: NodeJS.ProcessPermission
     pid [readonly]: number
-    platform [readonly]: Platform
+    platform [readonly]: NodeJS.Platform
     ppid [readonly]: number
-    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     reallyExit: (code?: number | undefined) => never
     ref: (maybeRefable: any) => void
-    release [readonly]: ProcessRelease
-    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
-    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    report: ProcessReport
-    resourceUsage: () => ResourceUsage
+    release [readonly]: NodeJS.ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): NodeJS.Process; (eventName?: string | symbol | undefined): NodeJS.Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    report: NodeJS.ProcessReport
+    resourceUsage: () => NodeJS.ResourceUsage
     revision: string
     send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
-    setMaxListeners: (n: number) => Process
+    setMaxListeners: (n: number) => NodeJS.Process
     setSourceMapsEnabled: (value: boolean) => void
     setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
     setegid [?]: ((id: number | string) => void) | undefined
     seteuid [?]: ((id: number | string) => void) | undefined
     setgid [?]: ((id: number | string) => void) | undefined
-    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<number | string>) => void) | undefined
     setuid [?]: ((id: number | string) => void) | undefined
     sourceMapsEnabled [readonly]: boolean
-    stderr: WriteStream & { fd: 2; }
-    stdin: ReadStream & { fd: 0; }
-    stdout: WriteStream & { fd: 1; }
-    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    stderr: NodeJS.WriteStream & { fd: 2; }
+    stdin: NodeJS.ReadStream & { fd: 0; }
+    stdout: NodeJS.WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     throwDeprecation: boolean
     title: string
     traceDeprecation: boolean
@@ -4526,45 +4499,11 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     unref: (maybeRefable: any) => void
     uptime: () => number
     version [readonly]: string
-    versions [readonly]: ProcessVersions
-  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
-    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
-    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+    versions [readonly]: NodeJS.ProcessVersions
   interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     NODE_ENV [?]: string | undefined
     TZ [?]: string | undefined
-  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
-    cached_builtins [readonly]: boolean
-    debug [readonly]: boolean
-    inspector [readonly]: boolean
-    ipv6 [readonly]: boolean
-    require_module [readonly]: boolean
-    tls [readonly]: boolean
-    tls_alpn [readonly]: boolean
-    tls_ocsp [readonly]: boolean
-    tls_sni [readonly]: boolean
-    typescript [readonly]: "strip" | false
-    uv [readonly]: boolean
-  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
-    has: (scope: string, reference?: string | undefined) => boolean
-  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
-    headersUrl [?]: string | undefined
-    libUrl [?]: string | undefined
-    lts [?]: string | undefined
-    name: string
-    sourceUrl [?]: string | undefined
-  interface NodeJS.ProcessReport (@types/node/process.d.ts)
-    compact: boolean
-    directory: string
-    excludeEnv: boolean
-    filename: string
-    getReport: (err?: Error | undefined) => object
-    reportOnFatalError: boolean
-    reportOnSignal: boolean
-    reportOnUncaughtException: boolean
-    signal: Signals
-    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
   interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     ares: string
@@ -4576,404 +4515,14 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     uv: string
     v8: string
     zlib: string
-  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined [readonly]
-  interface NodeJS.ReadStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    closed [readonly]: boolean
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    destroy: (error?: Error | undefined) => ReadStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    isPaused: () => boolean
-    isRaw: boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    pause: () => ReadStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => ReadStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
-    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    resetAndDestroy: () => ReadStream
-    resume: () => ReadStream
-    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
-    setMaxListeners: (n: number) => ReadStream
-    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
-    setRawMode: (mode: boolean) => ReadStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
-    setTypeOfService: (tos: number) => ReadStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => ReadStream
-    unref: () => ReadStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => ReadStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    pause: () => ReadWriteStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    resume: () => ReadWriteStream
-    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
-    setMaxListeners: (n: number) => ReadWriteStream
-    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadWriteStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    pause: () => ReadableStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    resume: () => ReadableStream
-    setEncoding: (encoding: BufferEncoding) => ReadableStream
-    setMaxListeners: (n: number) => ReadableStream
-    unpipe: (destination?: WritableStream | undefined) => ReadableStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadableStream
-  interface NodeJS.RefCounted (@types/node/globals.d.ts)
-    ref: () => RefCounted
-    unref: () => RefCounted
-  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
-  interface NodeJS.Require (@types/node/module.d.ts)
-    call (id: string): any
-    cache: Dict<Module>
-    extensions: RequireExtensions
-    main: Module | undefined
-    resolve: RequireResolve
-  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
-    index [string]: ((module: Module, filename: string) => any) | undefined
-    .js: (module: Module, filename: string) => any
-    .json: (module: Module, filename: string) => any
-    .node: (module: Module, filename: string) => any
-  interface NodeJS.RequireResolve (@types/node/module.d.ts)
-    call (request: string, options?: RequireResolveOptions | undefined): string
-    paths: (request: string) => Array<string> | null
-  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
-    paths [?]: Array<string> | undefined
-  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
-    fsRead: number
-    fsWrite: number
-    involuntaryContextSwitches: number
-    ipcReceived: number
-    ipcSent: number
-    majorPageFault: number
-    maxRSS: number
-    minorPageFault: number
-    sharedMemorySize: number
-    signalsCount: number
-    swappedOut: number
-    systemCPUTime: number
-    unsharedDataSize: number
-    unsharedStackSize: number
-    userCPUTime: number
-    voluntaryContextSwitches: number
-  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
-  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
-  interface NodeJS.Socket (@types/node/process.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    isTTY [?]: true | undefined
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    pause: () => Socket
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    resume: () => Socket
-    setEncoding: (encoding: BufferEncoding) => Socket
-    setMaxListeners: (n: number) => Socket
-    unpipe: (destination?: WritableStream | undefined) => Socket
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => Socket
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.Timeout (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.toPrimitive]: () => number
-    _onTimeout: (...args: Array<any>) => void
-    close: () => Timeout
-    hasRef: () => boolean
-    ref: () => Timeout
-    refresh: () => Timeout
-    unref: () => Timeout
-  interface NodeJS.Timer (@types/node/timers.d.ts)
-    [Symbol.toPrimitive]: () => number
-    hasRef: () => boolean
-    ref: () => Timer
-    refresh: () => Timer
-    unref: () => Timer
-  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
-  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
-  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
-  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
-  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
-  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
-  interface NodeJS.WritableStream (@types/node/stream.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    setMaxListeners: (n: number) => WritableStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.WriteStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
-    clearScreenDown: (callback?: (() => void) | undefined) => boolean
-    closed [readonly]: boolean
-    columns: number
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
-    destroy: (error?: Error | undefined) => WriteStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
-    getColorDepth: (env?: object | undefined) => number
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    getWindowSize: () => [number, number]
-    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
-    isPaused: () => boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
-    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    pause: () => WriteStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => WriteStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
-    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    resetAndDestroy: () => WriteStream
-    resume: () => WriteStream
-    rows: number
-    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
-    setMaxListeners: (n: number) => WriteStream
-    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
-    setTypeOfService: (tos: number) => WriteStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => WriteStream
-    unref: () => WriteStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => WriteStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
 interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
-  children: Array<Module>
+  children: Array<NodeJS.Module>
   exports: any
   filename: string
   id: string
   isPreloading: boolean
   loaded: boolean
-  parent: Module | null | undefined
+  parent: NodeJS.Module | null | undefined
   path: string
   paths: Array<string>
   require: (id: string) => any
@@ -5084,11 +4633,11 @@ interface Position (bun-types/globals.d.ts)
 interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts, lib.es2024.promise.d.ts, lib.es2025.promise.d.ts)
   construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
   [Symbol.species] [readonly]: PromiseConstructor
-  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
   prototype [readonly]: Promise<any>
-  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
   reject: <T = never>(reason?: any) => Promise<T>
   resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
   try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
@@ -5158,8 +4707,8 @@ interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
 interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
   closed [readonly]: Promise<void>
-  read: { (): Promise<ReadableStreamReadResult<R>>; (): Promise<ReadableStreamDefaultReadResult<R>> }
-  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  read: { (): Promise<ReadableStreamReadResult<R>>; (): Promise<Bun.ReadableStreamDefaultReadResult<R>> }
+  readMany: () => Bun.ReadableStreamDefaultReadManyResult<R> | Promise<Bun.ReadableStreamDefaultReadManyResult<R>>
   releaseLock: { (): void; (): void }
 var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
@@ -5169,7 +4718,7 @@ interface ReadableStreamDirectController (bun-types/globals.d.ts)
   end: () => Promise<number> | number
   flush: (wait?: boolean | undefined) => Promise<number> | number
   start: () => void
-  write: (data: BufferSource | string) => Promise<number> | number
+  write: (data: Bun.BufferSource | string) => Promise<number> | number
 interface ReadableStreamGenericReader (bun-types/globals.d.ts, lib.dom.d.ts)
   cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
   closed [readonly]: Promise<void>
@@ -5343,7 +4892,7 @@ var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d
   prototype: TextDecoderStream
 interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   encode: (input?: string | undefined) => Uint8Array<ArrayBuffer>
-  encodeInto: { (source: string, destination: Uint8Array<ArrayBufferLike>): TextEncoderEncodeIntoResult; (src?: string | undefined, dest?: BufferSource | undefined): TextEncoderEncodeIntoResult }
+  encodeInto: { (source: string, destination: Uint8Array<ArrayBufferLike>): TextEncoderEncodeIntoResult; (src?: string | undefined, dest?: Bun.BufferSource | undefined): TextEncoderEncodeIntoResult }
   encoding [readonly]: string
 var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   construct new (): TextEncoder
@@ -5460,7 +5009,7 @@ interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bu
   subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
   toBase64: { (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string; (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string }
   toHex: { (): string; (): string }
-  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: Intl.NumberFormatOptions | undefined): string }
   toReversed: () => Uint8Array<ArrayBuffer>
   toSorted: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<ArrayBuffer>
   toString: () => string
@@ -5483,113 +5032,87 @@ interface Uint8ArrayConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.t
   of: (...items: Array<number>) => Uint8Array<ArrayBuffer>
   prototype [readonly]: Uint8Array<ArrayBufferLike>
 namespace WebAssembly (bun-types/wasm.d.ts, lib.dom.d.ts)
-  type WebAssembly.AddressType (lib.dom.d.ts) = "i32" | "i64"
-  type WebAssembly.AddressValue (lib.dom.d.ts) = number
   interface WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (message?: string | undefined): CompileError
-    construct new (message?: string | undefined): CompileError
-    prototype: CompileError
-  interface WebAssembly.Exception (lib.dom.d.ts)
-    getArg: (exceptionTag: Tag, index: number) => any
-    is: (exceptionTag: Tag) => boolean
-    stack [readonly]: string | undefined
-  var WebAssembly.Exception (lib.dom.d.ts)
-    construct new (exceptionTag: Tag, payload: Array<any>, options?: ExceptionOptions | undefined): Exception
-    prototype: Exception
-  interface WebAssembly.ExceptionOptions (lib.dom.d.ts)
-    traceStack [?]: boolean | undefined
-  type WebAssembly.ExportValue (lib.dom.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
-  type WebAssembly.Exports (lib.dom.d.ts) = { [x: string]: ExportValue; }
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
+    call (message?: string | undefined): WebAssembly.CompileError
+    construct new (message?: string | undefined): WebAssembly.CompileError
+    prototype: WebAssembly.CompileError
+  interface WebAssembly.Global<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    value: WebAssembly.ValueTypeMap[T]
+    valueOf: () => WebAssembly.ValueTypeMap[T]
   var WebAssembly.Global (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
-    prototype: Global<keyof ValueTypeMap>
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new <T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap>(descriptor: WebAssembly.GlobalDescriptor<T>, v?: WebAssembly.ValueTypeMap[T] | undefined): WebAssembly.Global<T>
+    prototype: WebAssembly.Global<keyof WebAssembly.ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
     mutable [?]: boolean | undefined
     value: T
-  type WebAssembly.ImportExportKind (lib.dom.d.ts) = "function" | "global" | "memory" | "table" | "tag"
-  type WebAssembly.ImportValue (lib.dom.d.ts) = number | ExportValue
-  type WebAssembly.Imports (lib.dom.d.ts) = { [x: string]: ModuleImports; }
   interface WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: WebAssembly.Exports
   var WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (module: Module, importObject?: Imports | undefined): Instance
-    prototype: Instance
-  var WebAssembly.JSTag (lib.dom.d.ts): Tag
+    construct new (module: WebAssembly.Module, importObject?: WebAssembly.Imports | undefined): WebAssembly.Instance
+    prototype: WebAssembly.Instance
   interface WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (message?: string | undefined): LinkError
-    construct new (message?: string | undefined): LinkError
-    prototype: LinkError
+    call (message?: string | undefined): WebAssembly.LinkError
+    construct new (message?: string | undefined): WebAssembly.LinkError
+    prototype: WebAssembly.LinkError
   interface WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
     buffer [readonly]: ArrayBuffer
     grow: (delta: number) => number
     toFixedLengthBuffer: () => ArrayBuffer
     toResizableBuffer: () => ArrayBuffer
   var WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (descriptor: MemoryDescriptor): Memory
-    prototype: Memory
+    construct new (descriptor: WebAssembly.MemoryDescriptor): WebAssembly.Memory
+    prototype: WebAssembly.Memory
   interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    address [?]: AddressType | undefined
+    address [?]: WebAssembly.AddressType | undefined
     initial: number
     maximum [?]: number | undefined
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
   var WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Module
-    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
-    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
-    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
-    prototype: Module
+    construct new (bytes: BufferSource, options?: WebAssembly.WebAssemblyCompileOptions | undefined): WebAssembly.Module
+    customSections: (moduleObject: WebAssembly.Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleExportDescriptor>
+    imports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleImportDescriptor>
+    prototype: WebAssembly.Module
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    kind: ImportExportKind
+    kind: WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    kind: ImportExportKind
+    kind: WebAssembly.ImportExportKind
     module: string
     name: string
-  type WebAssembly.ModuleImports (lib.dom.d.ts) = { [x: string]: ImportValue; }
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (message?: string | undefined): RuntimeError
-    construct new (message?: string | undefined): RuntimeError
-    prototype: RuntimeError
+    call (message?: string | undefined): WebAssembly.RuntimeError
+    construct new (message?: string | undefined): WebAssembly.RuntimeError
+    prototype: WebAssembly.RuntimeError
   interface WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
     get: (index: number) => any
     grow: (delta: number, value?: any) => number
     length [readonly]: number
     set: (index: number, value?: any) => void
   var WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
-    construct new (descriptor: TableDescriptor, value?: any): Table
-    prototype: Table
+    construct new (descriptor: WebAssembly.TableDescriptor, value?: any): WebAssembly.Table
+    prototype: WebAssembly.Table
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
-    address [?]: AddressType | undefined
-    element: TableKind
+    address [?]: WebAssembly.AddressType | undefined
+    element: WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
-  type WebAssembly.TableKind (lib.dom.d.ts) = "anyfunc" | "externref"
-  interface WebAssembly.Tag (lib.dom.d.ts)
-  var WebAssembly.Tag (lib.dom.d.ts)
-    construct new (type: TagType): Tag
-    prototype: Tag
-  interface WebAssembly.TagType (lib.dom.d.ts)
-    parameters: Array<keyof ValueTypeMap>
-  type WebAssembly.ValueType (lib.dom.d.ts) = keyof ValueTypeMap
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts, lib.dom.d.ts)
     anyfunc: Function
     externref: any
@@ -5598,29 +5121,26 @@ namespace WebAssembly (bun-types/wasm.d.ts, lib.dom.d.ts)
     i32: number
     i64: bigint
     v128: never
-  interface WebAssembly.WebAssemblyCompileOptions (lib.dom.d.ts)
-    builtins [?]: Array<string> | undefined
-    importedStringConstants [?]: null | string | undefined
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts, lib.dom.d.ts)
-    instance: Instance
-    module: Module
+    instance: WebAssembly.Instance
+    module: WebAssembly.Module
   function WebAssembly.compile (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
-    call (bytes: BufferSource): Promise<Module>
+    call (bytes: BufferSource, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.Module>
+    call (bytes: Bun.BufferSource): Promise<WebAssembly.Module>
   function WebAssembly.compileStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (source: PromiseLike<Response> | Response, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
-    call (source: PromiseLike<Response> | Response): Promise<Module>
+    call (source: PromiseLike<Response> | Response, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.Module>
+    call (source: PromiseLike<Response> | Response): Promise<WebAssembly.Module>
   function WebAssembly.instantiate (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (bytes: BufferSource, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
-    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+    call (bytes: BufferSource, importObject?: WebAssembly.Imports | undefined, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (moduleObject: WebAssembly.Module, importObject?: WebAssembly.Imports | undefined): Promise<WebAssembly.Instance>
+    call (bytes: Bun.BufferSource, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (moduleObject: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.Instance>
   function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: WebAssembly.Imports | undefined, options?: WebAssembly.WebAssemblyCompileOptions | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
   function WebAssembly.validate (bun-types/wasm.d.ts, lib.dom.d.ts)
-    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): boolean
-    call (bytes: BufferSource): boolean
+    call (bytes: BufferSource, options?: WebAssembly.WebAssemblyCompileOptions | undefined): boolean
+    call (bytes: Bun.BufferSource): boolean
 interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
@@ -5698,21 +5218,21 @@ function addEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
   call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
   call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
   call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
 function alert (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message?: any): void
   call (message?: string | undefined): void
 function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (immediate: Immediate | undefined): void
+  call (immediate: NodeJS.Immediate | undefined): void
 function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (id: number | undefined): void
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (id: number | undefined): void
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function confirm (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message?: string | undefined): boolean
   call (message?: string | undefined): boolean
@@ -5734,7 +5254,7 @@ var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.t
 function postMessage (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message: any, targetOrigin: string, transfer?: Array<Transferable> | undefined): void
   call (message: any, options?: WindowPostMessageOptions | undefined): void
-  call (message: any, transfer?: Array<Transferable> | undefined): void
+  call (message: any, transfer?: Array<Bun.Transferable> | undefined): void
 function prompt (bun-types/globals.d.ts, lib.dom.d.ts)
   call (message?: string | undefined, _default?: string | undefined): null | string
   call (message?: string | undefined, _default?: string | undefined): null | string
@@ -5745,32 +5265,28 @@ function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.
 function removeEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
   call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
   call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
-  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void
 function reportError (bun-types/globals.d.ts, lib.dom.d.ts)
   call (e: any): void
   call (error: any): void
-var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): NodeJS.Require
 function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  call (handler: Bun.TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Immediate
   __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
-  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
 function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
-  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
   __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
-  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
   call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T
-  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T>(value: T, options?: Bun.StructuredSerializeOptions | undefined): T
   call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/esnext-dom.txt
+++ b/test/integration/bun-types/inventory/esnext-dom.txt
@@ -1,0 +1,5776 @@
+# bun-types inventory: preset esnext-dom
+# lib: lib.esnext.d.ts, lib.dom.d.ts, lib.dom.iterable.d.ts, lib.dom.asynciterable.d.ts
+# typescript: 6.0.2
+# @types/node: 26.2.0
+# undici-types: 8.3.0
+
+# module "*.html"
+
+# module "*.json5"
+
+# module "*.jsonc"
+
+# module "*.toml"
+
+# module "*.txt"
+
+# module "*.xml"
+
+# module "*.yaml"
+
+# module "*.yml"
+
+# module "*/bun.lock"
+
+# module "bun"
+type $ (bun-types/shell.d.ts) = typeof $
+function $ (bun-types/shell.d.ts)
+  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
+  Shell: new () => typeof $
+  ShellError: typeof ShellError
+  ShellPromise: typeof ShellPromise
+  braces: (pattern: string) => Array<string>
+  cwd: (newCwd?: string | undefined) => typeof $
+  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  escape: (input: string) => string
+  nothrow: () => typeof $
+  throws: (shouldThrow: boolean) => typeof $
+namespace $ (bun-types/shell.d.ts)
+  var $.Shell (bun-types/shell.d.ts)
+    construct new (): typeof $
+  class $.ShellError (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    cause [?]: unknown
+    exitCode [readonly]: number
+    json: () => any
+    message: string
+    name: string
+    stack [?]: string | undefined
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+    [static]
+      construct new (message?: string | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: ShellError
+      stackTraceLimit: number
+  interface $.ShellOutput (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    exitCode [readonly]: number
+    json: () => any
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+  class $.ShellPromise (bun-types/shell.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    arrayBuffer: () => Promise<ArrayBuffer>
+    blob: () => Promise<Blob>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
+    cwd: (newCwd: string) => ShellPromise
+    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    json: () => Promise<any>
+    lines: () => AsyncIterable<string>
+    nothrow: () => ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    stdin: WritableStream<any>
+    text: (encoding?: BufferEncoding | undefined) => Promise<string>
+    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => ShellPromise
+    [static]
+      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      [Symbol.species] [readonly]: PromiseConstructor
+      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+      prototype: ShellPromise
+      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      reject: <T = never>(reason?: any) => Promise<T>
+      resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+      try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
+      withResolvers: { <T>(): PromiseWithResolvers<T>; <T>(): { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; } }
+  function $.braces (bun-types/shell.d.ts)
+    call (pattern: string): Array<string>
+  function $.cwd (bun-types/shell.d.ts)
+    call (newCwd?: string | undefined): typeof $
+  function $.env (bun-types/shell.d.ts)
+    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+  function $.escape (bun-types/shell.d.ts)
+    call (input: string): string
+  function $.nothrow (bun-types/shell.d.ts)
+    call (): typeof $
+  function $.throws (bun-types/shell.d.ts)
+    call (shouldThrow: boolean): typeof $
+interface AbstractWorker (bun-types/bun.d.ts)
+  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+interface AbstractWorkerEventMap (bun-types/bun.d.ts)
+  error: ErrorEvent
+interface AddEventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc" | "ppc64" | "s390" | "s390x" | "x64"
+class Archive (bun-types/bun.d.ts)
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
+  [static]
+    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
+    prototype: Archive
+    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
+interface ArchiveExtractOptions (bun-types/bun.d.ts)
+  glob [?]: ReadonlyArray<string> | string | undefined
+type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+interface ArchiveOptions (bun-types/bun.d.ts)
+  compress [?]: "gzip" | undefined
+  level [?]: number | undefined
+class ArrayBufferSink (bun-types/bun.d.ts)
+  end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
+  flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
+  start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  [static]
+    construct new (): ArrayBufferSink
+    prototype: ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
+type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+interface BinaryTypeList (bun-types/bun.d.ts)
+  arraybuffer: ArrayBuffer
+  buffer: Buffer<ArrayBufferLike>
+  uint8array: Uint8Array<ArrayBuffer>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
+type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+namespace Build (bun-types/bun.d.ts)
+  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
+  type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
+interface BuildArtifact (bun-types/bun.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  hash: null | string
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
+  loader: Loader
+  path: string
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  sourcemap: BuildArtifact | null
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+interface BuildConfig (bun-types/bun.d.ts)
+  allowUnresolved [?]: Array<string> | undefined
+  banner [?]: string | undefined
+  bytecode [?]: boolean | undefined
+  bytecodeDepth [?]: number | undefined
+  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  conditions [?]: Array<string> | string | undefined
+  define [?]: Record<string, string> | undefined
+  deprecatedNamespaceObjectSetters [?]: boolean | undefined
+  drop [?]: Array<string> | undefined
+  emitDCEAnnotations [?]: boolean | undefined
+  entrypoints: Array<string>
+  env [?]: "disable" | "inline" | `${string}*` | undefined
+  external [?]: Array<string> | undefined
+  features [?]: Array<string> | undefined
+  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  footer [?]: string | undefined
+  format [?]: "cjs" | "esm" | "iife" | undefined
+  ignoreDCEAnnotations [?]: boolean | undefined
+  jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
+  loader [?]: undefined | { [x: string]: Loader; }
+  metafile [?]: boolean | undefined
+  minChunkSize [?]: number | undefined
+  minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
+  modulePreload [?]: boolean | undefined
+  naming [?]: string | undefined | { chunk?: string | undefined; entry?: string | undefined; asset?: string | undefined; }
+  optimizeImports [?]: Array<string> | undefined
+  outdir [?]: string | undefined
+  packages [?]: "bundle" | "external" | undefined
+  plugins [?]: Array<BunPlugin> | undefined
+  publicPath [?]: string | undefined
+  reactCompiler [?]: boolean | undefined
+  reactCompilerOutputMode [?]: "client" | "ssr" | undefined
+  reactFastRefresh [?]: boolean | undefined
+  root [?]: string | undefined
+  sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
+  splitRequire [?]: boolean | undefined
+  splitting [?]: boolean | undefined
+  target [?]: Target | undefined
+  throw [?]: boolean | undefined
+  treeShaking [?]: boolean | undefined
+  tsconfig [?]: string | undefined
+interface BuildMetafile (bun-types/bun.d.ts)
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+interface BuildOutput (bun-types/bun.d.ts)
+  logs: Array<BuildMessage | ResolveMessage>
+  metafile [?]: BuildMetafile | undefined
+  outputs: Array<BuildArtifact>
+  success: boolean
+interface BunFile (bun-types/bun.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface BunInspectOptions (bun-types/bun.d.ts)
+  colors [?]: boolean | undefined
+  compact [?]: boolean | undefined
+  depth [?]: number | undefined
+  sorted [?]: boolean | undefined
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+interface BunPlugin (bun-types/bun.d.ts)
+  name: string
+  setup: (build: PluginBuilder) => Promise<void> | void
+  target [?]: Target | undefined
+interface BunRegisterPlugin (bun-types/bun.d.ts)
+  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  clearAll: () => void
+interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  blob: () => Promise<Blob>
+  body [readonly]: ReadableStream<Uint8Array<ArrayBuffer>> | null
+  bodyUsed [readonly]: boolean
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cache [readonly]: RequestCache
+  clone: () => BunRequest<T>
+  cookies [readonly]: CookieMap
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  formData: () => Promise<FormData>
+  headers [readonly]: Headers
+  integrity [readonly]: string
+  json: () => Promise<any>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+namespace CSRF (bun-types/bun.d.ts)
+  function CSRF.generate (bun-types/bun.d.ts)
+    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+  function CSRF.verify (bun-types/bun.d.ts)
+    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
+interface CSRFGenerateOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  expiresIn [?]: number | undefined
+  sessionId [?]: string | undefined
+interface CSRFVerifyOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  maxAge [?]: number | undefined
+  secret [?]: string | undefined
+  sessionId [?]: string | undefined
+interface CloseEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  code [?]: number | undefined
+  composed [?]: boolean | undefined
+  reason [?]: string | undefined
+  wasClean [?]: boolean | undefined
+type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+interface CompileBuildOptions (bun-types/bun.d.ts)
+  assets [?]: Array<string> | undefined
+  autoloadBunfig [?]: boolean | undefined
+  autoloadDotenv [?]: boolean | undefined
+  autoloadPackageJson [?]: boolean | undefined
+  autoloadTsconfig [?]: boolean | undefined
+  execArgv [?]: Array<string> | undefined
+  executablePath [?]: string | undefined
+  outfile [?]: string | undefined
+  target [?]: CompileTarget | undefined
+  windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
+type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+class Cookie (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | undefined
+  httpOnly: boolean
+  isExpired: () => boolean
+  maxAge [?]: number | undefined
+  name [readonly]: string
+  partitioned: boolean
+  path: string
+  sameSite: CookieSameSite
+  secure: boolean
+  serialize: () => string
+  toJSON: () => CookieInit
+  toString: () => string
+  value: string
+  [static]
+    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
+    construct new (cookieString: string): Cookie
+    construct new (cookieObject?: CookieInit | undefined): Cookie
+    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
+    parse [static]: (cookieString: string) => Cookie
+    prototype: Cookie
+interface CookieInit (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | number | string | undefined
+  httpOnly [?]: boolean | undefined
+  maxAge [?]: number | undefined
+  name [?]: string | undefined
+  partitioned [?]: boolean | undefined
+  path [?]: string | undefined
+  sameSite [?]: CookieSameSite | undefined
+  secure [?]: boolean | undefined
+  value [?]: string | undefined
+class CookieMap (bun-types/bun.d.ts)
+  [Symbol.iterator]: () => IterableIterator<[string, string]>
+  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  get: (name: string) => null | string
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  size [readonly]: number
+  toJSON: () => Record<string, string>
+  toSetCookieHeaders: () => Array<string>
+  values: () => IterableIterator<string>
+  [static]
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
+    prototype: CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
+  domain [?]: null | string | undefined
+  name: string
+  path [?]: string | undefined
+interface CookieStoreGetOptions (bun-types/bun.d.ts)
+  name [?]: string | undefined
+  url [?]: string | undefined
+interface CronController (bun-types/bun.d.ts)
+  cron [readonly]: string
+  scheduledTime [readonly]: number
+  type [readonly]: "scheduled"
+interface CronJob (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  cron [readonly]: string
+  ref: () => CronJob
+  stop: () => CronJob
+  unref: () => CronJob
+interface CronOptions (bun-types/bun.d.ts)
+  tz [?]: string | undefined
+type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+class CryptoHashInterface<T> (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => T
+  [static]
+    construct new <T>(): CryptoHashInterface<T>
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHashInterface<any>
+class CryptoHasher (bun-types/bun.d.ts)
+  algorithm [readonly]: SupportedCryptoAlgorithms
+  byteLength [readonly]: number
+  copy: () => CryptoHasher
+  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
+  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  [static]
+    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
+    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHasher
+interface CustomEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  detail [?]: T | undefined
+interface DNSLookup (bun-types/bun.d.ts)
+  address: string
+  family: 4 | 6
+  ttl: number
+type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
+  type: "direct"
+type DisconnectListener (bun-types/bun.d.ts) = () => void
+interface EditorOptions (bun-types/bun.d.ts)
+  column [?]: number | undefined
+  editor [?]: "subl" | "vscode" | undefined
+  line [?]: number | undefined
+type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+interface Env (bun-types/bun.d.ts)
+  NODE_ENV [?]: string | undefined
+  TZ [?]: string | undefined
+interface ErrorEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  colno [?]: number | undefined
+  composed [?]: boolean | undefined
+  error [?]: any
+  filename [?]: string | undefined
+  lineno [?]: number | undefined
+  message [?]: string | undefined
+interface ErrorLike (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+interface EventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+interface EventListener (bun-types/bun.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (bun-types/bun.d.ts)
+  handleEvent: (object: Event) => void
+interface EventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+interface EventMap (bun-types/bun.d.ts)
+  fetch: FetchEvent
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  messageerror: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+interface EventSource (bun-types/bun.d.ts)
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: Event) => any) | null
+  onmessage: ((this: EventSource, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: number
+  ref: () => void
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => void
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+interface EventSourceEventMap (bun-types/bun.d.ts)
+  error: Event
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  open: Event
+type ExitListener (bun-types/bun.d.ts) = (code: number) => void
+type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
+interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  fd: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface FetchEvent (bun-types/bun.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface FileBlob (bun-types/bun.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface FileSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+class FileSystemRouter (bun-types/bun.d.ts)
+  assetPrefix [readonly]: string
+  match: (input: Request | Response | string) => MatchedRoute | null
+  origin [readonly]: string
+  reload: () => void
+  routes [readonly]: Record<string, string>
+  style [readonly]: string
+  [static]
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
+    prototype: FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+interface GenericTransformStream (bun-types/bun.d.ts)
+  readable [readonly]: ReadableStream<any>
+  writable [readonly]: WritableStream<any>
+class Glob (bun-types/bun.d.ts)
+  match: (str: string) => boolean
+  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  [static]
+    construct new (pattern: string): Glob
+    prototype: Glob
+interface GlobScanOptions (bun-types/bun.d.ts)
+  absolute [?]: boolean | undefined
+  cwd [?]: string | undefined
+  dot [?]: boolean | undefined
+  followSymlinks [?]: boolean | undefined
+  onlyFiles [?]: boolean | undefined
+  throwErrorOnBrokenSymlink [?]: boolean | undefined
+type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
+type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+interface HTMLBundle (bun-types/bun.d.ts)
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  index: string
+interface Hash (bun-types/bun.d.ts)
+  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Headers | Array<Array<string>> | Record<string, string | ReadonlyArray<string>>
+interface HeapSnapshot (bun-types/bun.d.ts)
+  edgeNames: Array<string>
+  edgeTypes: Array<string>
+  edges: Array<number>
+  nodeClassNames: Array<string>
+  nodes: Array<number>
+  type: string
+  version: number
+class Image (bun-types/bun.d.ts)
+  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  blob: () => Promise<Blob>
+  buffer: () => Promise<Buffer<ArrayBufferLike>>
+  bytes: () => Promise<Uint8Array<ArrayBufferLike>>
+  dataurl: () => Promise<string>
+  flip: () => Image
+  flop: () => Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  height [readonly]: number
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
+  metadata: () => Promise<Metadata>
+  modulate: (options: ModulateOptions) => Image
+  placeholder: (as?: "dataurl" | undefined) => Promise<string>
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
+  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
+  rotate: (degrees: number) => Image
+  toBase64: () => Promise<string>
+  toBuffer: () => Promise<Buffer<ArrayBufferLike>>
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  width [readonly]: number
+  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  [static]
+    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    backend [static]: "bun" | "system"
+    clipboardChangeCount [static]: () => number
+    fromClipboard [static]: () => Image | null
+    hasClipboardImage [static]: () => boolean
+    prototype: Image
+  interface Image.ConstructorOptions (bun-types/bun.d.ts)
+    autoOrient [?]: boolean | undefined
+    maxPixels [?]: number | undefined
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
+  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  interface Image.Metadata (bun-types/bun.d.ts)
+    format: Format
+    height: number
+    width: number
+  interface Image.ModulateOptions (bun-types/bun.d.ts)
+    brightness [?]: number | undefined
+    saturation [?]: number | undefined
+  interface Image.ResizeOptions (bun-types/bun.d.ts)
+    filter [?]: Filter | undefined
+    fit [?]: "fill" | "inside" | undefined
+    withoutEnlargement [?]: boolean | undefined
+  var Image.backend (bun-types/bun.d.ts): "bun" | "system"
+interface Import (bun-types/bun.d.ts)
+  kind: ImportKind
+  path: string
+type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+namespace JSON5 (bun-types/bun.d.ts)
+  function JSON5.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function JSON5.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+namespace JSONC (bun-types/bun.d.ts)
+  function JSONC.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+namespace JSONL (bun-types/bun.d.ts)
+  interface JSONL.ParseChunkResult (bun-types/bun.d.ts)
+    done: boolean
+    error: SyntaxError | null
+    read: number
+    values: Array<unknown>
+  function JSONL.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+  function JSONL.parseChunk (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
+interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
+  level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "libdeflate" | undefined
+type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+class MD4 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD4
+  [static]
+    construct new (): MD4
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD4
+class MD5 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD5
+  [static]
+    construct new (): MD5
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD5
+interface MMapOptions (bun-types/bun.d.ts)
+  offset [?]: number | undefined
+  shared [?]: boolean | undefined
+  size [?]: number | undefined
+  sync [?]: boolean | undefined
+type MacroMap (bun-types/bun.d.ts) = { [x: string]: Record<string, string>; }
+interface MatchedRoute (bun-types/bun.d.ts)
+  filePath [readonly]: string
+  kind [readonly]: "catch-all" | "dynamic" | "exact" | "optional-catch-all"
+  name [readonly]: string
+  params [readonly]: Record<string, string>
+  pathname [readonly]: string
+  query [readonly]: Record<string, string>
+  src [readonly]: string
+type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
+type MessageEvent<T = any> (bun-types/bun.d.ts) = { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+interface MessageEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  data [?]: T | undefined
+  lastEventId [?]: string | undefined
+  origin [?]: string | undefined
+  source [?]: null | undefined
+type MessageEventSource (bun-types/bun.d.ts) = undefined
+type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+interface NetworkSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  stat: () => Promise<Stats>
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
+type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+interface OnLoadArgs (bun-types/bun.d.ts)
+  defer: () => Promise<void>
+  loader: Loader
+  namespace: string
+  path: string
+type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+interface OnLoadResultObject (bun-types/bun.d.ts)
+  exports: Record<string, unknown>
+  loader: "object"
+interface OnLoadResultSourceCode (bun-types/bun.d.ts)
+  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Loader | undefined
+interface OnResolveArgs (bun-types/bun.d.ts)
+  importer: string
+  kind: ImportKind
+  namespace: string
+  path: string
+  resolveDir: string
+type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+interface OnResolveResult (bun-types/bun.d.ts)
+  external [?]: boolean | undefined
+  namespace [?]: string | undefined
+  path: string
+type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
+namespace Password (bun-types/bun.d.ts)
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  interface Password.Argon2Algorithm (bun-types/bun.d.ts)
+    algorithm: "argon2d" | "argon2i" | "argon2id"
+    memoryCost [?]: number | undefined
+    timeCost [?]: number | undefined
+  interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
+    algorithm: "bcrypt"
+    cost [?]: number | undefined
+type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
+type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+interface PluginBuilder (bun-types/bun.d.ts)
+  config: BuildConfig & { plugins: Array<BunPlugin>; }
+  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
+  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
+  onEnd: (callback: OnEndCallback) => PluginBuilder
+  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
+  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
+  onStart: (callback: OnStartCallback) => PluginBuilder
+interface PluginConstraints (bun-types/bun.d.ts)
+  filter: RegExp
+  namespace [?]: string | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
+interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
+  done: boolean
+  size: number
+  value: Array<T>
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
+type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+class RedisClient (bun-types/redis.d.ts)
+  append: (key: KeyLike, value: KeyLike) => Promise<number>
+  bitcount: (key: KeyLike) => Promise<number>
+  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
+  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
+  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
+  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  bufferedAmount [readonly]: number
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  client: (...args: Array<string | number>) => Promise<any>
+  close: () => void
+  command: (...args: Array<string | number>) => Promise<any>
+  config: (...args: Array<string | number>) => Promise<any>
+  connect: () => Promise<void>
+  connected [readonly]: boolean
+  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  dbsize: () => Promise<number>
+  debug: (...args: Array<string | number>) => Promise<any>
+  decr: (key: KeyLike) => Promise<number>
+  decrby: (key: KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<KeyLike>) => Promise<number>
+  dump: (key: KeyLike) => Promise<string | null>
+  duplicate: () => Promise<RedisClient>
+  echo: (message: string) => Promise<string>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  exists: (key: KeyLike) => Promise<boolean>
+  expire: (key: KeyLike, seconds: number) => Promise<number>
+  expireat: (key: KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  function: (...args: Array<KeyLike>) => Promise<any>
+  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
+  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
+  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
+  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
+  get: (key: KeyLike) => Promise<string | null>
+  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: KeyLike, offset: number) => Promise<number>
+  getdel: (key: KeyLike) => Promise<string | null>
+  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
+  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
+  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
+  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
+  hgetall: (key: KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
+  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
+  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: KeyLike) => Promise<Array<string>>
+  hlen: (key: KeyLike) => Promise<number>
+  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
+  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
+  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
+  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
+  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
+  hstrlen: (key: KeyLike, field: string) => Promise<number>
+  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hvals: (key: KeyLike) => Promise<Array<string>>
+  incr: (key: KeyLike) => Promise<number>
+  incrby: (key: KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  info: (...sections: Array<string>) => Promise<string>
+  keys: (pattern: string) => Promise<Array<string>>
+  lastsave: () => Promise<number>
+  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
+  lindex: (key: KeyLike, index: number) => Promise<string | null>
+  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
+  llen: (key: KeyLike) => Promise<number>
+  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
+  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
+  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
+  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
+  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
+  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
+  onclose: ((this: RedisClient, error: Error) => void) | null
+  onconnect: ((this: RedisClient) => void) | null
+  persist: (key: KeyLike) => Promise<number>
+  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: KeyLike) => Promise<number>
+  pfadd: (key: KeyLike, element: string) => Promise<number>
+  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
+  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
+  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
+  pttl: (key: KeyLike) => Promise<number>
+  publish: (channel: string, message: string) => Promise<number>
+  randomkey: () => Promise<string | null>
+  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
+  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
+  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
+  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
+  scard: (key: KeyLike) => Promise<number>
+  script: (...args: Array<string>) => Promise<any>
+  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  send: (command: string, args: Array<string>) => Promise<any>
+  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
+  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
+  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
+  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
+  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
+  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sismember: (key: KeyLike, member: string) => Promise<boolean>
+  smembers: (key: KeyLike) => Promise<Array<string>>
+  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
+  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
+  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
+  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: KeyLike, message: string) => Promise<number>
+  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
+  strlen: (key: KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
+  substr: (key: KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  time: () => Promise<[string, string]>
+  touch: (...keys: Array<KeyLike>) => Promise<number>
+  ttl: (key: KeyLike) => Promise<number>
+  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
+  unlink: (...keys: Array<KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  wait: (numreplicas: number, timeout: number) => Promise<number>
+  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
+  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
+  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
+  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xlen: (key: KeyLike) => Promise<number>
+  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
+  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<string | number>) => Promise<any>
+  xreadgroup: (...args: Array<string | number>) => Promise<any>
+  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
+  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
+  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  zcard: (key: KeyLike) => Promise<number>
+  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
+  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
+  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
+  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
+  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: KeyLike, member: string) => Promise<number | null>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  [static]
+    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
+    prototype: RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+  type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
+interface RedisOptions (bun-types/redis.d.ts)
+  autoReconnect [?]: boolean | undefined
+  connectionTimeout [?]: number | undefined
+  enableAutoPipelining [?]: boolean | undefined
+  enableOfflineQueue [?]: boolean | undefined
+  idleTimeout [?]: number | undefined
+  maxRetries [?]: number | undefined
+  tls [?]: TLSOptions | boolean | undefined
+type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
+interface ReservedSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  [Symbol.dispose]: () => void
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  release: () => void
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+interface ResourceUsage (bun-types/bun.d.ts)
+  contextSwitches: { voluntary: number; involuntary: number; }
+  cpuTime: { user: number; system: number; total: number; }
+  maxRSS: number
+  messages: { sent: number; received: number; }
+  ops: { in: number; out: number; }
+  shmSize: number
+  signalCount: number
+  swapCount: number
+class S3Client (bun-types/s3.d.ts)
+  delete: (path: string, options?: S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: S3Options | undefined) => S3File
+  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
+  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  [static]
+    construct new (options?: S3Options | undefined): S3Client
+    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: S3Options | undefined) => S3File
+    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
+    prototype: S3Client
+    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+interface S3File (bun-types/s3.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bucket [? readonly]: string | undefined
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  name [? readonly]: string | undefined
+  presign: (options?: S3FilePresignOptions | undefined) => string
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
+  stat: () => Promise<S3Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  writer: (options?: S3Options | undefined) => NetworkSink
+interface S3FilePresignOptions (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endings [?]: EndingType | undefined
+  endpoint [?]: string | undefined
+  expiresIn [?]: number | undefined
+  highWaterMark [?]: number | undefined
+  method [?]: "DELETE" | "GET" | "HEAD" | "POST" | "PUT" | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3ListObjectsOptions (bun-types/s3.d.ts)
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  fetchOwner [?]: boolean | undefined
+  maxKeys [?]: number | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3ListObjectsResponse (bun-types/s3.d.ts)
+  commonPrefixes [?]: Array<{ prefix: string; }> | undefined
+  contents [?]: Array<{ checksumAlgorithm?: "CRC32" | "CRC32C" | "SHA1" | "SHA256" | "CRC64NVME" | undefined; checksumType?: "COMPOSITE" | "FULL_OBJECT" | undefined; eTag?: string | undefined; key: string; lastModified?: string | undefined; owner?: { id?: string | undefined; displayName?: string | undefined; } | undefined; restoreStatus?: { isRestoreInProgress?: boolean | undefined; restoreExpiryDate?: string | undefined; } | undefined; size?: number | undefined; storageClass?: "STANDARD" | "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD_IA" | undefined; }> | undefined
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  isTruncated [?]: boolean | undefined
+  keyCount [?]: number | undefined
+  maxKeys [?]: number | undefined
+  name [?]: string | undefined
+  nextContinuationToken [?]: string | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3Options (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endings [?]: EndingType | undefined
+  endpoint [?]: string | undefined
+  highWaterMark [?]: number | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3Stats (bun-types/s3.d.ts)
+  etag: string
+  lastModified: Date
+  size: number
+  type: string
+class SHA1 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA1
+  [static]
+    construct new (): SHA1
+    byteLength [readonly static]: 20
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA1
+class SHA224 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA224
+  [static]
+    construct new (): SHA224
+    byteLength [readonly static]: 28
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA224
+class SHA256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA256
+  [static]
+    construct new (): SHA256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA256
+class SHA384 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA384
+  [static]
+    construct new (): SHA384
+    byteLength [readonly static]: 48
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA384
+class SHA512 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512
+  [static]
+    construct new (): SHA512
+    byteLength [readonly static]: 64
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512
+class SHA512_256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  [static]
+    construct new (): SHA512_256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512_256
+class SQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  [static]
+    construct new (connectionString: URL | string): SQL
+    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
+    construct new (options?: Options | undefined): SQL
+    MySQLError: typeof MySQLError
+    PostgresError: typeof PostgresError
+    SQLError: typeof SQLError
+    SQLiteError: typeof SQLiteError
+    prototype: SQL
+  type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  interface SQL.Helper<T> (bun-types/sql.d.ts)
+    columns [readonly]: Array<keyof T>
+    value [readonly]: Array<T>
+  interface SQL.ListenSubscription (bun-types/sql.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    channel [readonly]: string
+    unlisten: () => Promise<void>
+  class SQL.MySQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    errno [? readonly]: number | undefined
+    message: string
+    name: string
+    sqlState [? readonly]: string | undefined
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: MySQLError
+      stackTraceLimit: number
+  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  class SQL.PostgresError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    column [? readonly]: string | undefined
+    constraint [? readonly]: string | undefined
+    dataType [? readonly]: string | undefined
+    detail [? readonly]: string | undefined
+    errno [? readonly]: string | undefined
+    file [? readonly]: string | undefined
+    hint [? readonly]: string | undefined
+    internalPosition [? readonly]: string | undefined
+    internalQuery [? readonly]: string | undefined
+    line [? readonly]: string | undefined
+    message: string
+    name: string
+    position [? readonly]: string | undefined
+    routine [? readonly]: string | undefined
+    schema [? readonly]: string | undefined
+    severity [? readonly]: string | undefined
+    stack [?]: string | undefined
+    table [? readonly]: string | undefined
+    where [? readonly]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: PostgresError
+      stackTraceLimit: number
+  interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
+    adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
+    allowPublicKeyRetrieval [?]: boolean | undefined
+    bigint [?]: boolean | undefined
+    connectTimeout [?]: number | undefined
+    connect_timeout [?]: number | undefined
+    connection [?]: Record<string, string | number | boolean> | undefined
+    connectionTimeout [?]: number | undefined
+    connection_timeout [?]: number | undefined
+    database [?]: string | undefined
+    db [?]: string | undefined
+    host [?]: string | undefined
+    hostname [?]: string | undefined
+    idleTimeout [?]: number | undefined
+    idle_timeout [?]: number | undefined
+    max [?]: number | undefined
+    maxLifetime [?]: number | undefined
+    max_lifetime [?]: number | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    pass [?]: (() => MaybePromise<string>) | string | undefined
+    password [?]: (() => MaybePromise<string>) | string | undefined
+    path [?]: string | undefined
+    port [?]: number | string | undefined
+    prepare [?]: boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    url [?]: URL | string | undefined
+    user [?]: string | undefined
+    username [?]: string | undefined
+  interface SQL.Query<T> (bun-types/sql.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    active: boolean
+    cancel: () => Query<T>
+    cancelled: boolean
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
+    execute: () => Query<T>
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
+    raw: () => Query<T>
+    simple: () => Query<T>
+    then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    values: () => Query<T>
+  class SQL.SQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string): SQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLError
+      stackTraceLimit: number
+  class SQL.SQLiteError (bun-types/sql.d.ts)
+    byteOffset [? readonly]: number | undefined
+    cause [?]: unknown
+    code [readonly]: string
+    errno [readonly]: number
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLiteError
+      stackTraceLimit: number
+  interface SQL.SQLiteOptions (bun-types/sql.d.ts)
+    adapter [?]: "sqlite" | undefined
+    create [?]: boolean | undefined
+    filename [?]: ":memory:" | URL | string & {} | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    readonly [?]: boolean | undefined
+    readwrite [?]: boolean | undefined
+    safeIntegers [?]: boolean | undefined
+    strict [?]: boolean | undefined
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SQLArrayParameter (bun-types/sql.d.ts)
+  arrayType: ArrayType
+  serializedValues: string
+type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SavepointSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+namespace Security (bun-types/security.d.ts)
+  interface Security.Advisory (bun-types/security.d.ts)
+    description: null | string
+    level: "fatal" | "warn"
+    package: string
+    url: null | string
+  interface Security.Package (bun-types/security.d.ts)
+    name: string
+    requestedRange: string
+    tarball: string
+    version: string
+  interface Security.Scanner (bun-types/security.d.ts)
+    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    version: "1"
+namespace Serve (bun-types/serve.d.ts)
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
+  interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
+    dir: string
+    statCache [?]: boolean | undefined
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    http1 [?]: boolean | undefined
+    http2 [?]: boolean | undefined
+    http3 [?]: boolean | undefined
+    id [?]: null | string | undefined
+    idleTimeout [?]: number | undefined
+    ipv6Only [?]: boolean | undefined
+    maxRequestBodySize [?]: number | undefined
+    port [?]: number | string | undefined
+    reusePort [?]: boolean | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+  interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    unix [?]: string | undefined
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+interface Server<WebSocketData> (bun-types/serve.d.ts)
+  [Symbol.dispose]: () => void
+  closeIdleConnections: () => number
+  development [readonly]: boolean
+  fetch: (request: Request | string) => Promise<Response> | Response
+  hostname [readonly]: string | undefined
+  id [readonly]: string
+  pendingRequests [readonly]: number
+  pendingWebSockets [readonly]: number
+  port [readonly]: number | undefined
+  protocol [readonly]: "http" | "https" | null
+  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  ref: () => void
+  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
+  requestIP: (request: Request) => SocketAddress | null
+  stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
+  subscriberCount: (topic: string) => number
+  timeout: (request: Request, seconds: number) => void
+  unref: () => void
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  url [readonly]: URL
+interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
+  binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  data: T
+  getBufferedAmount: () => number
+  isSubscribed: (topic: string) => boolean
+  ping: (data?: Blob | BufferSource | string | undefined) => number
+  pong: (data?: Blob | BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  publishText: (topic: string, data: string, compress?: boolean | undefined) => number
+  readyState [readonly]: WebSocketReadyState
+  remoteAddress [readonly]: string
+  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  sendText: (data: string, compress?: boolean | undefined) => number
+  subscribe: (topic: string) => boolean
+  subscriptions [readonly]: Array<string>
+  terminate: () => void
+  unsubscribe: (topic: string) => boolean
+type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
+type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
+type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+interface SliceAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  ellipsis [?]: string | undefined
+interface Socket<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: Data
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface SocketAddress (bun-types/bun.d.ts)
+  address: string
+  family: "IPv4" | "IPv6"
+  port: number
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof BinaryTypeList | undefined
+  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+namespace Spawn (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
+  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    lazy [?]: boolean | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    terminal [?]: Terminal | TerminalOptions | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
+  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+SpawnOptions -> Spawn
+type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
+type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+interface StringWidthOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  countAnsiEscapeCodes [?]: boolean | undefined
+  perCodePoint [?]: boolean | undefined
+interface StructuredSerializeOptions (bun-types/bun.d.ts)
+  transfer [?]: Array<Transferable> | undefined
+interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  disconnect: () => void
+  exitCode [readonly]: null | number
+  exited [readonly]: Promise<number>
+  kill: (exitCode?: Signals | number | undefined) => void
+  killed [readonly]: boolean
+  pid [readonly]: number
+  readable [readonly]: ReadableToIO<Out>
+  ref: () => void
+  resourceUsage: () => ResourceUsage | undefined
+  send: (message: any) => void
+  signalCode [readonly]: Signals | null
+  stderr [readonly]: ReadableToIO<Err>
+  stdin [readonly]: WritableToIO<In>
+  stdio [readonly]: [null, null, null, ...(number | null)[]]
+  stdout [readonly]: ReadableToIO<Out>
+  terminal [readonly]: Terminal | undefined
+  unref: () => void
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  exitCode: number
+  exitedDueToMaxBuffer [?]: boolean | undefined
+  exitedDueToTimeout [?]: boolean | undefined
+  pid: number
+  resourceUsage: ResourceUsage
+  signalCode [?]: string | undefined
+  stderr: ReadableToSyncIO<Err>
+  stdout: ReadableToSyncIO<Out>
+  success: boolean
+interface SystemError (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface TCPSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  ipv6Only [?]: boolean | undefined
+  port: number
+  reusePort [?]: boolean | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  port: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  hostname [readonly]: string
+  port [readonly]: number
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface TLSSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls: TLSOptions | boolean
+namespace TOML (bun-types/bun.d.ts)
+  function TOML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+  function TOML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+interface TSConfig (bun-types/bun.d.ts)
+  compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
+  extends [?]: string | undefined
+type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+class Terminal (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => Promise<void>
+  close: () => void
+  closed [readonly]: boolean
+  controlFlags: number
+  inputFlags: number
+  localFlags: number
+  outputFlags: number
+  ref: () => void
+  resize: (cols: number, rows: number) => void
+  setRawMode: (enabled: boolean) => void
+  unref: () => void
+  write: (data: BufferSource | string) => number
+  [static]
+    construct new (options: TerminalOptions): Terminal
+    prototype: Terminal
+interface TerminalOptions (bun-types/bun.d.ts)
+  cols [?]: number | undefined
+  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Terminal) => void) | undefined
+  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  name [?]: string | undefined
+  rows [?]: number | undefined
+type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
+interface TransactionSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
+interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+interface TransformerStartCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): any
+interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
+  call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+class Transpiler (bun-types/bun.d.ts)
+  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
+  scanImports: (code: StringOrBuffer) => Array<Import>
+  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  [static]
+    construct new (options?: TranspilerOptions | undefined): Transpiler
+    prototype: Transpiler
+interface TranspilerOptions (bun-types/bun.d.ts)
+  allowBunRuntime [?]: boolean | undefined
+  autoImportJSX [?]: boolean | undefined
+  deadCodeElimination [?]: boolean | undefined
+  define [?]: Record<string, string> | undefined
+  exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
+  inline [?]: boolean | undefined
+  jsxOptimizationInline [?]: boolean | undefined
+  loader [?]: JavaScriptLoader | undefined
+  logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
+  macro [?]: MacroMap | undefined
+  minifyWhitespace [?]: boolean | undefined
+  replMode [?]: boolean | undefined
+  target [?]: Target | undefined
+  treeShaking [?]: boolean | undefined
+  trimUnusedImports [?]: boolean | undefined
+  tsconfig [?]: TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
+interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
+  abort [?]: UnderlyingSinkAbortCallback | undefined
+  close [?]: UnderlyingSinkCloseCallback | undefined
+  start [?]: UnderlyingSinkStartCallback | undefined
+  type [?]: "bytes" | "default" | undefined
+  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
+  call (): PromiseLike<void> | void
+interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
+  call (controller: WritableStreamDefaultController): any
+interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
+  call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
+interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull [?]: UnderlyingSourcePullCallback<R> | undefined
+  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  type [?]: undefined
+interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): any
+type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+interface UnixSocketListener<Data> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unix [readonly]: string
+  unref: () => void
+interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+  unix: string
+type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+interface WebSocket (bun-types/bun.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+interface WebSocketEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: Event
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  open: Event
+interface WebSocketHandler<T> (bun-types/serve.d.ts)
+  backpressureLimit [?]: number | undefined
+  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  closeOnBackpressureLimit [?]: boolean | undefined
+  data [?]: T | undefined
+  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  idleTimeout [?]: number | undefined
+  maxPayloadLength [?]: number | undefined
+  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
+  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  publishToSelf [?]: boolean | undefined
+  sendPings [?]: boolean | undefined
+type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
+type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
+class WebView (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => void
+  [Symbol.dispose]: () => void
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  back: () => Promise<void>
+  cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
+  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  evaluate: <T = unknown>(script: string) => Promise<T>
+  forward: () => Promise<void>
+  loading [readonly]: boolean
+  navigate: (url: string) => Promise<void>
+  onNavigated: ((url: string, title: string) => void) | null
+  onNavigationFailed: ((error: Error) => void) | null
+  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  reload: () => Promise<void>
+  removeEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean | undefined) => void
+  resize: (width: number, height: number) => Promise<void>
+  screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
+  scroll: (dx: number, dy: number) => Promise<void>
+  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  title [readonly]: string
+  type: (text: string) => Promise<void>
+  url [readonly]: string
+  [static]
+    construct new (options?: ConstructorOptions | undefined): WebView
+    closeAll [static]: () => void
+    prototype: WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+  interface WebView.ClickOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+    timeout [?]: number | undefined
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  interface WebView.ConstructorOptions (bun-types/bun.d.ts)
+    backend [?]: Backend | undefined
+    console [?]: ConsoleCapture | undefined
+    dataStore [?]: "ephemeral" | undefined | { directory: string; }
+    headless [?]: boolean | undefined
+    height [?]: number | undefined
+    url [?]: string | undefined
+    width [?]: number | undefined
+  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  interface WebView.PressOptions (bun-types/bun.d.ts)
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ScrollToOptions (bun-types/bun.d.ts)
+    block [?]: "center" | "end" | "nearest" | "start" | undefined
+    timeout [?]: number | undefined
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+interface WhichOptions (bun-types/bun.d.ts)
+  PATH [?]: string | undefined
+  cwd [?]: string | undefined
+interface Worker (bun-types/bun.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  onmessageerror: ((this: Worker, ev: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+interface WorkerEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: ErrorEvent
+  message: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  messageerror: { new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>; prototype: MessageEvent<any>; }
+  open: Event
+interface WorkerOptions (bun-types/bun.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
+interface WrapAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  hard [?]: boolean | undefined
+  trim [?]: boolean | undefined
+  wordWrap [?]: boolean | undefined
+type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+namespace XML (bun-types/bun.d.ts)
+  interface XML.Comment (bun-types/bun.d.ts)
+    comment: string
+  interface XML.Document (bun-types/bun.d.ts)
+    index [string]: Value
+  interface XML.Element (bun-types/bun.d.ts)
+    index [string]: Array<Value> | Value
+  interface XML.Node (bun-types/bun.d.ts)
+    attributes: Record<string, string>
+    children: Array<string | Comment | Node | ProcessingInstruction>
+    name: string
+  interface XML.NodeInput (bun-types/bun.d.ts)
+    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
+    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    name: string
+  interface XML.ParseOptions (bun-types/bun.d.ts)
+    compact [?]: boolean | undefined
+  interface XML.ProcessingInstruction (bun-types/bun.d.ts)
+    data: string
+    target: string
+  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
+  type XML.Value (bun-types/bun.d.ts) = string | Element
+  function XML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+  function XML.stringify (bun-types/bun.d.ts)
+    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+namespace YAML (bun-types/bun.d.ts)
+  function YAML.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function YAML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string
+interface ZlibCompressionOptions (bun-types/bun.d.ts)
+  level [?]: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "zlib" | undefined
+  memLevel [?]: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  strategy [?]: number | undefined
+  windowBits [?]: -10 | -11 | -12 | -13 | -14 | -15 | -9 | 10 | 11 | 12 | 13 | 14 | 15 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 9 | undefined
+namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/globals.d.ts)
+  interface __internal.BunEvent (bun-types/globals.d.ts)
+    bubbles [readonly]: boolean
+    cancelBubble: boolean
+    cancelable [readonly]: boolean
+    composed [readonly]: boolean
+    composedPath: () => [(EventTarget | undefined)?]
+    currentTarget [readonly]: EventTarget | null
+    defaultPrevented [readonly]: boolean
+    eventPhase [readonly]: number
+    isTrusted [readonly]: boolean
+    preventDefault: () => void
+    returnValue: boolean
+    srcElement [readonly]: EventTarget | null
+    stopImmediatePropagation: () => void
+    stopPropagation: () => void
+    target [readonly]: EventTarget | null
+    timeStamp [readonly]: number
+    type [readonly]: string
+  interface __internal.BunEventTarget (bun-types/globals.d.ts)
+    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    dispatchEvent: (event: Event) => boolean
+    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
+    count [readonly]: number
+    getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+    toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+  interface __internal.BunRequestOverride (bun-types/fetch.d.ts)
+    headers: BunHeadersOverride
+    textStream: () => ReadableStream<string>
+  interface __internal.BunResponseOverride (bun-types/fetch.d.ts)
+    headers: BunHeadersOverride
+    textStream: () => ReadableStream<string>
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
+  type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
+  type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = true
+  type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebDecompressionStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebTextDecoderStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeStreamWebTextEncoderStream (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeUtilTextDecoder (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeUtilTextEncoder (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrNodeWritableStream<T> (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceEntry (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceMark (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceMeasure (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceObserver (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceObserverEntryList (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrPerformanceResourceTiming (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrReadableByteStreamController (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrReadableStreamBYOBReader (bun-types/globals.d.ts) = {}
+  type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = {}
+  type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = {}
+  type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = {}
+  type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = {}
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = {}
+  type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
+  type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = typeof globalThis extends { [K in GlobalThisKeyName]: infer T; } ? T : Otherwise
+  type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+function allocUnsafe (bun-types/bun.d.ts)
+  call (size: number): Uint8Array<ArrayBuffer>
+var argv (bun-types/bun.d.ts): Array<string>
+function build (bun-types/bun.d.ts)
+  call (config: BuildConfig): Promise<BuildOutput>
+function color (bun-types/bun.d.ts)
+  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: ColorInput, outputFormat: "number"): null | number
+function concatArrayBuffers (bun-types/bun.d.ts)
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+function connect (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+var cron (bun-types/bun.d.ts)
+  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
+  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  remove: (title: string) => Promise<void>
+function deepEquals (bun-types/bun.d.ts)
+  call (a: any, b: any, strict?: boolean | undefined): boolean
+function deepMatch (bun-types/bun.d.ts)
+  call (subset: unknown, a: unknown): boolean
+function deflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+namespace dns (bun-types/bun.d.ts)
+  var dns.ADDRCONFIG (bun-types/bun.d.ts): number
+  var dns.ALL (bun-types/bun.d.ts): number
+  var dns.V4MAPPED (bun-types/bun.d.ts): number
+  function dns.getCacheStats (bun-types/bun.d.ts)
+    call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
+  function dns.lookup (bun-types/bun.d.ts)
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+  function dns.prefetch (bun-types/bun.d.ts)
+    call (hostname: string, port?: number | undefined): void
+var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
+var enableANSIColors (bun-types/bun.d.ts): boolean
+var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+function escapeHTML (bun-types/bun.d.ts)
+  call (input: boolean | number | object | string): string
+var fetch (bun-types/bun.d.ts): typeof fetch
+function file (bun-types/bun.d.ts)
+  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+function fileURLToPath (bun-types/bun.d.ts)
+  call (url: URL | string): string
+function gc (bun-types/bun.d.ts)
+  call (force?: boolean | undefined): void
+function generateHeapSnapshot (bun-types/bun.d.ts)
+  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format: "v8"): string
+  call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
+function gunzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function gzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+function indexOfLine (bun-types/bun.d.ts)
+  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+function inflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function inspect (bun-types/bun.d.ts)
+  call (arg: any, options?: BunInspectOptions | undefined): string
+  custom: typeof custom
+  table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
+namespace inspect (bun-types/bun.d.ts)
+  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  function inspect.table (bun-types/bun.d.ts)
+    call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
+    call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
+var isMainThread (bun-types/bun.d.ts): boolean
+var isStandaloneExecutable (bun-types/bun.d.ts): boolean
+function listen (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+var main (bun-types/bun.d.ts): string
+namespace markdown (bun-types/bun.d.ts)
+  interface markdown.AnsiTheme (bun-types/bun.d.ts)
+    colors [?]: boolean | undefined
+    columns [?]: number | undefined
+    hyperlinks [?]: boolean | undefined
+    kittyGraphics [?]: boolean | undefined
+    light [?]: boolean | undefined
+  interface markdown.CellMeta (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+  interface markdown.CellProps (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+    children: Array<unknown>
+  interface markdown.ChildrenProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+  interface markdown.CodeBlockMeta (bun-types/bun.d.ts)
+    language [?]: string | undefined
+  interface markdown.CodeBlockProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    language [?]: string | undefined
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  interface markdown.ComponentOverrides (bun-types/bun.d.ts)
+    a [?]: Component<LinkProps> | undefined
+    blockquote [?]: Component<ChildrenProps> | undefined
+    br [?]: Component<{}> | undefined
+    code [?]: Component<ChildrenProps> | undefined
+    del [?]: Component<ChildrenProps> | undefined
+    em [?]: Component<ChildrenProps> | undefined
+    h1 [?]: Component<HeadingProps> | undefined
+    h2 [?]: Component<HeadingProps> | undefined
+    h3 [?]: Component<HeadingProps> | undefined
+    h4 [?]: Component<HeadingProps> | undefined
+    h5 [?]: Component<HeadingProps> | undefined
+    h6 [?]: Component<HeadingProps> | undefined
+    hr [?]: Component<{}> | undefined
+    html [?]: Component<ChildrenProps> | undefined
+    img [?]: Component<ImageProps> | undefined
+    li [?]: Component<ListItemProps> | undefined
+    math [?]: Component<ChildrenProps> | undefined
+    ol [?]: Component<OrderedListProps> | undefined
+    p [?]: Component<ChildrenProps> | undefined
+    pre [?]: Component<CodeBlockProps> | undefined
+    strong [?]: Component<ChildrenProps> | undefined
+    table [?]: Component<ChildrenProps> | undefined
+    tbody [?]: Component<ChildrenProps> | undefined
+    td [?]: Component<CellProps> | undefined
+    th [?]: Component<CellProps> | undefined
+    thead [?]: Component<ChildrenProps> | undefined
+    tr [?]: Component<ChildrenProps> | undefined
+    u [?]: Component<ChildrenProps> | undefined
+    ul [?]: Component<ChildrenProps> | undefined
+  interface markdown.HeadingMeta (bun-types/bun.d.ts)
+    id [?]: string | undefined
+    level: number
+  interface markdown.HeadingProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    id [?]: string | undefined
+  interface markdown.ImageMeta (bun-types/bun.d.ts)
+    src: string
+    title [?]: string | undefined
+  interface markdown.ImageProps (bun-types/bun.d.ts)
+    alt [?]: string | undefined
+    src: string
+    title [?]: string | undefined
+  interface markdown.LinkMeta (bun-types/bun.d.ts)
+    href: string
+    title [?]: string | undefined
+  interface markdown.LinkProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    href: string
+    title [?]: string | undefined
+  interface markdown.ListItemMeta (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    depth: number
+    index: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.ListItemProps (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    children: Array<unknown>
+  interface markdown.ListMeta (bun-types/bun.d.ts)
+    depth: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.Options (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.OrderedListProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    start: number
+  interface markdown.ReactOptions (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    reactVersion [?]: 18 | 19 | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.RenderCallbacks (bun-types/bun.d.ts)
+    blockquote [?]: ((children: string) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    codespan [?]: ((children: string) => null | string | undefined) | undefined
+    emphasis [?]: ((children: string) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    hr [?]: ((children: string) => null | string | undefined) | undefined
+    html [?]: ((children: string) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    paragraph [?]: ((children: string) => null | string | undefined) | undefined
+    strikethrough [?]: ((children: string) => null | string | undefined) | undefined
+    strong [?]: ((children: string) => null | string | undefined) | undefined
+    table [?]: ((children: string) => null | string | undefined) | undefined
+    tbody [?]: ((children: string) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    text [?]: ((text: string) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    thead [?]: ((children: string) => null | string | undefined) | undefined
+    tr [?]: ((children: string) => null | string | undefined) | undefined
+  function markdown.ansi (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+  function markdown.html (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+  function markdown.react (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+  function markdown.render (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+function mmap (bun-types/bun.d.ts)
+  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+function nanoseconds (bun-types/bun.d.ts)
+  call (): number
+function openInEditor (bun-types/bun.d.ts)
+  call (path: string, options?: EditorOptions | undefined): void
+var password (bun-types/bun.d.ts)
+  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
+  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+function pathToFileURL (bun-types/bun.d.ts)
+  call (path: string): URL
+function peek (bun-types/bun.d.ts)
+  call <T = undefined>(promise: Promise<T> | T): Promise<T> | T
+  status: <T = undefined>(promise: Promise<T> | T) => "fulfilled" | "pending" | "rejected"
+namespace peek (bun-types/bun.d.ts)
+  function peek.status (bun-types/bun.d.ts)
+    call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
+var plugin (bun-types/bun.d.ts): BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): SQL
+function randomUUIDv5 (bun-types/bun.d.ts)
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+function randomUUIDv7 (bun-types/bun.d.ts)
+  call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
+  call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
+function readableStreamToArray (bun-types/bun.d.ts)
+  call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
+function readableStreamToArrayBuffer (bun-types/bun.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+function readableStreamToBlob (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<Blob>
+function readableStreamToBytes (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+function readableStreamToFormData (bun-types/bun.d.ts)
+  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+function readableStreamToJSON (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<any>
+function readableStreamToText (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<string>
+var redis (bun-types/redis.d.ts): RedisClient
+function resolve (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): Promise<string>
+function resolveSync (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): string
+var revision (bun-types/bun.d.ts): string
+var s3 (bun-types/s3.d.ts): S3Client
+var secrets (bun-types/bun.d.ts)
+  delete: (options: { service: string; name: string; }) => Promise<boolean>
+  get: (options: { service: string; name: string; }) => Promise<string | null>
+  set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
+namespace semver (bun-types/bun.d.ts)
+  function semver.order (bun-types/bun.d.ts)
+    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+  function semver.satisfies (bun-types/bun.d.ts)
+    call (version: StringLike, range: StringLike): boolean
+function serve (bun-types/serve.d.ts)
+  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+function sha (bun-types/bun.d.ts)
+  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
+  call (input: StringOrBuffer, encoding: DigestEncoding): string
+function shrink (bun-types/bun.d.ts)
+  call (): void
+function sleep (bun-types/bun.d.ts)
+  call (ms: Date | number): Promise<void>
+function sleepSync (bun-types/bun.d.ts)
+  call (ms: number): void
+function sliceAnsi (bun-types/bun.d.ts)
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+function spawn (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+function spawnSync (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): SQL
+var stderr (bun-types/bun.d.ts): BunFile
+var stdin (bun-types/bun.d.ts): BunFile
+var stdout (bun-types/bun.d.ts): BunFile
+function stringWidth (bun-types/bun.d.ts)
+  call (input: string, options?: StringWidthOptions | undefined): number
+function stripANSI (bun-types/bun.d.ts)
+  call (input: string): string
+namespace udp (bun-types/bun.d.ts)
+  interface udp.BaseUDPSocket (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    connect: { hostname: string; port: number; }
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: SocketAddress
+    send: (data: Data) => boolean
+    sendMany: (packets: ReadonlyArray<Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ReceiveFlags (bun-types/bun.d.ts)
+    ipv6: boolean
+    truncated: boolean
+  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: SocketHandler<DataBinaryType>) => void
+    send: (data: Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: SocketHandler<DataBinaryType> | undefined
+function udpSocket (bun-types/bun.d.ts)
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+namespace unsafe (bun-types/bun.d.ts)
+  function unsafe.arrayBufferToString (bun-types/bun.d.ts)
+    call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
+    call (buffer: Uint16Array<ArrayBufferLike>): string
+  function unsafe.gcAggressionLevel (bun-types/bun.d.ts)
+    call (level?: 0 | 1 | 2 | undefined): 0 | 1 | 2
+  function unsafe.memoryFootprint (bun-types/bun.d.ts)
+    call (): number | undefined
+  function unsafe.mimallocDump (bun-types/bun.d.ts)
+    call (): void
+var version (bun-types/bun.d.ts): string
+var version_with_sha (bun-types/bun.d.ts): string
+function which (bun-types/bun.d.ts)
+  call (command: string, options?: WhichOptions | undefined): null | string
+function wrapAnsi (bun-types/bun.d.ts)
+  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+function write (bun-types/bun.d.ts)
+  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+function zstdCompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+function zstdCompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+function zstdDecompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+function zstdDecompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+
+# module "bun:bundle"
+interface Registry (bun-types/bundle.d.ts)
+function feature (bun-types/bundle.d.ts)
+  call (flag: string): boolean
+
+# module "bun:ffi"
+function CFunction (bun-types/ffi.d.ts)
+  call (fn: FFIFunction & { ptr: number | bigint | Pointer; }): CallableFunction & { close(): void; }
+type CString (bun-types/ffi.d.ts) = string
+var CString (bun-types/ffi.d.ts): CStringConstructor
+interface CStringConstructor (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+  construct new (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts) = { [K in keyof Fns]: { (...args: Fns[K]["args"] extends infer A extends ReadonlyArray<FFITypeOrString> ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>]; } : [unknown] extends [Fns[K]["args"]] ? [] : never): [unknown] extends [Fns[K]["returns"]] ? undefined : FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>]; __ffi_function_callable: typeof FFIFunctionCallableSymbol; }; }
+interface FFIFunction (bun-types/ffi.d.ts)
+  args [? readonly]: ReadonlyArray<FFITypeOrString> | undefined
+  ptr [? readonly]: Pointer | bigint | undefined
+  returns [? readonly]: FFITypeOrString | undefined
+  threadsafe [? readonly]: boolean | undefined
+var FFIFunctionCallableSymbol (bun-types/ffi.d.ts): typeof FFIFunctionCallableSymbol
+enum FFIType (bun-types/ffi.d.ts)
+  char = FFIType.char
+  int8_t = FFIType.int8_t
+  i8 = FFIType.int8_t
+  uint8_t = FFIType.uint8_t
+  u8 = FFIType.uint8_t
+  int16_t = FFIType.int16_t
+  i16 = FFIType.int16_t
+  uint16_t = FFIType.uint16_t
+  u16 = FFIType.uint16_t
+  int32_t = FFIType.int32_t
+  i32 = FFIType.int32_t
+  int = FFIType.int32_t
+  uint32_t = FFIType.uint32_t
+  u32 = FFIType.uint32_t
+  int64_t = FFIType.int64_t
+  i64 = FFIType.int64_t
+  uint64_t = FFIType.uint64_t
+  u64 = FFIType.uint64_t
+  double = FFIType.double
+  f64 = FFIType.double
+  float = FFIType.float
+  f32 = FFIType.float
+  bool = FFIType.bool
+  ptr = FFIType.ptr
+  pointer = FFIType.ptr
+  void = FFIType.void
+  cstring = FFIType.cstring
+  i64_fast = FFIType.i64_fast
+  u64_fast = FFIType.u64_fast
+  function = FFIType.function
+  napi_env = FFIType.napi_env
+  napi_value = FFIType.napi_value
+  buffer = FFIType.buffer
+  buffer_length = FFIType.buffer_length
+type FFITypeOrString (bun-types/ffi.d.ts) = FFIType | keyof FFITypeStringToType
+interface FFITypeStringToType (bun-types/ffi.d.ts)
+  bool: FFIType.bool
+  buffer: FFIType.buffer
+  buffer_bytelength: FFIType.buffer_length
+  buffer_length: FFIType.buffer_length
+  callback: FFIType.ptr
+  char: FFIType.char
+  cstring: FFIType.cstring
+  double: FFIType.double
+  f32: FFIType.float
+  f64: FFIType.double
+  float: FFIType.float
+  function: FFIType.ptr
+  i16: FFIType.int16_t
+  i32: FFIType.int32_t
+  i64: FFIType.int64_t
+  i8: FFIType.int8_t
+  int: FFIType.int32_t
+  int16_t: FFIType.int16_t
+  int32_t: FFIType.int32_t
+  int64_t: FFIType.int64_t
+  int8_t: FFIType.int8_t
+  napi_env: FFIType.napi_env
+  napi_value: FFIType.napi_value
+  pointer: FFIType.ptr
+  ptr: FFIType.ptr
+  u16: FFIType.uint16_t
+  u32: FFIType.uint32_t
+  u64: FFIType.uint64_t
+  u8: FFIType.uint8_t
+  uint16_t: FFIType.uint16_t
+  uint32_t: FFIType.uint32_t
+  uint64_t: FFIType.uint64_t
+  uint8_t: FFIType.uint8_t
+  usize: FFIType.uint64_t
+  void: FFIType.void
+interface FFITypeToArgsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  13: undefined
+  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  15: bigint | number
+  16: bigint | number
+  17: JSCallback | Pointer
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint | number
+  8: bigint | number
+  9: number
+interface FFITypeToReturnsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | bigint | null
+  13: undefined
+  14: null | string
+  15: bigint | number
+  16: bigint | number
+  17: Pointer | bigint | null
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint
+  8: bigint
+  9: number
+class JSCallback (bun-types/ffi.d.ts)
+  close: () => void
+  ptr [readonly]: Pointer | null
+  threadsafe [readonly]: boolean
+  [static]
+    construct new (callback: (...args: Array<any>) => any, definition: FFIFunction): JSCallback
+    prototype: JSCallback
+interface Library<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts)
+  close: () => void
+  symbols: ConvertFns<Fns>
+type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
+type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
+type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
+function cc (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+function dlopen (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+function linkSymbols (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
+function ptr (bun-types/ffi.d.ts)
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+namespace read (bun-types/ffi.d.ts)
+  function read.f32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.f64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.i8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.intptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.ptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.u8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+var suffix (bun-types/ffi.d.ts): string
+function toArrayBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): ArrayBuffer
+function toBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): Buffer<ArrayBufferLike>
+function viewSource (bun-types/ffi.d.ts)
+  call (symbols: Readonly<Record<string, FFIFunction>>, is_callback?: false | undefined): Array<string>
+  call (callback: FFIFunction, is_callback: true): string
+
+# module "bun:jsc"
+interface HeapStats (bun-types/jsc.d.ts)
+  extraMemorySize: number
+  globalObjectCount: number
+  heapCapacity: number
+  heapSize: number
+  objectCount: number
+  objectTypeCounts: Record<string, number>
+  protectedGlobalObjectCount: number
+  protectedObjectCount: number
+  protectedObjectTypeCounts: Record<string, number>
+interface MemoryUsage (bun-types/jsc.d.ts)
+  current: number
+  currentCommit: number
+  pageFaults: number
+  peak: number
+  peakCommit: number
+interface SamplingProfile (bun-types/jsc.d.ts)
+  bytecodes: string
+  functions: string
+  stackTraces: SamplingProfileStackTraces
+interface SamplingProfileStackFrame (bun-types/jsc.d.ts)
+  category: string
+  column: number
+  flags: number
+  inliner [?]: undefined | { name: string; location: string; line: number; column: number; category: string; }
+  line: number
+  location: string
+  name: string
+  sourceID: number
+  sourceURL [?]: string | undefined
+interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
+  interval: number
+  sources: Array<{ sourceID: number; url?: string | undefined; sourceURL?: string | undefined; sourceMappingURL?: string | undefined; }>
+  traces: Array<{ timestamp: number; frames: Array<SamplingProfileStackFrame>; }>
+function callerSourceOrigin (bun-types/jsc.d.ts)
+  call (): null | string
+function deserialize (bun-types/jsc.d.ts)
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+function drainMicrotasks (bun-types/jsc.d.ts)
+  call (): void
+function edenGC (bun-types/jsc.d.ts)
+  call (): number
+function estimateShallowMemoryUsageOf (bun-types/jsc.d.ts)
+  call (value: CallableFunction | bigint | object | string | symbol): number
+function fullGC (bun-types/jsc.d.ts)
+  call (): number
+function gcAndSweep (bun-types/jsc.d.ts)
+  call (): number
+function getProtectedObjects (bun-types/jsc.d.ts)
+  call (): Array<any>
+function getRandomSeed (bun-types/jsc.d.ts)
+  call (): number
+function heapSize (bun-types/jsc.d.ts)
+  call (): number
+function heapStats (bun-types/jsc.d.ts)
+  call (): HeapStats
+function isRope (bun-types/jsc.d.ts)
+  call (input: string): boolean
+function jscDescribe (bun-types/jsc.d.ts)
+  call (value: any): string
+function jscDescribeArray (bun-types/jsc.d.ts)
+  call (array: Array<any>): string
+function memoryUsage (bun-types/jsc.d.ts)
+  call (): MemoryUsage
+function noFTL (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function noOSRExitFuzzing (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function numberOfDFGCompiles (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function optimizeNextInvocation (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function profile (bun-types/jsc.d.ts)
+  call <T extends (...args: Array<any>) => any>(callback: T, sampleInterval?: number | undefined, ...args: Parameters<T>): ReturnType<T> extends Promise<infer U> ? Promise<SamplingProfile> : SamplingProfile
+function releaseWeakRefs (bun-types/jsc.d.ts)
+  call (): void
+function reoptimizationRetryCount (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function serialize (bun-types/jsc.d.ts)
+  call (value: any, options?: undefined | { binaryType?: "arraybuffer" | undefined; }): SharedArrayBuffer
+  call (value: any, options?: undefined | { binaryType: "nodebuffer"; }): Buffer<ArrayBufferLike>
+function setRandomSeed (bun-types/jsc.d.ts)
+  call (value: number): void
+function setTimeZone (bun-types/jsc.d.ts)
+  call (timeZone: string): string
+function startRemoteDebugger (bun-types/jsc.d.ts)
+  call (host?: string | undefined, port?: number | undefined): void
+function startSamplingProfiler (bun-types/jsc.d.ts)
+  call (optionalDirectory?: string | undefined, sampleInterval?: number | undefined): void
+function totalCompileTime (bun-types/jsc.d.ts)
+  call (): number
+
+# module "bun:sqlite"
+interface Changes (bun-types/sqlite.d.ts)
+  changes: number
+  lastInsertRowid: bigint | number
+class Database (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  close: (throwOnError?: boolean | undefined) => void
+  exec: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  fileControl: { (op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number; (zDbName: string, op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number }
+  filename [readonly]: string
+  handle [readonly]: number
+  inTransaction: boolean
+  loadExtension: (extension: string, entryPoint?: string | undefined) => void
+  prepare: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string, params?: ParamsType | undefined) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  query: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  run: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  serialize: (name?: string | undefined) => Buffer<ArrayBufferLike>
+  transaction: <A extends Array<any>, T>(insideTransaction: (...args: A) => T) => { (...args: A): T; deferred: (...args: A) => T; immediate: (...args: A) => T; exclusive: (...args: A) => T; }
+  [static]
+    construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
+    MAX_QUERY_CACHE_SIZE [static]: number
+    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
+    prototype: Database
+    setCustomSQLite [static]: (path: string) => boolean
+interface DatabaseOptions (bun-types/sqlite.d.ts)
+  create [?]: boolean | undefined
+  readonly [?]: boolean | undefined
+  readwrite [?]: boolean | undefined
+  safeIntegers [?]: boolean | undefined
+  strict [?]: boolean | undefined
+type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+class SQLiteError (bun-types/sqlite.d.ts)
+  byteOffset [readonly]: number
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno: number
+  message: string
+  name [readonly]: "SQLiteError"
+  stack [?]: string | undefined
+  [static]
+    construct new (message?: string | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+    isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prototype: SQLiteError
+    stackTraceLimit: number
+class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  [Symbol.iterator]: () => IterableIterator<ReturnType>
+  all: (...params: ParamsType) => Array<ReturnType>
+  as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
+  columnNames [readonly]: Array<string>
+  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
+  declaredTypes [readonly]: Array<string | null>
+  finalize: () => void
+  get: (...params: ParamsType) => ReturnType | null
+  iterate: (...params: ParamsType) => IterableIterator<ReturnType>
+  native [readonly]: any
+  paramsCount [readonly]: number
+  raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
+  run: (...params: ParamsType) => Changes
+  toString: () => string
+  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  [static]
+    construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
+    prototype: Statement<any, any>
+namespace constants (bun-types/sqlite.d.ts)
+  var constants.SQLITE_FCNTL_BEGIN_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_BUSYHANDLER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CHUNK_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_DONE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_START (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKSM_FILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_PHASETWO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_DATA_VERSION (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_EXTERNAL_READER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_FILE_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_GET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_HAS_MOVED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_JOURNAL_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LAST_ERRNO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCKSTATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCK_TIMEOUT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_MMAP_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PDB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PERSIST_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_POWERSAFE_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PRAGMA (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RBU (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESERVE_BYTES (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESET_CACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_HINT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_LIMIT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC_OMITTED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TEMPFILENAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TRACE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFSNAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFS_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WAL_BLOCK (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_AV_RETRY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_GET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_SET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ZIPVFS (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_AUTOPROXY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_CREATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_DELETEONCLOSE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXCLUSIVE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXRESCODE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_FULLMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MEMORY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOFOLLOW (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_PRIVATECACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READONLY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SHAREDCACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUBJOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUPER_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TRANSIENT_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_URI (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NORMALIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NO_VTAB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_PERSISTENT (bun-types/sqlite.d.ts): number
+default -> Database
+var native (bun-types/sqlite.d.ts): any
+
+# module "bun:test"
+type AsymmetricMatcher (bun-types/test.d.ts) = any
+interface AsymmetricMatchers (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+type CustomMatcher<E, P extends Array<any>> (bun-types/test.d.ts) = (this: MatcherContext, expected: E, ...matcherArguments: P) => MatcherResult | Promise<MatcherResult>
+type CustomMatchersDetected (bun-types/test.d.ts) = Omit<Matchers<unknown>, keyof MatchersBuiltin<unknown>> & Omit<AsymmetricMatchers, keyof AsymmetricMatchersBuiltin>
+interface Describe<T extends ReadonlyArray<any>> (bun-types/test.d.ts)
+  call (fn: () => void): void
+  call (label: DescribeLabel, fn: (...args: T) => void): void
+  concurrent: Describe<T>
+  each: { <T extends readonly [any, ...any[]]>(table: ReadonlyArray<T>): Describe<[...T]>; <T extends Array<any>>(table: ReadonlyArray<T>): Describe<[...T]>; <T>(table: Array<T>): Describe<[T]> }
+  if: (condition: boolean) => Describe<T>
+  only: Describe<T>
+  serial: Describe<T>
+  skip: Describe<T>
+  skipIf: (condition: boolean) => Describe<T>
+  todo: Describe<T>
+  todoIf: (condition: boolean) => Describe<T>
+type EqualsFunction (bun-types/test.d.ts) = (a: unknown, b: unknown) => boolean
+interface Expect (bun-types/test.d.ts)
+  call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
+  call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
+  call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  assertions: (neededAssertions: number) => void
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  extend: <M>(matchers: ExpectExtendMatchers<M>) => void
+  hasAssertions: () => void
+  not: ExpectNot
+  objectContaining: (obj: object) => any
+  rejectsTo: AsymmetricMatchers
+  resolvesTo: AsymmetricMatchers
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+  unreachable: (msg?: Error | string | undefined) => never
+type ExpectExtendMatchers<M> (bun-types/test.d.ts) = { [k in keyof M]: k extends never ? CustomMatcher<unknown, Parameters<CustomMatchersDetected[k]>> : CustomMatcher<unknown, Array<any>>; }
+interface MatcherResult (bun-types/test.d.ts)
+  message [?]: (() => string) | string | undefined
+  pass: boolean
+interface Matchers<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
+  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  concurrent: Test<T>
+  concurrentIf: (condition: boolean) => Test<T>
+  each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
+  failing: Test<T>
+  failingIf: (condition: boolean) => Test<T>
+  if: (condition: boolean) => Test<T>
+  only: Test<T>
+  serial: Test<T>
+  serialIf: (condition: boolean) => Test<T>
+  skip: Test<T>
+  skipIf: (condition: boolean) => Test<T>
+  todo: Test<T>
+  todoIf: (condition: boolean) => Test<T>
+interface TestOptions (bun-types/test.d.ts)
+  repeats [?]: number | undefined
+  retry [?]: number | undefined
+  timeout [?]: number | undefined
+type Tester (bun-types/test.d.ts) = (this: TesterContext, a: any, b: any, customTesters: Array<Tester>) => boolean | undefined
+interface TesterContext (bun-types/test.d.ts)
+  equals: EqualsFunction
+function afterAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function afterEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+var describe (bun-types/test.d.ts): Describe<[]>
+var expect (bun-types/test.d.ts): Expect
+var expectTypeOf (bun-types/test.d.ts)
+  call <Actual>(actual: Actual): PositiveExpectTypeOf<Actual>
+  call <Actual>(): PositiveExpectTypeOf<Actual>
+var it (bun-types/test.d.ts): Test<[]>
+namespace jest (bun-types/test.d.ts)
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
+  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  function jest.advanceTimersByTime (bun-types/test.d.ts)
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.clearAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.clearAllTimers (bun-types/test.d.ts)
+    call (): void
+  function jest.fn (bun-types/test.d.ts)
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+  function jest.getTimerCount (bun-types/test.d.ts)
+    call (): number
+  function jest.isFakeTimers (bun-types/test.d.ts)
+    call (): boolean
+  function jest.resetAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.restoreAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.runAllTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.runOnlyPendingTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.setSystemTime (bun-types/test.d.ts)
+    call (now?: Date | number | undefined): void
+  function jest.setTimeout (bun-types/test.d.ts)
+    call (milliseconds: number): void
+  function jest.spyOn (bun-types/test.d.ts)
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+  function jest.useFakeTimers (bun-types/test.d.ts)
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.useRealTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var mock (bun-types/test.d.ts)
+  call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
+  clearAllMocks: () => void
+  module: (id: string, factory: () => any) => Promise<void> | void
+  restore: () => void
+function onTestFinished (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function setDefaultTimeout (bun-types/test.d.ts)
+  call (milliseconds: number): void
+function setSystemTime (bun-types/test.d.ts)
+  call (now?: Date | number | undefined): ThisType<void>
+function spyOn (bun-types/test.d.ts)
+  call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+test -> it
+var vi (bun-types/test.d.ts)
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  clearAllMocks: () => void
+  clearAllTimers: () => void
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  getTimerCount: () => number
+  isFakeTimers: () => boolean
+  mock: (id: string, factory: () => any) => Promise<void> | void
+  resetAllMocks: () => void
+  restoreAllMocks: () => void
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var xdescribe (bun-types/test.d.ts): Describe<[]>
+var xit (bun-types/test.d.ts): Test<[]>
+xtest -> xit
+
+# globals
+interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  abort: { (reason?: any): void; (reason?: any): void }
+  signal [readonly]: AbortSignal
+var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): AbortController
+  prototype: AbortController
+interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  aborted [readonly]: boolean
+  addEventListener: { <K extends "abort">(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onabort: ((this: AbortSignal, ev: Event) => any) | null
+  reason [readonly]: any
+  removeEventListener: { <K extends "abort">(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  throwIfAborted: { (): void; (): void }
+var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): AbortSignal
+  abort: (reason?: any) => AbortSignal
+  any: (signals: Array<AbortSignal>) => AbortSignal
+  prototype: AbortSignal
+  timeout: (milliseconds: number) => AbortSignal
+interface AddEventListenerOptions (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2024.arraybuffer.d.ts, lib.es5.d.ts)
+  [Symbol.toStringTag] [readonly]: "ArrayBuffer"
+  byteLength [readonly]: number
+  detached: boolean
+  maxByteLength: number
+  resizable: boolean
+  resize: { (newByteLength?: number | undefined): void; (byteLength: number): ArrayBuffer }
+  slice: { (begin?: number | undefined, end?: number | undefined): ArrayBuffer; (begin: number, end?: number | undefined): ArrayBuffer }
+  transfer: (newByteLength?: number | undefined) => ArrayBuffer
+  transferToFixedLength: (newByteLength?: number | undefined) => ArrayBuffer
+var ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2024.arraybuffer.d.ts, lib.es5.d.ts): ArrayBufferConstructor
+interface ArrayBufferConstructor (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2017.arraybuffer.d.ts, lib.es2024.arraybuffer.d.ts, lib.es5.d.ts)
+  construct new (byteLength: number): ArrayBuffer
+  construct new (): ArrayBuffer
+  construct new (byteLength: number, options?: undefined | { maxByteLength?: number | undefined; }): ArrayBuffer
+  construct new (byteLength: number, options: { maxByteLength?: number | undefined; }): ArrayBuffer
+  [Symbol.species] [readonly]: ArrayBufferConstructor
+  isView: (arg: any) => arg is ArrayBufferView<ArrayBufferLike>
+  prototype [readonly]: ArrayBuffer
+interface ArrayConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts, lib.esnext.array.d.ts)
+  call (arrayLength?: number | undefined): Array<any>
+  call <T>(arrayLength: number): Array<T>
+  call <T>(...items: Array<T>): Array<T>
+  construct new (arrayLength?: number | undefined): Array<any>
+  construct new <T>(arrayLength: number): Array<T>
+  construct new <T>(...items: Array<T>): Array<T>
+  [Symbol.species] [readonly]: ArrayConstructor
+  from: { <T>(arrayLike: ArrayLike<T>): Array<T>; <T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>; <T>(iterable: ArrayLike<T> | Iterable<T>): Array<T>; <T, U>(iterable: ArrayLike<T> | Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U> }
+  fromAsync: { <T>(iterableOrArrayLike: ArrayLike<T | PromiseLike<T>> | AsyncIterable<T> | Iterable<T | PromiseLike<T>>): Promise<Array<T>>; <T, U>(iterableOrArrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Array<Awaited<U>>>; <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
+  isArray: (arg: any) => arg is any[]
+  of: <T>(...items: Array<T>) => Array<T>
+  prototype [readonly]: Array<any>
+interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
+interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  endings [?]: EndingType | undefined
+  type [?]: string | undefined
+interface BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  name [readonly]: string
+  onmessage: ((this: BroadcastChannel, ev: MessageEvent<any>) => any) | null
+  onmessageerror: ((this: BroadcastChannel, ev: MessageEvent<any>) => any) | null
+  postMessage: (message: any) => void
+  removeEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+var BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (name: string): BroadcastChannel
+  prototype: BroadcastChannel
+var BuildError (bun-types/deprecated.d.ts): typeof BuildMessage
+class BuildMessage (bun-types/globals.d.ts)
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "BuildMessage"
+  position [readonly]: Position | null
+  [static]
+    construct new (): BuildMessage
+    prototype: BuildMessage
+Bun -> module "bun"
+interface BunFetchRequestInit (bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
+  credentials [?]: RequestCredentials | undefined
+  decompress [?]: boolean | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  maxRedirects [?]: number | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  priority [?]: RequestPriority | undefined
+  protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  s3 [?]: S3Options | undefined
+  signal [?]: AbortSignal | null | undefined
+  timeout [?]: boolean | number | undefined
+  tls [?]: BunFetchRequestInitTLS | undefined
+  unix [?]: string | undefined
+  verbose [?]: boolean | undefined
+  window [?]: null | undefined
+interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<ArrayBufferView<ArrayBufferLike>>
+var ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init: QueuingStrategyInit): ByteLengthQueuingStrategy
+  prototype: ByteLengthQueuingStrategy
+interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  code [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  reason [readonly]: string
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  wasClean [readonly]: boolean
+var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  prototype: CloseEvent
+interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  writable [readonly]: WritableStream<BufferSource>
+var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (format: CompressionFormat): CompressionStream
+  prototype: CompressionStream
+interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
+  assert: { (condition?: boolean | undefined, ...data: Array<any>): void; (condition?: boolean | undefined, ...data: Array<any>): void }
+  clear: { (): void; (): void }
+  count: { (label?: string | undefined): void; (label?: string | undefined): void }
+  countReset: { (label?: string | undefined): void; (label?: string | undefined): void }
+  debug: { (...data: Array<any>): void; (...data: Array<any>): void }
+  dir: { (item?: any, options?: any): void; (item?: any, options?: any): void }
+  dirxml: { (...data: Array<any>): void; (...data: Array<any>): void }
+  error: { (...data: Array<any>): void; (...data: Array<any>): void }
+  group: { (...data: Array<any>): void; (...data: Array<any>): void }
+  groupCollapsed: { (...data: Array<any>): void; (...data: Array<any>): void }
+  groupEnd: { (): void; (): void }
+  info: { (...data: Array<any>): void; (...data: Array<any>): void }
+  log: { (...data: Array<any>): void; (...data: Array<any>): void }
+  profile: (label?: string | undefined) => void
+  profileEnd: (label?: string | undefined) => void
+  table: { (tabularData?: any, properties?: Array<string> | undefined): void; (tabularData?: any, properties?: Array<string> | undefined): void }
+  time: { (label?: string | undefined): void; (label?: string | undefined): void }
+  timeEnd: { (label?: string | undefined): void; (label?: string | undefined): void }
+  timeLog: { (label?: string | undefined, ...data: Array<any>): void; (label?: string | undefined, ...data: Array<any>): void }
+  timeStamp: { (label?: string | undefined): void; (label?: string | undefined): void }
+  trace: { (...data: Array<any>): void; (...data: Array<any>): void }
+  warn: { (...data: Array<any>): void; (...data: Array<any>): void }
+  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+interface ConsoleOptions (bun-types/globals.d.ts)
+  colorMode [?]: "auto" | boolean | undefined
+  groupIndentation [?]: number | undefined
+  ignoreErrors [?]: boolean | undefined
+  inspectOptions [?]: InspectOptions | undefined
+  stderr [?]: Writable | undefined
+  stdout: Writable
+interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<any>
+var CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init: QueuingStrategyInit): CountQueuingStrategy
+  prototype: CountQueuingStrategy
+interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  getRandomValues: { <T extends ArrayBufferView<ArrayBuffer>>(array: T): T; <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T): T }
+  randomUUID: { (): `${string}-${string}-${string}-${string}-${string}`; (): `${string}-${string}-${string}-${string}-${string}` }
+  subtle [readonly]: SubtleCrypto
+  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): Crypto
+  prototype: Crypto
+interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  algorithm [readonly]: KeyAlgorithm
+  extractable [readonly]: boolean
+  type [readonly]: KeyType
+  usages [readonly]: Array<KeyUsage>
+var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): CryptoKey
+  prototype: CryptoKey
+interface CryptoKeyPair (bun-types/globals.d.ts, lib.dom.d.ts)
+  privateKey: CryptoKey
+  publicKey: CryptoKey
+interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  detail [readonly]: T
+  eventPhase [readonly]: number
+  initCustomEvent: { (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, detail?: T | undefined): void; (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, detail?: T | undefined): void }
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  prototype: CustomEvent<any>
+interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  cause [?]: unknown
+  code [readonly]: number
+  message [readonly]: string
+  name [readonly]: string
+  stack [?]: string | undefined
+var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (message?: string | undefined, name?: string | undefined): DOMException
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  prototype: DOMException
+interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  writable [readonly]: WritableStream<BufferSource>
+var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (format: CompressionFormat): DecompressionStream
+  prototype: DecompressionStream
+interface Dict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined
+interface ErrnoException (bun-types/globals.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts)
+  cause [?]: unknown
+  message: string
+  name: string
+  stack [?]: string | undefined
+var Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts): ErrorConstructor
+interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts, lib.esnext.error.d.ts)
+  call (message?: string | undefined): Error
+  call (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+  isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prototype [readonly]: Error
+  stackTraceLimit: number
+interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  colno [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  error [readonly]: any
+  eventPhase [readonly]: number
+  filename [readonly]: string
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  lineno [readonly]: number
+  message [readonly]: string
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  prototype: ErrorEvent
+interface ErrorOptions (bun-types/globals.d.ts, lib.es2022.error.d.ts)
+  cause [?]: unknown
+interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  prototype: Event
+interface EventListener (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (evt: Event): void
+  call (evt: Event): void
+interface EventListenerObject (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  handleEvent: { (object: Event): void; (object: Event): void }
+interface EventMap (bun-types/globals.d.ts)
+  fetch: FetchEvent
+  message: MessageEvent<any>
+  messageerror: MessageEvent<any>
+interface EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: MessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: Event) => any) | null
+  onmessage: ((this: EventSource, ev: MessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: number
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: MessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  prototype: EventSource
+interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  withCredentials [?]: boolean | undefined
+interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  removeEventListener: (type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean | undefined) => void
+var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): EventTarget
+  prototype: EventTarget
+interface FetchEvent (bun-types/globals.d.ts)
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<Uint8Array<ArrayBuffer>>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified [readonly]: number
+  name [readonly]: string
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<Uint8Array<ArrayBuffer>>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: { (): Promise<string>; (): Promise<string> }
+  type [readonly]: string
+  webkitRelativePath [readonly]: string
+var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (fileBits: Array<BlobPart>, fileName: string, options?: FilePropertyBag | undefined): File
+  prototype: File
+interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.iterator]: () => FormDataIterator<[string, FormDataEntryValue]>
+  append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  delete: { (name: string): void; (name: string): void }
+  entries: { (): FormDataIterator<[string, FormDataEntryValue]>; (): IterableIterator<[string, string]> }
+  forEach: { (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void; (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void }
+  get: { (name: string): FormDataEntryValue | null; (name: string): FormDataEntryValue | null }
+  getAll: { (name: string): Array<FormDataEntryValue>; (name: string): Array<FormDataEntryValue> }
+  has: { (name: string): boolean; (name: string): boolean }
+  keys: { (): FormDataIterator<string>; (): IterableIterator<string> }
+  set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void; (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  values: { (): FormDataIterator<FormDataEntryValue>; (): IterableIterator<string> }
+var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (form?: HTMLFormElement | undefined, submitter?: HTMLElement | null | undefined): FormData
+  prototype: FormData
+class HTMLRewriter (bun-types/html-rewriter.d.ts)
+  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  [static]
+    construct new (): HTMLRewriter
+    prototype: HTMLRewriter
+namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
+  interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Comment
+    before: (content: string, options?: ContentOptions | undefined) => Comment
+    remove: () => Comment
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    text: string
+  type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
+  interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
+    html [?]: boolean | undefined
+  interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
+    name [readonly]: null | string
+    publicId [readonly]: null | string
+    remove: () => Doctype
+    removed [readonly]: boolean
+    systemId [readonly]: null | string
+  interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
+    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+  interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Element
+    append: (content: string, options?: ContentOptions | undefined) => Element
+    attributes [readonly]: IterableIterator<[string, string]>
+    before: (content: string, options?: ContentOptions | undefined) => Element
+    canHaveContent [readonly]: boolean
+    getAttribute: (name: string) => null | string
+    hasAttribute: (name: string) => boolean
+    namespaceURI [readonly]: string
+    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: ContentOptions | undefined) => Element
+    remove: () => Element
+    removeAndKeepContent: () => Element
+    removeAttribute: (name: string) => Element
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Element
+    selfClosing [readonly]: boolean
+    setAttribute: (name: string, value: string) => Element
+    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    tagName: string
+  interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => EndTag
+    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    name: string
+    remove: () => EndTag
+  interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: Element) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Text
+    before: (content: string, options?: ContentOptions | undefined) => Text
+    lastInTextNode [readonly]: boolean
+    remove: () => Text
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Text
+    text [readonly]: string
+interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.iterator]: () => HeadersIterator<[string, string]>
+  append: (name: string, value: string) => void
+  count [readonly]: number
+  delete: (name: string) => void
+  entries: () => HeadersIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+  getSetCookie: () => Array<string>
+  has: (name: string) => boolean
+  keys: () => HeadersIterator<string>
+  set: (name: string, value: string) => void
+  toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+  values: () => HeadersIterator<string>
+var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init?: HeadersInit | undefined): Headers
+  prototype: Headers
+interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.dom.d.ts, lib.es5.d.ts)
+  dir [readonly]: string
+  dirname: string
+  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  file [readonly]: string
+  filename: string
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  main: boolean
+  path [readonly]: string
+  require: Require
+  resolve: { (specifier: string): string; (specifier: string, parent?: URL | string | undefined): string }
+  resolveSync: (moduleId: string, parent?: string | undefined) => string
+  url: string
+interface ImportMetaEnv (bun-types/globals.d.ts)
+  index [string]: string | undefined
+var Loader (bun-types/globals.d.ts)
+  dependencyKeysIfEvaluated: (specifier: string) => Array<string>
+  registry: Map<string, { key: string; state: number; fetch: Promise<any>; instantiate: Promise<any>; satisfy: Promise<any>; dependencies: Array<any>; module: { dependenciesMap: Map<string, any>; }; linkError?: any; linkSucceeded: boolean; evaluated: boolean; then?: any; isAsync: boolean; }>
+  resolve: (specifier: string, referrer: string) => string
+interface MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  port1 [readonly]: MessagePort
+  port2 [readonly]: MessagePort
+var MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): MessageChannel
+  prototype: MessageChannel
+interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => Array<EventTarget>
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined) => void
+  initMessageEvent: { (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: MessageEventSource | null | undefined, ports?: Array<MessagePort> | undefined): void; (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: MessageEventSource | null | undefined, ports?: Iterable<MessagePort> | undefined): void }
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  prototype: MessageEvent<any>
+  returnValue: boolean
+  source [readonly]: MessageEventSource | null
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<T>
+  prototype: MessageEvent<any>
+interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (this: MessagePort, ev: MessagePortEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onmessage: ((this: MessagePort, ev: MessageEvent<any>) => any) | null
+  onmessageerror: ((this: MessagePort, ev: MessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  removeEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (this: MessagePort, ev: MessagePortEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  start: () => void
+var MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): MessagePort
+  prototype: MessagePort
+interface Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  appCodeName [readonly]: string
+  appName [readonly]: string
+  appVersion [readonly]: string
+  canShare: (data?: ShareData | undefined) => boolean
+  clearAppBadge: () => Promise<void>
+  clipboard [readonly]: Clipboard
+  cookieEnabled [readonly]: boolean
+  credentials [readonly]: CredentialsContainer
+  doNotTrack [readonly]: null | string
+  geolocation [readonly]: Geolocation
+  getGamepads: () => Array<Gamepad | null>
+  gpu [readonly]: GPU
+  hardwareConcurrency [readonly]: number
+  javaEnabled: () => boolean
+  language [readonly]: string
+  languages [readonly]: ReadonlyArray<string>
+  locks [readonly]: LockManager
+  login [readonly]: NavigatorLogin
+  maxTouchPoints [readonly]: number
+  mediaCapabilities [readonly]: MediaCapabilities
+  mediaDevices [readonly]: MediaDevices
+  mediaSession [readonly]: MediaSession
+  mimeTypes [readonly]: MimeTypeArray
+  onLine [readonly]: boolean
+  pdfViewerEnabled [readonly]: boolean
+  permissions [readonly]: Permissions
+  platform [readonly]: "Linux x86_64" | "MacIntel" | "Win32"
+  plugins [readonly]: PluginArray
+  product [readonly]: string
+  productSub [readonly]: string
+  registerProtocolHandler: (scheme: string, url: URL | string) => void
+  requestMIDIAccess: (options?: MIDIOptions | undefined) => Promise<MIDIAccess>
+  requestMediaKeySystemAccess: { (keySystem: string, supportedConfigurations: Array<MediaKeySystemConfiguration>): Promise<MediaKeySystemAccess>; (keySystem: string, supportedConfigurations: Iterable<MediaKeySystemConfiguration>): Promise<MediaKeySystemAccess> }
+  sendBeacon: (url: URL | string, data?: BodyInit | null | undefined) => boolean
+  serviceWorker [readonly]: ServiceWorkerContainer
+  setAppBadge: (contents?: number | undefined) => Promise<void>
+  share: (data?: ShareData | undefined) => Promise<void>
+  storage [readonly]: StorageManager
+  userActivation [readonly]: UserActivation
+  userAgent [readonly]: string
+  vendor [readonly]: string
+  vendorSub [readonly]: string
+  vibrate: { (pattern: VibratePattern): boolean; (pattern: Iterable<number>): boolean }
+  wakeLock [readonly]: WakeLock
+  webdriver [readonly]: boolean
+var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): Navigator
+  prototype: Navigator
+namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
+  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
+    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
+    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
+  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
+  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
+  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
+  interface NodeJS.CallSite (@types/node/globals.d.ts)
+    getColumnNumber: () => null | number
+    getEnclosingColumnNumber: () => null | number
+    getEnclosingLineNumber: () => null | number
+    getEvalOrigin: () => string | undefined
+    getFileName: () => null | string
+    getFunction: () => Function | undefined
+    getFunctionName: () => null | string
+    getLineNumber: () => null | number
+    getMethodName: () => null | string
+    getPosition: () => number
+    getPromiseIndex: () => null | number
+    getScriptHash: () => string
+    getScriptNameOrSourceURL: () => null | string
+    getThis: () => unknown
+    getTypeName: () => null | string
+    isAsync: () => boolean
+    isConstructor: () => boolean
+    isEval: () => boolean
+    isNative: () => boolean
+    isPromiseAll: () => boolean
+    isToplevel: () => boolean
+  interface NodeJS.CpuUsage (@types/node/process.d.ts)
+    system: number
+    user: number
+  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined
+  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
+  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
+    code [?]: string | undefined
+    ctor [?]: Function | undefined
+    detail [?]: string | undefined
+    type [?]: string | undefined
+  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
+    cause [?]: unknown
+    code [?]: string | undefined
+    errno [?]: number | undefined
+    message: string
+    name: string
+    path [?]: string | undefined
+    stack [?]: string | undefined
+    syscall [?]: string | undefined
+  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
+    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
+    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    setMaxListeners: (n: number) => EventEmitter<T>
+  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
+  interface NodeJS.GCFunction (@types/node/globals.d.ts)
+    call (minor?: boolean | undefined): void
+    call (options: GCOptions & { execution: "async"; }): Promise<void>
+    call (options: GCOptions): void
+  interface NodeJS.GCOptions (@types/node/globals.d.ts)
+    execution [?]: "async" | "sync" | undefined
+    filename [?]: string | undefined
+    flavor [?]: "last-resort" | "regular" | undefined
+    type [?]: "major" | "major-snapshot" | "minor" | undefined
+  interface NodeJS.HRTime (@types/node/process.d.ts)
+    call (time?: [number, number] | undefined): [number, number]
+    bigint: () => bigint
+  interface NodeJS.Immediate (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    _onImmediate: (...args: Array<any>) => void
+    hasRef: () => boolean
+    ref: () => Immediate
+    unref: () => Immediate
+  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
+    [Symbol.toStringTag] [readonly]: string
+    drop: (count: number) => IteratorObject<T, undefined, unknown>
+    every: (predicate: (value: T, index: number) => unknown) => boolean
+    filter: { <S>(predicate: (value: T, index: number) => value is S): IteratorObject<S, undefined, unknown>; (predicate: (value: T, index: number) => unknown): IteratorObject<T, undefined, unknown> }
+    find: { <S>(predicate: (value: T, index: number) => value is S): S | undefined; (predicate: (value: T, index: number) => unknown): T | undefined }
+    flatMap: <U>(callback: (value: T, index: number) => Iterable<U, unknown, undefined> | Iterator<U, unknown, undefined>) => IteratorObject<U, undefined, unknown>
+    forEach: (callbackfn: (value: T, index: number) => void) => void
+    map: <U>(callbackfn: (value: T, index: number) => U) => IteratorObject<U, undefined, unknown>
+    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
+    reduce: { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number) => U, initialValue: U): U }
+    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
+    some: (predicate: (value: T, index: number) => unknown) => boolean
+    take: (limit: number) => IteratorObject<T, undefined, unknown>
+    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
+    toArray: () => Array<T>
+  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
+    arrayBuffers: number
+    external: number
+    heapTotal: number
+    heapUsed: number
+    rss: number
+  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
+    call (): MemoryUsage
+    rss: () => number
+  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
+  interface NodeJS.Module (@types/node/module.d.ts)
+    children: Array<Module>
+    exports: any
+    filename: string
+    id: string
+    isPreloading: boolean
+    loaded: boolean
+    parent: Module | null | undefined
+    path: string
+    paths: Array<string>
+    require: (id: string) => any
+  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
+  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
+  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
+  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
+  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
+  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
+  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
+  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
+  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
+  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
+  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+  interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    _exiting: boolean
+    abort: () => never
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
+    allowedNodeEnvironmentFlags: ReadonlySet<string>
+    arch [readonly]: Architecture
+    argv: Array<string>
+    argv0: string
+    assert: (value: unknown, message?: Error | string | undefined) => asserts value
+    availableMemory: () => number
+    binding: { (m: "constants"): { os: typeof constants; fs: typeof constants; crypto: typeof constants; zlib: typeof constants; trace: { TRACE_EVENT_PHASE_BEGIN: number; TRACE_EVENT_PHASE_END: number; TRACE_EVENT_PHASE_COMPLETE: number; TRACE_EVENT_PHASE_INSTANT: number; TRACE_EVENT_PHASE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_ASYNC_STEP_INTO: number; TRACE_EVENT_PHASE_ASYNC_STEP_PAST: number; TRACE_EVENT_PHASE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_INSTANT: number; TRACE_EVENT_PHASE_FLOW_BEGIN: number; TRACE_EVENT_PHASE_FLOW_STEP: number; TRACE_EVENT_PHASE_FLOW_END: number; TRACE_EVENT_PHASE_METADATA: number; TRACE_EVENT_PHASE_COUNTER: number; TRACE_EVENT_PHASE_SAMPLE: number; TRACE_EVENT_PHASE_CREATE_OBJECT: number; TRACE_EVENT_PHASE_SNAPSHOT_OBJECT: number; TRACE_EVENT_PHASE_DELETE_OBJECT: number; TRACE_EVENT_PHASE_MEMORY_DUMP: number; TRACE_EVENT_PHASE_MARK: number; TRACE_EVENT_PHASE_CLOCK_SYNC: number; TRACE_EVENT_PHASE_ENTER_CONTEXT: number; TRACE_EVENT_PHASE_LEAVE_CONTEXT: number; TRACE_EVENT_PHASE_LINK_IDS: number; }; }; (m: "uv"): { errname(code: number): string; UV_E2BIG: number; UV_EACCES: number; UV_EADDRINUSE: number; UV_EADDRNOTAVAIL: number; UV_EAFNOSUPPORT: number; UV_EAGAIN: number; UV_EAI_ADDRFAMILY: number; UV_EAI_AGAIN: number; UV_EAI_BADFLAGS: number; UV_EAI_BADHINTS: number; UV_EAI_CANCELED: number; UV_EAI_FAIL: number; UV_EAI_FAMILY: number; UV_EAI_MEMORY: number; UV_EAI_NODATA: number; UV_EAI_NONAME: number; UV_EAI_OVERFLOW: number; UV_EAI_PROTOCOL: number; UV_EAI_SERVICE: number; UV_EAI_SOCKTYPE: number; UV_EALREADY: number; UV_EBADF: number; UV_EBUSY: number; UV_ECANCELED: number; UV_ECHARSET: number; UV_ECONNABORTED: number; UV_ECONNREFUSED: number; UV_ECONNRESET: number; UV_EDESTADDRREQ: number; UV_EEXIST: number; UV_EFAULT: number; UV_EFBIG: number; UV_EHOSTUNREACH: number; UV_EINTR: number; UV_EINVAL: number; UV_EIO: number; UV_EISCONN: number; UV_EISDIR: number; UV_ELOOP: number; UV_EMFILE: number; UV_EMSGSIZE: number; UV_ENAMETOOLONG: number; UV_ENETDOWN: number; UV_ENETUNREACH: number; UV_ENFILE: number; UV_ENOBUFS: number; UV_ENODEV: number; UV_ENOENT: number; UV_ENOMEM: number; UV_ENONET: number; UV_ENOPROTOOPT: number; UV_ENOSPC: number; UV_ENOSYS: number; UV_ENOTCONN: number; UV_ENOTDIR: number; UV_ENOTEMPTY: number; UV_ENOTSOCK: number; UV_ENOTSUP: number; UV_EOVERFLOW: number; UV_EPERM: number; UV_EPIPE: number; UV_EPROTO: number; UV_EPROTONOSUPPORT: number; UV_EPROTOTYPE: number; UV_ERANGE: number; UV_EROFS: number; UV_ESHUTDOWN: number; UV_ESPIPE: number; UV_ESRCH: number; UV_ETIMEDOUT: number; UV_ETXTBSY: number; UV_EXDEV: number; UV_UNKNOWN: number; UV_EOF: number; UV_ENXIO: number; UV_EMLINK: number; UV_EHOSTDOWN: number; UV_EREMOTEIO: number; UV_ENOTTY: number; UV_EFTYPE: number; UV_EILSEQ: number; UV_ESOCKTNOSUPPORT: number; UV_ENODATA: number; UV_EUNATCH: number; }; (m: "http_parser"): { methods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "QUERY"]; allMethods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "PRI", "DESCRIBE", "ANNOUNCE", "SETUP", "PLAY", "PAUSE", "TEARDOWN", "GET_PARAMETER", "SET_PARAMETER", "REDIRECT", "RECORD", "FLUSH", "QUERY"]; HTTPParser: unknown; ConnectionsList: unknown; }; (m: string): object }
+    browser: boolean
+    channel [?]: Control | undefined
+    chdir: (directory: string) => void
+    config [readonly]: ProcessConfig
+    connected: boolean
+    constrainedMemory: () => number
+    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cwd: () => string
+    debugPort: number
+    disconnect [?]: (() => void) | undefined
+    dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
+    emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
+    env: ProcessEnv
+    eventNames: () => Array<string | symbol>
+    execArgv: Array<string>
+    execPath: string
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    exit: (code?: null | number | string | undefined) => never
+    exitCode: null | number | string | undefined
+    features [readonly]: ProcessFeatures
+    finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
+    getActiveResourcesInfo: () => Array<string>
+    getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
+    getMaxListeners: () => number
+    getegid [?]: (() => number) | undefined
+    geteuid [?]: (() => number) | undefined
+    getgid [?]: (() => number) | undefined
+    getgroups [?]: (() => Array<number>) | undefined
+    getuid [?]: (() => number) | undefined
+    hasUncaughtExceptionCaptureCallback: () => boolean
+    hrtime: HRTime
+    isBun: true
+    kill: (pid: number, signal?: number | string | undefined) => true
+    listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    loadEnvFile: (path?: PathLike | undefined) => void
+    mainModule [?]: Module | undefined
+    memoryUsage: MemoryUsageFn
+    nextTick: (callback: Function, ...args: Array<any>) => void
+    noDeprecation [?]: boolean | undefined
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    permission: ProcessPermission
+    pid [readonly]: number
+    platform [readonly]: Platform
+    ppid [readonly]: number
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    reallyExit: (code?: number | undefined) => never
+    ref: (maybeRefable: any) => void
+    release [readonly]: ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    report: ProcessReport
+    resourceUsage: () => ResourceUsage
+    revision: string
+    send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
+    setMaxListeners: (n: number) => Process
+    setSourceMapsEnabled: (value: boolean) => void
+    setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
+    setegid [?]: ((id: number | string) => void) | undefined
+    seteuid [?]: ((id: number | string) => void) | undefined
+    setgid [?]: ((id: number | string) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setuid [?]: ((id: number | string) => void) | undefined
+    sourceMapsEnabled [readonly]: boolean
+    stderr: WriteStream & { fd: 2; }
+    stdin: ReadStream & { fd: 0; }
+    stdout: WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    throwDeprecation: boolean
+    title: string
+    traceDeprecation: boolean
+    traceProcessWarnings: boolean
+    umask: { (): number; (mask: number | string): number }
+    unref: (maybeRefable: any) => void
+    uptime: () => number
+    version [readonly]: string
+    versions [readonly]: ProcessVersions
+  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
+    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
+    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+  interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    NODE_ENV [?]: string | undefined
+    TZ [?]: string | undefined
+  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
+    cached_builtins [readonly]: boolean
+    debug [readonly]: boolean
+    inspector [readonly]: boolean
+    ipv6 [readonly]: boolean
+    require_module [readonly]: boolean
+    tls [readonly]: boolean
+    tls_alpn [readonly]: boolean
+    tls_ocsp [readonly]: boolean
+    tls_sni [readonly]: boolean
+    typescript [readonly]: "strip" | false
+    uv [readonly]: boolean
+  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
+    has: (scope: string, reference?: string | undefined) => boolean
+  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
+    headersUrl [?]: string | undefined
+    libUrl [?]: string | undefined
+    lts [?]: string | undefined
+    name: string
+    sourceUrl [?]: string | undefined
+  interface NodeJS.ProcessReport (@types/node/process.d.ts)
+    compact: boolean
+    directory: string
+    excludeEnv: boolean
+    filename: string
+    getReport: (err?: Error | undefined) => object
+    reportOnFatalError: boolean
+    reportOnSignal: boolean
+    reportOnUncaughtException: boolean
+    signal: Signals
+    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
+  interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    ares: string
+    bun: string
+    http_parser: string
+    modules: string
+    node: string
+    openssl: string
+    uv: string
+    v8: string
+    zlib: string
+  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined [readonly]
+  interface NodeJS.ReadStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    closed [readonly]: boolean
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    destroy: (error?: Error | undefined) => ReadStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    isPaused: () => boolean
+    isRaw: boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    pause: () => ReadStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => ReadStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
+    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    resetAndDestroy: () => ReadStream
+    resume: () => ReadStream
+    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
+    setMaxListeners: (n: number) => ReadStream
+    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
+    setRawMode: (mode: boolean) => ReadStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
+    setTypeOfService: (tos: number) => ReadStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => ReadStream
+    unref: () => ReadStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => ReadStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    pause: () => ReadWriteStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    resume: () => ReadWriteStream
+    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
+    setMaxListeners: (n: number) => ReadWriteStream
+    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadWriteStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    pause: () => ReadableStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    resume: () => ReadableStream
+    setEncoding: (encoding: BufferEncoding) => ReadableStream
+    setMaxListeners: (n: number) => ReadableStream
+    unpipe: (destination?: WritableStream | undefined) => ReadableStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadableStream
+  interface NodeJS.RefCounted (@types/node/globals.d.ts)
+    ref: () => RefCounted
+    unref: () => RefCounted
+  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
+  interface NodeJS.Require (@types/node/module.d.ts)
+    call (id: string): any
+    cache: Dict<Module>
+    extensions: RequireExtensions
+    main: Module | undefined
+    resolve: RequireResolve
+  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
+    index [string]: ((module: Module, filename: string) => any) | undefined
+    .js: (module: Module, filename: string) => any
+    .json: (module: Module, filename: string) => any
+    .node: (module: Module, filename: string) => any
+  interface NodeJS.RequireResolve (@types/node/module.d.ts)
+    call (request: string, options?: RequireResolveOptions | undefined): string
+    paths: (request: string) => Array<string> | null
+  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
+    paths [?]: Array<string> | undefined
+  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
+    fsRead: number
+    fsWrite: number
+    involuntaryContextSwitches: number
+    ipcReceived: number
+    ipcSent: number
+    majorPageFault: number
+    maxRSS: number
+    minorPageFault: number
+    sharedMemorySize: number
+    signalsCount: number
+    swappedOut: number
+    systemCPUTime: number
+    unsharedDataSize: number
+    unsharedStackSize: number
+    userCPUTime: number
+    voluntaryContextSwitches: number
+  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
+  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
+  interface NodeJS.Socket (@types/node/process.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    isTTY [?]: true | undefined
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    pause: () => Socket
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    resume: () => Socket
+    setEncoding: (encoding: BufferEncoding) => Socket
+    setMaxListeners: (n: number) => Socket
+    unpipe: (destination?: WritableStream | undefined) => Socket
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => Socket
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.Timeout (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.toPrimitive]: () => number
+    _onTimeout: (...args: Array<any>) => void
+    close: () => Timeout
+    hasRef: () => boolean
+    ref: () => Timeout
+    refresh: () => Timeout
+    unref: () => Timeout
+  interface NodeJS.Timer (@types/node/timers.d.ts)
+    [Symbol.toPrimitive]: () => number
+    hasRef: () => boolean
+    ref: () => Timer
+    refresh: () => Timer
+    unref: () => Timer
+  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
+  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
+  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
+  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
+  interface NodeJS.WritableStream (@types/node/stream.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    setMaxListeners: (n: number) => WritableStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.WriteStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
+    clearScreenDown: (callback?: (() => void) | undefined) => boolean
+    closed [readonly]: boolean
+    columns: number
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
+    destroy: (error?: Error | undefined) => WriteStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<void>
+    getColorDepth: (env?: object | undefined) => number
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    getWindowSize: () => [number, number]
+    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
+    isPaused: () => boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
+    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    pause: () => WriteStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => WriteStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
+    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    resetAndDestroy: () => WriteStream
+    resume: () => WriteStream
+    rows: number
+    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
+    setMaxListeners: (n: number) => WriteStream
+    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
+    setTypeOfService: (tos: number) => WriteStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "concurrency" | "signal"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => WriteStream
+    unref: () => WriteStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => WriteStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
+  children: Array<Module>
+  exports: any
+  filename: string
+  id: string
+  isPreloading: boolean
+  loaded: boolean
+  parent: Module | null | undefined
+  path: string
+  paths: Array<string>
+  require: (id: string) => any
+interface Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (this: Performance, ev: PerformanceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  clearMarks: (markName?: string | undefined) => void
+  clearMeasures: (measureName?: string | undefined) => void
+  clearResourceTimings: () => void
+  dispatchEvent: (event: Event) => boolean
+  eventCounts [readonly]: EventCounts
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: string | undefined) => PerformanceEntryList
+  getEntriesByType: (type: string) => PerformanceEntryList
+  interactionCount [readonly]: number
+  mark: (markName: string, markOptions?: PerformanceMarkOptions | undefined) => PerformanceMark
+  measure: (measureName: string, startOrMeasureOptions?: PerformanceMeasureOptions | string | undefined, endMark?: string | undefined) => PerformanceMeasure
+  navigation [readonly]: PerformanceNavigation
+  now: () => number
+  onresourcetimingbufferfull: ((this: Performance, ev: Event) => any) | null
+  removeEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (this: Performance, ev: PerformanceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  setResourceTimingBufferSize: (maxSize: number) => void
+  timeOrigin [readonly]: number
+  timing [readonly]: PerformanceTiming
+  toJSON: () => any
+var Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): Performance
+  prototype: Performance
+interface PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  duration [readonly]: number
+  entryType [readonly]: string
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceEntry
+  prototype: PerformanceEntry
+interface PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: string
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (markName: string, markOptions?: PerformanceMarkOptions | undefined): PerformanceMark
+  prototype: PerformanceMark
+interface PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: string
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceMeasure
+  prototype: PerformanceMeasure
+interface PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  disconnect: () => void
+  observe: (options?: PerformanceObserverInit | undefined) => void
+  takeRecords: () => PerformanceEntryList
+var PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (callback: PerformanceObserverCallback): PerformanceObserver
+  prototype: PerformanceObserver
+  supportedEntryTypes [readonly]: ReadonlyArray<string>
+interface PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: string | undefined) => PerformanceEntryList
+  getEntriesByType: (type: string) => PerformanceEntryList
+var PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceObserverEntryList
+  prototype: PerformanceObserverEntryList
+interface PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  connectEnd [readonly]: number
+  connectStart [readonly]: number
+  decodedBodySize [readonly]: number
+  domainLookupEnd [readonly]: number
+  domainLookupStart [readonly]: number
+  duration [readonly]: number
+  encodedBodySize [readonly]: number
+  entryType [readonly]: string
+  fetchStart [readonly]: number
+  initiatorType [readonly]: string
+  name [readonly]: string
+  nextHopProtocol [readonly]: string
+  redirectEnd [readonly]: number
+  redirectStart [readonly]: number
+  requestStart [readonly]: number
+  responseEnd [readonly]: number
+  responseStart [readonly]: number
+  responseStatus [readonly]: number
+  secureConnectionStart [readonly]: number
+  serverTiming [readonly]: ReadonlyArray<PerformanceServerTiming>
+  startTime [readonly]: number
+  toJSON: () => any
+  transferSize [readonly]: number
+  workerStart [readonly]: number
+var PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): PerformanceResourceTiming
+  prototype: PerformanceResourceTiming
+interface Position (bun-types/globals.d.ts)
+  column: number
+  file: string
+  length: number
+  line: number
+  lineText: string
+  namespace: string
+  offset: number
+interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts, lib.es2024.promise.d.ts, lib.es2025.promise.d.ts)
+  construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
+  [Symbol.species] [readonly]: PromiseConstructor
+  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  prototype [readonly]: Promise<any>
+  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  reject: <T = never>(reason?: any) => Promise<T>
+  resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+  try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
+  withResolvers: { <T>(): PromiseWithResolvers<T>; <T>(): { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; } }
+interface QueuingStrategy<T = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark [?]: number | undefined
+  size [?]: QueuingStrategySize<T> | undefined
+interface QueuingStrategyInit (bun-types/globals.d.ts, lib.dom.d.ts)
+  highWaterMark: number
+interface QueuingStrategySize<T = any> (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (chunk: T): number
+  call (chunk?: T | undefined): number
+interface ReadOnlyDict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined [readonly]
+interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  byobRequest [readonly]: ReadableStreamBYOBRequest | null
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk: ArrayBufferView<ArrayBuffer>) => void
+  error: (e?: any) => void
+var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): ReadableByteStreamController
+  prototype: ReadableByteStreamController
+interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (underlyingSource: UnderlyingByteSource, strategy?: undefined | { highWaterMark?: number | undefined; }): ReadableStream<Uint8Array<ArrayBuffer>>
+  construct new <R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  prototype: ReadableStream<any>
+interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  closed [readonly]: Promise<void>
+  read: <T extends ArrayBufferView<ArrayBuffer>>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  releaseLock: () => void
+var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (stream: ReadableStream<Uint8Array<ArrayBuffer>>): ReadableStreamBYOBReader
+  prototype: ReadableStreamBYOBReader
+interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  respond: (bytesWritten: number) => void
+  respondWithNewView: (view: ArrayBufferView<ArrayBuffer>) => void
+  view [readonly]: ArrayBufferView<ArrayBuffer> | null
+var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): ReadableStreamBYOBRequest
+  prototype: ReadableStreamBYOBRequest
+interface ReadableStreamDefaultController<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  close: { (): void; (): void }
+  desiredSize [readonly]: null | number
+  enqueue: { (chunk: R): void; (chunk?: R | undefined): void }
+  error: { (e?: any): void; (e?: any): void }
+var ReadableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): ReadableStreamDefaultController<any>
+  prototype: ReadableStreamDefaultController<any>
+interface ReadableStreamDefaultReadDoneResult (bun-types/globals.d.ts)
+  done: true
+  value [?]: undefined
+interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
+  done: false
+  value: T
+interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  closed [readonly]: Promise<void>
+  read: { (): Promise<ReadableStreamReadResult<R>>; (): Promise<ReadableStreamDefaultReadResult<R>> }
+  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  releaseLock: { (): void; (): void }
+var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
+  prototype: ReadableStreamDefaultReader<any>
+interface ReadableStreamDirectController (bun-types/globals.d.ts)
+  close: (error?: Error | undefined) => void
+  end: () => Promise<number> | number
+  flush: (wait?: boolean | undefined) => Promise<number> | number
+  start: () => void
+  write: (data: BufferSource | string) => Promise<number> | number
+interface ReadableStreamGenericReader (bun-types/globals.d.ts, lib.dom.d.ts)
+  cancel: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  closed [readonly]: Promise<void>
+interface ReadableWritablePair<R = any, W = any> (bun-types/globals.d.ts, lib.dom.d.ts)
+  readable: ReadableStream<R>
+  writable: WritableStream<W>
+interface RegExpConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2025.regexp.d.ts, lib.es5.d.ts)
+  call (pattern: RegExp | string): RegExp
+  call (pattern: string, flags?: string | undefined): RegExp
+  call (pattern: RegExp | string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string): RegExp
+  construct new (pattern: string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string, flags?: string | undefined): RegExp
+  $&: string
+  $': string
+  $+: string
+  $1: string
+  $2: string
+  $3: string
+  $4: string
+  $5: string
+  $6: string
+  $7: string
+  $8: string
+  $9: string
+  $_: string
+  $`: string
+  [Symbol.species] [readonly]: RegExpConstructor
+  escape: { (string: string): string; (string: string): string }
+  input: string
+  lastMatch: string
+  lastParen: string
+  leftContext: string
+  prototype [readonly]: RegExp
+  rightContext: string
+interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  blob: () => Promise<Blob>
+  body [readonly]: ReadableStream<Uint8Array<ArrayBuffer>> | null
+  bodyUsed [readonly]: boolean
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cache [readonly]: RequestCache
+  clone: () => Request
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  formData: () => Promise<FormData>
+  headers [readonly]: Headers
+  integrity [readonly]: string
+  json: () => Promise<any>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (input: RequestInfo | URL, init?: RequestInit | undefined): Request
+  prototype: Request
+interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  credentials [?]: RequestCredentials | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  priority [?]: RequestPriority | undefined
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  signal [?]: AbortSignal | null | undefined
+  window [?]: null | undefined
+var ResolveError (bun-types/deprecated.d.ts): typeof ResolveMessage
+class ResolveMessage (bun-types/globals.d.ts)
+  code [readonly]: string
+  importKind [readonly]: "at" | "at_conditional" | "dynamic" | "entry_point" | "import" | "internal" | "require" | "require_resolve" | "stmt" | "url"
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "ResolveMessage"
+  position [readonly]: Position | null
+  referrer [readonly]: string
+  specifier [readonly]: string
+  toString: () => string
+  [static]
+    construct new (): ResolveMessage
+    prototype: ResolveMessage
+interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  blob: () => Promise<Blob>
+  body [readonly]: ReadableStream<Uint8Array<ArrayBuffer>> | null
+  bodyUsed [readonly]: boolean
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  clone: () => Response
+  formData: () => Promise<FormData>
+  headers [readonly]: Headers
+  json: () => Promise<any>
+  ok [readonly]: boolean
+  redirected [readonly]: boolean
+  status [readonly]: number
+  statusText [readonly]: string
+  text: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  type [readonly]: ResponseType
+  url [readonly]: string
+var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  error: () => Response
+  json: (data: any, init?: ResponseInit | undefined) => Response
+  prototype: Response
+  redirect: (url: URL | string, status?: number | undefined) => Response
+interface ResponseInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  headers [?]: HeadersInit | undefined
+  status [?]: number | undefined
+  statusText [?]: string | undefined
+interface ShadowRealm (bun-types/globals.d.ts)
+  evaluate: (sourceText: string) => any
+  importValue: (specifier: string, bindingName: string) => Promise<any>
+var ShadowRealm (bun-types/globals.d.ts)
+  construct new (): ShadowRealm
+  prototype: ShadowRealm
+interface SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts, lib.es2024.sharedmemory.d.ts)
+  [Symbol.toStringTag] [readonly]: "SharedArrayBuffer"
+  byteLength [readonly]: number
+  grow: { (newByteLength?: number | undefined): void; (size: number): SharedArrayBuffer }
+  growable: boolean
+  maxByteLength: number
+  slice: (begin?: number | undefined, end?: number | undefined) => SharedArrayBuffer
+var SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts, lib.es2024.sharedmemory.d.ts): SharedArrayBufferConstructor
+interface StreamPipeOptions (bun-types/globals.d.ts, lib.dom.d.ts)
+  preventAbort [?]: boolean | undefined
+  preventCancel [?]: boolean | undefined
+  preventClose [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  decrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: { (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HkdfParams | HmacImportParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HkdfParams | HmacImportParams | Pbkdf2Params, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey> }
+  digest: (algorithm: AlgorithmIdentifier, data: BufferSource) => Promise<ArrayBuffer>
+  encrypt: (algorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
+  generateKey: { (algorithm: "Ed25519" | { name: "Ed25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"sign" | "verify">): Promise<CryptoKeyPair>; (algorithm: "X25519" | { name: "X25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"deriveBits" | "deriveKey">): Promise<CryptoKeyPair>; (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair>; (algorithm: "Ed25519" | { name: "Ed25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"sign" | "verify">): Promise<CryptoKeyPair>; (algorithm: "X25519" | { name: "X25519"; }, extractable: boolean, keyUsages: ReadonlyArray<"deriveBits" | "deriveKey">): Promise<CryptoKeyPair>; (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
+  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey> }
+  sign: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: { (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Iterable<KeyUsage>): Promise<CryptoKey> }
+  verify: (algorithm: AlgorithmIdentifier | EcdsaParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
+  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AesCbcParams | AesCtrParams | AesGcmParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): SubtleCrypto
+  prototype: SubtleCrypto
+interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (label?: string | undefined, options?: TextDecoderOptions | undefined): TextDecoder
+  prototype: TextDecoder
+interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+  readable [readonly]: ReadableStream<string>
+  writable [readonly]: WritableStream<BufferSource>
+var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (label?: string | undefined, options?: TextDecoderOptions | undefined): TextDecoderStream
+  prototype: TextDecoderStream
+interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  encode: (input?: string | undefined) => Uint8Array<ArrayBuffer>
+  encodeInto: { (source: string, destination: Uint8Array<ArrayBufferLike>): TextEncoderEncodeIntoResult; (src?: string | undefined, dest?: BufferSource | undefined): TextEncoderEncodeIntoResult }
+  encoding [readonly]: string
+var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): TextEncoder
+  prototype: TextEncoder
+interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  encoding [readonly]: string
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  writable [readonly]: WritableStream<string>
+var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): TextEncoderStream
+  prototype: TextEncoderStream
+interface Timer (bun-types/globals.d.ts)
+  [Symbol.toPrimitive]: () => number
+  hasRef: () => boolean
+  ref: () => Timer
+  refresh: () => Timer
+  unref: () => Timer
+interface TransformStream<I = any, O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  readable [readonly]: ReadableStream<O>
+  writable [readonly]: WritableStream<I>
+var TransformStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <I = any, O = any>(transformer?: Transformer<I, O> | undefined, writableStrategy?: QueuingStrategy<I> | undefined, readableStrategy?: QueuingStrategy<O> | undefined): TransformStream<I, O>
+  prototype: TransformStream<any, any>
+interface TransformStreamDefaultController<O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  desiredSize [readonly]: null | number
+  enqueue: { (chunk?: O | undefined): void; (chunk?: O | undefined): void }
+  error: { (reason?: any): void; (reason?: any): void }
+  terminate: { (): void; (): void }
+var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): TransformStreamDefaultController<any>
+  prototype: TransformStreamDefaultController<any>
+interface Transformer<I = any, O = any> (bun-types/globals.d.ts, lib.dom.d.ts)
+  flush [?]: TransformerFlushCallback<O> | undefined
+  readableType [?]: undefined
+  start [?]: TransformerStartCallback<O> | undefined
+  transform [?]: TransformerTransformCallback<I, O> | undefined
+  writableType [?]: undefined
+interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  hash: string
+  host: string
+  hostname: string
+  href: string
+  origin [readonly]: string
+  password: string
+  pathname: string
+  port: string
+  protocol: string
+  search: string
+  searchParams [readonly]: URLSearchParams
+  toJSON: () => string
+  toString: () => string
+  username: string
+var URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (url: URL | string, base?: URL | string | undefined): URL
+  canParse: (url: URL | string, base?: URL | string | undefined) => boolean
+  createObjectURL: (obj: Blob | MediaSource) => string
+  parse: (url: URL | string, base?: URL | string | undefined) => URL | null
+  prototype: URL
+  revokeObjectURL: (url: string) => void
+interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  toString: () => string
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (init?: Array<Array<string>> | Record<string, string> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts, lib.esnext.typedarrays.d.ts)
+  index [number]: number
+  BYTES_PER_ELEMENT [readonly]: number
+  [Symbol.iterator]: () => ArrayIterator<number>
+  [Symbol.toStringTag] [readonly]: "Uint8Array"
+  at: (index: number) => number | undefined
+  buffer [readonly]: TArrayBuffer
+  byteLength [readonly]: number
+  byteOffset [readonly]: number
+  copyWithin: (target: number, start: number, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  entries: () => ArrayIterator<[number, number]>
+  every: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  fill: (value: number, start?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  filter: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => any, thisArg?: any) => Uint8Array<ArrayBuffer>
+  find: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number | undefined
+  findIndex: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number
+  findLast: { <S extends number>(predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => value is S, thisArg?: any): S | undefined; (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any): number | undefined }
+  findLastIndex: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => number
+  forEach: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => void, thisArg?: any) => void
+  includes: (searchElement: number, fromIndex?: number | undefined) => boolean
+  indexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  join: (separator?: string | undefined) => string
+  keys: () => ArrayIterator<number>
+  lastIndexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  length [readonly]: number
+  map: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => number, thisArg?: any) => Uint8Array<ArrayBuffer>
+  reduce: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reduceRight: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reverse: () => Uint8Array<TArrayBuffer>
+  set: (array: ArrayLike<number>, offset?: number | undefined) => void
+  setFromBase64: { (string: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }): { read: number; written: number; }; (base64: string, offset?: number | undefined): { read: number; written: number; } }
+  setFromHex: { (string: string): { read: number; written: number; }; (hex: string): { read: number; written: number; } }
+  slice: (start?: number | undefined, end?: number | undefined) => Uint8Array<ArrayBuffer>
+  some: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  sort: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<TArrayBuffer>
+  subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  toBase64: { (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string; (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string }
+  toHex: { (): string; (): string }
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toReversed: () => Uint8Array<ArrayBuffer>
+  toSorted: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<ArrayBuffer>
+  toString: () => string
+  valueOf: () => Uint8Array<TArrayBuffer>
+  values: () => ArrayIterator<number>
+  with: (index: number, value: number) => Uint8Array<ArrayBuffer>
+var Uint8Array (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts, lib.esnext.typedarrays.d.ts): Uint8ArrayConstructor
+interface Uint8ArrayConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2017.typedarrays.d.ts, lib.es5.d.ts, lib.esnext.typedarrays.d.ts)
+  construct new (length: number): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<TArrayBuffer>
+  construct new (buffer: ArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayBuffer | ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new (elements: Iterable<number>): Uint8Array<ArrayBuffer>
+  construct new (): Uint8Array<ArrayBuffer>
+  BYTES_PER_ELEMENT [readonly]: number
+  from: { (arrayLike: ArrayLike<number>): Uint8Array<ArrayBuffer>; <T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array<ArrayBuffer>; (elements: Iterable<number>): Uint8Array<ArrayBuffer>; <T>(elements: Iterable<T>, mapfn?: ((v: T, k: number) => number) | undefined, thisArg?: any): Uint8Array<ArrayBuffer> }
+  fromBase64: { (string: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }): Uint8Array<ArrayBuffer>; (base64: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }): Uint8Array<ArrayBuffer> }
+  fromHex: { (string: string): Uint8Array<ArrayBuffer>; (hex: string): Uint8Array<ArrayBuffer> }
+  of: (...items: Array<number>) => Uint8Array<ArrayBuffer>
+  prototype [readonly]: Uint8Array<ArrayBufferLike>
+namespace WebAssembly (bun-types/wasm.d.ts, lib.dom.d.ts)
+  type WebAssembly.AddressType (lib.dom.d.ts) = "i32" | "i64"
+  type WebAssembly.AddressValue (lib.dom.d.ts) = number
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.CompileError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (message?: string | undefined): CompileError
+    construct new (message?: string | undefined): CompileError
+    prototype: CompileError
+  interface WebAssembly.Exception (lib.dom.d.ts)
+    getArg: (exceptionTag: Tag, index: number) => any
+    is: (exceptionTag: Tag) => boolean
+    stack [readonly]: string | undefined
+  var WebAssembly.Exception (lib.dom.d.ts)
+    construct new (exceptionTag: Tag, payload: Array<any>, options?: ExceptionOptions | undefined): Exception
+    prototype: Exception
+  interface WebAssembly.ExceptionOptions (lib.dom.d.ts)
+    traceStack [?]: boolean | undefined
+  type WebAssembly.ExportValue (lib.dom.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
+  type WebAssembly.Exports (lib.dom.d.ts) = { [x: string]: ExportValue; }
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  var WebAssembly.Global (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
+    prototype: Global<keyof ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts, lib.dom.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  type WebAssembly.ImportExportKind (lib.dom.d.ts) = "function" | "global" | "memory" | "table" | "tag"
+  type WebAssembly.ImportValue (lib.dom.d.ts) = number | ExportValue
+  type WebAssembly.Imports (lib.dom.d.ts) = { [x: string]: ModuleImports; }
+  interface WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
+    exports [readonly]: Exports
+  var WebAssembly.Instance (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (module: Module, importObject?: Imports | undefined): Instance
+    prototype: Instance
+  var WebAssembly.JSTag (lib.dom.d.ts): Tag
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.LinkError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (message?: string | undefined): LinkError
+    construct new (message?: string | undefined): LinkError
+    prototype: LinkError
+  interface WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+    toFixedLengthBuffer: () => ArrayBuffer
+    toResizableBuffer: () => ArrayBuffer
+  var WebAssembly.Memory (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (descriptor: MemoryDescriptor): Memory
+    prototype: Memory
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    address [?]: AddressType | undefined
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
+  var WebAssembly.Module (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Module
+    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
+    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
+    prototype: Module
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  type WebAssembly.ModuleImports (lib.dom.d.ts) = { [x: string]: ImportValue; }
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.RuntimeError (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (message?: string | undefined): RuntimeError
+    construct new (message?: string | undefined): RuntimeError
+    prototype: RuntimeError
+  interface WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  var WebAssembly.Table (bun-types/wasm.d.ts, lib.dom.d.ts)
+    construct new (descriptor: TableDescriptor, value?: any): Table
+    prototype: Table
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts, lib.dom.d.ts)
+    address [?]: AddressType | undefined
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  type WebAssembly.TableKind (lib.dom.d.ts) = "anyfunc" | "externref"
+  interface WebAssembly.Tag (lib.dom.d.ts)
+  var WebAssembly.Tag (lib.dom.d.ts)
+    construct new (type: TagType): Tag
+    prototype: Tag
+  interface WebAssembly.TagType (lib.dom.d.ts)
+    parameters: Array<keyof ValueTypeMap>
+  type WebAssembly.ValueType (lib.dom.d.ts) = keyof ValueTypeMap
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts, lib.dom.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyCompileOptions (lib.dom.d.ts)
+    builtins [?]: Array<string> | undefined
+    importedStringConstants [?]: null | string | undefined
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts, lib.dom.d.ts)
+    instance: Instance
+    module: Module
+  function WebAssembly.compile (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
+    call (bytes: BufferSource): Promise<Module>
+  function WebAssembly.compileStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (source: PromiseLike<Response> | Response, options?: WebAssemblyCompileOptions | undefined): Promise<Module>
+    call (source: PromiseLike<Response> | Response): Promise<Module>
+  function WebAssembly.instantiate (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (bytes: BufferSource, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+  function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined, options?: WebAssemblyCompileOptions | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+  function WebAssembly.validate (bun-types/wasm.d.ts, lib.dom.d.ts)
+    call (bytes: BufferSource, options?: WebAssemblyCompileOptions | undefined): boolean
+    call (bytes: BufferSource): boolean
+interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: BinaryType
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: MessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  send: (data: Blob | BufferSource | string) => void
+  url [readonly]: string
+var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  prototype: WebSocket
+interface Worker (bun-types/globals.d.ts, lib.dom.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: MessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+var Worker (bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  prototype: Worker
+interface WorkerOptions (bun-types/globals.d.ts, lib.dom.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  getWriter: () => WritableStreamDefaultWriter<W>
+  locked [readonly]: boolean
+var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  prototype: WritableStream<any>
+interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  error: { (e?: any): void; (e?: any): void }
+  signal [readonly]: AbortSignal
+var WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new (): WritableStreamDefaultController
+  prototype: WritableStreamDefaultController
+interface WritableStreamDefaultWriter<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  abort: { (reason?: any): Promise<void>; (reason?: any): Promise<void> }
+  close: { (): Promise<void>; (): Promise<void> }
+  closed [readonly]: Promise<void>
+  desiredSize [readonly]: null | number
+  ready [readonly]: Promise<void>
+  releaseLock: { (): void; (): void }
+  write: { (chunk?: W | undefined): Promise<void>; (chunk?: W | undefined): Promise<void> }
+var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  construct new <W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>
+  prototype: WritableStreamDefaultWriter<any>
+function addEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
+  call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+function alert (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message?: any): void
+  call (message?: string | undefined): void
+function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (immediate: Immediate | undefined): void
+function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (id: number | undefined): void
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (id: number | undefined): void
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function confirm (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message?: string | undefined): boolean
+  call (message?: string | undefined): boolean
+var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Console
+var crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Crypto
+var exports (@types/node/module.d.ts, bun-types/globals.d.ts): any
+function fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>
+  call (input: Request | URL | string, init?: BunFetchRequestInit | undefined): Promise<Response>
+  call (input: Request | URL | string, init?: RequestInit | undefined): Promise<Response>
+  preconnect: (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }) => void
+namespace fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  function fetch.preconnect (bun-types/globals.d.ts)
+    call (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }): void
+var module (@types/node/module.d.ts, bun-types/globals.d.ts): NodeModule
+var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Navigator
+var onmessage (bun-types/index.d.ts, lib.dom.d.ts): ((this: Window, ev: MessageEvent<any>) => any) | null
+var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts, lib.dom.d.ts): Performance
+function postMessage (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message: any, targetOrigin: string, transfer?: Array<Transferable> | undefined): void
+  call (message: any, options?: WindowPostMessageOptions | undefined): void
+  call (message: any, transfer?: Array<Transferable> | undefined): void
+function prompt (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (message?: string | undefined, _default?: string | undefined): null | string
+  call (message?: string | undefined, _default?: string | undefined): null | string
+function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (callback: VoidFunction): void
+  call (callback: (...args: Array<any>) => void): void
+  call (callback: () => void): void
+function removeEventListener (bun-types/globals.d.ts, lib.dom.d.ts)
+  call <K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+function reportError (bun-types/globals.d.ts, lib.dom.d.ts)
+  call (e: any): void
+  call (error: any): void
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
+  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): number
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts, lib.dom.d.ts)
+  call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/esnext.txt
+++ b/test/integration/bun-types/inventory/esnext.txt
@@ -1,0 +1,5711 @@
+# bun-types inventory: preset esnext
+# lib: lib.esnext.d.ts
+# typescript: 6.0.2
+# @types/node: 26.2.0
+# undici-types: 8.3.0
+
+# module "*.html"
+
+# module "*.json5"
+
+# module "*.jsonc"
+
+# module "*.toml"
+
+# module "*.txt"
+
+# module "*.xml"
+
+# module "*.yaml"
+
+# module "*.yml"
+
+# module "*/bun.lock"
+
+# module "bun"
+type $ (bun-types/shell.d.ts) = typeof $
+function $ (bun-types/shell.d.ts)
+  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
+  Shell: new () => typeof $
+  ShellError: typeof ShellError
+  ShellPromise: typeof ShellPromise
+  braces: (pattern: string) => Array<string>
+  cwd: (newCwd?: string | undefined) => typeof $
+  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  escape: (input: string) => string
+  nothrow: () => typeof $
+  throws: (shouldThrow: boolean) => typeof $
+namespace $ (bun-types/shell.d.ts)
+  var $.Shell (bun-types/shell.d.ts)
+    construct new (): typeof $
+  class $.ShellError (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    cause [?]: unknown
+    exitCode [readonly]: number
+    json: () => any
+    message: string
+    name: string
+    stack [?]: string | undefined
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+    [static]
+      construct new (message?: string | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: ShellError
+      stackTraceLimit: number
+  interface $.ShellOutput (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    exitCode [readonly]: number
+    json: () => any
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+  class $.ShellPromise (bun-types/shell.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    arrayBuffer: () => Promise<ArrayBuffer>
+    blob: () => Promise<Blob>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
+    cwd: (newCwd: string) => ShellPromise
+    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    json: () => Promise<any>
+    lines: () => AsyncIterable<string>
+    nothrow: () => ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    stdin: WritableStream<any>
+    text: (encoding?: BufferEncoding | undefined) => Promise<string>
+    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => ShellPromise
+    [static]
+      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      [Symbol.species] [readonly]: PromiseConstructor
+      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+      prototype: ShellPromise
+      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      reject: <T = never>(reason?: any) => Promise<T>
+      resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+      try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
+      withResolvers: { <T>(): PromiseWithResolvers<T>; <T>(): { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; } }
+  function $.braces (bun-types/shell.d.ts)
+    call (pattern: string): Array<string>
+  function $.cwd (bun-types/shell.d.ts)
+    call (newCwd?: string | undefined): typeof $
+  function $.env (bun-types/shell.d.ts)
+    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+  function $.escape (bun-types/shell.d.ts)
+    call (input: string): string
+  function $.nothrow (bun-types/shell.d.ts)
+    call (): typeof $
+  function $.throws (bun-types/shell.d.ts)
+    call (shouldThrow: boolean): typeof $
+interface AbstractWorker (bun-types/bun.d.ts)
+  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+interface AbstractWorkerEventMap (bun-types/bun.d.ts)
+  error: ErrorEvent
+interface AddEventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc" | "ppc64" | "s390" | "s390x" | "x64"
+class Archive (bun-types/bun.d.ts)
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
+  [static]
+    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
+    prototype: Archive
+    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
+interface ArchiveExtractOptions (bun-types/bun.d.ts)
+  glob [?]: ReadonlyArray<string> | string | undefined
+type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+interface ArchiveOptions (bun-types/bun.d.ts)
+  compress [?]: "gzip" | undefined
+  level [?]: number | undefined
+class ArrayBufferSink (bun-types/bun.d.ts)
+  end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
+  flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
+  start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  [static]
+    construct new (): ArrayBufferSink
+    prototype: ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
+type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+interface BinaryTypeList (bun-types/bun.d.ts)
+  arraybuffer: ArrayBuffer
+  buffer: Buffer<ArrayBufferLike>
+  uint8array: Uint8Array<ArrayBuffer>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
+type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+namespace Build (bun-types/bun.d.ts)
+  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
+  type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
+interface BuildArtifact (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  hash: null | string
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
+  loader: Loader
+  path: string
+  size [readonly]: number
+  sourcemap: BuildArtifact | null
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+interface BuildConfig (bun-types/bun.d.ts)
+  allowUnresolved [?]: Array<string> | undefined
+  banner [?]: string | undefined
+  bytecode [?]: boolean | undefined
+  bytecodeDepth [?]: number | undefined
+  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  conditions [?]: Array<string> | string | undefined
+  define [?]: Record<string, string> | undefined
+  deprecatedNamespaceObjectSetters [?]: boolean | undefined
+  drop [?]: Array<string> | undefined
+  emitDCEAnnotations [?]: boolean | undefined
+  entrypoints: Array<string>
+  env [?]: "disable" | "inline" | `${string}*` | undefined
+  external [?]: Array<string> | undefined
+  features [?]: Array<string> | undefined
+  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  footer [?]: string | undefined
+  format [?]: "cjs" | "esm" | "iife" | undefined
+  ignoreDCEAnnotations [?]: boolean | undefined
+  jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
+  loader [?]: undefined | { [x: string]: Loader; }
+  metafile [?]: boolean | undefined
+  minChunkSize [?]: number | undefined
+  minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
+  modulePreload [?]: boolean | undefined
+  naming [?]: string | undefined | { chunk?: string | undefined; entry?: string | undefined; asset?: string | undefined; }
+  optimizeImports [?]: Array<string> | undefined
+  outdir [?]: string | undefined
+  packages [?]: "bundle" | "external" | undefined
+  plugins [?]: Array<BunPlugin> | undefined
+  publicPath [?]: string | undefined
+  reactCompiler [?]: boolean | undefined
+  reactCompilerOutputMode [?]: "client" | "ssr" | undefined
+  reactFastRefresh [?]: boolean | undefined
+  root [?]: string | undefined
+  sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
+  splitRequire [?]: boolean | undefined
+  splitting [?]: boolean | undefined
+  target [?]: Target | undefined
+  throw [?]: boolean | undefined
+  treeShaking [?]: boolean | undefined
+  tsconfig [?]: string | undefined
+interface BuildMetafile (bun-types/bun.d.ts)
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+interface BuildOutput (bun-types/bun.d.ts)
+  logs: Array<BuildMessage | ResolveMessage>
+  metafile [?]: BuildMetafile | undefined
+  outputs: Array<BuildArtifact>
+  success: boolean
+interface BunFile (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface BunInspectOptions (bun-types/bun.d.ts)
+  colors [?]: boolean | undefined
+  compact [?]: boolean | undefined
+  depth [?]: number | undefined
+  sorted [?]: boolean | undefined
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+interface BunPlugin (bun-types/bun.d.ts)
+  name: string
+  setup: (build: PluginBuilder) => Promise<void> | void
+  target [?]: Target | undefined
+interface BunRegisterPlugin (bun-types/bun.d.ts)
+  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  clearAll: () => void
+interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  cache [readonly]: RequestCache
+  clone: () => BunRequest<T>
+  cookies [readonly]: CookieMap
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  duplex [readonly]: "half"
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  integrity [readonly]: string
+  json [readonly]: () => Promise<unknown>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+namespace CSRF (bun-types/bun.d.ts)
+  function CSRF.generate (bun-types/bun.d.ts)
+    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+  function CSRF.verify (bun-types/bun.d.ts)
+    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
+interface CSRFGenerateOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  expiresIn [?]: number | undefined
+  sessionId [?]: string | undefined
+interface CSRFVerifyOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  maxAge [?]: number | undefined
+  secret [?]: string | undefined
+  sessionId [?]: string | undefined
+interface CloseEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  code [?]: number | undefined
+  composed [?]: boolean | undefined
+  reason [?]: string | undefined
+  wasClean [?]: boolean | undefined
+type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+interface CompileBuildOptions (bun-types/bun.d.ts)
+  assets [?]: Array<string> | undefined
+  autoloadBunfig [?]: boolean | undefined
+  autoloadDotenv [?]: boolean | undefined
+  autoloadPackageJson [?]: boolean | undefined
+  autoloadTsconfig [?]: boolean | undefined
+  execArgv [?]: Array<string> | undefined
+  executablePath [?]: string | undefined
+  outfile [?]: string | undefined
+  target [?]: CompileTarget | undefined
+  windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
+type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+class Cookie (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | undefined
+  httpOnly: boolean
+  isExpired: () => boolean
+  maxAge [?]: number | undefined
+  name [readonly]: string
+  partitioned: boolean
+  path: string
+  sameSite: CookieSameSite
+  secure: boolean
+  serialize: () => string
+  toJSON: () => CookieInit
+  toString: () => string
+  value: string
+  [static]
+    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
+    construct new (cookieString: string): Cookie
+    construct new (cookieObject?: CookieInit | undefined): Cookie
+    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
+    parse [static]: (cookieString: string) => Cookie
+    prototype: Cookie
+interface CookieInit (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | number | string | undefined
+  httpOnly [?]: boolean | undefined
+  maxAge [?]: number | undefined
+  name [?]: string | undefined
+  partitioned [?]: boolean | undefined
+  path [?]: string | undefined
+  sameSite [?]: CookieSameSite | undefined
+  secure [?]: boolean | undefined
+  value [?]: string | undefined
+class CookieMap (bun-types/bun.d.ts)
+  [Symbol.iterator]: () => IterableIterator<[string, string]>
+  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  get: (name: string) => null | string
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  size [readonly]: number
+  toJSON: () => Record<string, string>
+  toSetCookieHeaders: () => Array<string>
+  values: () => IterableIterator<string>
+  [static]
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
+    prototype: CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
+  domain [?]: null | string | undefined
+  name: string
+  path [?]: string | undefined
+interface CookieStoreGetOptions (bun-types/bun.d.ts)
+  name [?]: string | undefined
+  url [?]: string | undefined
+interface CronController (bun-types/bun.d.ts)
+  cron [readonly]: string
+  scheduledTime [readonly]: number
+  type [readonly]: "scheduled"
+interface CronJob (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  cron [readonly]: string
+  ref: () => CronJob
+  stop: () => CronJob
+  unref: () => CronJob
+interface CronOptions (bun-types/bun.d.ts)
+  tz [?]: string | undefined
+type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+class CryptoHashInterface<T> (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => T
+  [static]
+    construct new <T>(): CryptoHashInterface<T>
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHashInterface<any>
+class CryptoHasher (bun-types/bun.d.ts)
+  algorithm [readonly]: SupportedCryptoAlgorithms
+  byteLength [readonly]: number
+  copy: () => CryptoHasher
+  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
+  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  [static]
+    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
+    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHasher
+interface CustomEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  detail [?]: T | undefined
+interface DNSLookup (bun-types/bun.d.ts)
+  address: string
+  family: 4 | 6
+  ttl: number
+type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
+  type: "direct"
+type DisconnectListener (bun-types/bun.d.ts) = () => void
+interface EditorOptions (bun-types/bun.d.ts)
+  column [?]: number | undefined
+  editor [?]: "subl" | "vscode" | undefined
+  line [?]: number | undefined
+type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+interface Env (bun-types/bun.d.ts)
+  NODE_ENV [?]: string | undefined
+  TZ [?]: string | undefined
+interface ErrorEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  colno [?]: number | undefined
+  composed [?]: boolean | undefined
+  error [?]: any
+  filename [?]: string | undefined
+  lineno [?]: number | undefined
+  message [?]: string | undefined
+interface ErrorLike (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+interface EventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+interface EventListener (bun-types/bun.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (bun-types/bun.d.ts)
+  handleEvent: (object: Event) => void
+interface EventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+interface EventMap (bun-types/bun.d.ts)
+  fetch: FetchEvent
+  message: BunMessageEvent<any>
+  messageerror: BunMessageEvent<any>
+interface EventSource (bun-types/bun.d.ts)
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: Event) => any) | null
+  onmessage: ((this: EventSource, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: number
+  ref: () => void
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => void
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+interface EventSourceEventMap (bun-types/bun.d.ts)
+  error: Event
+  message: BunMessageEvent<any>
+  open: Event
+type ExitListener (bun-types/bun.d.ts) = (code: number) => void
+type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
+interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  fd: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface FetchEvent (bun-types/bun.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface FileBlob (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface FileSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+class FileSystemRouter (bun-types/bun.d.ts)
+  assetPrefix [readonly]: string
+  match: (input: Request | Response | string) => MatchedRoute | null
+  origin [readonly]: string
+  reload: () => void
+  routes [readonly]: Record<string, string>
+  style [readonly]: string
+  [static]
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
+    prototype: FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+interface GenericTransformStream (bun-types/bun.d.ts)
+  readable [readonly]: ReadableStream<any>
+  writable [readonly]: WritableStream<any>
+class Glob (bun-types/bun.d.ts)
+  match: (str: string) => boolean
+  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  [static]
+    construct new (pattern: string): Glob
+    prototype: Glob
+interface GlobScanOptions (bun-types/bun.d.ts)
+  absolute [?]: boolean | undefined
+  cwd [?]: string | undefined
+  dot [?]: boolean | undefined
+  followSymlinks [?]: boolean | undefined
+  onlyFiles [?]: boolean | undefined
+  throwErrorOnBrokenSymlink [?]: boolean | undefined
+type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
+type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+interface HTMLBundle (bun-types/bun.d.ts)
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  index: string
+interface Hash (bun-types/bun.d.ts)
+  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Record<string, string | ReadonlyArray<string>> | Headers
+interface HeapSnapshot (bun-types/bun.d.ts)
+  edgeNames: Array<string>
+  edgeTypes: Array<string>
+  edges: Array<number>
+  nodeClassNames: Array<string>
+  nodes: Array<number>
+  type: string
+  version: number
+class Image (bun-types/bun.d.ts)
+  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  blob: () => Promise<Blob>
+  buffer: () => Promise<Buffer<ArrayBufferLike>>
+  bytes: () => Promise<Uint8Array<ArrayBufferLike>>
+  dataurl: () => Promise<string>
+  flip: () => Image
+  flop: () => Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  height [readonly]: number
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
+  metadata: () => Promise<Metadata>
+  modulate: (options: ModulateOptions) => Image
+  placeholder: (as?: "dataurl" | undefined) => Promise<string>
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
+  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
+  rotate: (degrees: number) => Image
+  toBase64: () => Promise<string>
+  toBuffer: () => Promise<Buffer<ArrayBufferLike>>
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  width [readonly]: number
+  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  [static]
+    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    backend [static]: "bun" | "system"
+    clipboardChangeCount [static]: () => number
+    fromClipboard [static]: () => Image | null
+    hasClipboardImage [static]: () => boolean
+    prototype: Image
+  interface Image.ConstructorOptions (bun-types/bun.d.ts)
+    autoOrient [?]: boolean | undefined
+    maxPixels [?]: number | undefined
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
+  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  interface Image.Metadata (bun-types/bun.d.ts)
+    format: Format
+    height: number
+    width: number
+  interface Image.ModulateOptions (bun-types/bun.d.ts)
+    brightness [?]: number | undefined
+    saturation [?]: number | undefined
+  interface Image.ResizeOptions (bun-types/bun.d.ts)
+    filter [?]: Filter | undefined
+    fit [?]: "fill" | "inside" | undefined
+    withoutEnlargement [?]: boolean | undefined
+  var Image.backend (bun-types/bun.d.ts): "bun" | "system"
+interface Import (bun-types/bun.d.ts)
+  kind: ImportKind
+  path: string
+type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+namespace JSON5 (bun-types/bun.d.ts)
+  function JSON5.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function JSON5.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+namespace JSONC (bun-types/bun.d.ts)
+  function JSONC.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+namespace JSONL (bun-types/bun.d.ts)
+  interface JSONL.ParseChunkResult (bun-types/bun.d.ts)
+    done: boolean
+    error: SyntaxError | null
+    read: number
+    values: Array<unknown>
+  function JSONL.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+  function JSONL.parseChunk (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
+interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
+  level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "libdeflate" | undefined
+type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+class MD4 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD4
+  [static]
+    construct new (): MD4
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD4
+class MD5 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD5
+  [static]
+    construct new (): MD5
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD5
+interface MMapOptions (bun-types/bun.d.ts)
+  offset [?]: number | undefined
+  shared [?]: boolean | undefined
+  size [?]: number | undefined
+  sync [?]: boolean | undefined
+type MacroMap (bun-types/bun.d.ts) = { [x: string]: Record<string, string>; }
+interface MatchedRoute (bun-types/bun.d.ts)
+  filePath [readonly]: string
+  kind [readonly]: "catch-all" | "dynamic" | "exact" | "optional-catch-all"
+  name [readonly]: string
+  params [readonly]: Record<string, string>
+  pathname [readonly]: string
+  query [readonly]: Record<string, string>
+  src [readonly]: string
+type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
+type MessageEvent<T = any> (bun-types/bun.d.ts) = BunMessageEvent<T>
+interface MessageEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  data [?]: T | undefined
+  lastEventId [?]: string | undefined
+  origin [?]: string | undefined
+  source [?]: null | undefined
+type MessageEventSource (bun-types/bun.d.ts) = undefined
+type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+interface NetworkSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  stat: () => Promise<Stats>
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
+type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+interface OnLoadArgs (bun-types/bun.d.ts)
+  defer: () => Promise<void>
+  loader: Loader
+  namespace: string
+  path: string
+type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+interface OnLoadResultObject (bun-types/bun.d.ts)
+  exports: Record<string, unknown>
+  loader: "object"
+interface OnLoadResultSourceCode (bun-types/bun.d.ts)
+  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Loader | undefined
+interface OnResolveArgs (bun-types/bun.d.ts)
+  importer: string
+  kind: ImportKind
+  namespace: string
+  path: string
+  resolveDir: string
+type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+interface OnResolveResult (bun-types/bun.d.ts)
+  external [?]: boolean | undefined
+  namespace [?]: string | undefined
+  path: string
+type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
+namespace Password (bun-types/bun.d.ts)
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  interface Password.Argon2Algorithm (bun-types/bun.d.ts)
+    algorithm: "argon2d" | "argon2i" | "argon2id"
+    memoryCost [?]: number | undefined
+    timeCost [?]: number | undefined
+  interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
+    algorithm: "bcrypt"
+    cost [?]: number | undefined
+type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
+type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+interface PluginBuilder (bun-types/bun.d.ts)
+  config: BuildConfig & { plugins: Array<BunPlugin>; }
+  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
+  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
+  onEnd: (callback: OnEndCallback) => PluginBuilder
+  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
+  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
+  onStart: (callback: OnStartCallback) => PluginBuilder
+interface PluginConstraints (bun-types/bun.d.ts)
+  filter: RegExp
+  namespace [?]: string | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
+interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
+  done: boolean
+  size: number
+  value: Array<T>
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
+type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+class RedisClient (bun-types/redis.d.ts)
+  append: (key: KeyLike, value: KeyLike) => Promise<number>
+  bitcount: (key: KeyLike) => Promise<number>
+  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
+  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
+  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
+  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  bufferedAmount [readonly]: number
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  client: (...args: Array<string | number>) => Promise<any>
+  close: () => void
+  command: (...args: Array<string | number>) => Promise<any>
+  config: (...args: Array<string | number>) => Promise<any>
+  connect: () => Promise<void>
+  connected [readonly]: boolean
+  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  dbsize: () => Promise<number>
+  debug: (...args: Array<string | number>) => Promise<any>
+  decr: (key: KeyLike) => Promise<number>
+  decrby: (key: KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<KeyLike>) => Promise<number>
+  dump: (key: KeyLike) => Promise<string | null>
+  duplicate: () => Promise<RedisClient>
+  echo: (message: string) => Promise<string>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  exists: (key: KeyLike) => Promise<boolean>
+  expire: (key: KeyLike, seconds: number) => Promise<number>
+  expireat: (key: KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  function: (...args: Array<KeyLike>) => Promise<any>
+  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
+  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
+  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
+  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
+  get: (key: KeyLike) => Promise<string | null>
+  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: KeyLike, offset: number) => Promise<number>
+  getdel: (key: KeyLike) => Promise<string | null>
+  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
+  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
+  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
+  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
+  hgetall: (key: KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
+  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
+  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: KeyLike) => Promise<Array<string>>
+  hlen: (key: KeyLike) => Promise<number>
+  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
+  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
+  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
+  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
+  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
+  hstrlen: (key: KeyLike, field: string) => Promise<number>
+  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hvals: (key: KeyLike) => Promise<Array<string>>
+  incr: (key: KeyLike) => Promise<number>
+  incrby: (key: KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  info: (...sections: Array<string>) => Promise<string>
+  keys: (pattern: string) => Promise<Array<string>>
+  lastsave: () => Promise<number>
+  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
+  lindex: (key: KeyLike, index: number) => Promise<string | null>
+  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
+  llen: (key: KeyLike) => Promise<number>
+  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
+  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
+  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
+  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
+  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
+  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
+  onclose: ((this: RedisClient, error: Error) => void) | null
+  onconnect: ((this: RedisClient) => void) | null
+  persist: (key: KeyLike) => Promise<number>
+  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: KeyLike) => Promise<number>
+  pfadd: (key: KeyLike, element: string) => Promise<number>
+  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
+  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
+  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
+  pttl: (key: KeyLike) => Promise<number>
+  publish: (channel: string, message: string) => Promise<number>
+  randomkey: () => Promise<string | null>
+  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
+  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
+  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
+  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
+  scard: (key: KeyLike) => Promise<number>
+  script: (...args: Array<string>) => Promise<any>
+  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  send: (command: string, args: Array<string>) => Promise<any>
+  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
+  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
+  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
+  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
+  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
+  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sismember: (key: KeyLike, member: string) => Promise<boolean>
+  smembers: (key: KeyLike) => Promise<Array<string>>
+  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
+  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
+  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
+  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: KeyLike, message: string) => Promise<number>
+  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
+  strlen: (key: KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
+  substr: (key: KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  time: () => Promise<[string, string]>
+  touch: (...keys: Array<KeyLike>) => Promise<number>
+  ttl: (key: KeyLike) => Promise<number>
+  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
+  unlink: (...keys: Array<KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  wait: (numreplicas: number, timeout: number) => Promise<number>
+  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
+  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
+  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
+  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xlen: (key: KeyLike) => Promise<number>
+  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
+  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<string | number>) => Promise<any>
+  xreadgroup: (...args: Array<string | number>) => Promise<any>
+  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
+  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
+  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  zcard: (key: KeyLike) => Promise<number>
+  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
+  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
+  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
+  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
+  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: KeyLike, member: string) => Promise<number | null>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  [static]
+    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
+    prototype: RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+  type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
+interface RedisOptions (bun-types/redis.d.ts)
+  autoReconnect [?]: boolean | undefined
+  connectionTimeout [?]: number | undefined
+  enableAutoPipelining [?]: boolean | undefined
+  enableOfflineQueue [?]: boolean | undefined
+  idleTimeout [?]: number | undefined
+  maxRetries [?]: number | undefined
+  tls [?]: TLSOptions | boolean | undefined
+type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
+interface ReservedSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  [Symbol.dispose]: () => void
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  release: () => void
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+interface ResourceUsage (bun-types/bun.d.ts)
+  contextSwitches: { voluntary: number; involuntary: number; }
+  cpuTime: { user: number; system: number; total: number; }
+  maxRSS: number
+  messages: { sent: number; received: number; }
+  ops: { in: number; out: number; }
+  shmSize: number
+  signalCount: number
+  swapCount: number
+class S3Client (bun-types/s3.d.ts)
+  delete: (path: string, options?: S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: S3Options | undefined) => S3File
+  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
+  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  [static]
+    construct new (options?: S3Options | undefined): S3Client
+    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: S3Options | undefined) => S3File
+    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
+    prototype: S3Client
+    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+interface S3File (bun-types/s3.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bucket [? readonly]: string | undefined
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  name [? readonly]: string | undefined
+  presign: (options?: S3FilePresignOptions | undefined) => string
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
+  stat: () => Promise<S3Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  writer: (options?: S3Options | undefined) => NetworkSink
+interface S3FilePresignOptions (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endpoint [?]: string | undefined
+  expiresIn [?]: number | undefined
+  highWaterMark [?]: number | undefined
+  method [?]: "DELETE" | "GET" | "HEAD" | "POST" | "PUT" | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3ListObjectsOptions (bun-types/s3.d.ts)
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  fetchOwner [?]: boolean | undefined
+  maxKeys [?]: number | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3ListObjectsResponse (bun-types/s3.d.ts)
+  commonPrefixes [?]: Array<{ prefix: string; }> | undefined
+  contents [?]: Array<{ checksumAlgorithm?: "CRC32" | "CRC32C" | "SHA1" | "SHA256" | "CRC64NVME" | undefined; checksumType?: "COMPOSITE" | "FULL_OBJECT" | undefined; eTag?: string | undefined; key: string; lastModified?: string | undefined; owner?: { id?: string | undefined; displayName?: string | undefined; } | undefined; restoreStatus?: { isRestoreInProgress?: boolean | undefined; restoreExpiryDate?: string | undefined; } | undefined; size?: number | undefined; storageClass?: "STANDARD" | "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD_IA" | undefined; }> | undefined
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  isTruncated [?]: boolean | undefined
+  keyCount [?]: number | undefined
+  maxKeys [?]: number | undefined
+  name [?]: string | undefined
+  nextContinuationToken [?]: string | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3Options (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endpoint [?]: string | undefined
+  highWaterMark [?]: number | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3Stats (bun-types/s3.d.ts)
+  etag: string
+  lastModified: Date
+  size: number
+  type: string
+class SHA1 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA1
+  [static]
+    construct new (): SHA1
+    byteLength [readonly static]: 20
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA1
+class SHA224 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA224
+  [static]
+    construct new (): SHA224
+    byteLength [readonly static]: 28
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA224
+class SHA256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA256
+  [static]
+    construct new (): SHA256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA256
+class SHA384 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA384
+  [static]
+    construct new (): SHA384
+    byteLength [readonly static]: 48
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA384
+class SHA512 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512
+  [static]
+    construct new (): SHA512
+    byteLength [readonly static]: 64
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512
+class SHA512_256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  [static]
+    construct new (): SHA512_256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512_256
+class SQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  [static]
+    construct new (connectionString: URL | string): SQL
+    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
+    construct new (options?: Options | undefined): SQL
+    MySQLError: typeof MySQLError
+    PostgresError: typeof PostgresError
+    SQLError: typeof SQLError
+    SQLiteError: typeof SQLiteError
+    prototype: SQL
+  type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  interface SQL.Helper<T> (bun-types/sql.d.ts)
+    columns [readonly]: Array<keyof T>
+    value [readonly]: Array<T>
+  interface SQL.ListenSubscription (bun-types/sql.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    channel [readonly]: string
+    unlisten: () => Promise<void>
+  class SQL.MySQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    errno [? readonly]: number | undefined
+    message: string
+    name: string
+    sqlState [? readonly]: string | undefined
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: MySQLError
+      stackTraceLimit: number
+  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  class SQL.PostgresError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    column [? readonly]: string | undefined
+    constraint [? readonly]: string | undefined
+    dataType [? readonly]: string | undefined
+    detail [? readonly]: string | undefined
+    errno [? readonly]: string | undefined
+    file [? readonly]: string | undefined
+    hint [? readonly]: string | undefined
+    internalPosition [? readonly]: string | undefined
+    internalQuery [? readonly]: string | undefined
+    line [? readonly]: string | undefined
+    message: string
+    name: string
+    position [? readonly]: string | undefined
+    routine [? readonly]: string | undefined
+    schema [? readonly]: string | undefined
+    severity [? readonly]: string | undefined
+    stack [?]: string | undefined
+    table [? readonly]: string | undefined
+    where [? readonly]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: PostgresError
+      stackTraceLimit: number
+  interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
+    adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
+    allowPublicKeyRetrieval [?]: boolean | undefined
+    bigint [?]: boolean | undefined
+    connectTimeout [?]: number | undefined
+    connect_timeout [?]: number | undefined
+    connection [?]: Record<string, string | number | boolean> | undefined
+    connectionTimeout [?]: number | undefined
+    connection_timeout [?]: number | undefined
+    database [?]: string | undefined
+    db [?]: string | undefined
+    host [?]: string | undefined
+    hostname [?]: string | undefined
+    idleTimeout [?]: number | undefined
+    idle_timeout [?]: number | undefined
+    max [?]: number | undefined
+    maxLifetime [?]: number | undefined
+    max_lifetime [?]: number | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    pass [?]: (() => MaybePromise<string>) | string | undefined
+    password [?]: (() => MaybePromise<string>) | string | undefined
+    path [?]: string | undefined
+    port [?]: number | string | undefined
+    prepare [?]: boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    url [?]: URL | string | undefined
+    user [?]: string | undefined
+    username [?]: string | undefined
+  interface SQL.Query<T> (bun-types/sql.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    active: boolean
+    cancel: () => Query<T>
+    cancelled: boolean
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
+    execute: () => Query<T>
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
+    raw: () => Query<T>
+    simple: () => Query<T>
+    then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    values: () => Query<T>
+  class SQL.SQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string): SQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLError
+      stackTraceLimit: number
+  class SQL.SQLiteError (bun-types/sql.d.ts)
+    byteOffset [? readonly]: number | undefined
+    cause [?]: unknown
+    code [readonly]: string
+    errno [readonly]: number
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLiteError
+      stackTraceLimit: number
+  interface SQL.SQLiteOptions (bun-types/sql.d.ts)
+    adapter [?]: "sqlite" | undefined
+    create [?]: boolean | undefined
+    filename [?]: ":memory:" | URL | string & {} | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    readonly [?]: boolean | undefined
+    readwrite [?]: boolean | undefined
+    safeIntegers [?]: boolean | undefined
+    strict [?]: boolean | undefined
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SQLArrayParameter (bun-types/sql.d.ts)
+  arrayType: ArrayType
+  serializedValues: string
+type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SavepointSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+namespace Security (bun-types/security.d.ts)
+  interface Security.Advisory (bun-types/security.d.ts)
+    description: null | string
+    level: "fatal" | "warn"
+    package: string
+    url: null | string
+  interface Security.Package (bun-types/security.d.ts)
+    name: string
+    requestedRange: string
+    tarball: string
+    version: string
+  interface Security.Scanner (bun-types/security.d.ts)
+    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    version: "1"
+namespace Serve (bun-types/serve.d.ts)
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
+  interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
+    dir: string
+    statCache [?]: boolean | undefined
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    http1 [?]: boolean | undefined
+    http2 [?]: boolean | undefined
+    http3 [?]: boolean | undefined
+    id [?]: null | string | undefined
+    idleTimeout [?]: number | undefined
+    ipv6Only [?]: boolean | undefined
+    maxRequestBodySize [?]: number | undefined
+    port [?]: number | string | undefined
+    reusePort [?]: boolean | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+  interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    unix [?]: string | undefined
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+interface Server<WebSocketData> (bun-types/serve.d.ts)
+  [Symbol.dispose]: () => void
+  closeIdleConnections: () => number
+  development [readonly]: boolean
+  fetch: (request: Request | string) => Promise<Response> | Response
+  hostname [readonly]: string | undefined
+  id [readonly]: string
+  pendingRequests [readonly]: number
+  pendingWebSockets [readonly]: number
+  port [readonly]: number | undefined
+  protocol [readonly]: "http" | "https" | null
+  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  ref: () => void
+  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
+  requestIP: (request: Request) => SocketAddress | null
+  stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
+  subscriberCount: (topic: string) => number
+  timeout: (request: Request, seconds: number) => void
+  unref: () => void
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  url [readonly]: URL
+interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
+  binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  data: T
+  getBufferedAmount: () => number
+  isSubscribed: (topic: string) => boolean
+  ping: (data?: Blob | BufferSource | string | undefined) => number
+  pong: (data?: Blob | BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  publishText: (topic: string, data: string, compress?: boolean | undefined) => number
+  readyState [readonly]: WebSocketReadyState
+  remoteAddress [readonly]: string
+  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  sendText: (data: string, compress?: boolean | undefined) => number
+  subscribe: (topic: string) => boolean
+  subscriptions [readonly]: Array<string>
+  terminate: () => void
+  unsubscribe: (topic: string) => boolean
+type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
+type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
+type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+interface SliceAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  ellipsis [?]: string | undefined
+interface Socket<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: Data
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface SocketAddress (bun-types/bun.d.ts)
+  address: string
+  family: "IPv4" | "IPv6"
+  port: number
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof BinaryTypeList | undefined
+  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+namespace Spawn (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
+  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    lazy [?]: boolean | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    terminal [?]: Terminal | TerminalOptions | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
+  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+SpawnOptions -> Spawn
+type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
+type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+interface StringWidthOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  countAnsiEscapeCodes [?]: boolean | undefined
+  perCodePoint [?]: boolean | undefined
+interface StructuredSerializeOptions (bun-types/bun.d.ts)
+  transfer [?]: Array<Transferable> | undefined
+interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  disconnect: () => void
+  exitCode [readonly]: null | number
+  exited [readonly]: Promise<number>
+  kill: (exitCode?: Signals | number | undefined) => void
+  killed [readonly]: boolean
+  pid [readonly]: number
+  readable [readonly]: ReadableToIO<Out>
+  ref: () => void
+  resourceUsage: () => ResourceUsage | undefined
+  send: (message: any) => void
+  signalCode [readonly]: Signals | null
+  stderr [readonly]: ReadableToIO<Err>
+  stdin [readonly]: WritableToIO<In>
+  stdio [readonly]: [null, null, null, ...(number | null)[]]
+  stdout [readonly]: ReadableToIO<Out>
+  terminal [readonly]: Terminal | undefined
+  unref: () => void
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  exitCode: number
+  exitedDueToMaxBuffer [?]: boolean | undefined
+  exitedDueToTimeout [?]: boolean | undefined
+  pid: number
+  resourceUsage: ResourceUsage
+  signalCode [?]: string | undefined
+  stderr: ReadableToSyncIO<Err>
+  stdout: ReadableToSyncIO<Out>
+  success: boolean
+interface SystemError (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface TCPSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  ipv6Only [?]: boolean | undefined
+  port: number
+  reusePort [?]: boolean | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  port: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  hostname [readonly]: string
+  port [readonly]: number
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface TLSSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls: TLSOptions | boolean
+namespace TOML (bun-types/bun.d.ts)
+  function TOML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+  function TOML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+interface TSConfig (bun-types/bun.d.ts)
+  compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
+  extends [?]: string | undefined
+type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+class Terminal (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => Promise<void>
+  close: () => void
+  closed [readonly]: boolean
+  controlFlags: number
+  inputFlags: number
+  localFlags: number
+  outputFlags: number
+  ref: () => void
+  resize: (cols: number, rows: number) => void
+  setRawMode: (enabled: boolean) => void
+  unref: () => void
+  write: (data: BufferSource | string) => number
+  [static]
+    construct new (options: TerminalOptions): Terminal
+    prototype: Terminal
+interface TerminalOptions (bun-types/bun.d.ts)
+  cols [?]: number | undefined
+  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Terminal) => void) | undefined
+  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  name [?]: string | undefined
+  rows [?]: number | undefined
+type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
+interface TransactionSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
+interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+interface TransformerStartCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): any
+interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
+  call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+class Transpiler (bun-types/bun.d.ts)
+  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
+  scanImports: (code: StringOrBuffer) => Array<Import>
+  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  [static]
+    construct new (options?: TranspilerOptions | undefined): Transpiler
+    prototype: Transpiler
+interface TranspilerOptions (bun-types/bun.d.ts)
+  allowBunRuntime [?]: boolean | undefined
+  autoImportJSX [?]: boolean | undefined
+  deadCodeElimination [?]: boolean | undefined
+  define [?]: Record<string, string> | undefined
+  exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
+  inline [?]: boolean | undefined
+  jsxOptimizationInline [?]: boolean | undefined
+  loader [?]: JavaScriptLoader | undefined
+  logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
+  macro [?]: MacroMap | undefined
+  minifyWhitespace [?]: boolean | undefined
+  replMode [?]: boolean | undefined
+  target [?]: Target | undefined
+  treeShaking [?]: boolean | undefined
+  trimUnusedImports [?]: boolean | undefined
+  tsconfig [?]: TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
+interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
+  abort [?]: UnderlyingSinkAbortCallback | undefined
+  close [?]: UnderlyingSinkCloseCallback | undefined
+  start [?]: UnderlyingSinkStartCallback | undefined
+  type [?]: "bytes" | "default" | undefined
+  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
+  call (): PromiseLike<void> | void
+interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
+  call (controller: WritableStreamDefaultController): any
+interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
+  call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
+interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull [?]: UnderlyingSourcePullCallback<R> | undefined
+  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  type [?]: undefined
+interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): any
+type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+interface UnixSocketListener<Data> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unix [readonly]: string
+  unref: () => void
+interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+  unix: string
+type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+interface WebSocket (bun-types/bun.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+interface WebSocketEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: Event
+  message: BunMessageEvent<any>
+  open: Event
+interface WebSocketHandler<T> (bun-types/serve.d.ts)
+  backpressureLimit [?]: number | undefined
+  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  closeOnBackpressureLimit [?]: boolean | undefined
+  data [?]: T | undefined
+  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  idleTimeout [?]: number | undefined
+  maxPayloadLength [?]: number | undefined
+  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
+  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  publishToSelf [?]: boolean | undefined
+  sendPings [?]: boolean | undefined
+type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
+type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
+class WebView (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => void
+  [Symbol.dispose]: () => void
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: BunMessageEvent<T>) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  back: () => Promise<void>
+  cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
+  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  evaluate: <T = unknown>(script: string) => Promise<T>
+  forward: () => Promise<void>
+  loading [readonly]: boolean
+  navigate: (url: string) => Promise<void>
+  onNavigated: ((url: string, title: string) => void) | null
+  onNavigationFailed: ((error: Error) => void) | null
+  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  reload: () => Promise<void>
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  resize: (width: number, height: number) => Promise<void>
+  screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
+  scroll: (dx: number, dy: number) => Promise<void>
+  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  title [readonly]: string
+  type: (text: string) => Promise<void>
+  url [readonly]: string
+  [static]
+    construct new (options?: ConstructorOptions | undefined): WebView
+    closeAll [static]: () => void
+    prototype: WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+  interface WebView.ClickOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+    timeout [?]: number | undefined
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  interface WebView.ConstructorOptions (bun-types/bun.d.ts)
+    backend [?]: Backend | undefined
+    console [?]: ConsoleCapture | undefined
+    dataStore [?]: "ephemeral" | undefined | { directory: string; }
+    headless [?]: boolean | undefined
+    height [?]: number | undefined
+    url [?]: string | undefined
+    width [?]: number | undefined
+  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  interface WebView.PressOptions (bun-types/bun.d.ts)
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ScrollToOptions (bun-types/bun.d.ts)
+    block [?]: "center" | "end" | "nearest" | "start" | undefined
+    timeout [?]: number | undefined
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+interface WhichOptions (bun-types/bun.d.ts)
+  PATH [?]: string | undefined
+  cwd [?]: string | undefined
+interface Worker (bun-types/bun.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+interface WorkerEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: ErrorEvent
+  message: BunMessageEvent<any>
+  messageerror: BunMessageEvent<any>
+  open: Event
+interface WorkerOptions (bun-types/bun.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
+interface WrapAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  hard [?]: boolean | undefined
+  trim [?]: boolean | undefined
+  wordWrap [?]: boolean | undefined
+type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+namespace XML (bun-types/bun.d.ts)
+  interface XML.Comment (bun-types/bun.d.ts)
+    comment: string
+  interface XML.Document (bun-types/bun.d.ts)
+    index [string]: Value
+  interface XML.Element (bun-types/bun.d.ts)
+    index [string]: Array<Value> | Value
+  interface XML.Node (bun-types/bun.d.ts)
+    attributes: Record<string, string>
+    children: Array<string | Comment | Node | ProcessingInstruction>
+    name: string
+  interface XML.NodeInput (bun-types/bun.d.ts)
+    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
+    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    name: string
+  interface XML.ParseOptions (bun-types/bun.d.ts)
+    compact [?]: boolean | undefined
+  interface XML.ProcessingInstruction (bun-types/bun.d.ts)
+    data: string
+    target: string
+  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
+  type XML.Value (bun-types/bun.d.ts) = string | Element
+  function XML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+  function XML.stringify (bun-types/bun.d.ts)
+    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+namespace YAML (bun-types/bun.d.ts)
+  function YAML.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function YAML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string
+interface ZlibCompressionOptions (bun-types/bun.d.ts)
+  level [?]: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "zlib" | undefined
+  memLevel [?]: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  strategy [?]: number | undefined
+  windowBits [?]: -10 | -11 | -12 | -13 | -14 | -15 | -9 | 10 | 11 | 12 | 13 | 14 | 15 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 9 | undefined
+namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/globals.d.ts)
+  interface __internal.BunEvent (bun-types/globals.d.ts)
+    bubbles [readonly]: boolean
+    cancelBubble: boolean
+    cancelable [readonly]: boolean
+    composed [readonly]: boolean
+    composedPath: () => [(EventTarget | undefined)?]
+    currentTarget [readonly]: EventTarget | null
+    defaultPrevented [readonly]: boolean
+    eventPhase [readonly]: number
+    isTrusted [readonly]: boolean
+    preventDefault: () => void
+    returnValue: boolean
+    srcElement [readonly]: EventTarget | null
+    stopImmediatePropagation: () => void
+    stopPropagation: () => void
+    target [readonly]: EventTarget | null
+    timeStamp [readonly]: number
+    type [readonly]: string
+  interface __internal.BunEventTarget (bun-types/globals.d.ts)
+    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    dispatchEvent: (event: Event) => boolean
+    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
+    [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
+    append [readonly]: (name: string, value: string) => void
+    count [readonly]: number
+    delete [readonly]: (name: string) => void
+    entries [readonly]: () => SpecIterableIterator<[string, string]>
+    forEach [readonly]: (callbackfn: (value: string, key: string, iterable: Headers) => void, thisArg?: unknown) => void
+    get [readonly]: (name: string) => null | string
+    getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+    getSetCookie [readonly]: () => Array<string>
+    has [readonly]: (name: string) => boolean
+    keys [readonly]: () => SpecIterableIterator<string>
+    set [readonly]: (name: string, value: string) => void
+    toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+    values [readonly]: () => SpecIterableIterator<string>
+  interface __internal.BunRequestOverride (bun-types/fetch.d.ts)
+    arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+    blob [readonly]: () => Promise<Blob>
+    body [readonly]: ReadableStream<any> | null
+    bodyUsed [readonly]: boolean
+    bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+    cache [readonly]: RequestCache
+    clone: () => Request
+    credentials [readonly]: RequestCredentials
+    destination [readonly]: RequestDestination
+    duplex [readonly]: "half"
+    formData [readonly]: () => Promise<FormData>
+    headers: BunHeadersOverride
+    integrity [readonly]: string
+    json [readonly]: () => Promise<unknown>
+    keepalive [readonly]: boolean
+    method [readonly]: string
+    mode [readonly]: RequestMode
+    redirect [readonly]: RequestRedirect
+    referrer [readonly]: string
+    referrerPolicy [readonly]: ReferrerPolicy
+    signal [readonly]: AbortSignal
+    text [readonly]: () => Promise<string>
+    textStream: () => ReadableStream<string>
+    url [readonly]: string
+  interface __internal.BunResponseOverride (bun-types/fetch.d.ts)
+    arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+    blob [readonly]: () => Promise<Blob>
+    body [readonly]: ReadableStream<any> | null
+    bodyUsed [readonly]: boolean
+    bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+    clone: () => Response
+    formData [readonly]: () => Promise<FormData>
+    headers: BunHeadersOverride
+    json [readonly]: () => Promise<unknown>
+    ok [readonly]: boolean
+    redirected [readonly]: boolean
+    status [readonly]: number
+    statusText [readonly]: string
+    text [readonly]: () => Promise<string>
+    textStream: () => ReadableStream<string>
+    type [readonly]: ResponseType
+    url [readonly]: string
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
+  type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
+  type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = false
+  type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = BroadcastChannel
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = BunEvent
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = BunEventTarget
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = WebSocket
+  type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = EventSource
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = SubtleCrypto
+  type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = MessagePort
+  type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = ReadableStream<T>
+  type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = CompressionStream
+  type __internal.LibEmptyOrNodeStreamWebDecompressionStream (bun-types/globals.d.ts) = DecompressionStream
+  type __internal.LibEmptyOrNodeStreamWebTextDecoderStream (bun-types/globals.d.ts) = TextDecoderStream
+  type __internal.LibEmptyOrNodeStreamWebTextEncoderStream (bun-types/globals.d.ts) = TextEncoderStream
+  type __internal.LibEmptyOrNodeUtilTextDecoder (bun-types/globals.d.ts) = TextDecoder
+  type __internal.LibEmptyOrNodeUtilTextEncoder (bun-types/globals.d.ts) = TextEncoder
+  type __internal.LibEmptyOrNodeWritableStream<T> (bun-types/globals.d.ts) = WritableStream<T>
+  type __internal.LibEmptyOrPerformanceEntry (bun-types/globals.d.ts) = PerformanceEntry
+  type __internal.LibEmptyOrPerformanceMark (bun-types/globals.d.ts) = PerformanceMark
+  type __internal.LibEmptyOrPerformanceMeasure (bun-types/globals.d.ts) = PerformanceMeasure
+  type __internal.LibEmptyOrPerformanceObserver (bun-types/globals.d.ts) = PerformanceObserver
+  type __internal.LibEmptyOrPerformanceObserverEntryList (bun-types/globals.d.ts) = PerformanceObserverEntryList
+  type __internal.LibEmptyOrPerformanceResourceTiming (bun-types/globals.d.ts) = PerformanceResourceTiming
+  type __internal.LibEmptyOrReadableByteStreamController (bun-types/globals.d.ts) = ReadableByteStreamController
+  type __internal.LibEmptyOrReadableStreamBYOBReader (bun-types/globals.d.ts) = ReadableStreamBYOBReader
+  type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = ReadableStreamBYOBRequest
+  type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = Headers
+  type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = Request
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: BodyInit | null | undefined; headers?: HeadersInit | undefined; }
+  type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = Response
+  type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = ResponseInit
+  type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = Performance
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Worker
+  type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
+  type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = Otherwise
+  type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+function allocUnsafe (bun-types/bun.d.ts)
+  call (size: number): Uint8Array<ArrayBuffer>
+var argv (bun-types/bun.d.ts): Array<string>
+function build (bun-types/bun.d.ts)
+  call (config: BuildConfig): Promise<BuildOutput>
+function color (bun-types/bun.d.ts)
+  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: ColorInput, outputFormat: "number"): null | number
+function concatArrayBuffers (bun-types/bun.d.ts)
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+function connect (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+var cron (bun-types/bun.d.ts)
+  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
+  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  remove: (title: string) => Promise<void>
+function deepEquals (bun-types/bun.d.ts)
+  call (a: any, b: any, strict?: boolean | undefined): boolean
+function deepMatch (bun-types/bun.d.ts)
+  call (subset: unknown, a: unknown): boolean
+function deflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+namespace dns (bun-types/bun.d.ts)
+  var dns.ADDRCONFIG (bun-types/bun.d.ts): number
+  var dns.ALL (bun-types/bun.d.ts): number
+  var dns.V4MAPPED (bun-types/bun.d.ts): number
+  function dns.getCacheStats (bun-types/bun.d.ts)
+    call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
+  function dns.lookup (bun-types/bun.d.ts)
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+  function dns.prefetch (bun-types/bun.d.ts)
+    call (hostname: string, port?: number | undefined): void
+var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
+var enableANSIColors (bun-types/bun.d.ts): boolean
+var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+function escapeHTML (bun-types/bun.d.ts)
+  call (input: boolean | number | object | string): string
+var fetch (bun-types/bun.d.ts): typeof fetch
+function file (bun-types/bun.d.ts)
+  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+function fileURLToPath (bun-types/bun.d.ts)
+  call (url: URL | string): string
+function gc (bun-types/bun.d.ts)
+  call (force?: boolean | undefined): void
+function generateHeapSnapshot (bun-types/bun.d.ts)
+  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format: "v8"): string
+  call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
+function gunzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function gzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+function indexOfLine (bun-types/bun.d.ts)
+  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+function inflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function inspect (bun-types/bun.d.ts)
+  call (arg: any, options?: BunInspectOptions | undefined): string
+  custom: typeof custom
+  table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
+namespace inspect (bun-types/bun.d.ts)
+  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  function inspect.table (bun-types/bun.d.ts)
+    call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
+    call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
+var isMainThread (bun-types/bun.d.ts): boolean
+var isStandaloneExecutable (bun-types/bun.d.ts): boolean
+function listen (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+var main (bun-types/bun.d.ts): string
+namespace markdown (bun-types/bun.d.ts)
+  interface markdown.AnsiTheme (bun-types/bun.d.ts)
+    colors [?]: boolean | undefined
+    columns [?]: number | undefined
+    hyperlinks [?]: boolean | undefined
+    kittyGraphics [?]: boolean | undefined
+    light [?]: boolean | undefined
+  interface markdown.CellMeta (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+  interface markdown.CellProps (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+    children: Array<unknown>
+  interface markdown.ChildrenProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+  interface markdown.CodeBlockMeta (bun-types/bun.d.ts)
+    language [?]: string | undefined
+  interface markdown.CodeBlockProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    language [?]: string | undefined
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  interface markdown.ComponentOverrides (bun-types/bun.d.ts)
+    a [?]: Component<LinkProps> | undefined
+    blockquote [?]: Component<ChildrenProps> | undefined
+    br [?]: Component<{}> | undefined
+    code [?]: Component<ChildrenProps> | undefined
+    del [?]: Component<ChildrenProps> | undefined
+    em [?]: Component<ChildrenProps> | undefined
+    h1 [?]: Component<HeadingProps> | undefined
+    h2 [?]: Component<HeadingProps> | undefined
+    h3 [?]: Component<HeadingProps> | undefined
+    h4 [?]: Component<HeadingProps> | undefined
+    h5 [?]: Component<HeadingProps> | undefined
+    h6 [?]: Component<HeadingProps> | undefined
+    hr [?]: Component<{}> | undefined
+    html [?]: Component<ChildrenProps> | undefined
+    img [?]: Component<ImageProps> | undefined
+    li [?]: Component<ListItemProps> | undefined
+    math [?]: Component<ChildrenProps> | undefined
+    ol [?]: Component<OrderedListProps> | undefined
+    p [?]: Component<ChildrenProps> | undefined
+    pre [?]: Component<CodeBlockProps> | undefined
+    strong [?]: Component<ChildrenProps> | undefined
+    table [?]: Component<ChildrenProps> | undefined
+    tbody [?]: Component<ChildrenProps> | undefined
+    td [?]: Component<CellProps> | undefined
+    th [?]: Component<CellProps> | undefined
+    thead [?]: Component<ChildrenProps> | undefined
+    tr [?]: Component<ChildrenProps> | undefined
+    u [?]: Component<ChildrenProps> | undefined
+    ul [?]: Component<ChildrenProps> | undefined
+  interface markdown.HeadingMeta (bun-types/bun.d.ts)
+    id [?]: string | undefined
+    level: number
+  interface markdown.HeadingProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    id [?]: string | undefined
+  interface markdown.ImageMeta (bun-types/bun.d.ts)
+    src: string
+    title [?]: string | undefined
+  interface markdown.ImageProps (bun-types/bun.d.ts)
+    alt [?]: string | undefined
+    src: string
+    title [?]: string | undefined
+  interface markdown.LinkMeta (bun-types/bun.d.ts)
+    href: string
+    title [?]: string | undefined
+  interface markdown.LinkProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    href: string
+    title [?]: string | undefined
+  interface markdown.ListItemMeta (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    depth: number
+    index: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.ListItemProps (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    children: Array<unknown>
+  interface markdown.ListMeta (bun-types/bun.d.ts)
+    depth: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.Options (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.OrderedListProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    start: number
+  interface markdown.ReactOptions (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    reactVersion [?]: 18 | 19 | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.RenderCallbacks (bun-types/bun.d.ts)
+    blockquote [?]: ((children: string) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    codespan [?]: ((children: string) => null | string | undefined) | undefined
+    emphasis [?]: ((children: string) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    hr [?]: ((children: string) => null | string | undefined) | undefined
+    html [?]: ((children: string) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    paragraph [?]: ((children: string) => null | string | undefined) | undefined
+    strikethrough [?]: ((children: string) => null | string | undefined) | undefined
+    strong [?]: ((children: string) => null | string | undefined) | undefined
+    table [?]: ((children: string) => null | string | undefined) | undefined
+    tbody [?]: ((children: string) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    text [?]: ((text: string) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    thead [?]: ((children: string) => null | string | undefined) | undefined
+    tr [?]: ((children: string) => null | string | undefined) | undefined
+  function markdown.ansi (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+  function markdown.html (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+  function markdown.react (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+  function markdown.render (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+function mmap (bun-types/bun.d.ts)
+  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+function nanoseconds (bun-types/bun.d.ts)
+  call (): number
+function openInEditor (bun-types/bun.d.ts)
+  call (path: string, options?: EditorOptions | undefined): void
+var password (bun-types/bun.d.ts)
+  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
+  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+function pathToFileURL (bun-types/bun.d.ts)
+  call (path: string): URL
+function peek (bun-types/bun.d.ts)
+  call <T = undefined>(promise: Promise<T> | T): Promise<T> | T
+  status: <T = undefined>(promise: Promise<T> | T) => "fulfilled" | "pending" | "rejected"
+namespace peek (bun-types/bun.d.ts)
+  function peek.status (bun-types/bun.d.ts)
+    call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
+var plugin (bun-types/bun.d.ts): BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): SQL
+function randomUUIDv5 (bun-types/bun.d.ts)
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+function randomUUIDv7 (bun-types/bun.d.ts)
+  call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
+  call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
+function readableStreamToArray (bun-types/bun.d.ts)
+  call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
+function readableStreamToArrayBuffer (bun-types/bun.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+function readableStreamToBlob (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<Blob>
+function readableStreamToBytes (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+function readableStreamToFormData (bun-types/bun.d.ts)
+  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+function readableStreamToJSON (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<any>
+function readableStreamToText (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<string>
+var redis (bun-types/redis.d.ts): RedisClient
+function resolve (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): Promise<string>
+function resolveSync (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): string
+var revision (bun-types/bun.d.ts): string
+var s3 (bun-types/s3.d.ts): S3Client
+var secrets (bun-types/bun.d.ts)
+  delete: (options: { service: string; name: string; }) => Promise<boolean>
+  get: (options: { service: string; name: string; }) => Promise<string | null>
+  set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
+namespace semver (bun-types/bun.d.ts)
+  function semver.order (bun-types/bun.d.ts)
+    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+  function semver.satisfies (bun-types/bun.d.ts)
+    call (version: StringLike, range: StringLike): boolean
+function serve (bun-types/serve.d.ts)
+  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+function sha (bun-types/bun.d.ts)
+  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
+  call (input: StringOrBuffer, encoding: DigestEncoding): string
+function shrink (bun-types/bun.d.ts)
+  call (): void
+function sleep (bun-types/bun.d.ts)
+  call (ms: Date | number): Promise<void>
+function sleepSync (bun-types/bun.d.ts)
+  call (ms: number): void
+function sliceAnsi (bun-types/bun.d.ts)
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+function spawn (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+function spawnSync (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): SQL
+var stderr (bun-types/bun.d.ts): BunFile
+var stdin (bun-types/bun.d.ts): BunFile
+var stdout (bun-types/bun.d.ts): BunFile
+function stringWidth (bun-types/bun.d.ts)
+  call (input: string, options?: StringWidthOptions | undefined): number
+function stripANSI (bun-types/bun.d.ts)
+  call (input: string): string
+namespace udp (bun-types/bun.d.ts)
+  interface udp.BaseUDPSocket (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    connect: { hostname: string; port: number; }
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: SocketAddress
+    send: (data: Data) => boolean
+    sendMany: (packets: ReadonlyArray<Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ReceiveFlags (bun-types/bun.d.ts)
+    ipv6: boolean
+    truncated: boolean
+  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: SocketHandler<DataBinaryType>) => void
+    send: (data: Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: SocketHandler<DataBinaryType> | undefined
+function udpSocket (bun-types/bun.d.ts)
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+namespace unsafe (bun-types/bun.d.ts)
+  function unsafe.arrayBufferToString (bun-types/bun.d.ts)
+    call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
+    call (buffer: Uint16Array<ArrayBufferLike>): string
+  function unsafe.gcAggressionLevel (bun-types/bun.d.ts)
+    call (level?: 0 | 1 | 2 | undefined): 0 | 1 | 2
+  function unsafe.memoryFootprint (bun-types/bun.d.ts)
+    call (): number | undefined
+  function unsafe.mimallocDump (bun-types/bun.d.ts)
+    call (): void
+var version (bun-types/bun.d.ts): string
+var version_with_sha (bun-types/bun.d.ts): string
+function which (bun-types/bun.d.ts)
+  call (command: string, options?: WhichOptions | undefined): null | string
+function wrapAnsi (bun-types/bun.d.ts)
+  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+function write (bun-types/bun.d.ts)
+  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+function zstdCompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+function zstdCompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+function zstdDecompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+function zstdDecompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+
+# module "bun:bundle"
+interface Registry (bun-types/bundle.d.ts)
+function feature (bun-types/bundle.d.ts)
+  call (flag: string): boolean
+
+# module "bun:ffi"
+function CFunction (bun-types/ffi.d.ts)
+  call (fn: FFIFunction & { ptr: number | bigint | Pointer; }): CallableFunction & { close(): void; }
+type CString (bun-types/ffi.d.ts) = string
+var CString (bun-types/ffi.d.ts): CStringConstructor
+interface CStringConstructor (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+  construct new (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts) = { [K in keyof Fns]: { (...args: Fns[K]["args"] extends infer A extends ReadonlyArray<FFITypeOrString> ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>]; } : [unknown] extends [Fns[K]["args"]] ? [] : never): [unknown] extends [Fns[K]["returns"]] ? undefined : FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>]; __ffi_function_callable: typeof FFIFunctionCallableSymbol; }; }
+interface FFIFunction (bun-types/ffi.d.ts)
+  args [? readonly]: ReadonlyArray<FFITypeOrString> | undefined
+  ptr [? readonly]: Pointer | bigint | undefined
+  returns [? readonly]: FFITypeOrString | undefined
+  threadsafe [? readonly]: boolean | undefined
+var FFIFunctionCallableSymbol (bun-types/ffi.d.ts): typeof FFIFunctionCallableSymbol
+enum FFIType (bun-types/ffi.d.ts)
+  char = FFIType.char
+  int8_t = FFIType.int8_t
+  i8 = FFIType.int8_t
+  uint8_t = FFIType.uint8_t
+  u8 = FFIType.uint8_t
+  int16_t = FFIType.int16_t
+  i16 = FFIType.int16_t
+  uint16_t = FFIType.uint16_t
+  u16 = FFIType.uint16_t
+  int32_t = FFIType.int32_t
+  i32 = FFIType.int32_t
+  int = FFIType.int32_t
+  uint32_t = FFIType.uint32_t
+  u32 = FFIType.uint32_t
+  int64_t = FFIType.int64_t
+  i64 = FFIType.int64_t
+  uint64_t = FFIType.uint64_t
+  u64 = FFIType.uint64_t
+  double = FFIType.double
+  f64 = FFIType.double
+  float = FFIType.float
+  f32 = FFIType.float
+  bool = FFIType.bool
+  ptr = FFIType.ptr
+  pointer = FFIType.ptr
+  void = FFIType.void
+  cstring = FFIType.cstring
+  i64_fast = FFIType.i64_fast
+  u64_fast = FFIType.u64_fast
+  function = FFIType.function
+  napi_env = FFIType.napi_env
+  napi_value = FFIType.napi_value
+  buffer = FFIType.buffer
+  buffer_length = FFIType.buffer_length
+type FFITypeOrString (bun-types/ffi.d.ts) = FFIType | keyof FFITypeStringToType
+interface FFITypeStringToType (bun-types/ffi.d.ts)
+  bool: FFIType.bool
+  buffer: FFIType.buffer
+  buffer_bytelength: FFIType.buffer_length
+  buffer_length: FFIType.buffer_length
+  callback: FFIType.ptr
+  char: FFIType.char
+  cstring: FFIType.cstring
+  double: FFIType.double
+  f32: FFIType.float
+  f64: FFIType.double
+  float: FFIType.float
+  function: FFIType.ptr
+  i16: FFIType.int16_t
+  i32: FFIType.int32_t
+  i64: FFIType.int64_t
+  i8: FFIType.int8_t
+  int: FFIType.int32_t
+  int16_t: FFIType.int16_t
+  int32_t: FFIType.int32_t
+  int64_t: FFIType.int64_t
+  int8_t: FFIType.int8_t
+  napi_env: FFIType.napi_env
+  napi_value: FFIType.napi_value
+  pointer: FFIType.ptr
+  ptr: FFIType.ptr
+  u16: FFIType.uint16_t
+  u32: FFIType.uint32_t
+  u64: FFIType.uint64_t
+  u8: FFIType.uint8_t
+  uint16_t: FFIType.uint16_t
+  uint32_t: FFIType.uint32_t
+  uint64_t: FFIType.uint64_t
+  uint8_t: FFIType.uint8_t
+  usize: FFIType.uint64_t
+  void: FFIType.void
+interface FFITypeToArgsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  13: undefined
+  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  15: bigint | number
+  16: bigint | number
+  17: JSCallback | Pointer
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint | number
+  8: bigint | number
+  9: number
+interface FFITypeToReturnsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | bigint | null
+  13: undefined
+  14: null | string
+  15: bigint | number
+  16: bigint | number
+  17: Pointer | bigint | null
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint
+  8: bigint
+  9: number
+class JSCallback (bun-types/ffi.d.ts)
+  close: () => void
+  ptr [readonly]: Pointer | null
+  threadsafe [readonly]: boolean
+  [static]
+    construct new (callback: (...args: Array<any>) => any, definition: FFIFunction): JSCallback
+    prototype: JSCallback
+interface Library<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts)
+  close: () => void
+  symbols: ConvertFns<Fns>
+type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
+type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
+type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
+function cc (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+function dlopen (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+function linkSymbols (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
+function ptr (bun-types/ffi.d.ts)
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+namespace read (bun-types/ffi.d.ts)
+  function read.f32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.f64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.i8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.intptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.ptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.u8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+var suffix (bun-types/ffi.d.ts): string
+function toArrayBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): ArrayBuffer
+function toBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): Buffer<ArrayBufferLike>
+function viewSource (bun-types/ffi.d.ts)
+  call (symbols: Readonly<Record<string, FFIFunction>>, is_callback?: false | undefined): Array<string>
+  call (callback: FFIFunction, is_callback: true): string
+
+# module "bun:jsc"
+interface HeapStats (bun-types/jsc.d.ts)
+  extraMemorySize: number
+  globalObjectCount: number
+  heapCapacity: number
+  heapSize: number
+  objectCount: number
+  objectTypeCounts: Record<string, number>
+  protectedGlobalObjectCount: number
+  protectedObjectCount: number
+  protectedObjectTypeCounts: Record<string, number>
+interface MemoryUsage (bun-types/jsc.d.ts)
+  current: number
+  currentCommit: number
+  pageFaults: number
+  peak: number
+  peakCommit: number
+interface SamplingProfile (bun-types/jsc.d.ts)
+  bytecodes: string
+  functions: string
+  stackTraces: SamplingProfileStackTraces
+interface SamplingProfileStackFrame (bun-types/jsc.d.ts)
+  category: string
+  column: number
+  flags: number
+  inliner [?]: undefined | { name: string; location: string; line: number; column: number; category: string; }
+  line: number
+  location: string
+  name: string
+  sourceID: number
+  sourceURL [?]: string | undefined
+interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
+  interval: number
+  sources: Array<{ sourceID: number; url?: string | undefined; sourceURL?: string | undefined; sourceMappingURL?: string | undefined; }>
+  traces: Array<{ timestamp: number; frames: Array<SamplingProfileStackFrame>; }>
+function callerSourceOrigin (bun-types/jsc.d.ts)
+  call (): null | string
+function deserialize (bun-types/jsc.d.ts)
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+function drainMicrotasks (bun-types/jsc.d.ts)
+  call (): void
+function edenGC (bun-types/jsc.d.ts)
+  call (): number
+function estimateShallowMemoryUsageOf (bun-types/jsc.d.ts)
+  call (value: CallableFunction | bigint | object | string | symbol): number
+function fullGC (bun-types/jsc.d.ts)
+  call (): number
+function gcAndSweep (bun-types/jsc.d.ts)
+  call (): number
+function getProtectedObjects (bun-types/jsc.d.ts)
+  call (): Array<any>
+function getRandomSeed (bun-types/jsc.d.ts)
+  call (): number
+function heapSize (bun-types/jsc.d.ts)
+  call (): number
+function heapStats (bun-types/jsc.d.ts)
+  call (): HeapStats
+function isRope (bun-types/jsc.d.ts)
+  call (input: string): boolean
+function jscDescribe (bun-types/jsc.d.ts)
+  call (value: any): string
+function jscDescribeArray (bun-types/jsc.d.ts)
+  call (array: Array<any>): string
+function memoryUsage (bun-types/jsc.d.ts)
+  call (): MemoryUsage
+function noFTL (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function noOSRExitFuzzing (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function numberOfDFGCompiles (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function optimizeNextInvocation (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function profile (bun-types/jsc.d.ts)
+  call <T extends (...args: Array<any>) => any>(callback: T, sampleInterval?: number | undefined, ...args: Parameters<T>): ReturnType<T> extends Promise<infer U> ? Promise<SamplingProfile> : SamplingProfile
+function releaseWeakRefs (bun-types/jsc.d.ts)
+  call (): void
+function reoptimizationRetryCount (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function serialize (bun-types/jsc.d.ts)
+  call (value: any, options?: undefined | { binaryType?: "arraybuffer" | undefined; }): SharedArrayBuffer
+  call (value: any, options?: undefined | { binaryType: "nodebuffer"; }): Buffer<ArrayBufferLike>
+function setRandomSeed (bun-types/jsc.d.ts)
+  call (value: number): void
+function setTimeZone (bun-types/jsc.d.ts)
+  call (timeZone: string): string
+function startRemoteDebugger (bun-types/jsc.d.ts)
+  call (host?: string | undefined, port?: number | undefined): void
+function startSamplingProfiler (bun-types/jsc.d.ts)
+  call (optionalDirectory?: string | undefined, sampleInterval?: number | undefined): void
+function totalCompileTime (bun-types/jsc.d.ts)
+  call (): number
+
+# module "bun:sqlite"
+interface Changes (bun-types/sqlite.d.ts)
+  changes: number
+  lastInsertRowid: bigint | number
+class Database (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  close: (throwOnError?: boolean | undefined) => void
+  exec: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  fileControl: { (op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number; (zDbName: string, op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number }
+  filename [readonly]: string
+  handle [readonly]: number
+  inTransaction: boolean
+  loadExtension: (extension: string, entryPoint?: string | undefined) => void
+  prepare: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string, params?: ParamsType | undefined) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  query: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  run: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  serialize: (name?: string | undefined) => Buffer<ArrayBufferLike>
+  transaction: <A extends Array<any>, T>(insideTransaction: (...args: A) => T) => { (...args: A): T; deferred: (...args: A) => T; immediate: (...args: A) => T; exclusive: (...args: A) => T; }
+  [static]
+    construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
+    MAX_QUERY_CACHE_SIZE [static]: number
+    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
+    prototype: Database
+    setCustomSQLite [static]: (path: string) => boolean
+interface DatabaseOptions (bun-types/sqlite.d.ts)
+  create [?]: boolean | undefined
+  readonly [?]: boolean | undefined
+  readwrite [?]: boolean | undefined
+  safeIntegers [?]: boolean | undefined
+  strict [?]: boolean | undefined
+type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+class SQLiteError (bun-types/sqlite.d.ts)
+  byteOffset [readonly]: number
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno: number
+  message: string
+  name [readonly]: "SQLiteError"
+  stack [?]: string | undefined
+  [static]
+    construct new (message?: string | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+    isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prototype: SQLiteError
+    stackTraceLimit: number
+class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  [Symbol.iterator]: () => IterableIterator<ReturnType>
+  all: (...params: ParamsType) => Array<ReturnType>
+  as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
+  columnNames [readonly]: Array<string>
+  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
+  declaredTypes [readonly]: Array<string | null>
+  finalize: () => void
+  get: (...params: ParamsType) => ReturnType | null
+  iterate: (...params: ParamsType) => IterableIterator<ReturnType>
+  native [readonly]: any
+  paramsCount [readonly]: number
+  raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
+  run: (...params: ParamsType) => Changes
+  toString: () => string
+  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  [static]
+    construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
+    prototype: Statement<any, any>
+namespace constants (bun-types/sqlite.d.ts)
+  var constants.SQLITE_FCNTL_BEGIN_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_BUSYHANDLER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CHUNK_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_DONE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_START (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKSM_FILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_PHASETWO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_DATA_VERSION (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_EXTERNAL_READER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_FILE_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_GET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_HAS_MOVED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_JOURNAL_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LAST_ERRNO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCKSTATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCK_TIMEOUT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_MMAP_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PDB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PERSIST_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_POWERSAFE_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PRAGMA (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RBU (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESERVE_BYTES (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESET_CACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_HINT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_LIMIT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC_OMITTED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TEMPFILENAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TRACE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFSNAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFS_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WAL_BLOCK (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_AV_RETRY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_GET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_SET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ZIPVFS (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_AUTOPROXY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_CREATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_DELETEONCLOSE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXCLUSIVE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXRESCODE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_FULLMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MEMORY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOFOLLOW (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_PRIVATECACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READONLY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SHAREDCACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUBJOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUPER_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TRANSIENT_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_URI (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NORMALIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NO_VTAB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_PERSISTENT (bun-types/sqlite.d.ts): number
+default -> Database
+var native (bun-types/sqlite.d.ts): any
+
+# module "bun:test"
+type AsymmetricMatcher (bun-types/test.d.ts) = any
+interface AsymmetricMatchers (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+type CustomMatcher<E, P extends Array<any>> (bun-types/test.d.ts) = (this: MatcherContext, expected: E, ...matcherArguments: P) => MatcherResult | Promise<MatcherResult>
+type CustomMatchersDetected (bun-types/test.d.ts) = Omit<Matchers<unknown>, keyof MatchersBuiltin<unknown>> & Omit<AsymmetricMatchers, keyof AsymmetricMatchersBuiltin>
+interface Describe<T extends ReadonlyArray<any>> (bun-types/test.d.ts)
+  call (fn: () => void): void
+  call (label: DescribeLabel, fn: (...args: T) => void): void
+  concurrent: Describe<T>
+  each: { <T extends readonly [any, ...any[]]>(table: ReadonlyArray<T>): Describe<[...T]>; <T extends Array<any>>(table: ReadonlyArray<T>): Describe<[...T]>; <T>(table: Array<T>): Describe<[T]> }
+  if: (condition: boolean) => Describe<T>
+  only: Describe<T>
+  serial: Describe<T>
+  skip: Describe<T>
+  skipIf: (condition: boolean) => Describe<T>
+  todo: Describe<T>
+  todoIf: (condition: boolean) => Describe<T>
+type EqualsFunction (bun-types/test.d.ts) = (a: unknown, b: unknown) => boolean
+interface Expect (bun-types/test.d.ts)
+  call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
+  call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
+  call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  assertions: (neededAssertions: number) => void
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  extend: <M>(matchers: ExpectExtendMatchers<M>) => void
+  hasAssertions: () => void
+  not: ExpectNot
+  objectContaining: (obj: object) => any
+  rejectsTo: AsymmetricMatchers
+  resolvesTo: AsymmetricMatchers
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+  unreachable: (msg?: Error | string | undefined) => never
+type ExpectExtendMatchers<M> (bun-types/test.d.ts) = { [k in keyof M]: k extends never ? CustomMatcher<unknown, Parameters<CustomMatchersDetected[k]>> : CustomMatcher<unknown, Array<any>>; }
+interface MatcherResult (bun-types/test.d.ts)
+  message [?]: (() => string) | string | undefined
+  pass: boolean
+interface Matchers<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
+  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  concurrent: Test<T>
+  concurrentIf: (condition: boolean) => Test<T>
+  each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
+  failing: Test<T>
+  failingIf: (condition: boolean) => Test<T>
+  if: (condition: boolean) => Test<T>
+  only: Test<T>
+  serial: Test<T>
+  serialIf: (condition: boolean) => Test<T>
+  skip: Test<T>
+  skipIf: (condition: boolean) => Test<T>
+  todo: Test<T>
+  todoIf: (condition: boolean) => Test<T>
+interface TestOptions (bun-types/test.d.ts)
+  repeats [?]: number | undefined
+  retry [?]: number | undefined
+  timeout [?]: number | undefined
+type Tester (bun-types/test.d.ts) = (this: TesterContext, a: any, b: any, customTesters: Array<Tester>) => boolean | undefined
+interface TesterContext (bun-types/test.d.ts)
+  equals: EqualsFunction
+function afterAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function afterEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+var describe (bun-types/test.d.ts): Describe<[]>
+var expect (bun-types/test.d.ts): Expect
+var expectTypeOf (bun-types/test.d.ts)
+  call <Actual>(actual: Actual): PositiveExpectTypeOf<Actual>
+  call <Actual>(): PositiveExpectTypeOf<Actual>
+var it (bun-types/test.d.ts): Test<[]>
+namespace jest (bun-types/test.d.ts)
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
+  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  function jest.advanceTimersByTime (bun-types/test.d.ts)
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.clearAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.clearAllTimers (bun-types/test.d.ts)
+    call (): void
+  function jest.fn (bun-types/test.d.ts)
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+  function jest.getTimerCount (bun-types/test.d.ts)
+    call (): number
+  function jest.isFakeTimers (bun-types/test.d.ts)
+    call (): boolean
+  function jest.resetAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.restoreAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.runAllTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.runOnlyPendingTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.setSystemTime (bun-types/test.d.ts)
+    call (now?: Date | number | undefined): void
+  function jest.setTimeout (bun-types/test.d.ts)
+    call (milliseconds: number): void
+  function jest.spyOn (bun-types/test.d.ts)
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+  function jest.useFakeTimers (bun-types/test.d.ts)
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.useRealTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var mock (bun-types/test.d.ts)
+  call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
+  clearAllMocks: () => void
+  module: (id: string, factory: () => any) => Promise<void> | void
+  restore: () => void
+function onTestFinished (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function setDefaultTimeout (bun-types/test.d.ts)
+  call (milliseconds: number): void
+function setSystemTime (bun-types/test.d.ts)
+  call (now?: Date | number | undefined): ThisType<void>
+function spyOn (bun-types/test.d.ts)
+  call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+test -> it
+var vi (bun-types/test.d.ts)
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  clearAllMocks: () => void
+  clearAllTimers: () => void
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  getTimerCount: () => number
+  isFakeTimers: () => boolean
+  mock: (id: string, factory: () => any) => Promise<void> | void
+  resetAllMocks: () => void
+  restoreAllMocks: () => void
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var xdescribe (bun-types/test.d.ts): Describe<[]>
+var xit (bun-types/test.d.ts): Test<[]>
+xtest -> xit
+
+# globals
+interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => void
+  signal [readonly]: AbortSignal
+var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  construct new (): AbortController
+  prototype: AbortController
+interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  aborted [readonly]: boolean
+  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  onabort: ((this: AbortSignal, ev: Event) => any) | null
+  reason [readonly]: any
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  throwIfAborted: () => void
+var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  construct new (): AbortSignal
+  abort: (reason?: any) => AbortSignal
+  any: (signals: Array<AbortSignal>) => AbortSignal
+  prototype: AbortSignal
+  timeout: (ms: number) => AbortSignal
+interface AddEventListenerOptions (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2024.arraybuffer.d.ts, lib.es5.d.ts)
+  [Symbol.toStringTag] [readonly]: "ArrayBuffer"
+  byteLength [readonly]: number
+  detached: boolean
+  maxByteLength: number
+  resizable: boolean
+  resize: { (newByteLength?: number | undefined): void; (byteLength: number): ArrayBuffer }
+  slice: { (begin?: number | undefined, end?: number | undefined): ArrayBuffer; (begin: number, end?: number | undefined): ArrayBuffer }
+  transfer: (newByteLength?: number | undefined) => ArrayBuffer
+  transferToFixedLength: (newByteLength?: number | undefined) => ArrayBuffer
+var ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2024.arraybuffer.d.ts, lib.es5.d.ts): ArrayBufferConstructor
+interface ArrayBufferConstructor (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2017.arraybuffer.d.ts, lib.es2024.arraybuffer.d.ts, lib.es5.d.ts)
+  construct new (byteLength: number): ArrayBuffer
+  construct new (): ArrayBuffer
+  construct new (byteLength: number, options?: undefined | { maxByteLength?: number | undefined; }): ArrayBuffer
+  construct new (byteLength: number, options: { maxByteLength?: number | undefined; }): ArrayBuffer
+  [Symbol.species] [readonly]: ArrayBufferConstructor
+  isView: (arg: any) => arg is ArrayBufferView<ArrayBufferLike>
+  prototype [readonly]: ArrayBuffer
+interface ArrayConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts, lib.esnext.array.d.ts)
+  call (arrayLength?: number | undefined): Array<any>
+  call <T>(arrayLength: number): Array<T>
+  call <T>(...items: Array<T>): Array<T>
+  construct new (arrayLength?: number | undefined): Array<any>
+  construct new <T>(arrayLength: number): Array<T>
+  construct new <T>(...items: Array<T>): Array<T>
+  [Symbol.species] [readonly]: ArrayConstructor
+  from: { <T>(arrayLike: ArrayLike<T>): Array<T>; <T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>; <T>(iterable: ArrayLike<T> | Iterable<T>): Array<T>; <T, U>(iterable: ArrayLike<T> | Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U> }
+  fromAsync: { <T>(iterableOrArrayLike: ArrayLike<T | PromiseLike<T>> | AsyncIterable<T> | Iterable<T | PromiseLike<T>>): Promise<Array<T>>; <T, U>(iterableOrArrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Array<Awaited<U>>>; <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
+  isArray: (arg: any) => arg is any[]
+  of: <T>(...items: Array<T>) => Array<T>
+  prototype [readonly]: Array<any>
+interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  size [readonly]: number
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
+interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  type [?]: string | undefined
+interface BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (ev: BroadcastChannelEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  name [readonly]: string
+  onmessage: ((ev: MessageEvent<any>) => void) | null
+  onmessageerror: ((ev: MessageEvent<any>) => void) | null
+  postMessage: (message: any) => void
+  ref: () => BroadcastChannel
+  removeEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (ev: BroadcastChannelEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => BroadcastChannel
+var BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (name: string): BroadcastChannel
+  prototype: BroadcastChannel
+var BuildError (bun-types/deprecated.d.ts): typeof BuildMessage
+class BuildMessage (bun-types/globals.d.ts)
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "BuildMessage"
+  position [readonly]: Position | null
+  [static]
+    construct new (): BuildMessage
+    prototype: BuildMessage
+Bun -> module "bun"
+interface BunFetchRequestInit (bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
+  credentials [?]: RequestCredentials | undefined
+  decompress [?]: boolean | undefined
+  dispatcher [?]: Dispatcher | undefined
+  duplex [?]: "half" | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  maxRedirects [?]: number | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  s3 [?]: S3Options | undefined
+  signal [?]: AbortSignal | null | undefined
+  timeout [?]: boolean | number | undefined
+  tls [?]: BunFetchRequestInitTLS | undefined
+  unix [?]: string | undefined
+  verbose [?]: boolean | undefined
+  window [?]: null | undefined
+interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<ArrayBufferView<ArrayBufferLike>>
+var ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (init: QueuingStrategyInit): ByteLengthQueuingStrategy
+  prototype: ByteLengthQueuingStrategy
+interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  code [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  reason [readonly]: string
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  wasClean [readonly]: boolean
+var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  prototype: CloseEvent
+interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<BufferSource>
+var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
+  prototype: CompressionStream
+interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
+  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
+  assert: (condition?: boolean | undefined, ...data: Array<any>) => void
+  clear: () => void
+  count: (label?: string | undefined) => void
+  countReset: (label?: string | undefined) => void
+  debug: (...data: Array<any>) => void
+  dir: (item?: any, options?: any) => void
+  dirxml: (...data: Array<any>) => void
+  error: (...data: Array<any>) => void
+  group: (...data: Array<any>) => void
+  groupCollapsed: (...data: Array<any>) => void
+  groupEnd: () => void
+  info: (...data: Array<any>) => void
+  log: (...data: Array<any>) => void
+  profile: (label?: string | undefined) => void
+  profileEnd: (label?: string | undefined) => void
+  table: (tabularData?: any, properties?: Array<string> | undefined) => void
+  time: (label?: string | undefined) => void
+  timeEnd: (label?: string | undefined) => void
+  timeLog: (label?: string | undefined, ...data: Array<any>) => void
+  timeStamp: (label?: string | undefined) => void
+  trace: (...data: Array<any>) => void
+  warn: (...data: Array<any>) => void
+  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+interface ConsoleOptions (bun-types/globals.d.ts)
+  colorMode [?]: "auto" | boolean | undefined
+  groupIndentation [?]: number | undefined
+  ignoreErrors [?]: boolean | undefined
+  inspectOptions [?]: InspectOptions | undefined
+  stderr [?]: Writable | undefined
+  stdout: Writable
+interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<any>
+var CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (init: QueuingStrategyInit): CountQueuingStrategy
+  prototype: CountQueuingStrategy
+interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  getRandomValues: <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T) => T
+  randomUUID: () => `${string}-${string}-${string}-${string}-${string}`
+  subtle [readonly]: SubtleCrypto
+  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): Crypto
+  prototype: Crypto
+interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  algorithm [readonly]: KeyAlgorithm
+  extractable [readonly]: boolean
+  type [readonly]: KeyType
+  usages [readonly]: Array<KeyUsage>
+var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): CryptoKey
+  prototype: CryptoKey
+interface CryptoKeyPair (bun-types/globals.d.ts)
+  privateKey: CryptoKey
+  publicKey: CryptoKey
+interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  detail [readonly]: T
+  eventPhase [readonly]: number
+  initCustomEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, detail?: T | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  prototype: CustomEvent<any>
+interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  cause [?]: unknown
+  code [readonly]: number
+  message [readonly]: string
+  name [readonly]: string
+  stack [?]: string | undefined
+var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  construct new (message?: string | undefined, name?: string | undefined): DOMException
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  prototype: DOMException
+interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<BufferSource>
+var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
+  prototype: DecompressionStream
+interface Dict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined
+interface ErrnoException (bun-types/globals.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts)
+  cause [?]: unknown
+  message: string
+  name: string
+  stack [?]: string | undefined
+var Error (bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts): ErrorConstructor
+interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, lib.es2022.error.d.ts, lib.es5.d.ts, lib.esnext.error.d.ts)
+  call (message?: string | undefined): Error
+  call (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+  isError: { (error: unknown): error is Error; (value: unknown): value is Error }
+  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prototype [readonly]: Error
+  stackTraceLimit: number
+interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  colno [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  error [readonly]: any
+  eventPhase [readonly]: number
+  filename [readonly]: string
+  isTrusted [readonly]: boolean
+  lineno [readonly]: number
+  message [readonly]: string
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  prototype: ErrorEvent
+interface ErrorOptions (bun-types/globals.d.ts, lib.es2022.error.d.ts)
+  cause [?]: unknown
+interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  prototype: Event
+interface EventListener (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  handleEvent: (object: Event) => void
+interface EventMap (bun-types/globals.d.ts)
+  fetch: FetchEvent
+  message: MessageEvent<any>
+  messageerror: MessageEvent<any>
+interface EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: ErrorEvent) => any) | null
+  onmessage: ((this: EventSource, ev: MessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: 0 | 1 | 2
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (): EventSource
+  prototype: EventSource
+interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  withCredentials [?]: boolean | undefined
+interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  construct new (): EventTarget
+  prototype: EventTarget
+interface FetchEvent (bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified [readonly]: number
+  name [readonly]: string
+  size [readonly]: number
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  construct new (parts: Array<BlobPart>, name: string, options?: BlobPropertyBag & { lastModified?: number | Date | undefined; } | undefined): File
+  prototype: File
+interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  delete: (name: string) => void
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
+  get: (name: string) => FormDataEntryValue | null
+  getAll: (name: string) => Array<FormDataEntryValue>
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  values: () => IterableIterator<string>
+var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (): FormData
+  prototype: FormData
+class HTMLRewriter (bun-types/html-rewriter.d.ts)
+  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  [static]
+    construct new (): HTMLRewriter
+    prototype: HTMLRewriter
+namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
+  interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Comment
+    before: (content: string, options?: ContentOptions | undefined) => Comment
+    remove: () => Comment
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    text: string
+  type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
+  interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
+    html [?]: boolean | undefined
+  interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
+    name [readonly]: null | string
+    publicId [readonly]: null | string
+    remove: () => Doctype
+    removed [readonly]: boolean
+    systemId [readonly]: null | string
+  interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
+    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+  interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Element
+    append: (content: string, options?: ContentOptions | undefined) => Element
+    attributes [readonly]: IterableIterator<[string, string]>
+    before: (content: string, options?: ContentOptions | undefined) => Element
+    canHaveContent [readonly]: boolean
+    getAttribute: (name: string) => null | string
+    hasAttribute: (name: string) => boolean
+    namespaceURI [readonly]: string
+    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: ContentOptions | undefined) => Element
+    remove: () => Element
+    removeAndKeepContent: () => Element
+    removeAttribute: (name: string) => Element
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Element
+    selfClosing [readonly]: boolean
+    setAttribute: (name: string, value: string) => Element
+    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    tagName: string
+  interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => EndTag
+    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    name: string
+    remove: () => EndTag
+  interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: Element) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Text
+    before: (content: string, options?: ContentOptions | undefined) => Text
+    lastInTextNode [readonly]: boolean
+    remove: () => Text
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Text
+    text [readonly]: string
+interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
+  append [readonly]: (name: string, value: string) => void
+  count [readonly]: number
+  delete [readonly]: (name: string) => void
+  entries [readonly]: () => SpecIterableIterator<[string, string]>
+  forEach [readonly]: (callbackfn: (value: string, key: string, iterable: Headers) => void, thisArg?: unknown) => void
+  get [readonly]: (name: string) => null | string
+  getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+  getSetCookie [readonly]: () => Array<string>
+  has [readonly]: (name: string) => boolean
+  keys [readonly]: () => SpecIterableIterator<string>
+  set [readonly]: (name: string, value: string) => void
+  toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+  values [readonly]: () => SpecIterableIterator<string>
+var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (init?: HeadersInit | undefined): Headers
+  prototype: Headers
+interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.es5.d.ts)
+  dir [readonly]: string
+  dirname: string
+  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  file [readonly]: string
+  filename: string
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  main: boolean
+  path [readonly]: string
+  require: Require
+  resolve: (specifier: string, parent?: URL | string | undefined) => string
+  resolveSync: (moduleId: string, parent?: string | undefined) => string
+  url: string
+interface ImportMetaEnv (bun-types/globals.d.ts)
+  index [string]: string | undefined
+var Loader (bun-types/globals.d.ts)
+  dependencyKeysIfEvaluated: (specifier: string) => Array<string>
+  registry: Map<string, { key: string; state: number; fetch: Promise<any>; instantiate: Promise<any>; satisfy: Promise<any>; dependencies: Array<any>; module: { dependenciesMap: Map<string, any>; }; linkError?: any; linkSucceeded: boolean; evaluated: boolean; then?: any; isAsync: boolean; }>
+  resolve: (specifier: string, referrer: string) => string
+interface MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  port1 [readonly]: MessagePort
+  port2 [readonly]: MessagePort
+var MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (): MessageChannel
+  prototype: MessageChannel
+interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<any>
+  prototype: MessageEvent<any>
+interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addListener: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  emit: { (event: "close", ev: Event): boolean; (event: "message", value: any): boolean; (event: "messageerror", error: Error): boolean; (event: string, arg: any): boolean }
+  eventNames: () => Array<string>
+  getMaxListeners: () => number
+  hasRef: () => boolean
+  listenerCount: (type: string) => number
+  off: { (event: "close", listener: (ev: Event) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "message", listener: (value: any) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions | undefined): MessagePort; (event: string, listener: (arg: any) => void, options?: EventListenerOptions | undefined): MessagePort }
+  on: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  once: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  onclose: ((ev: Event) => void) | null
+  onmessage: ((ev: MessageEvent<any>) => void) | null
+  onmessageerror: ((ev: MessageEvent<any>) => void) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeAllListeners: (type?: string | undefined) => MessagePort
+  removeEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeListener: { (event: "close", listener: (ev: Event) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "message", listener: (value: any) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions | undefined): MessagePort; (event: string, listener: (arg: any) => void, options?: EventListenerOptions | undefined): MessagePort }
+  setMaxListeners: (n: number) => void
+  start: () => void
+  unref: () => void
+var MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (): MessagePort
+  prototype: MessagePort
+interface Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
+  hardwareConcurrency [readonly]: number
+  language [readonly]: string
+  languages [readonly]: ReadonlyArray<string>
+  locks [readonly]: LockManager
+  platform [readonly]: "Linux x86_64" | "MacIntel" | "Win32"
+  userAgent [readonly]: string
+var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
+  construct new (): Navigator
+  prototype: Navigator
+namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
+  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
+    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
+    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
+  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
+  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
+  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
+  interface NodeJS.CallSite (@types/node/globals.d.ts)
+    getColumnNumber: () => null | number
+    getEnclosingColumnNumber: () => null | number
+    getEnclosingLineNumber: () => null | number
+    getEvalOrigin: () => string | undefined
+    getFileName: () => null | string
+    getFunction: () => Function | undefined
+    getFunctionName: () => null | string
+    getLineNumber: () => null | number
+    getMethodName: () => null | string
+    getPosition: () => number
+    getPromiseIndex: () => null | number
+    getScriptHash: () => string
+    getScriptNameOrSourceURL: () => null | string
+    getThis: () => unknown
+    getTypeName: () => null | string
+    isAsync: () => boolean
+    isConstructor: () => boolean
+    isEval: () => boolean
+    isNative: () => boolean
+    isPromiseAll: () => boolean
+    isToplevel: () => boolean
+  interface NodeJS.CpuUsage (@types/node/process.d.ts)
+    system: number
+    user: number
+  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined
+  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
+  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
+    code [?]: string | undefined
+    ctor [?]: Function | undefined
+    detail [?]: string | undefined
+    type [?]: string | undefined
+  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
+    cause [?]: unknown
+    code [?]: string | undefined
+    errno [?]: number | undefined
+    message: string
+    name: string
+    path [?]: string | undefined
+    stack [?]: string | undefined
+    syscall [?]: string | undefined
+  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
+    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
+    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    setMaxListeners: (n: number) => EventEmitter<T>
+  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
+  interface NodeJS.GCFunction (@types/node/globals.d.ts)
+    call (minor?: boolean | undefined): void
+    call (options: GCOptions & { execution: "async"; }): Promise<void>
+    call (options: GCOptions): void
+  interface NodeJS.GCOptions (@types/node/globals.d.ts)
+    execution [?]: "async" | "sync" | undefined
+    filename [?]: string | undefined
+    flavor [?]: "last-resort" | "regular" | undefined
+    type [?]: "major" | "major-snapshot" | "minor" | undefined
+  interface NodeJS.HRTime (@types/node/process.d.ts)
+    call (time?: [number, number] | undefined): [number, number]
+    bigint: () => bigint
+  interface NodeJS.Immediate (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    _onImmediate: (...args: Array<any>) => void
+    hasRef: () => boolean
+    ref: () => Immediate
+    unref: () => Immediate
+  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
+    [Symbol.toStringTag] [readonly]: string
+    drop: (count: number) => IteratorObject<T, undefined, unknown>
+    every: (predicate: (value: T, index: number) => unknown) => boolean
+    filter: { <S>(predicate: (value: T, index: number) => value is S): IteratorObject<S, undefined, unknown>; (predicate: (value: T, index: number) => unknown): IteratorObject<T, undefined, unknown> }
+    find: { <S>(predicate: (value: T, index: number) => value is S): S | undefined; (predicate: (value: T, index: number) => unknown): T | undefined }
+    flatMap: <U>(callback: (value: T, index: number) => Iterable<U, unknown, undefined> | Iterator<U, unknown, undefined>) => IteratorObject<U, undefined, unknown>
+    forEach: (callbackfn: (value: T, index: number) => void) => void
+    map: <U>(callbackfn: (value: T, index: number) => U) => IteratorObject<U, undefined, unknown>
+    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
+    reduce: { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number) => U, initialValue: U): U }
+    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
+    some: (predicate: (value: T, index: number) => unknown) => boolean
+    take: (limit: number) => IteratorObject<T, undefined, unknown>
+    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
+    toArray: () => Array<T>
+  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
+    arrayBuffers: number
+    external: number
+    heapTotal: number
+    heapUsed: number
+    rss: number
+  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
+    call (): MemoryUsage
+    rss: () => number
+  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
+  interface NodeJS.Module (@types/node/module.d.ts)
+    children: Array<Module>
+    exports: any
+    filename: string
+    id: string
+    isPreloading: boolean
+    loaded: boolean
+    parent: Module | null | undefined
+    path: string
+    paths: Array<string>
+    require: (id: string) => any
+  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
+  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
+  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
+  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
+  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
+  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
+  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
+  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
+  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
+  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
+  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+  interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    _exiting: boolean
+    abort: () => never
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
+    allowedNodeEnvironmentFlags: ReadonlySet<string>
+    arch [readonly]: Architecture
+    argv: Array<string>
+    argv0: string
+    assert: (value: unknown, message?: Error | string | undefined) => asserts value
+    availableMemory: () => number
+    binding: { (m: "constants"): { os: typeof constants; fs: typeof constants; crypto: typeof constants; zlib: typeof constants; trace: { TRACE_EVENT_PHASE_BEGIN: number; TRACE_EVENT_PHASE_END: number; TRACE_EVENT_PHASE_COMPLETE: number; TRACE_EVENT_PHASE_INSTANT: number; TRACE_EVENT_PHASE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_ASYNC_STEP_INTO: number; TRACE_EVENT_PHASE_ASYNC_STEP_PAST: number; TRACE_EVENT_PHASE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_INSTANT: number; TRACE_EVENT_PHASE_FLOW_BEGIN: number; TRACE_EVENT_PHASE_FLOW_STEP: number; TRACE_EVENT_PHASE_FLOW_END: number; TRACE_EVENT_PHASE_METADATA: number; TRACE_EVENT_PHASE_COUNTER: number; TRACE_EVENT_PHASE_SAMPLE: number; TRACE_EVENT_PHASE_CREATE_OBJECT: number; TRACE_EVENT_PHASE_SNAPSHOT_OBJECT: number; TRACE_EVENT_PHASE_DELETE_OBJECT: number; TRACE_EVENT_PHASE_MEMORY_DUMP: number; TRACE_EVENT_PHASE_MARK: number; TRACE_EVENT_PHASE_CLOCK_SYNC: number; TRACE_EVENT_PHASE_ENTER_CONTEXT: number; TRACE_EVENT_PHASE_LEAVE_CONTEXT: number; TRACE_EVENT_PHASE_LINK_IDS: number; }; }; (m: "uv"): { errname(code: number): string; UV_E2BIG: number; UV_EACCES: number; UV_EADDRINUSE: number; UV_EADDRNOTAVAIL: number; UV_EAFNOSUPPORT: number; UV_EAGAIN: number; UV_EAI_ADDRFAMILY: number; UV_EAI_AGAIN: number; UV_EAI_BADFLAGS: number; UV_EAI_BADHINTS: number; UV_EAI_CANCELED: number; UV_EAI_FAIL: number; UV_EAI_FAMILY: number; UV_EAI_MEMORY: number; UV_EAI_NODATA: number; UV_EAI_NONAME: number; UV_EAI_OVERFLOW: number; UV_EAI_PROTOCOL: number; UV_EAI_SERVICE: number; UV_EAI_SOCKTYPE: number; UV_EALREADY: number; UV_EBADF: number; UV_EBUSY: number; UV_ECANCELED: number; UV_ECHARSET: number; UV_ECONNABORTED: number; UV_ECONNREFUSED: number; UV_ECONNRESET: number; UV_EDESTADDRREQ: number; UV_EEXIST: number; UV_EFAULT: number; UV_EFBIG: number; UV_EHOSTUNREACH: number; UV_EINTR: number; UV_EINVAL: number; UV_EIO: number; UV_EISCONN: number; UV_EISDIR: number; UV_ELOOP: number; UV_EMFILE: number; UV_EMSGSIZE: number; UV_ENAMETOOLONG: number; UV_ENETDOWN: number; UV_ENETUNREACH: number; UV_ENFILE: number; UV_ENOBUFS: number; UV_ENODEV: number; UV_ENOENT: number; UV_ENOMEM: number; UV_ENONET: number; UV_ENOPROTOOPT: number; UV_ENOSPC: number; UV_ENOSYS: number; UV_ENOTCONN: number; UV_ENOTDIR: number; UV_ENOTEMPTY: number; UV_ENOTSOCK: number; UV_ENOTSUP: number; UV_EOVERFLOW: number; UV_EPERM: number; UV_EPIPE: number; UV_EPROTO: number; UV_EPROTONOSUPPORT: number; UV_EPROTOTYPE: number; UV_ERANGE: number; UV_EROFS: number; UV_ESHUTDOWN: number; UV_ESPIPE: number; UV_ESRCH: number; UV_ETIMEDOUT: number; UV_ETXTBSY: number; UV_EXDEV: number; UV_UNKNOWN: number; UV_EOF: number; UV_ENXIO: number; UV_EMLINK: number; UV_EHOSTDOWN: number; UV_EREMOTEIO: number; UV_ENOTTY: number; UV_EFTYPE: number; UV_EILSEQ: number; UV_ESOCKTNOSUPPORT: number; UV_ENODATA: number; UV_EUNATCH: number; }; (m: "http_parser"): { methods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "QUERY"]; allMethods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "PRI", "DESCRIBE", "ANNOUNCE", "SETUP", "PLAY", "PAUSE", "TEARDOWN", "GET_PARAMETER", "SET_PARAMETER", "REDIRECT", "RECORD", "FLUSH", "QUERY"]; HTTPParser: unknown; ConnectionsList: unknown; }; (m: string): object }
+    browser: boolean
+    channel [?]: Control | undefined
+    chdir: (directory: string) => void
+    config [readonly]: ProcessConfig
+    connected: boolean
+    constrainedMemory: () => number
+    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cwd: () => string
+    debugPort: number
+    disconnect [?]: (() => void) | undefined
+    dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
+    emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
+    env: ProcessEnv
+    eventNames: () => Array<string | symbol>
+    execArgv: Array<string>
+    execPath: string
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    exit: (code?: null | number | string | undefined) => never
+    exitCode: null | number | string | undefined
+    features [readonly]: ProcessFeatures
+    finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
+    getActiveResourcesInfo: () => Array<string>
+    getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
+    getMaxListeners: () => number
+    getegid [?]: (() => number) | undefined
+    geteuid [?]: (() => number) | undefined
+    getgid [?]: (() => number) | undefined
+    getgroups [?]: (() => Array<number>) | undefined
+    getuid [?]: (() => number) | undefined
+    hasUncaughtExceptionCaptureCallback: () => boolean
+    hrtime: HRTime
+    isBun: true
+    kill: (pid: number, signal?: number | string | undefined) => true
+    listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    loadEnvFile: (path?: PathLike | undefined) => void
+    mainModule [?]: Module | undefined
+    memoryUsage: MemoryUsageFn
+    nextTick: (callback: Function, ...args: Array<any>) => void
+    noDeprecation [?]: boolean | undefined
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    permission: ProcessPermission
+    pid [readonly]: number
+    platform [readonly]: Platform
+    ppid [readonly]: number
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    reallyExit: (code?: number | undefined) => never
+    ref: (maybeRefable: any) => void
+    release [readonly]: ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    report: ProcessReport
+    resourceUsage: () => ResourceUsage
+    revision: string
+    send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
+    setMaxListeners: (n: number) => Process
+    setSourceMapsEnabled: (value: boolean) => void
+    setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
+    setegid [?]: ((id: number | string) => void) | undefined
+    seteuid [?]: ((id: number | string) => void) | undefined
+    setgid [?]: ((id: number | string) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setuid [?]: ((id: number | string) => void) | undefined
+    sourceMapsEnabled [readonly]: boolean
+    stderr: WriteStream & { fd: 2; }
+    stdin: ReadStream & { fd: 0; }
+    stdout: WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    throwDeprecation: boolean
+    title: string
+    traceDeprecation: boolean
+    traceProcessWarnings: boolean
+    umask: { (): number; (mask: number | string): number }
+    unref: (maybeRefable: any) => void
+    uptime: () => number
+    version [readonly]: string
+    versions [readonly]: ProcessVersions
+  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
+    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
+    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+  interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    NODE_ENV [?]: string | undefined
+    TZ [?]: string | undefined
+  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
+    cached_builtins [readonly]: boolean
+    debug [readonly]: boolean
+    inspector [readonly]: boolean
+    ipv6 [readonly]: boolean
+    require_module [readonly]: boolean
+    tls [readonly]: boolean
+    tls_alpn [readonly]: boolean
+    tls_ocsp [readonly]: boolean
+    tls_sni [readonly]: boolean
+    typescript [readonly]: "strip" | false
+    uv [readonly]: boolean
+  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
+    has: (scope: string, reference?: string | undefined) => boolean
+  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
+    headersUrl [?]: string | undefined
+    libUrl [?]: string | undefined
+    lts [?]: string | undefined
+    name: string
+    sourceUrl [?]: string | undefined
+  interface NodeJS.ProcessReport (@types/node/process.d.ts)
+    compact: boolean
+    directory: string
+    excludeEnv: boolean
+    filename: string
+    getReport: (err?: Error | undefined) => object
+    reportOnFatalError: boolean
+    reportOnSignal: boolean
+    reportOnUncaughtException: boolean
+    signal: Signals
+    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
+  interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    ares: string
+    bun: string
+    http_parser: string
+    modules: string
+    node: string
+    openssl: string
+    uv: string
+    v8: string
+    zlib: string
+  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined [readonly]
+  interface NodeJS.ReadStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    closed [readonly]: boolean
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    destroy: (error?: Error | undefined) => ReadStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    isPaused: () => boolean
+    isRaw: boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    pause: () => ReadStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => ReadStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
+    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    resetAndDestroy: () => ReadStream
+    resume: () => ReadStream
+    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
+    setMaxListeners: (n: number) => ReadStream
+    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
+    setRawMode: (mode: boolean) => ReadStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
+    setTypeOfService: (tos: number) => ReadStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => ReadStream
+    unref: () => ReadStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => ReadStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    pause: () => ReadWriteStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    resume: () => ReadWriteStream
+    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
+    setMaxListeners: (n: number) => ReadWriteStream
+    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadWriteStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    pause: () => ReadableStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    resume: () => ReadableStream
+    setEncoding: (encoding: BufferEncoding) => ReadableStream
+    setMaxListeners: (n: number) => ReadableStream
+    unpipe: (destination?: WritableStream | undefined) => ReadableStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadableStream
+  interface NodeJS.RefCounted (@types/node/globals.d.ts)
+    ref: () => RefCounted
+    unref: () => RefCounted
+  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
+  interface NodeJS.Require (@types/node/module.d.ts)
+    call (id: string): any
+    cache: Dict<Module>
+    extensions: RequireExtensions
+    main: Module | undefined
+    resolve: RequireResolve
+  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
+    index [string]: ((module: Module, filename: string) => any) | undefined
+    .js: (module: Module, filename: string) => any
+    .json: (module: Module, filename: string) => any
+    .node: (module: Module, filename: string) => any
+  interface NodeJS.RequireResolve (@types/node/module.d.ts)
+    call (request: string, options?: RequireResolveOptions | undefined): string
+    paths: (request: string) => Array<string> | null
+  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
+    paths [?]: Array<string> | undefined
+  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
+    fsRead: number
+    fsWrite: number
+    involuntaryContextSwitches: number
+    ipcReceived: number
+    ipcSent: number
+    majorPageFault: number
+    maxRSS: number
+    minorPageFault: number
+    sharedMemorySize: number
+    signalsCount: number
+    swappedOut: number
+    systemCPUTime: number
+    unsharedDataSize: number
+    unsharedStackSize: number
+    userCPUTime: number
+    voluntaryContextSwitches: number
+  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
+  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
+  interface NodeJS.Socket (@types/node/process.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    isTTY [?]: true | undefined
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    pause: () => Socket
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    resume: () => Socket
+    setEncoding: (encoding: BufferEncoding) => Socket
+    setMaxListeners: (n: number) => Socket
+    unpipe: (destination?: WritableStream | undefined) => Socket
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => Socket
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.Timeout (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.toPrimitive]: () => number
+    _onTimeout: (...args: Array<any>) => void
+    close: () => Timeout
+    hasRef: () => boolean
+    ref: () => Timeout
+    refresh: () => Timeout
+    unref: () => Timeout
+  interface NodeJS.Timer (@types/node/timers.d.ts)
+    [Symbol.toPrimitive]: () => number
+    hasRef: () => boolean
+    ref: () => Timer
+    refresh: () => Timer
+    unref: () => Timer
+  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
+  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
+  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
+  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
+  interface NodeJS.WritableStream (@types/node/stream.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    setMaxListeners: (n: number) => WritableStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.WriteStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
+    clearScreenDown: (callback?: (() => void) | undefined) => boolean
+    closed [readonly]: boolean
+    columns: number
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
+    destroy: (error?: Error | undefined) => WriteStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
+    getColorDepth: (env?: object | undefined) => number
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    getWindowSize: () => [number, number]
+    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
+    isPaused: () => boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
+    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    pause: () => WriteStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => WriteStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
+    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    resetAndDestroy: () => WriteStream
+    resume: () => WriteStream
+    rows: number
+    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
+    setMaxListeners: (n: number) => WriteStream
+    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
+    setTypeOfService: (tos: number) => WriteStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => WriteStream
+    unref: () => WriteStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => WriteStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
+  children: Array<Module>
+  exports: any
+  filename: string
+  id: string
+  isPreloading: boolean
+  loaded: boolean
+  parent: Module | null | undefined
+  path: string
+  paths: Array<string>
+  require: (id: string) => any
+interface Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (ev: PerformanceEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  clearMarks: (markName?: string | undefined) => void
+  clearMeasures: (measureName?: string | undefined) => void
+  clearResourceTimings: (resourceTimingName?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  eventLoopUtilization: (utilization1?: EventLoopUtilization | undefined, utilization2?: EventLoopUtilization | undefined) => EventLoopUtilization
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: EntryType | undefined) => PerformanceEntryList
+  getEntriesByType: (type: EntryType) => PerformanceEntryList
+  mark: (markName: string, markOptions?: PerformanceMarkOptions | undefined) => PerformanceMark
+  markResourceTiming: (timingInfo: FetchTimingInfo, requestedUrl: string, initiatorType: string, global: unknown, cacheMode: string, bodyInfo: unknown, responseStatus: number, deliveryType?: string | undefined) => PerformanceResourceTiming
+  measure: { (measureName: string, startMark?: string | undefined, endMark?: string | undefined): PerformanceMeasure; (measureName: string, options: PerformanceMeasureOptions, endMark?: string | undefined): PerformanceMeasure }
+  nodeTiming [readonly]: PerformanceNodeTiming
+  now: () => number
+  onresourcetimingbufferfull: ((ev: Event) => void) | null
+  removeEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (ev: PerformanceEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  setResourceTimingBufferSize: (maxSize: number) => void
+  timeOrigin [readonly]: number
+  timerify: <T extends (...args: Array<any>) => any>(fn: T, options?: TimerifyOptions | undefined) => T
+  toJSON: () => any
+var Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): Performance
+  prototype: Performance
+interface PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  duration [readonly]: number
+  entryType [readonly]: EntryType
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceEntry
+  prototype: PerformanceEntry
+interface PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: "mark"
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceMark
+  prototype: PerformanceMark
+interface PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: "measure"
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceMeasure
+  prototype: PerformanceMeasure
+interface PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  disconnect: () => void
+  observe: (options: PerformanceObserverInit) => void
+  takeRecords: () => PerformanceEntryList
+var PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceObserver
+  prototype: PerformanceObserver
+interface PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: EntryType | undefined) => PerformanceEntryList
+  getEntriesByType: (type: EntryType) => PerformanceEntryList
+var PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceObserverEntryList
+  prototype: PerformanceObserverEntryList
+interface PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  connectEnd [readonly]: number
+  connectStart [readonly]: number
+  decodedBodySize [readonly]: number
+  domainLookupEnd [readonly]: number
+  domainLookupStart [readonly]: number
+  duration [readonly]: number
+  encodedBodySize [readonly]: number
+  entryType [readonly]: "resource"
+  fetchStart [readonly]: number
+  initiatorType [readonly]: string
+  name [readonly]: string
+  nextHopProtocol [readonly]: string
+  redirectEnd [readonly]: number
+  redirectStart [readonly]: number
+  requestStart [readonly]: number
+  responseEnd [readonly]: number
+  responseStart [readonly]: number
+  responseStatus [readonly]: number
+  secureConnectionStart [readonly]: number
+  startTime [readonly]: number
+  toJSON: () => any
+  transferSize [readonly]: number
+  workerStart [readonly]: number
+var PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceResourceTiming
+  prototype: PerformanceResourceTiming
+interface Position (bun-types/globals.d.ts)
+  column: number
+  file: string
+  length: number
+  line: number
+  lineText: string
+  namespace: string
+  offset: number
+interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts, lib.es2024.promise.d.ts, lib.es2025.promise.d.ts)
+  construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
+  [Symbol.species] [readonly]: PromiseConstructor
+  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  prototype [readonly]: Promise<any>
+  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  reject: <T = never>(reason?: any) => Promise<T>
+  resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+  try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
+  withResolvers: { <T>(): PromiseWithResolvers<T>; <T>(): { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; } }
+interface QueuingStrategy<T = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [?]: number | undefined
+  size [?]: QueuingStrategySize<T> | undefined
+interface QueuingStrategyInit (bun-types/globals.d.ts)
+  highWaterMark: number
+interface QueuingStrategySize<T = any> (bun-types/globals.d.ts)
+  call (chunk?: T | undefined): number
+interface ReadOnlyDict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined [readonly]
+interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  byobRequest [readonly]: ReadableStreamBYOBRequest | null
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk: NonSharedArrayBufferView) => void
+  error: (e?: any) => void
+var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableByteStreamController
+  prototype: ReadableByteStreamController
+interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  prototype: ReadableStream<any>
+interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+  read: <T extends NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  releaseLock: () => void
+var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamBYOBReader
+  prototype: ReadableStreamBYOBReader
+interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  respond: (bytesWritten: number) => void
+  respondWithNewView: (view: NonSharedArrayBufferView) => void
+  view [readonly]: NonSharedArrayBufferView | null
+var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamBYOBRequest
+  prototype: ReadableStreamBYOBRequest
+interface ReadableStreamDefaultController<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk?: R | undefined) => void
+  error: (e?: any) => void
+var ReadableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamDefaultController<any>
+  prototype: ReadableStreamDefaultController<any>
+interface ReadableStreamDefaultReadDoneResult (bun-types/globals.d.ts)
+  done: true
+  value [?]: undefined
+interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
+  done: false
+  value: T
+interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+  read: () => Promise<ReadableStreamDefaultReadResult<R>>
+  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  releaseLock: () => void
+var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
+  prototype: ReadableStreamDefaultReader<any>
+interface ReadableStreamDirectController (bun-types/globals.d.ts)
+  close: (error?: Error | undefined) => void
+  end: () => Promise<number> | number
+  flush: (wait?: boolean | undefined) => Promise<number> | number
+  start: () => void
+  write: (data: BufferSource | string) => Promise<number> | number
+interface ReadableStreamGenericReader (bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+interface ReadableWritablePair<R = any, W = any> (bun-types/globals.d.ts)
+  readable: ReadableStream<R>
+  writable: WritableStream<W>
+interface RegExpConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2025.regexp.d.ts, lib.es5.d.ts)
+  call (pattern: RegExp | string): RegExp
+  call (pattern: string, flags?: string | undefined): RegExp
+  call (pattern: RegExp | string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string): RegExp
+  construct new (pattern: string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string, flags?: string | undefined): RegExp
+  $&: string
+  $': string
+  $+: string
+  $1: string
+  $2: string
+  $3: string
+  $4: string
+  $5: string
+  $6: string
+  $7: string
+  $8: string
+  $9: string
+  $_: string
+  $`: string
+  [Symbol.species] [readonly]: RegExpConstructor
+  escape: { (string: string): string; (string: string): string }
+  input: string
+  lastMatch: string
+  lastParen: string
+  leftContext: string
+  prototype [readonly]: RegExp
+  rightContext: string
+interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  cache [readonly]: RequestCache
+  clone: () => Request
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  duplex [readonly]: "half"
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  integrity [readonly]: string
+  json [readonly]: () => Promise<unknown>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (requestInfo: string, init?: RequestInit | undefined): Request
+  construct new (requestInfo: RequestInit & { url: string; }): Request
+  construct new (requestInfo: Request, init?: RequestInit | undefined): Request
+  prototype: Request
+interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  credentials [?]: RequestCredentials | undefined
+  dispatcher [?]: Dispatcher | undefined
+  duplex [?]: "half" | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  signal [?]: AbortSignal | null | undefined
+  window [?]: null | undefined
+var ResolveError (bun-types/deprecated.d.ts): typeof ResolveMessage
+class ResolveMessage (bun-types/globals.d.ts)
+  code [readonly]: string
+  importKind [readonly]: "at" | "at_conditional" | "dynamic" | "entry_point" | "import" | "internal" | "require" | "require_resolve" | "stmt" | "url"
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "ResolveMessage"
+  position [readonly]: Position | null
+  referrer [readonly]: string
+  specifier [readonly]: string
+  toString: () => string
+  [static]
+    construct new (): ResolveMessage
+    prototype: ResolveMessage
+interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  clone: () => Response
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  json [readonly]: () => Promise<unknown>
+  ok [readonly]: boolean
+  redirected [readonly]: boolean
+  status [readonly]: number
+  statusText [readonly]: string
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  type [readonly]: ResponseType
+  url [readonly]: string
+var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  error: () => Response
+  json: (body?: any, init?: ResponseInit | number | undefined) => Response
+  redirect: { (url: string, status?: number | undefined): Response; (url: string, init?: ResponseInit | undefined): Response }
+interface ResponseInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  headers [? readonly]: HeadersInit | undefined
+  status [? readonly]: number | undefined
+  statusText [? readonly]: string | undefined
+interface ShadowRealm (bun-types/globals.d.ts)
+  evaluate: (sourceText: string) => any
+  importValue: (specifier: string, bindingName: string) => Promise<any>
+var ShadowRealm (bun-types/globals.d.ts)
+  construct new (): ShadowRealm
+  prototype: ShadowRealm
+interface SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts, lib.es2024.sharedmemory.d.ts)
+  [Symbol.toStringTag] [readonly]: "SharedArrayBuffer"
+  byteLength [readonly]: number
+  grow: { (newByteLength?: number | undefined): void; (size: number): SharedArrayBuffer }
+  growable: boolean
+  maxByteLength: number
+  slice: (begin?: number | undefined, end?: number | undefined) => SharedArrayBuffer
+var SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts, lib.es2024.sharedmemory.d.ts): SharedArrayBufferConstructor
+interface StreamPipeOptions (bun-types/globals.d.ts)
+  preventAbort [?]: boolean | undefined
+  preventCancel [?]: boolean | undefined
+  preventClose [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  decapsulateBits: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource) => Promise<ArrayBuffer>
+  decapsulateKey: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<CryptoKey>
+  decrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>) => Promise<CryptoKey>
+  digest: (algorithm: AlgorithmIdentifier | CShakeParams | KangarooTwelveParams | TurboShakeParams, data: BufferSource) => Promise<ArrayBuffer>
+  encapsulateBits: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey) => Promise<EncapsulatedBits>
+  encapsulateKey: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<EncapsulatedKey>
+  encrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
+  generateKey: { (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | KmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
+  getPublicKey: (key: CryptoKey, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
+  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey> }
+  sign: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
+  verify: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
+  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): SubtleCrypto
+  prototype: SubtleCrypto
+interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
+  prototype: TextDecoder
+interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+  readable [readonly]: ReadableStream<string>
+  writable [readonly]: WritableStream<BufferSource>
+var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TextDecoderStream
+  prototype: TextDecoderStream
+interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  encode: (input?: string | undefined) => NonSharedUint8Array
+  encodeInto: (src?: string | undefined, dest?: BufferSource | undefined) => TextEncoderEncodeIntoResult
+  encoding [readonly]: string
+var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
+  prototype: TextEncoder
+interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  encoding [readonly]: string
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<string>
+var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TextEncoderStream
+  prototype: TextEncoderStream
+interface Timer (bun-types/globals.d.ts)
+  [Symbol.toPrimitive]: () => number
+  hasRef: () => boolean
+  ref: () => Timer
+  refresh: () => Timer
+  unref: () => Timer
+interface TransformStream<I = any, O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<O>
+  writable [readonly]: WritableStream<I>
+var TransformStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <I = any, O = any>(transformer?: Transformer<I, O> | undefined, writableStrategy?: QueuingStrategy<I> | undefined, readableStrategy?: QueuingStrategy<O> | undefined): TransformStream<I, O>
+  prototype: TransformStream<any, any>
+interface TransformStreamDefaultController<O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  desiredSize [readonly]: null | number
+  enqueue: (chunk?: O | undefined) => void
+  error: (reason?: any) => void
+  terminate: () => void
+var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TransformStreamDefaultController<any>
+  prototype: TransformStreamDefaultController<any>
+interface Transformer<I = any, O = any> (bun-types/globals.d.ts)
+  flush [?]: TransformerFlushCallback<O> | undefined
+  readableType [?]: undefined
+  start [?]: TransformerStartCallback<O> | undefined
+  transform [?]: TransformerTransformCallback<I, O> | undefined
+  writableType [?]: undefined
+interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  hash: string
+  host: string
+  hostname: string
+  href: string
+  origin [readonly]: string
+  password: string
+  pathname: string
+  port: string
+  protocol: string
+  search: string
+  searchParams [readonly]: URLSearchParams
+  toJSON: () => string
+  username: string
+var URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  construct new (url: URL | string, base?: URL | string | undefined): URL
+  canParse: (url: string, base?: string | undefined) => boolean
+  createObjectURL: (object: Blob) => `blob:${string}`
+  parse: (url: string, base?: string | undefined) => URL | null
+  prototype: URL
+  revokeObjectURL: (url: string) => void
+interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, string | ReadonlyArray<string>> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts, lib.esnext.typedarrays.d.ts)
+  index [number]: number
+  BYTES_PER_ELEMENT [readonly]: number
+  [Symbol.iterator]: () => ArrayIterator<number>
+  [Symbol.toStringTag] [readonly]: "Uint8Array"
+  at: (index: number) => number | undefined
+  buffer [readonly]: TArrayBuffer
+  byteLength [readonly]: number
+  byteOffset [readonly]: number
+  copyWithin: (target: number, start: number, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  entries: () => ArrayIterator<[number, number]>
+  every: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  fill: (value: number, start?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  filter: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => any, thisArg?: any) => Uint8Array<ArrayBuffer>
+  find: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number | undefined
+  findIndex: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number
+  findLast: { <S extends number>(predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => value is S, thisArg?: any): S | undefined; (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any): number | undefined }
+  findLastIndex: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => number
+  forEach: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => void, thisArg?: any) => void
+  includes: (searchElement: number, fromIndex?: number | undefined) => boolean
+  indexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  join: (separator?: string | undefined) => string
+  keys: () => ArrayIterator<number>
+  lastIndexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  length [readonly]: number
+  map: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => number, thisArg?: any) => Uint8Array<ArrayBuffer>
+  reduce: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reduceRight: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reverse: () => Uint8Array<TArrayBuffer>
+  set: (array: ArrayLike<number>, offset?: number | undefined) => void
+  setFromBase64: { (string: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }): { read: number; written: number; }; (base64: string, offset?: number | undefined): { read: number; written: number; } }
+  setFromHex: { (string: string): { read: number; written: number; }; (hex: string): { read: number; written: number; } }
+  slice: (start?: number | undefined, end?: number | undefined) => Uint8Array<ArrayBuffer>
+  some: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  sort: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<TArrayBuffer>
+  subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  toBase64: { (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string; (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string }
+  toHex: { (): string; (): string }
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toReversed: () => Uint8Array<ArrayBuffer>
+  toSorted: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<ArrayBuffer>
+  toString: () => string
+  valueOf: () => Uint8Array<TArrayBuffer>
+  values: () => ArrayIterator<number>
+  with: (index: number, value: number) => Uint8Array<ArrayBuffer>
+var Uint8Array (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts, lib.esnext.typedarrays.d.ts): Uint8ArrayConstructor
+interface Uint8ArrayConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2017.typedarrays.d.ts, lib.es5.d.ts, lib.esnext.typedarrays.d.ts)
+  construct new (length: number): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<TArrayBuffer>
+  construct new (buffer: ArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayBuffer | ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new (elements: Iterable<number>): Uint8Array<ArrayBuffer>
+  construct new (): Uint8Array<ArrayBuffer>
+  BYTES_PER_ELEMENT [readonly]: number
+  from: { (arrayLike: ArrayLike<number>): Uint8Array<ArrayBuffer>; <T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array<ArrayBuffer>; (elements: Iterable<number>): Uint8Array<ArrayBuffer>; <T>(elements: Iterable<T>, mapfn?: ((v: T, k: number) => number) | undefined, thisArg?: any): Uint8Array<ArrayBuffer> }
+  fromBase64: { (string: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }): Uint8Array<ArrayBuffer>; (base64: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }): Uint8Array<ArrayBuffer> }
+  fromHex: { (string: string): Uint8Array<ArrayBuffer>; (hex: string): Uint8Array<ArrayBuffer> }
+  of: (...items: Array<number>) => Uint8Array<ArrayBuffer>
+  prototype [readonly]: Uint8Array<ArrayBufferLike>
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.CompileError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): CompileError
+    construct new (message?: string | undefined): CompileError
+    prototype: CompileError
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  var WebAssembly.Global (bun-types/wasm.d.ts)
+    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
+    prototype: Global<keyof ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  var WebAssembly.Instance (bun-types/wasm.d.ts)
+    construct new (module: Module, importObject?: Imports | undefined): Instance
+    prototype: Instance
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.LinkError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): LinkError
+    construct new (message?: string | undefined): LinkError
+    prototype: LinkError
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  var WebAssembly.Memory (bun-types/wasm.d.ts)
+    construct new (descriptor: MemoryDescriptor): Memory
+    prototype: Memory
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  var WebAssembly.Module (bun-types/wasm.d.ts)
+    construct new (bytes: BufferSource): Module
+    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
+    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
+    prototype: Module
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): RuntimeError
+    construct new (message?: string | undefined): RuntimeError
+    prototype: RuntimeError
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  var WebAssembly.Table (bun-types/wasm.d.ts)
+    construct new (descriptor: TableDescriptor, value?: any): Table
+    prototype: Table
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+  function WebAssembly.compile (bun-types/wasm.d.ts)
+    call (bytes: BufferSource): Promise<Module>
+  function WebAssembly.compileStreaming (bun-types/wasm.d.ts)
+    call (source: PromiseLike<Response> | Response): Promise<Module>
+  function WebAssembly.instantiate (bun-types/wasm.d.ts)
+    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+  function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts)
+    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+  function WebAssembly.validate (bun-types/wasm.d.ts)
+    call (bytes: BufferSource): boolean
+interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (url: URL | string, options?: WebSocketOptions | undefined): WebSocket
+  construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  prototype: WebSocket
+interface Worker (bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+var Worker (bun-types/globals.d.ts)
+  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  data: any
+  prototype: Worker
+interface WorkerOptions (bun-types/globals.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  getWriter: () => WritableStreamDefaultWriter<W>
+  locked [readonly]: boolean
+var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  prototype: WritableStream<any>
+interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  error: (e?: any) => void
+var WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): WritableStreamDefaultController
+  prototype: WritableStreamDefaultController
+interface WritableStreamDefaultWriter<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  closed [readonly]: Promise<void>
+  desiredSize [readonly]: null | number
+  ready [readonly]: Promise<void>
+  releaseLock: () => void
+  write: (chunk?: W | undefined) => Promise<void>
+var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>
+  prototype: WritableStreamDefaultWriter<any>
+function addEventListener (bun-types/globals.d.ts)
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+function alert (bun-types/globals.d.ts)
+  call (message?: string | undefined): void
+function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (immediate: Immediate | undefined): void
+function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function confirm (bun-types/globals.d.ts)
+  call (message?: string | undefined): boolean
+var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts): Console
+var crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts): Crypto
+var exports (@types/node/module.d.ts, bun-types/globals.d.ts): any
+function fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  call (input: Request | URL | string, init?: BunFetchRequestInit | undefined): Promise<Response>
+  call (input: Request | URL | string, init?: RequestInit | undefined): Promise<Response>
+  preconnect: (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }) => void
+namespace fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  function fetch.preconnect (bun-types/globals.d.ts)
+    call (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }): void
+var module (@types/node/module.d.ts, bun-types/globals.d.ts): NodeModule
+var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts): Navigator
+var onmessage (bun-types/index.d.ts): never
+var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts): Performance
+function postMessage (bun-types/globals.d.ts)
+  call (message: any, transfer?: Array<Transferable> | undefined): void
+function prompt (bun-types/globals.d.ts)
+  call (message?: string | undefined, _default?: string | undefined): null | string
+function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (callback: (...args: Array<any>) => void): void
+  call (callback: () => void): void
+function removeEventListener (bun-types/globals.d.ts)
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+function reportError (bun-types/globals.d.ts)
+  call (error: any): void
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/esnext.txt
+++ b/test/integration/bun-types/inventory/esnext.txt
@@ -5,39 +5,64 @@
 # undici-types: 8.3.0
 
 # module "*.html"
+export = Bun.HTMLBundle
 
 # module "*.json5"
+export = any
 
 # module "*.jsonc"
+export = any
 
 # module "*.toml"
+export = any
 
 # module "*.txt"
+export = string
 
 # module "*.xml"
+export = Bun.XML.Document
 
 # module "*.yaml"
+export = any
 
 # module "*.yml"
+export = any
 
 # module "*/bun.lock"
+export = Bun.BunLockFile
+
+# module "buffer"
+interface Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<NodeJS.NonSharedUint8Array>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
+  json: () => Promise<any>
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<NodeJS.NonSharedUint8Array>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
 
 # module "bun"
-type $ (bun-types/shell.d.ts) = typeof $
+type $ (bun-types/shell.d.ts) = typeof Bun.$
 function $ (bun-types/shell.d.ts)
-  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
-  Shell: new () => typeof $
-  ShellError: typeof ShellError
-  ShellPromise: typeof ShellPromise
+  call (strings: TemplateStringsArray, ...expressions: Array<Bun.ShellExpression>): Bun.$.ShellPromise
+  Shell: new () => typeof Bun.$
+  ShellError: typeof Bun.$.ShellError
+  ShellPromise: typeof Bun.$.ShellPromise
   braces: (pattern: string) => Array<string>
-  cwd: (newCwd?: string | undefined) => typeof $
-  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  cwd: (newCwd?: string | undefined) => typeof Bun.$
+  env: (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => typeof Bun.$
   escape: (input: string) => string
-  nothrow: () => typeof $
-  throws: (shouldThrow: boolean) => typeof $
+  nothrow: () => typeof Bun.$
+  throws: (shouldThrow: boolean) => typeof Bun.$
 namespace $ (bun-types/shell.d.ts)
   var $.Shell (bun-types/shell.d.ts)
-    construct new (): typeof $
+    construct new (): typeof Bun.$
   class $.ShellError (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
     blob: () => Blob
@@ -52,13 +77,13 @@ namespace $ (bun-types/shell.d.ts)
     stdout [readonly]: Buffer<ArrayBufferLike>
     text: (encoding?: BufferEncoding | undefined) => string
     [static]
-      construct new (message?: string | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: ShellError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.$.ShellError
       stackTraceLimit: number
   interface $.ShellOutput (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
@@ -73,26 +98,26 @@ namespace $ (bun-types/shell.d.ts)
     [Symbol.toStringTag] [readonly]: string
     arrayBuffer: () => Promise<ArrayBuffer>
     blob: () => Promise<Blob>
-    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
-    cwd: (newCwd: string) => ShellPromise
-    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
-    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<Bun.$.ShellOutput | TResult>
+    cwd: (newCwd: string) => Bun.$.ShellPromise
+    env: (newEnv: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => Bun.$.ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<Bun.$.ShellOutput>
     json: () => Promise<any>
     lines: () => AsyncIterable<string>
-    nothrow: () => ShellPromise
-    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    nothrow: () => Bun.$.ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => Bun.$.ShellPromise
     stdin: WritableStream<any>
     text: (encoding?: BufferEncoding | undefined) => Promise<string>
-    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    throws: (shouldThrow: boolean) => ShellPromise
+    then: <TResult1 = Bun.$.ShellOutput, TResult2 = never>(onfulfilled?: ((value: Bun.$.ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => Bun.$.ShellPromise
     [static]
-      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      construct new (executor: (resolve: (value: Bun.$.ShellOutput | PromiseLike<Bun.$.ShellOutput>) => void, reject: (reason?: any) => void) => void): Bun.$.ShellPromise
       [Symbol.species] [readonly]: PromiseConstructor
-      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
-      prototype: ShellPromise
-      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
+      prototype: Bun.$.ShellPromise
+      race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
       reject: <T = never>(reason?: any) => Promise<T>
       resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
       try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
@@ -100,19 +125,19 @@ namespace $ (bun-types/shell.d.ts)
   function $.braces (bun-types/shell.d.ts)
     call (pattern: string): Array<string>
   function $.cwd (bun-types/shell.d.ts)
-    call (newCwd?: string | undefined): typeof $
+    call (newCwd?: string | undefined): typeof Bun.$
   function $.env (bun-types/shell.d.ts)
-    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+    call (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined): typeof Bun.$
   function $.escape (bun-types/shell.d.ts)
     call (input: string): string
   function $.nothrow (bun-types/shell.d.ts)
-    call (): typeof $
+    call (): typeof Bun.$
   function $.throws (bun-types/shell.d.ts)
-    call (shouldThrow: boolean): typeof $
+    call (shouldThrow: boolean): typeof Bun.$
 interface AbstractWorker (bun-types/bun.d.ts)
-  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
 interface AbstractWorkerEventMap (bun-types/bun.d.ts)
   error: ErrorEvent
 interface AddEventListenerOptions (bun-types/bun.d.ts)
@@ -124,16 +149,16 @@ type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips
 class Archive (bun-types/bun.d.ts)
   blob: () => Promise<Blob>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
-  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  extract: (path: string, options?: Bun.ArchiveExtractOptions | undefined) => Promise<number>
   files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
   [static]
-    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
-    prototype: Archive
-    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+    construct new (data: Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined): Bun.Archive
+    prototype: Bun.Archive
+    write [static]: (path: string, data: Bun.Archive | Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined) => Promise<void>
 type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
 interface ArchiveExtractOptions (bun-types/bun.d.ts)
   glob [?]: ReadonlyArray<string> | string | undefined
-type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+type ArchiveInput (bun-types/bun.d.ts) = ArrayBufferLike | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Record<string, Bun.BlobPart>
 interface ArchiveOptions (bun-types/bun.d.ts)
   compress [?]: "gzip" | undefined
   level [?]: number | undefined
@@ -141,25 +166,25 @@ class ArrayBufferSink (bun-types/bun.d.ts)
   end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
   flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
   start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
   [static]
-    construct new (): ArrayBufferSink
-    prototype: ArrayBufferSink
-type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+    construct new (): Bun.ArrayBufferSink
+    prototype: Bun.ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = DataView<TArrayBuffer> | NodeJS.TypedArray<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "ACLITEM" | "BIGINT" | "BIT" | "BOOLEAN" | "BOX" | "BYTEA" | "CHAR" | "CID" | "CIDR" | "CIRCLE" | "DATE" | "DOUBLE PRECISION" | "INET" | "INT" | "INT2VECTOR" | "INTEGER" | "INTERVAL" | "JSON" | "JSONB" | "JSONPATH" | "LINE" | "LSEG" | "MACADDR" | "MACADDR8" | "MONEY" | "NAME" | "NUMERIC" | "OID" | "PATH" | "PG_DATABASE" | "POINT" | "POLYGON" | "REAL" | "SMALLINT" | "TEXT" | "TID" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "TIMETZ" | "VARBIT" | "VARCHAR" | "XID" | "XML" | (string & {})
 type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
-type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+type BinaryType (bun-types/bun.d.ts) = keyof Bun.BinaryTypeList
 interface BinaryTypeList (bun-types/bun.d.ts)
   arraybuffer: ArrayBuffer
   buffer: Buffer<ArrayBufferLike>
   uint8array: Uint8Array<ArrayBuffer>
-type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
-type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
-type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
-type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string
+type BlobPart (bun-types/bun.d.ts) = Blob | Bun.BufferSource | string
+type BodyInit (bun-types/fetch.d.ts) = (() => AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any>) | AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any> | AsyncIterable<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string> | Bun.Image | Bun.XMLHttpRequestBodyInit | ReadableStream<any>
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
 namespace Build (bun-types/bun.d.ts)
-  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
-  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Architecture (bun-types/bun.d.ts) = "aarch64" | "arm64" | "x64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-aarch64" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-darwin-arm64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-linux-aarch64" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-modern" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-linux-aarch64-musl" | "bun-linux-arm64" | "bun-linux-arm64-baseline" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-glibc" | "bun-linux-arm64-modern" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-arm64-musl" | "bun-linux-x64" | "bun-linux-x64-baseline" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-modern" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-x64-musl" | "bun-windows-aarch64" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
   type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
   type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
 interface BuildArtifact (bun-types/bun.d.ts)
@@ -167,13 +192,13 @@ interface BuildArtifact (bun-types/bun.d.ts)
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
   hash: null | string
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
-  loader: Loader
+  loader: Bun.Loader
   path: string
   size [readonly]: number
-  sourcemap: BuildArtifact | null
+  sourcemap: Bun.BuildArtifact | null
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
@@ -182,7 +207,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   banner [?]: string | undefined
   bytecode [?]: boolean | undefined
   bytecodeDepth [?]: number | undefined
-  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  compile [?]: Bun.Build.CompileTarget | Bun.CompileBuildOptions | boolean | undefined
   conditions [?]: Array<string> | string | undefined
   define [?]: Record<string, string> | undefined
   deprecatedNamespaceObjectSetters [?]: boolean | undefined
@@ -192,12 +217,12 @@ interface BuildConfig (bun-types/bun.d.ts)
   env [?]: "disable" | "inline" | `${string}*` | undefined
   external [?]: Array<string> | undefined
   features [?]: Array<string> | undefined
-  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  files [?]: Record<string, ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string> | undefined
   footer [?]: string | undefined
   format [?]: "cjs" | "esm" | "iife" | undefined
   ignoreDCEAnnotations [?]: boolean | undefined
   jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
-  loader [?]: undefined | { [x: string]: Loader; }
+  loader [?]: undefined | { [x: string]: Bun.Loader; }
   metafile [?]: boolean | undefined
   minChunkSize [?]: number | undefined
   minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
@@ -206,7 +231,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   optimizeImports [?]: Array<string> | undefined
   outdir [?]: string | undefined
   packages [?]: "bundle" | "external" | undefined
-  plugins [?]: Array<BunPlugin> | undefined
+  plugins [?]: Array<Bun.BunPlugin> | undefined
   publicPath [?]: string | undefined
   reactCompiler [?]: boolean | undefined
   reactCompilerOutputMode [?]: "client" | "ssr" | undefined
@@ -215,17 +240,17 @@ interface BuildConfig (bun-types/bun.d.ts)
   sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
   splitRequire [?]: boolean | undefined
   splitting [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   throw [?]: boolean | undefined
   treeShaking [?]: boolean | undefined
   tsconfig [?]: string | undefined
 interface BuildMetafile (bun-types/bun.d.ts)
-  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
-  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: Bun.ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: Bun.ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
 interface BuildOutput (bun-types/bun.d.ts)
   logs: Array<BuildMessage | ResolveMessage>
-  metafile [?]: BuildMetafile | undefined
-  outputs: Array<BuildArtifact>
+  metafile [?]: Bun.BuildMetafile | undefined
+  outputs: Array<Bun.BuildArtifact>
   success: boolean
 interface BunFile (bun-types/bun.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
@@ -233,29 +258,29 @@ interface BunFile (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface BunInspectOptions (bun-types/bun.d.ts)
   colors [?]: boolean | undefined
   compact [?]: boolean | undefined
   depth [?]: number | undefined
   sorted [?]: boolean | undefined
-type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: Bun.BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: Bun.BunLockFilePackageArray; }; }
 type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
-type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
-type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
-type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, info: Bun.BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Bun.BunLockFilePackageInfo] | [pkg: string, info: Pick<Bun.BunLockFileBasePackageInfo, "bin" | "binDir">] | [pkg: string, registry: string, info: Bun.BunLockFilePackageInfo, integrity: string] | [pkg: string]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
 interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -282,10 +307,10 @@ interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.t
   type [readonly]: string
 interface BunPlugin (bun-types/bun.d.ts)
   name: string
-  setup: (build: PluginBuilder) => Promise<void> | void
-  target [?]: Target | undefined
+  setup: (build: Bun.PluginBuilder) => Promise<void> | void
+  target [?]: Bun.Target | undefined
 interface BunRegisterPlugin (bun-types/bun.d.ts)
-  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  call <T extends Bun.BunPlugin>(options: T): ReturnType<T["setup"]>
   clearAll: () => void
 interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   arrayBuffer [readonly]: () => Promise<ArrayBuffer>
@@ -294,19 +319,19 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   bodyUsed [readonly]: boolean
   bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
   cache [readonly]: RequestCache
-  clone: () => BunRequest<T>
-  cookies [readonly]: CookieMap
+  clone: () => Bun.BunRequest<T>
+  cookies [readonly]: Bun.CookieMap
   credentials [readonly]: RequestCredentials
   destination [readonly]: RequestDestination
   duplex [readonly]: "half"
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   integrity [readonly]: string
   json [readonly]: () => Promise<unknown>
   keepalive [readonly]: boolean
   method [readonly]: string
   mode [readonly]: RequestMode
-  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  params [readonly]: { [Key in keyof Bun.Serve.ExtractRouteParams<T>]: Bun.Serve.ExtractRouteParams<T>[Key]; }
   redirect [readonly]: RequestRedirect
   referrer [readonly]: string
   referrerPolicy [readonly]: ReferrerPolicy
@@ -316,17 +341,17 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   url [readonly]: string
 namespace CSRF (bun-types/bun.d.ts)
   function CSRF.generate (bun-types/bun.d.ts)
-    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+    call (secret?: string | undefined, options?: Bun.CSRFGenerateOptions | undefined): string
   function CSRF.verify (bun-types/bun.d.ts)
-    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+    call (token: string, options?: Bun.CSRFVerifyOptions | undefined): boolean
 type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
 interface CSRFGenerateOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   expiresIn [?]: number | undefined
   sessionId [?]: string | undefined
 interface CSRFVerifyOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   maxAge [?]: number | undefined
   secret [?]: string | undefined
@@ -338,7 +363,7 @@ interface CloseEventInit (bun-types/bun.d.ts)
   composed [?]: boolean | undefined
   reason [?]: string | undefined
   wasClean [?]: boolean | undefined
-type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+type ColorInput (bun-types/bun.d.ts) = Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | [number, number, number, number] | [number, number, number] | number | string | { r: number; g: number; b: number; a?: number | undefined; } | { toString(): string; }
 interface CompileBuildOptions (bun-types/bun.d.ts)
   assets [?]: Array<string> | undefined
   autoloadBunfig [?]: boolean | undefined
@@ -348,9 +373,9 @@ interface CompileBuildOptions (bun-types/bun.d.ts)
   execArgv [?]: Array<string> | undefined
   executablePath [?]: string | undefined
   outfile [?]: string | undefined
-  target [?]: CompileTarget | undefined
+  target [?]: Bun.Build.CompileTarget | undefined
   windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
-type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+type CompressionFormat (bun-types/bun.d.ts) = "brotli" | "deflate" | "deflate-raw" | "gzip" | "zstd"
 class Cookie (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | undefined
@@ -360,19 +385,19 @@ class Cookie (bun-types/bun.d.ts)
   name [readonly]: string
   partitioned: boolean
   path: string
-  sameSite: CookieSameSite
+  sameSite: Bun.CookieSameSite
   secure: boolean
   serialize: () => string
-  toJSON: () => CookieInit
+  toJSON: () => Bun.CookieInit
   toString: () => string
   value: string
   [static]
-    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
-    construct new (cookieString: string): Cookie
-    construct new (cookieObject?: CookieInit | undefined): Cookie
-    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
-    parse [static]: (cookieString: string) => Cookie
-    prototype: Cookie
+    construct new (name: string, value: string, options?: Bun.CookieInit | undefined): Bun.Cookie
+    construct new (cookieString: string): Bun.Cookie
+    construct new (cookieObject?: Bun.CookieInit | undefined): Bun.Cookie
+    from [static]: (name: string, value: string, options?: Bun.CookieInit | undefined) => Bun.Cookie
+    parse [static]: (cookieString: string) => Bun.Cookie
+    prototype: Bun.Cookie
 interface CookieInit (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | number | string | undefined
@@ -381,26 +406,26 @@ interface CookieInit (bun-types/bun.d.ts)
   name [?]: string | undefined
   partitioned [?]: boolean | undefined
   path [?]: string | undefined
-  sameSite [?]: CookieSameSite | undefined
+  sameSite [?]: Bun.CookieSameSite | undefined
   secure [?]: boolean | undefined
   value [?]: string | undefined
 class CookieMap (bun-types/bun.d.ts)
   [Symbol.iterator]: () => IterableIterator<[string, string]>
-  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  delete: { (name: string): void; (options: Bun.CookieStoreDeleteOptions): void; (name: string, options: Omit<Bun.CookieStoreDeleteOptions, "name">): void }
   entries: () => IterableIterator<[string, string]>
-  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  forEach: (callback: (value: string, key: string, map: Bun.CookieMap) => void) => void
   get: (name: string) => null | string
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
-  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  set: { (name: string, value: string, options?: Bun.CookieInit | undefined): void; (options: Bun.CookieInit): void }
   size [readonly]: number
   toJSON: () => Record<string, string>
   toSetCookieHeaders: () => Array<string>
   values: () => IterableIterator<string>
   [static]
-    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
-    prototype: CookieMap
-type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): Bun.CookieMap
+    prototype: Bun.CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "lax" | "none" | "strict"
 interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
   domain [?]: null | string | undefined
   name: string
@@ -415,30 +440,30 @@ interface CronController (bun-types/bun.d.ts)
 interface CronJob (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   cron [readonly]: string
-  ref: () => CronJob
-  stop: () => CronJob
-  unref: () => CronJob
+  ref: () => Bun.CronJob
+  stop: () => Bun.CronJob
+  unref: () => Bun.CronJob
 interface CronOptions (bun-types/bun.d.ts)
   tz [?]: string | undefined
-type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+type CronWithAutocomplete (bun-types/bun.d.ts) = "@annually" | "@daily" | "@hourly" | "@midnight" | "@monthly" | "@weekly" | "@yearly" | (string & {}) | `${string} ${string} ${string} ${string} ${string}`
 class CryptoHashInterface<T> (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => T
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => T
   [static]
-    construct new <T>(): CryptoHashInterface<T>
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHashInterface<any>
+    construct new <T>(): Bun.CryptoHashInterface<T>
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHashInterface<any>
 class CryptoHasher (bun-types/bun.d.ts)
-  algorithm [readonly]: SupportedCryptoAlgorithms
+  algorithm [readonly]: Bun.SupportedCryptoAlgorithms
   byteLength [readonly]: number
-  copy: () => CryptoHasher
-  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
-  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  copy: () => Bun.CryptoHasher
+  digest: { (encoding: Bun.DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (input: Bun.BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => Bun.CryptoHasher
   [static]
-    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
-    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
-    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHasher
+    construct new (algorithm: Bun.SupportedCryptoAlgorithms, hmacKey?: NodeJS.TypedArray<ArrayBufferLike> | string | undefined): Bun.CryptoHasher
+    algorithms [readonly static]: Array<Bun.SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHasher
 interface CustomEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -449,9 +474,9 @@ interface DNSLookup (bun-types/bun.d.ts)
   family: 4 | 6
   ttl: number
 type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
-type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "base64" | "base64url" | "hex" | "latin1" | "ucs2" | "utf16le" | "utf8"
 interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
   pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
   type: "direct"
 type DisconnectListener (bun-types/bun.d.ts) = () => void
@@ -459,7 +484,7 @@ interface EditorOptions (bun-types/bun.d.ts)
   column [?]: number | undefined
   editor [?]: "subl" | "vscode" | undefined
   line [?]: number | undefined
-type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+type Encoding (bun-types/bun.d.ts) = "866" | "ansi_x3.4-1968" | "arabic" | "ascii" | "asmo-708" | "big5" | "big5-hkscs" | "chinese" | "cn-big5" | "cp1250" | "cp1251" | "cp1252" | "cp1253" | "cp1254" | "cp1255" | "cp1256" | "cp1257" | "cp1258" | "cp819" | "cp866" | "csbig5" | "cseuckr" | "cseucpkdfmtjapanese" | "csgb2312" | "csibm866" | "csiso2022jp" | "csiso58gb231280" | "csiso88596e" | "csiso88596i" | "csiso88598e" | "csiso88598i" | "csisolatin1" | "csisolatin2" | "csisolatin3" | "csisolatin4" | "csisolatin5" | "csisolatin6" | "csisolatin9" | "csisolatinarabic" | "csisolatincyrillic" | "csisolatingreek" | "csisolatinhebrew" | "cskoi8r" | "csksc56011987" | "csmacintosh" | "csshiftjis" | "csunicode" | "cyrillic" | "dos-874" | "ecma-114" | "ecma-118" | "elot_928" | "euc-jp" | "euc-kr" | "gb18030" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "greek" | "greek8" | "hebrew" | "ibm819" | "ibm866" | "iso-10646-ucs-2" | "iso-2022-jp" | "iso-8859-1" | "iso-8859-10" | "iso-8859-11" | "iso-8859-13" | "iso-8859-14" | "iso-8859-15" | "iso-8859-16" | "iso-8859-2" | "iso-8859-3" | "iso-8859-4" | "iso-8859-5" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-8859-7" | "iso-8859-8" | "iso-8859-8-e" | "iso-8859-8-i" | "iso-8859-9" | "iso-ir-100" | "iso-ir-101" | "iso-ir-109" | "iso-ir-110" | "iso-ir-126" | "iso-ir-127" | "iso-ir-138" | "iso-ir-144" | "iso-ir-148" | "iso-ir-149" | "iso-ir-157" | "iso-ir-58" | "iso8859-1" | "iso8859-10" | "iso8859-11" | "iso8859-13" | "iso8859-14" | "iso8859-15" | "iso8859-2" | "iso8859-3" | "iso8859-4" | "iso8859-5" | "iso8859-6" | "iso8859-7" | "iso8859-8" | "iso8859-9" | "iso88591" | "iso885910" | "iso885911" | "iso885913" | "iso885914" | "iso885915" | "iso88592" | "iso88593" | "iso88594" | "iso88595" | "iso88596" | "iso88597" | "iso88598" | "iso88599" | "iso_8859-1" | "iso_8859-15" | "iso_8859-1:1987" | "iso_8859-2" | "iso_8859-2:1987" | "iso_8859-3" | "iso_8859-3:1988" | "iso_8859-4" | "iso_8859-4:1988" | "iso_8859-5" | "iso_8859-5:1988" | "iso_8859-6" | "iso_8859-6:1987" | "iso_8859-7" | "iso_8859-7:1987" | "iso_8859-8" | "iso_8859-8:1988" | "iso_8859-9" | "iso_8859-9:1989" | "koi" | "koi8" | "koi8-r" | "koi8-ru" | "koi8-u" | "koi8_r" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "l1" | "l2" | "l3" | "l4" | "l5" | "l6" | "l9" | "latin1" | "latin2" | "latin3" | "latin4" | "latin5" | "latin6" | "logical" | "mac" | "macintosh" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "sun_eu_greek" | "tis-620" | "ucs-2" | "unicode" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "unicodefeff" | "unicodefffe" | "us-ascii" | "utf-16" | "utf-16be" | "utf-16le" | "utf-8" | "utf8" | "visual" | "windows-1250" | "windows-1251" | "windows-1252" | "windows-1253" | "windows-1254" | "windows-1255" | "windows-1256" | "windows-1257" | "windows-1258" | "windows-31j" | "windows-874" | "windows-949" | "x-cp1250" | "x-cp1251" | "x-cp1252" | "x-cp1253" | "x-cp1254" | "x-cp1255" | "x-cp1256" | "x-cp1257" | "x-cp1258" | "x-euc-jp" | "x-gbk" | "x-mac-cyrillic" | "x-mac-roman" | "x-mac-ukrainian" | "x-sjis" | "x-unicode20utf8" | "x-user-defined" | "x-x-big5"
 interface Env (bun-types/bun.d.ts)
   NODE_ENV [?]: string | undefined
   TZ [?]: string | undefined
@@ -480,7 +505,7 @@ interface ErrorLike (bun-types/bun.d.ts)
   name: string
   stack [?]: string | undefined
   syscall [?]: string | undefined
-type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+type Errorlike (bun-types/deprecated.d.ts) = Bun.ErrorLike
 interface EventInit (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -491,31 +516,31 @@ interface EventListenerObject (bun-types/bun.d.ts)
   handleEvent: (object: Event) => void
 interface EventListenerOptions (bun-types/bun.d.ts)
   capture [?]: boolean | undefined
-type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = Bun.EventListener | Bun.EventListenerObject
 interface EventMap (bun-types/bun.d.ts)
-  fetch: FetchEvent
-  message: BunMessageEvent<any>
-  messageerror: BunMessageEvent<any>
+  fetch: Bun.FetchEvent
+  message: Bun.BunMessageEvent<any>
+  messageerror: Bun.BunMessageEvent<any>
 interface EventSource (bun-types/bun.d.ts)
-  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): Bun.EventSource
   CLOSED [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
-  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: Bun.BunMessageEvent<any>) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   close: () => void
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: EventSource, ev: Event) => any) | null
-  onmessage: ((this: EventSource, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: EventSource, ev: Event) => any) | null
+  onerror: ((this: Bun.EventSource, ev: Event) => any) | null
+  onmessage: ((this: Bun.EventSource, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.EventSource, ev: Event) => any) | null
   readyState [readonly]: number
   ref: () => void
-  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: Bun.BunMessageEvent<any>) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   unref: () => void
   url [readonly]: string
   withCredentials [readonly]: boolean
 interface EventSourceEventMap (bun-types/bun.d.ts)
   error: Event
-  message: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
   open: Event
 type ExitListener (bun-types/bun.d.ts) = (code: number) => void
 type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
@@ -523,8 +548,8 @@ interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   fd: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface FetchEvent (bun-types/bun.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -553,47 +578,47 @@ interface FileBlob (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface FileSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
   ref: () => void
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
 class FileSystemRouter (bun-types/bun.d.ts)
   assetPrefix [readonly]: string
-  match: (input: Request | Response | string) => MatchedRoute | null
+  match: (input: Request | Response | string) => Bun.MatchedRoute | null
   origin [readonly]: string
   reload: () => void
   routes [readonly]: Record<string, string>
   style [readonly]: string
   [static]
-    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
-    prototype: FileSystemRouter
-type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): Bun.FileSystemRouter
+    prototype: Bun.FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = File | string
 interface GenericTransformStream (bun-types/bun.d.ts)
   readable [readonly]: ReadableStream<any>
   writable [readonly]: WritableStream<any>
 class Glob (bun-types/bun.d.ts)
   match: (str: string) => boolean
-  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
-  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  scan: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => IterableIterator<string>
   [static]
-    construct new (pattern: string): Glob
-    prototype: Glob
+    construct new (pattern: string): Bun.Glob
+    prototype: Bun.Glob
 interface GlobScanOptions (bun-types/bun.d.ts)
   absolute [?]: boolean | undefined
   cwd [?]: string | undefined
@@ -601,25 +626,25 @@ interface GlobScanOptions (bun-types/bun.d.ts)
   followSymlinks [?]: boolean | undefined
   onlyFiles [?]: boolean | undefined
   throwErrorOnBrokenSymlink [?]: boolean | undefined
-type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
-type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+type HMREvent (bun-types/devserver.d.ts) = "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:beforeUpdate" | "bun:error" | "bun:invalidate" | "bun:ws:connect" | "bun:ws:disconnect" | (string & {})
+type HMREventNames (bun-types/devserver.d.ts) = "afterUpdate" | "beforeFullReload" | "beforePrune" | "beforeUpdate" | "error" | "invalidate" | "ws:connect" | "ws:disconnect"
 interface HTMLBundle (bun-types/bun.d.ts)
-  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Bun.Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
   index: string
 interface Hash (bun-types/bun.d.ts)
-  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Record<string, string | ReadonlyArray<string>> | Headers
+  adler32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Headers | Record<string, ReadonlyArray<string> | string>
 interface HeapSnapshot (bun-types/bun.d.ts)
   edgeNames: Array<string>
   edgeTypes: Array<string>
@@ -629,56 +654,56 @@ interface HeapSnapshot (bun-types/bun.d.ts)
   type: string
   version: number
 class Image (bun-types/bun.d.ts)
-  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  avif: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   blob: () => Promise<Blob>
   buffer: () => Promise<Buffer<ArrayBufferLike>>
   bytes: () => Promise<Uint8Array<ArrayBufferLike>>
   dataurl: () => Promise<string>
-  flip: () => Image
-  flop: () => Image
-  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  flip: () => Bun.Image
+  flop: () => Bun.Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   height [readonly]: number
-  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
-  metadata: () => Promise<Metadata>
-  modulate: (options: ModulateOptions) => Image
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Bun.Image
+  metadata: () => Promise<Bun.Image.Metadata>
+  modulate: (options: Bun.Image.ModulateOptions) => Bun.Image
   placeholder: (as?: "dataurl" | undefined) => Promise<string>
-  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
-  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
-  rotate: (degrees: number) => Image
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Bun.Image
+  resize: (width: number, height?: number | undefined, options?: Bun.Image.ResizeOptions | undefined) => Bun.Image
+  rotate: (degrees: number) => Bun.Image
   toBase64: () => Promise<string>
   toBuffer: () => Promise<Buffer<ArrayBufferLike>>
-  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Bun.Image
   width [readonly]: number
-  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  write: (dest: Bun.BunFile | Bun.PathLike | Bun.S3File | number) => Promise<number>
   [static]
-    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    construct new (input: ArrayBuffer | Blob | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.Image.ConstructorOptions | undefined): Bun.Image
     backend [static]: "bun" | "system"
     clipboardChangeCount [static]: () => number
-    fromClipboard [static]: () => Image | null
+    fromClipboard [static]: () => Bun.Image | null
     hasClipboardImage [static]: () => boolean
-    prototype: Image
+    prototype: Bun.Image
   interface Image.ConstructorOptions (bun-types/bun.d.ts)
     autoOrient [?]: boolean | undefined
     maxPixels [?]: number | undefined
-  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
-  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
-  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "bilinear" | "box" | "cubic" | "lanczos2" | "lanczos3" | "linear" | "mitchell" | "mks2013" | "mks2021" | "nearest"
+  type Image.Format (bun-types/bun.d.ts) = "avif" | "bmp" | "gif" | "heic" | "jpeg" | "png" | "tiff" | "webp"
   interface Image.Metadata (bun-types/bun.d.ts)
-    format: Format
+    format: Bun.Image.Format
     height: number
     width: number
   interface Image.ModulateOptions (bun-types/bun.d.ts)
     brightness [?]: number | undefined
     saturation [?]: number | undefined
   interface Image.ResizeOptions (bun-types/bun.d.ts)
-    filter [?]: Filter | undefined
+    filter [?]: Bun.Image.Filter | undefined
     fit [?]: "fill" | "inside" | undefined
     withoutEnlargement [?]: boolean | undefined
   var Image.backend (bun-types/bun.d.ts): "bun" | "system"
 interface Import (bun-types/bun.d.ts)
-  kind: ImportKind
+  kind: Bun.ImportKind
   path: string
-type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+type ImportKind (bun-types/bun.d.ts) = "dynamic-import" | "entry-point-build" | "entry-point-run" | "import-rule" | "import-statement" | "internal" | "require-call" | "require-resolve" | "url-token"
 namespace JSON5 (bun-types/bun.d.ts)
   function JSON5.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -694,30 +719,30 @@ namespace JSONL (bun-types/bun.d.ts)
     read: number
     values: Array<unknown>
   function JSONL.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Array<unknown>
   function JSONL.parseChunk (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): Bun.JSONL.ParseChunkResult
 type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
 interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
   level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
   library [?]: "libdeflate" | undefined
-type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+type Loader (bun-types/bun.d.ts) = "css" | "file" | "html" | "js" | "json" | "jsonc" | "jsx" | "napi" | "text" | "toml" | "ts" | "tsx" | "wasm" | "xml" | "yaml"
 class MD4 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD4
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD4
   [static]
-    construct new (): MD4
+    construct new (): Bun.MD4
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD4
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD4
 class MD5 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD5
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD5
   [static]
-    construct new (): MD5
+    construct new (): Bun.MD5
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD5
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD5
 interface MMapOptions (bun-types/bun.d.ts)
   offset [?]: number | undefined
   shared [?]: boolean | undefined
@@ -732,8 +757,8 @@ interface MatchedRoute (bun-types/bun.d.ts)
   pathname [readonly]: string
   query [readonly]: Record<string, string>
   src [readonly]: string
-type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
-type MessageEvent<T = any> (bun-types/bun.d.ts) = BunMessageEvent<T>
+type MaybePromise<T> (bun-types/bun.d.ts) = Promise<T> | T
+type MessageEvent<T = any> (bun-types/bun.d.ts) = Bun.BunMessageEvent<T>
 interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -744,8 +769,8 @@ interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   source [?]: null | undefined
 type MessageEventSource (bun-types/bun.d.ts) = undefined
 type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
-type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
-type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: Bun.MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "reject" | "resolve"
 interface NetworkSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
@@ -753,38 +778,38 @@ interface NetworkSink (bun-types/s3.d.ts)
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   stat: () => Promise<Stats>
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
-type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
-type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
 type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
-type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+type OnEndCallback (bun-types/bun.d.ts) = (result: Bun.BuildOutput) => void | Promise<void>
 interface OnLoadArgs (bun-types/bun.d.ts)
   defer: () => Promise<void>
-  loader: Loader
+  loader: Bun.Loader
   namespace: string
   path: string
-type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
-type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+type OnLoadCallback (bun-types/bun.d.ts) = (args: Bun.OnLoadArgs) => Bun.OnLoadResult | Promise<Bun.OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = Bun.OnLoadResultObject | Bun.OnLoadResultSourceCode | undefined | void
 interface OnLoadResultObject (bun-types/bun.d.ts)
   exports: Record<string, unknown>
   loader: "object"
 interface OnLoadResultSourceCode (bun-types/bun.d.ts)
-  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
-  loader [?]: Loader | undefined
+  contents: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Bun.Loader | undefined
 interface OnResolveArgs (bun-types/bun.d.ts)
   importer: string
-  kind: ImportKind
+  kind: Bun.ImportKind
   namespace: string
   path: string
   resolveDir: string
-type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+type OnResolveCallback (bun-types/bun.d.ts) = (args: Bun.OnResolveArgs) => Bun.OnResolveResult | Promise<Bun.OnResolveResult | null | undefined> | null | undefined
 interface OnResolveResult (bun-types/bun.d.ts)
   external [?]: boolean | undefined
   namespace [?]: string | undefined
   path: string
 type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
 namespace Password (bun-types/bun.d.ts)
-  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "argon2d" | "argon2i" | "argon2id" | "bcrypt"
   interface Password.Argon2Algorithm (bun-types/bun.d.ts)
     algorithm: "argon2d" | "argon2i" | "argon2id"
     memoryCost [?]: number | undefined
@@ -792,243 +817,243 @@ namespace Password (bun-types/bun.d.ts)
   interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
     algorithm: "bcrypt"
     cost [?]: number | undefined
-type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
-type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
-type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+type PathLike (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | URL | string
+type PipedSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "cygwin" | "darwin" | "freebsd" | "haiku" | "linux" | "netbsd" | "openbsd" | "sunos" | "win32"
 interface PluginBuilder (bun-types/bun.d.ts)
-  config: BuildConfig & { plugins: Array<BunPlugin>; }
-  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
-  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
-  onEnd: (callback: OnEndCallback) => PluginBuilder
-  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
-  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
-  onStart: (callback: OnStartCallback) => PluginBuilder
+  config: Bun.BuildConfig & { plugins: Array<Bun.BunPlugin>; }
+  module: (specifier: string, callback: () => Bun.OnLoadResult | Promise<Bun.OnLoadResult>) => Bun.PluginBuilder
+  onBeforeParse: (constraints: Bun.PluginConstraints, callback: Bun.OnBeforeParseCallback) => Bun.PluginBuilder
+  onEnd: (callback: Bun.OnEndCallback) => Bun.PluginBuilder
+  onLoad: (constraints: Bun.PluginConstraints, callback: Bun.OnLoadCallback) => Bun.PluginBuilder
+  onResolve: (constraints: Bun.PluginConstraints, callback: Bun.OnResolveCallback) => Bun.PluginBuilder
+  onStart: (callback: Bun.OnStartCallback) => Bun.PluginBuilder
 interface PluginConstraints (bun-types/bun.d.ts)
   filter: RegExp
   namespace [?]: string | undefined
-type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined
 type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
 interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
   done: boolean
   size: number
   value: Array<T>
-type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadDoneResult | ReadableStreamDefaultReadValueResult<T>
 type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
-type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
-type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+type ReadableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"pipe", "pipe">
 class RedisClient (bun-types/redis.d.ts)
-  append: (key: KeyLike, value: KeyLike) => Promise<number>
-  bitcount: (key: KeyLike) => Promise<number>
-  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
-  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
-  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
-  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
-  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  append: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  bitcount: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  bitfield: (key: Bun.RedisClient.KeyLike, ...operations: Array<number | string>) => Promise<Array<null | number>>
+  bitop: { (operation: "NOT" | "not", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  bitpos: (key: Bun.RedisClient.KeyLike, bit: 0 | 1, ...options: Array<number | string>) => Promise<number>
+  blmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<null | string>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, timeout: number) => Promise<null | string>
   bufferedAmount [readonly]: number
-  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  client: (...args: Array<string | number>) => Promise<any>
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  client: (...args: Array<number | string>) => Promise<any>
   close: () => void
-  command: (...args: Array<string | number>) => Promise<any>
-  config: (...args: Array<string | number>) => Promise<any>
+  command: (...args: Array<number | string>) => Promise<any>
+  config: (...args: Array<number | string>) => Promise<any>
   connect: () => Promise<void>
   connected [readonly]: boolean
-  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  copy: { (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike): Promise<number>; (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, replace: "REPLACE"): Promise<number> }
   dbsize: () => Promise<number>
-  debug: (...args: Array<string | number>) => Promise<any>
-  decr: (key: KeyLike) => Promise<number>
-  decrby: (key: KeyLike, decrement: number) => Promise<number>
-  del: (...keys: Array<KeyLike>) => Promise<number>
-  dump: (key: KeyLike) => Promise<string | null>
-  duplicate: () => Promise<RedisClient>
+  debug: (...args: Array<number | string>) => Promise<any>
+  decr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  decrby: (key: Bun.RedisClient.KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  dump: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  duplicate: () => Promise<Bun.RedisClient>
   echo: (message: string) => Promise<string>
-  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  exists: (key: KeyLike) => Promise<boolean>
-  expire: (key: KeyLike, seconds: number) => Promise<number>
-  expireat: (key: KeyLike, timestamp: number) => Promise<number>
-  expiretime: (key: KeyLike) => Promise<number>
-  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  exists: (key: Bun.RedisClient.KeyLike) => Promise<boolean>
+  expire: (key: Bun.RedisClient.KeyLike, seconds: number) => Promise<number>
+  expireat: (key: Bun.RedisClient.KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
   flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
   flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
-  function: (...args: Array<KeyLike>) => Promise<any>
-  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
-  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
-  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
-  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
-  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
-  get: (key: KeyLike) => Promise<string | null>
-  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
-  getbit: (key: KeyLike, offset: number) => Promise<number>
-  getdel: (key: KeyLike) => Promise<string | null>
-  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
-  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
-  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
-  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
-  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
-  hgetall: (key: KeyLike) => Promise<Record<string, string>>
-  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
-  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
-  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
-  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
-  hkeys: (key: KeyLike) => Promise<Array<string>>
-  hlen: (key: KeyLike) => Promise<number>
-  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
-  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
-  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
-  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
-  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
-  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
-  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
-  hstrlen: (key: KeyLike, field: string) => Promise<number>
-  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hvals: (key: KeyLike) => Promise<Array<string>>
-  incr: (key: KeyLike) => Promise<number>
-  incrby: (key: KeyLike, increment: number) => Promise<number>
-  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  function: (...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  geoadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  geodist: { (key: Bun.RedisClient.KeyLike, member1: string, member2: string): Promise<null | string>; (key: Bun.RedisClient.KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<null | string> }
+  geohash: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<null | string>>
+  geopos: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<unknown>>
+  geosearchstore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  get: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getBuffer: (key: Bun.RedisClient.KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: Bun.RedisClient.KeyLike, offset: number) => Promise<number>
+  getdel: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getex: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST"): Promise<null | string> }
+  getrange: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hdel: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  hexists: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hexpire: { (key: Bun.RedisClient.KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hget: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hgetall: (key: Bun.RedisClient.KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  hgetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>> }
+  hincrby: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  hlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  hmget: { (key: Bun.RedisClient.KeyLike, ...fields: Array<string>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, fields: Array<string>): Promise<Array<null | string>> }
+  hmset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<"OK"> }
+  hpersist: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: Bun.RedisClient.KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpttl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: Bun.RedisClient.KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<number>; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetnx: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hstrlen: (key: Bun.RedisClient.KeyLike, field: string) => Promise<number>
+  httl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hvals: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  incr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  incrby: (key: Bun.RedisClient.KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: Bun.RedisClient.KeyLike, increment: number | string) => Promise<string>
   info: (...sections: Array<string>) => Promise<string>
   keys: (pattern: string) => Promise<Array<string>>
   lastsave: () => Promise<number>
-  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
-  lindex: (key: KeyLike, index: number) => Promise<string | null>
-  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
-  llen: (key: KeyLike) => Promise<number>
-  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
-  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
-  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
-  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
-  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
-  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
-  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
-  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
-  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
-  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
-  onclose: ((this: RedisClient, error: Error) => void) | null
-  onconnect: ((this: RedisClient) => void) | null
-  persist: (key: KeyLike) => Promise<number>
-  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
-  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
-  pexpiretime: (key: KeyLike) => Promise<number>
-  pfadd: (key: KeyLike, element: string) => Promise<number>
-  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
-  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
-  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
-  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
-  pttl: (key: KeyLike) => Promise<number>
+  lcs: (key1: Bun.RedisClient.KeyLike, key2: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<any>
+  lindex: (key: Bun.RedisClient.KeyLike, index: number) => Promise<null | string>
+  linsert: (key: Bun.RedisClient.KeyLike, position: "AFTER" | "BEFORE", pivot: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike) => Promise<number>
+  llen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  lmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<null | string>
+  lmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<Array<number> | null | number>
+  lpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  lpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  lrange: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: Bun.RedisClient.KeyLike, count: number, element: Bun.RedisClient.KeyLike) => Promise<number>
+  lset: (key: Bun.RedisClient.KeyLike, index: number, element: Bun.RedisClient.KeyLike) => Promise<string>
+  ltrim: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  mset: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  onclose: ((this: Bun.RedisClient, error: Error) => void) | null
+  onconnect: ((this: Bun.RedisClient) => void) | null
+  persist: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pexpire: (key: Bun.RedisClient.KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: Bun.RedisClient.KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pfadd: (key: Bun.RedisClient.KeyLike, element: string) => Promise<number>
+  pfcount: (key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  pfmerge: (destkey: Bun.RedisClient.KeyLike, ...sourcekeys: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: Bun.RedisClient.KeyLike): Promise<string> }
+  psetex: (key: Bun.RedisClient.KeyLike, milliseconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  pttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
   publish: (channel: string, message: string) => Promise<number>
-  randomkey: () => Promise<string | null>
-  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
-  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
-  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
-  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
-  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
-  scard: (key: KeyLike) => Promise<number>
+  randomkey: () => Promise<null | string>
+  rename: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<"OK">
+  renamenx: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<number>
+  rpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike) => Promise<null | string>
+  rpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  rpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sadd: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<number | string>): Promise<[string, Array<string>]> }
+  scard: (key: Bun.RedisClient.KeyLike) => Promise<number>
   script: (...args: Array<string>) => Promise<any>
-  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sdiff: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   send: (command: string, args: Array<string>) => Promise<any>
-  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
-  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
-  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
-  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
-  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
-  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
-  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
-  sismember: (key: KeyLike, member: string) => Promise<boolean>
-  smembers: (key: KeyLike) => Promise<Array<string>>
-  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
-  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
-  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
-  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  spublish: (channel: KeyLike, message: string) => Promise<number>
-  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
-  strlen: (key: KeyLike) => Promise<number>
-  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
-  substr: (key: KeyLike, start: number, end: number) => Promise<string>
-  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  set: { (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, nx: "NX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, xx: "XX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, get: "GET"): Promise<null | string>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...options: Array<string>): Promise<null | string> }
+  setbit: (key: Bun.RedisClient.KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: Bun.RedisClient.KeyLike, seconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  setnx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  setrange: (key: Bun.RedisClient.KeyLike, offset: number, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sinter: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: Bun.RedisClient.KeyLike, ...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<number>
+  sinterstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  sismember: (key: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  smembers: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  smismember: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  smove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  sort: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<null | string> | number>
+  spop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: Bun.RedisClient.KeyLike, message: string) => Promise<number>
+  srandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...args: Array<number | string>) => Promise<[string, Array<string>]>
+  strlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<number>; (channels: Array<string>, listener: Bun.RedisClient.StringPubSubListener): Promise<number> }
+  substr: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   time: () => Promise<[string, string]>
-  touch: (...keys: Array<KeyLike>) => Promise<number>
-  ttl: (key: KeyLike) => Promise<number>
-  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
-  unlink: (...keys: Array<KeyLike>) => Promise<number>
-  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  touch: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  ttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  type: (key: Bun.RedisClient.KeyLike) => Promise<"hash" | "list" | "none" | "set" | "stream" | "string" | "zset">
+  unlink: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
   wait: (numreplicas: number, timeout: number) => Promise<number>
-  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
-  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
-  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
-  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
-  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
-  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xlen: (key: KeyLike) => Promise<number>
-  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
-  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xread: (...args: Array<string | number>) => Promise<any>
-  xreadgroup: (...args: Array<string | number>) => Promise<any>
-  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
-  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
-  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  zcard: (key: KeyLike) => Promise<number>
-  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
-  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
-  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
-  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
-  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
-  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
-  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
-  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
-  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
-  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
-  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
-  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
-  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
-  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
-  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
-  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
-  zscore: (key: KeyLike, member: string) => Promise<number | null>
-  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  xack: (key: Bun.RedisClient.KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<null | string>
+  xautoclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<number | string>) => Promise<any>
+  xclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<number | string>) => Promise<any>
+  xdel: (key: Bun.RedisClient.KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  xpending: (key: Bun.RedisClient.KeyLike, group: string, ...args: Array<number | string>) => Promise<any>
+  xrange: (key: Bun.RedisClient.KeyLike, start: string, end: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<number | string>) => Promise<any>
+  xreadgroup: (...args: Array<number | string>) => Promise<any>
+  xrevrange: (key: Bun.RedisClient.KeyLike, end: string, start: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: Bun.RedisClient.KeyLike, lastId: string, ...options: Array<number | string>) => Promise<"OK">
+  xtrim: (key: Bun.RedisClient.KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<number | string>) => Promise<number>
+  zadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  zcard: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  zcount: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: Bun.RedisClient.KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zincrby: (key: Bun.RedisClient.KeyLike, increment: number, member: Bun.RedisClient.KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<number>; (numkeys: number, ...args: Array<Bun.RedisClient.KeyLike | number>): Promise<number> }
+  zinterstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
+  zlexcount: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | number>>
+  zpopmax: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null>; (key: Bun.RedisClient.KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: Bun.RedisClient.KeyLike, min: string, max: string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangebyscore: { (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangestore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zremrangebylex: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: Bun.RedisClient.KeyLike, start: number, stop: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: Bun.RedisClient.KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrevrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: Bun.RedisClient.KeyLike, member: string) => Promise<null | number>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zunionstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
   [static]
-    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
-    prototype: RedisClient
-  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+    construct new (url?: string | undefined, options?: Bun.RedisOptions | undefined): Bun.RedisClient
+    prototype: Bun.RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = Blob | Bun.ArrayBufferView<ArrayBufferLike> | string
   type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
 interface RedisOptions (bun-types/redis.d.ts)
   autoReconnect [?]: boolean | undefined
@@ -1037,34 +1062,34 @@ interface RedisOptions (bun-types/redis.d.ts)
   enableOfflineQueue [?]: boolean | undefined
   idleTimeout [?]: number | undefined
   maxRetries [?]: number | undefined
-  tls [?]: TLSOptions | boolean | undefined
+  tls [?]: Bun.TLSOptions | boolean | undefined
 type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
 interface ReservedSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
   [Symbol.dispose]: () => void
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
   release: () => void
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 interface ResourceUsage (bun-types/bun.d.ts)
   contextSwitches: { voluntary: number; involuntary: number; }
   cpuTime: { user: number; system: number; total: number; }
@@ -1075,27 +1100,27 @@ interface ResourceUsage (bun-types/bun.d.ts)
   signalCount: number
   swapCount: number
 class S3Client (bun-types/s3.d.ts)
-  delete: (path: string, options?: S3Options | undefined) => Promise<void>
-  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
-  file: (path: string, options?: S3Options | undefined) => S3File
-  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
-  size: (path: string, options?: S3Options | undefined) => Promise<number>
-  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
-  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  delete: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+  list: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+  presign: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+  unlink: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  write: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
   [static]
-    construct new (options?: S3Options | undefined): S3Client
-    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
-    file [static]: (path: string, options?: S3Options | undefined) => S3File
-    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
-    prototype: S3Client
-    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
-    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+    construct new (options?: Bun.S3Options | undefined): Bun.S3Client
+    delete [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+    list [static]: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+    presign [static]: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+    prototype: Bun.S3Client
+    size [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+    unlink [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
 interface S3File (bun-types/s3.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bucket [? readonly]: string | undefined
@@ -1103,20 +1128,20 @@ interface S3File (bun-types/s3.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   name [? readonly]: string | undefined
-  presign: (options?: S3FilePresignOptions | undefined) => string
+  presign: (options?: Bun.S3FilePresignOptions | undefined) => string
   readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
-  stat: () => Promise<S3Stats>
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.S3File; (begin?: number | undefined, contentType?: string | undefined): Bun.S3File; (contentType?: string | undefined): Bun.S3File }
+  stat: () => Promise<Bun.S3Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
-  writer: (options?: S3Options | undefined) => NetworkSink
+  write: (data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
+  writer: (options?: Bun.S3Options | undefined) => Bun.NetworkSink
 interface S3FilePresignOptions (bun-types/s3.d.ts)
   accessKeyId [?]: string | undefined
   acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
@@ -1182,89 +1207,89 @@ interface S3Stats (bun-types/s3.d.ts)
   size: number
   type: string
 class SHA1 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA1
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA1
   [static]
-    construct new (): SHA1
+    construct new (): Bun.SHA1
     byteLength [readonly static]: 20
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA1
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA1
 class SHA224 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA224
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA224
   [static]
-    construct new (): SHA224
+    construct new (): Bun.SHA224
     byteLength [readonly static]: 28
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA224
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA224
 class SHA256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA256
   [static]
-    construct new (): SHA256
+    construct new (): Bun.SHA256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA256
 class SHA384 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA384
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA384
   [static]
-    construct new (): SHA384
+    construct new (): Bun.SHA384
     byteLength [readonly static]: 48
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA384
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA384
 class SHA512 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512
   [static]
-    construct new (): SHA512
+    construct new (): Bun.SHA512
     byteLength [readonly static]: 64
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512
 class SHA512_256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512_256
   [static]
-    construct new (): SHA512_256
+    construct new (): Bun.SHA512_256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512_256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512_256
 class SQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   [static]
-    construct new (connectionString: URL | string): SQL
-    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
-    construct new (options?: Options | undefined): SQL
-    MySQLError: typeof MySQLError
-    PostgresError: typeof PostgresError
-    SQLError: typeof SQLError
-    SQLiteError: typeof SQLiteError
-    prototype: SQL
+    construct new (connectionString: URL | string): Bun.SQL
+    construct new (connectionString: URL | string, options: Omit<Bun.SQL.PostgresOrMySQLOptions, "filename" | "url"> | Omit<Bun.SQL.SQLiteOptions, "filename" | "url">): Bun.SQL
+    construct new (options?: Bun.SQL.Options | undefined): Bun.SQL
+    MySQLError: typeof Bun.SQL.MySQLError
+    PostgresError: typeof Bun.SQL.PostgresError
+    SQLError: typeof Bun.SQL.SQLError
+    SQLiteError: typeof Bun.SQL.SQLiteError
+    prototype: Bun.SQL
   type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
-  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
-  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => Bun.MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? Bun.SQL.AwaitPromisesArray<T> : Awaited<T>
   interface SQL.Helper<T> (bun-types/sql.d.ts)
     columns [readonly]: Array<keyof T>
     value [readonly]: Array<T>
@@ -1281,13 +1306,13 @@ class SQL (bun-types/sql.d.ts)
     sqlState [? readonly]: string | undefined
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): Bun.SQL.MySQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: MySQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.MySQLError
       stackTraceLimit: number
-  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  type SQL.Options (bun-types/sql.d.ts) = Bun.SQL.PostgresOrMySQLOptions | Bun.SQL.SQLiteOptions
   class SQL.PostgresError (bun-types/sql.d.ts)
     cause [?]: unknown
     code [readonly]: string
@@ -1311,11 +1336,11 @@ class SQL (bun-types/sql.d.ts)
     table [? readonly]: string | undefined
     where [? readonly]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): Bun.SQL.PostgresError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: PostgresError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.PostgresError
       stackTraceLimit: number
   interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
     adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
@@ -1323,7 +1348,7 @@ class SQL (bun-types/sql.d.ts)
     bigint [?]: boolean | undefined
     connectTimeout [?]: number | undefined
     connect_timeout [?]: number | undefined
-    connection [?]: Record<string, string | number | boolean> | undefined
+    connection [?]: Record<string, boolean | number | string> | undefined
     connectionTimeout [?]: number | undefined
     connection_timeout [?]: number | undefined
     database [?]: string | undefined
@@ -1337,39 +1362,39 @@ class SQL (bun-types/sql.d.ts)
     max_lifetime [?]: number | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
-    pass [?]: (() => MaybePromise<string>) | string | undefined
-    password [?]: (() => MaybePromise<string>) | string | undefined
+    pass [?]: (() => Bun.MaybePromise<string>) | string | undefined
+    password [?]: (() => Bun.MaybePromise<string>) | string | undefined
     path [?]: string | undefined
     port [?]: number | string | undefined
     prepare [?]: boolean | undefined
-    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
-    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
     url [?]: URL | string | undefined
     user [?]: string | undefined
     username [?]: string | undefined
   interface SQL.Query<T> (bun-types/sql.d.ts)
     [Symbol.toStringTag] [readonly]: string
     active: boolean
-    cancel: () => Query<T>
+    cancel: () => Bun.SQL.Query<T>
     cancelled: boolean
     catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
-    execute: () => Query<T>
+    execute: () => Bun.SQL.Query<T>
     finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
-    raw: () => Query<T>
-    simple: () => Query<T>
+    raw: () => Bun.SQL.Query<T>
+    simple: () => Bun.SQL.Query<T>
     then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    values: () => Query<T>
+    values: () => Bun.SQL.Query<T>
   class SQL.SQLError (bun-types/sql.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string): SQLError
+      construct new (message: string): Bun.SQL.SQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLError
       stackTraceLimit: number
   class SQL.SQLiteError (bun-types/sql.d.ts)
     byteOffset [? readonly]: number | undefined
@@ -1380,55 +1405,55 @@ class SQL (bun-types/sql.d.ts)
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): Bun.SQL.SQLiteError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLiteError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLiteError
       stackTraceLimit: number
   interface SQL.SQLiteOptions (bun-types/sql.d.ts)
     adapter [?]: "sqlite" | undefined
     create [?]: boolean | undefined
-    filename [?]: ":memory:" | URL | string & {} | undefined
+    filename [?]: ":memory:" | (string & {}) | URL | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
     readonly [?]: boolean | undefined
     readwrite [?]: boolean | undefined
     safeIntegers [?]: boolean | undefined
     strict [?]: boolean | undefined
-  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SQLArrayParameter (bun-types/sql.d.ts)
-  arrayType: ArrayType
+  arrayType: Bun.ArrayType
   serializedValues: string
-type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
-type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
-type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+type SQLOptions (bun-types/deprecated.d.ts) = Bun.SQL.Options
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Bun.SQL.Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SavepointSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 namespace Security (bun-types/security.d.ts)
   interface Security.Advisory (bun-types/security.d.ts)
     description: null | string
@@ -1441,29 +1466,29 @@ namespace Security (bun-types/security.d.ts)
     tarball: string
     version: string
   interface Security.Scanner (bun-types/security.d.ts)
-    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    scan: (info: { packages: Array<Bun.Security.Package>; }) => Promise<Array<Bun.Security.Advisory>>
     version: "1"
 namespace Serve (bun-types/serve.d.ts)
-  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = Bun.BunFile | Bun.HTMLBundle | Bun.Serve.DirectoryRouteOptions | Response | false
   interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
   type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
   interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
     dir: string
     statCache [?]: boolean | undefined
-  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
-  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
-  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
-  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
-  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & Bun.Serve.ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes?: Bun.Serve.Routes<WebSocketData, R> | undefined; } | { fetch?(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes: Bun.Serve.Routes<WebSocketData, R>; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = Bun.Serve.FetchOrRoutesWithWebSocket<WebSocketData, R>
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => Bun.MaybePromise<Res>
   interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
-    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | (string & {}) | undefined
     http1 [?]: boolean | undefined
     http2 [?]: boolean | undefined
     http3 [?]: boolean | undefined
@@ -1473,18 +1498,18 @@ namespace Serve (bun-types/serve.d.ts)
     maxRequestBodySize [?]: number | undefined
     port [?]: number | string | undefined
     reusePort [?]: boolean | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
-  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
-  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
-  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = Bun.Serve.Options<WebSocketData, R>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined>>>; }
   interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
     unix [?]: string | undefined
-type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = Bun.ServeOptions<T, R>
 interface Server<WebSocketData> (bun-types/serve.d.ts)
   [Symbol.dispose]: () => void
   closeIdleConnections: () => number
@@ -1496,41 +1521,41 @@ interface Server<WebSocketData> (bun-types/serve.d.ts)
   pendingWebSockets [readonly]: number
   port [readonly]: number | undefined
   protocol [readonly]: "http" | "https" | null
-  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  publish: (topic: string, data: ArrayBuffer | Blob | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, compress?: boolean | undefined) => number
   ref: () => void
-  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
-  requestIP: (request: Request) => SocketAddress | null
+  reload: <R extends string>(options: Bun.Serve.Options<WebSocketData, R>) => Bun.Server<WebSocketData>
+  requestIP: (request: Request) => Bun.SocketAddress | null
   stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
   subscriberCount: (topic: string) => number
   timeout: (request: Request, seconds: number) => void
   unref: () => void
-  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: Bun.HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: Bun.HeadersInit | undefined; data: WebSocketData; }]) => boolean
   url [readonly]: URL
 interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
   binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
   close: (code?: number | undefined, reason?: string | undefined) => void
-  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  cork: <T = unknown>(callback: (ws: Bun.ServerWebSocket<T>) => T) => T
   data: T
   getBufferedAmount: () => number
   isSubscribed: (topic: string) => boolean
-  ping: (data?: Blob | BufferSource | string | undefined) => number
-  pong: (data?: Blob | BufferSource | string | undefined) => number
-  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  ping: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  pong: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   publishText: (topic: string, data: string, compress?: boolean | undefined) => number
-  readyState [readonly]: WebSocketReadyState
+  readyState [readonly]: Bun.WebSocketReadyState
   remoteAddress [readonly]: string
-  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  send: (data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   sendText: (data: string, compress?: boolean | undefined) => number
   subscribe: (topic: string) => boolean
   subscriptions [readonly]: Array<string>
   terminate: () => void
   unsubscribe: (topic: string) => boolean
 type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
-type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellExpression (bun-types/shell.d.ts) = Array<Bun.ShellExpression> | BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | Blob | Bun.BunFile | Bun.Subprocess<Bun.SpawnOptions.Writable, Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | ReadableStream<any> | ReadableStream<any> | Request | Response | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | null | number | string | undefined | { raw: string; } | { toString(): string; }
 type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
-type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+type SignalsListener (bun-types/bun.d.ts) = (signal: NodeJS.Signals) => void
 interface SliceAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   ellipsis [?]: string | undefined
@@ -1542,8 +1567,8 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   close: () => void
   data: Data
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1560,14 +1585,14 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1577,154 +1602,154 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface SocketAddress (bun-types/bun.d.ts)
   address: string
   family: "IPv4" | "IPv6"
   port: number
-interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
-  binaryType [?]: keyof BinaryTypeList | undefined
-  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
-  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
-  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
-  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof Bun.BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof Bun.BinaryTypeList | undefined
+  close [?]: ((socket: Bun.Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Bun.Socket<Data>, data: Bun.BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Bun.Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
 interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
+  socket: Bun.SocketHandler<Data, "buffer">
 namespace Spawn (bun-types/bun.d.ts)
-  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
-  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
-  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
-  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
-  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  type Spawn.OptionsObject<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = Bun.SpawnOptions.BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | null | number | undefined
+  type Spawn.ReadableToIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | Bun.BunFile | Bun.ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     lazy [?]: boolean | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
-    terminal [?]: Terminal | TerminalOptions | undefined
+    terminal [?]: Bun.Terminal | Bun.TerminalOptions | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.SpawnSyncOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
-  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
-  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | null | number | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = Bun.FileSink | number | undefined
+  type Spawn.WritableToIO<X extends Bun.SpawnOptions.Writable> (bun-types/bun.d.ts) = X extends "pipe" ? Bun.FileSink : X extends number | Bun.BunFile | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
 SpawnOptions -> Spawn
 type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
-type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type StringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | string
 interface StringWidthOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   countAnsiEscapeCodes [?]: boolean | undefined
   perCodePoint [?]: boolean | undefined
 interface StructuredSerializeOptions (bun-types/bun.d.ts)
-  transfer [?]: Array<Transferable> | undefined
-interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  transfer [?]: Array<Bun.Transferable> | undefined
+interface Subprocess<In extends Bun.SpawnOptions.Writable = Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => PromiseLike<void>
   disconnect: () => void
   exitCode [readonly]: null | number
   exited [readonly]: Promise<number>
-  kill: (exitCode?: Signals | number | undefined) => void
+  kill: (exitCode?: NodeJS.Signals | number | undefined) => void
   killed [readonly]: boolean
   pid [readonly]: number
-  readable [readonly]: ReadableToIO<Out>
+  readable [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
   ref: () => void
-  resourceUsage: () => ResourceUsage | undefined
+  resourceUsage: () => Bun.ResourceUsage | undefined
   send: (message: any) => void
-  signalCode [readonly]: Signals | null
-  stderr [readonly]: ReadableToIO<Err>
-  stdin [readonly]: WritableToIO<In>
+  signalCode [readonly]: NodeJS.Signals | null
+  stderr [readonly]: Bun.SpawnOptions.ReadableToIO<Err>
+  stdin [readonly]: Bun.SpawnOptions.WritableToIO<In>
   stdio [readonly]: [null, null, null, ...(number | null)[]]
-  stdout [readonly]: ReadableToIO<Out>
-  terminal [readonly]: Terminal | undefined
+  stdout [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
+  terminal [readonly]: Bun.Terminal | undefined
   unref: () => void
-type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
-interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha256" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "sha384" | "sha512" | "sha512-224" | "sha512-256" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   exitCode: number
   exitedDueToMaxBuffer [?]: boolean | undefined
   exitedDueToTimeout [?]: boolean | undefined
   pid: number
-  resourceUsage: ResourceUsage
+  resourceUsage: Bun.ResourceUsage
   signalCode [?]: string | undefined
-  stderr: ReadableToSyncIO<Err>
-  stdout: ReadableToSyncIO<Out>
+  stderr: Bun.SpawnOptions.ReadableToSyncIO<Err>
+  stdout: Bun.SpawnOptions.ReadableToSyncIO<Out>
   success: boolean
 interface SystemError (bun-types/bun.d.ts)
   cause [?]: unknown
@@ -1743,8 +1768,8 @@ interface TCPSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1761,14 +1786,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1778,14 +1803,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
@@ -1794,36 +1819,36 @@ interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   ipv6Only [?]: boolean | undefined
   port: number
   reusePort [?]: boolean | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   exclusive [?]: boolean | undefined
   hostname: string
   port: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   hostname [readonly]: string
   port [readonly]: number
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -1839,8 +1864,8 @@ interface TLSSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1857,14 +1882,14 @@ interface TLSSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1874,27 +1899,27 @@ interface TLSSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls: TLSOptions | boolean
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls: Bun.TLSOptions | boolean
 namespace TOML (bun-types/bun.d.ts)
   function TOML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): object
   function TOML.stringify (bun-types/bun.d.ts)
     call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
 interface TSConfig (bun-types/bun.d.ts)
   compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
   extends [?]: string | undefined
-type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+type Target (bun-types/bun.d.ts) = "browser" | "bun" | "node"
 class Terminal (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => Promise<void>
   close: () => void
@@ -1907,43 +1932,43 @@ class Terminal (bun-types/bun.d.ts)
   resize: (cols: number, rows: number) => void
   setRawMode: (enabled: boolean) => void
   unref: () => void
-  write: (data: BufferSource | string) => number
+  write: (data: Bun.BufferSource | string) => number
   [static]
-    construct new (options: TerminalOptions): Terminal
-    prototype: Terminal
+    construct new (options: Bun.TerminalOptions): Bun.Terminal
+    prototype: Bun.Terminal
 interface TerminalOptions (bun-types/bun.d.ts)
   cols [?]: number | undefined
-  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
-  drain [?]: ((terminal: Terminal) => void) | undefined
-  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  data [?]: ((terminal: Bun.Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Bun.Terminal) => void) | undefined
+  exit [?]: ((terminal: Bun.Terminal, exitCode: number, signal: null | string) => void) | undefined
   name [?]: string | undefined
   rows [?]: number | undefined
 type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
 interface TransactionSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  savepoint: { <T>(name: string, fn: Bun.SQL.SavepointContextCallback<T>): Promise<T>; <T>(fn: Bun.SQL.SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
 interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
   call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
@@ -1952,13 +1977,13 @@ interface TransformerStartCallback<O> (bun-types/bun.d.ts)
 interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
   call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
 class Transpiler (bun-types/bun.d.ts)
-  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
-  scanImports: (code: StringOrBuffer) => Array<Import>
-  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
-  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  scan: (code: Bun.StringOrBuffer) => { exports: Array<string>; imports: Array<Bun.Import>; }
+  scanImports: (code: Bun.StringOrBuffer) => Array<Bun.Import>
+  transform: (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: Bun.StringOrBuffer, loader: Bun.JavaScriptLoader, ctx: object): string; (code: Bun.StringOrBuffer, ctx: object): string; (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined): string }
   [static]
-    construct new (options?: TranspilerOptions | undefined): Transpiler
-    prototype: Transpiler
+    construct new (options?: Bun.TranspilerOptions | undefined): Bun.Transpiler
+    prototype: Bun.Transpiler
 interface TranspilerOptions (bun-types/bun.d.ts)
   allowBunRuntime [?]: boolean | undefined
   autoImportJSX [?]: boolean | undefined
@@ -1967,23 +1992,23 @@ interface TranspilerOptions (bun-types/bun.d.ts)
   exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
   inline [?]: boolean | undefined
   jsxOptimizationInline [?]: boolean | undefined
-  loader [?]: JavaScriptLoader | undefined
+  loader [?]: Bun.JavaScriptLoader | undefined
   logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
-  macro [?]: MacroMap | undefined
+  macro [?]: Bun.MacroMap | undefined
   minifyWhitespace [?]: boolean | undefined
   replMode [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   treeShaking [?]: boolean | undefined
   trimUnusedImports [?]: boolean | undefined
-  tsconfig [?]: TSConfig | string | undefined
-type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  tsconfig [?]: Bun.TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: Bun.UncaughtExceptionOrigin) => void
 type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
 interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
-  abort [?]: UnderlyingSinkAbortCallback | undefined
-  close [?]: UnderlyingSinkCloseCallback | undefined
-  start [?]: UnderlyingSinkStartCallback | undefined
+  abort [?]: Bun.UnderlyingSinkAbortCallback | undefined
+  close [?]: Bun.UnderlyingSinkCloseCallback | undefined
+  start [?]: Bun.UnderlyingSinkStartCallback | undefined
   type [?]: "bytes" | "default" | undefined
-  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+  write [?]: Bun.UnderlyingSinkWriteCallback<W> | undefined
 interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
@@ -1993,30 +2018,30 @@ interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
 interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
   call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
 interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
-  pull [?]: UnderlyingSourcePullCallback<R> | undefined
-  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
+  pull [?]: Bun.UnderlyingSourcePullCallback<R> | undefined
+  start [?]: Bun.UnderlyingSourceStartCallback<R> | undefined
   type [?]: undefined
 interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+  call (controller: Bun.ReadableStreamController<R>): PromiseLike<void> | void
 interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): any
+  call (controller: Bun.ReadableStreamController<R>): any
 type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
 interface UnixSocketListener<Data> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unix [readonly]: string
   unref: () => void
 interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
   unix: string
 type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
 namespace WebAssembly (bun-types/wasm.d.ts)
@@ -2025,19 +2050,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     message: string
     name: string
     stack [?]: string | undefined
-  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
-  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.Global<keyof Bun.WebAssembly.ValueTypeMap> | Bun.WebAssembly.Memory | Bun.WebAssembly.Table | Function
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ExportValue; }
+  interface WebAssembly.Global<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
-  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
-  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.ExportValue | number
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ModuleImports; }
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2052,13 +2077,13 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
-  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ImportValue; }
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2070,11 +2095,11 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     length [readonly]: number
     set: (index: number, value?: any) => void
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
-  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof Bun.WebAssembly.ValueTypeMap
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
     anyfunc: Function
     externref: any
@@ -2084,70 +2109,70 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
 interface WebSocket (bun-types/bun.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
-type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+type WebSocketCompressor (bun-types/serve.d.ts) = "128KB" | "16KB" | "256KB" | "32KB" | "3KB" | "4KB" | "64KB" | "8KB" | "dedicated" | "disable" | "shared"
 interface WebSocketEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: Event
-  message: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
   open: Event
 interface WebSocketHandler<T> (bun-types/serve.d.ts)
   backpressureLimit [?]: number | undefined
-  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  close [?]: ((ws: Bun.ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
   closeOnBackpressureLimit [?]: boolean | undefined
   data [?]: T | undefined
-  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  drain [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
   idleTimeout [?]: number | undefined
   maxPayloadLength [?]: number | undefined
-  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
-  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
-  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
-  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
-  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  message: (ws: Bun.ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | Bun.WebSocketCompressor | undefined; decompress?: boolean | Bun.WebSocketCompressor | undefined; }
+  ping [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
   publishToSelf [?]: boolean | undefined
   sendPings [?]: boolean | undefined
-type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptions (bun-types/bun.d.ts) = Bun.WebSocketOptions
 type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
 type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
-type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocol?: string | undefined; } | { protocols?: string | Array<string> | undefined; }
 type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
-type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: Bun.TLSOptions | undefined; }
 type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
 class WebView (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => void
   [Symbol.dispose]: () => void
-  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: BunMessageEvent<T>) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: Bun.BunMessageEvent<T>) => void, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   back: () => Promise<void>
   cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
-  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  click: { (x: number, y: number, options?: Bun.WebView.ClickOptions | undefined): Promise<void>; (selector: string, options?: Bun.WebView.ClickSelectorOptions | undefined): Promise<void> }
   close: () => void
   dispatchEvent: (event: Event) => boolean
   evaluate: <T = unknown>(script: string) => Promise<T>
@@ -2156,66 +2181,66 @@ class WebView (bun-types/bun.d.ts)
   navigate: (url: string) => Promise<void>
   onNavigated: ((url: string, title: string) => void) | null
   onNavigationFailed: ((error: Error) => void) | null
-  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  press: (key: (string & {}) | Bun.WebView.VirtualKey, options?: Bun.WebView.PressOptions | undefined) => Promise<void>
   reload: () => Promise<void>
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   resize: (width: number, height: number) => Promise<void>
   screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
   scroll: (dx: number, dy: number) => Promise<void>
-  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  scrollTo: (selector: string, options?: Bun.WebView.ScrollToOptions | undefined) => Promise<void>
   title [readonly]: string
   type: (text: string) => Promise<void>
   url [readonly]: string
   [static]
-    construct new (options?: ConstructorOptions | undefined): WebView
+    construct new (options?: Bun.WebView.ConstructorOptions | undefined): Bun.WebView
     closeAll [static]: () => void
-    prototype: WebView
-  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+    prototype: Bun.WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "chrome" | "webkit" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
   interface WebView.ClickOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
     timeout [?]: number | undefined
-  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = ((type: string, ...args: Array<unknown>) => void) | Console
   interface WebView.ConstructorOptions (bun-types/bun.d.ts)
-    backend [?]: Backend | undefined
-    console [?]: ConsoleCapture | undefined
+    backend [?]: Bun.WebView.Backend | undefined
+    console [?]: Bun.WebView.ConsoleCapture | undefined
     dataStore [?]: "ephemeral" | undefined | { directory: string; }
     headless [?]: boolean | undefined
     height [?]: number | undefined
     url [?]: string | undefined
     width [?]: number | undefined
-  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  type WebView.Modifier (bun-types/bun.d.ts) = "Alt" | "Control" | "Meta" | "Shift"
   interface WebView.PressOptions (bun-types/bun.d.ts)
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ScrollToOptions (bun-types/bun.d.ts)
     block [?]: "center" | "end" | "nearest" | "start" | undefined
     timeout [?]: number | undefined
-  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "Backspace" | "Delete" | "End" | "Enter" | "Escape" | "Home" | "PageDown" | "PageUp" | "Space" | "Tab"
 interface WhichOptions (bun-types/bun.d.ts)
   PATH [?]: string | undefined
   cwd [?]: string | undefined
 interface Worker (bun-types/bun.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
 interface WorkerEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: ErrorEvent
-  message: BunMessageEvent<any>
-  messageerror: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
+  messageerror: Bun.BunMessageEvent<any>
   open: Event
 interface WorkerOptions (bun-types/bun.d.ts)
   argv [?]: Array<any> | undefined
@@ -2225,44 +2250,44 @@ interface WorkerOptions (bun-types/bun.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
 interface WrapAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   hard [?]: boolean | undefined
   trim [?]: boolean | undefined
   wordWrap [?]: boolean | undefined
-type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+type WritableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", any, any>
 namespace XML (bun-types/bun.d.ts)
   interface XML.Comment (bun-types/bun.d.ts)
     comment: string
   interface XML.Document (bun-types/bun.d.ts)
-    index [string]: Value
+    index [string]: Bun.XML.Value
   interface XML.Element (bun-types/bun.d.ts)
-    index [string]: Array<Value> | Value
+    index [string]: Array<Bun.XML.Value> | Bun.XML.Value
   interface XML.Node (bun-types/bun.d.ts)
     attributes: Record<string, string>
-    children: Array<string | Comment | Node | ProcessingInstruction>
+    children: Array<Bun.XML.Comment | Bun.XML.Node | Bun.XML.ProcessingInstruction | string>
     name: string
   interface XML.NodeInput (bun-types/bun.d.ts)
-    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
-    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    attributes [?]: null | undefined | { [name: string]: Bun.XML.Scalar | null | undefined; }
+    children [?]: Array<Bun.XML.Comment | Bun.XML.NodeInput | Bun.XML.ProcessingInstruction | Bun.XML.Scalar | null | undefined> | null | undefined
     name: string
   interface XML.ParseOptions (bun-types/bun.d.ts)
     compact [?]: boolean | undefined
   interface XML.ProcessingInstruction (bun-types/bun.d.ts)
     data: string
     target: string
-  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
-  type XML.Value (bun-types/bun.d.ts) = string | Element
+  type XML.Scalar (bun-types/bun.d.ts) = Date | bigint | boolean | number | string
+  type XML.Value (bun-types/bun.d.ts) = Bun.XML.Element | string
   function XML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: (Bun.XML.ParseOptions & { compact?: true | undefined; }) | undefined): Bun.XML.Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options: Bun.XML.ParseOptions & { compact: false; }): Bun.XML.Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.XML.ParseOptions | undefined): Bun.XML.Document | Bun.XML.Node
   function XML.stringify (bun-types/bun.d.ts)
-    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: Bun.XML.Document | Bun.XML.NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
     call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
-type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = Blob | Bun.BufferSource | FormData | URLSearchParams | string
 namespace YAML (bun-types/bun.d.ts)
   function YAML.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -2294,9 +2319,9 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     timeStamp [readonly]: number
     type [readonly]: string
   interface __internal.BunEventTarget (bun-types/globals.d.ts)
-    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
     dispatchEvent: (event: Event) => boolean
-    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+    removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
     [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
     append [readonly]: (name: string, value: string) => void
@@ -2324,7 +2349,7 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     destination [readonly]: RequestDestination
     duplex [readonly]: "half"
     formData [readonly]: () => Promise<FormData>
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     integrity [readonly]: string
     json [readonly]: () => Promise<unknown>
     keepalive [readonly]: boolean
@@ -2345,7 +2370,7 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
     clone: () => Response
     formData [readonly]: () => Promise<FormData>
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     json [readonly]: () => Promise<unknown>
     ok [readonly]: boolean
     redirected [readonly]: boolean
@@ -2355,16 +2380,16 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     textStream: () => ReadableStream<string>
     type [readonly]: ResponseType
     url [readonly]: string
-  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Bun.__internal.Merge<T, Exclude<Else, T>> : never
   type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
   type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
   type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = false
   type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = BroadcastChannel
-  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = BunEvent
-  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = BunEventTarget
-  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = WebSocket
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = Bun.__internal.BunEvent
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = Bun.__internal.BunEventTarget
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = Bun.WebSocket
   type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = EventSource
-  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = SubtleCrypto
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = webcrypto.SubtleCrypto
   type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = MessagePort
   type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = ReadableStream<T>
   type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = CompressionStream
@@ -2385,48 +2410,48 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
   type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = ReadableStreamBYOBRequest
   type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = Headers
   type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = Request
-  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: BodyInit | null | undefined; headers?: HeadersInit | undefined; }
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: Bun.BodyInit | null | undefined; headers?: Bun.HeadersInit | undefined; }
   type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = Response
   type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = ResponseInit
   type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = Performance
-  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Worker
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Bun.Worker
   type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
   type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
-  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
-  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = webcrypto.CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = webcrypto.CryptoKeyPair
   type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = Otherwise
   type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
-  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Bun.__internal.Without<A, B> | Bun.__internal.Without<B, A>
 function allocUnsafe (bun-types/bun.d.ts)
   call (size: number): Uint8Array<ArrayBuffer>
 var argv (bun-types/bun.d.ts): Array<string>
 function build (bun-types/bun.d.ts)
-  call (config: BuildConfig): Promise<BuildOutput>
+  call (config: Bun.BuildConfig): Promise<Bun.BuildOutput>
 function color (bun-types/bun.d.ts)
-  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
-  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
-  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
-  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
-  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
-  call (input: ColorInput, outputFormat: "number"): null | number
+  call (input: Bun.ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: Bun.ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: Bun.ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: Bun.ColorInput, outputFormat: "number"): null | number
 function concatArrayBuffers (bun-types/bun.d.ts)
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
 function connect (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: Bun.TCPSocketConnectOptions<Data>): Promise<Bun.Socket<Data>>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Promise<Bun.Socket<Data>>
 var cron (bun-types/bun.d.ts)
-  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
-  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
-  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  call (schedule: Bun.CronWithAutocomplete, handler: (this: Bun.CronJob) => unknown, options?: Bun.CronOptions | undefined): Bun.CronJob
+  call (path: string, schedule: Bun.CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: Bun.CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: Bun.CronOptions | undefined) => Date | null
   remove: (title: string) => Promise<void>
 function deepEquals (bun-types/bun.d.ts)
   call (a: any, b: any, strict?: boolean | undefined): boolean
 function deepMatch (bun-types/bun.d.ts)
   call (subset: unknown, a: unknown): boolean
 function deflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 namespace dns (bun-types/bun.d.ts)
   var dns.ADDRCONFIG (bun-types/bun.d.ts): number
   var dns.ALL (bun-types/bun.d.ts): number
@@ -2434,50 +2459,50 @@ namespace dns (bun-types/bun.d.ts)
   function dns.getCacheStats (bun-types/bun.d.ts)
     call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
   function dns.lookup (bun-types/bun.d.ts)
-    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<Bun.DNSLookup>>
   function dns.prefetch (bun-types/bun.d.ts)
     call (hostname: string, port?: number | undefined): void
 var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
 var enableANSIColors (bun-types/bun.d.ts): boolean
-var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+var env (bun-types/bun.d.ts): Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
 function escapeHTML (bun-types/bun.d.ts)
   call (input: boolean | number | object | string): string
 var fetch (bun-types/bun.d.ts): typeof fetch
 function file (bun-types/bun.d.ts)
-  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
-  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
-  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+  call (path: URL | string, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): Bun.BunFile
 function fileURLToPath (bun-types/bun.d.ts)
   call (url: URL | string): string
 function gc (bun-types/bun.d.ts)
   call (force?: boolean | undefined): void
 function generateHeapSnapshot (bun-types/bun.d.ts)
-  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format?: "jsc" | undefined): Bun.HeapSnapshot
   call (format: "v8"): string
   call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
 function gunzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function gzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
-var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | number | undefined) => bigint | number) & Bun.Hash
 function indexOfLine (bun-types/bun.d.ts)
-  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+  call (buffer: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
 function inflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function inspect (bun-types/bun.d.ts)
-  call (arg: any, options?: BunInspectOptions | undefined): string
-  custom: typeof custom
+  call (arg: any, options?: Bun.BunInspectOptions | undefined): string
+  custom: typeof inspect.custom
   table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
 namespace inspect (bun-types/bun.d.ts)
-  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  var inspect.custom (bun-types/bun.d.ts): typeof inspect.custom
   function inspect.table (bun-types/bun.d.ts)
     call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
     call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
 var isMainThread (bun-types/bun.d.ts): boolean
 var isStandaloneExecutable (bun-types/bun.d.ts): boolean
 function listen (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+  call <Data = undefined>(options: Bun.TCPSocketListenOptions<Data>): Bun.TCPSocketListener<Data>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Bun.UnixSocketListener<Data>
 var main (bun-types/bun.d.ts): string
 namespace markdown (bun-types/bun.d.ts)
   interface markdown.AnsiTheme (bun-types/bun.d.ts)
@@ -2498,37 +2523,37 @@ namespace markdown (bun-types/bun.d.ts)
   interface markdown.CodeBlockProps (bun-types/bun.d.ts)
     children: Array<unknown>
     language [?]: string | undefined
-  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = ((props: P) => any) | (new (props: P) => any) | string
   interface markdown.ComponentOverrides (bun-types/bun.d.ts)
-    a [?]: Component<LinkProps> | undefined
-    blockquote [?]: Component<ChildrenProps> | undefined
-    br [?]: Component<{}> | undefined
-    code [?]: Component<ChildrenProps> | undefined
-    del [?]: Component<ChildrenProps> | undefined
-    em [?]: Component<ChildrenProps> | undefined
-    h1 [?]: Component<HeadingProps> | undefined
-    h2 [?]: Component<HeadingProps> | undefined
-    h3 [?]: Component<HeadingProps> | undefined
-    h4 [?]: Component<HeadingProps> | undefined
-    h5 [?]: Component<HeadingProps> | undefined
-    h6 [?]: Component<HeadingProps> | undefined
-    hr [?]: Component<{}> | undefined
-    html [?]: Component<ChildrenProps> | undefined
-    img [?]: Component<ImageProps> | undefined
-    li [?]: Component<ListItemProps> | undefined
-    math [?]: Component<ChildrenProps> | undefined
-    ol [?]: Component<OrderedListProps> | undefined
-    p [?]: Component<ChildrenProps> | undefined
-    pre [?]: Component<CodeBlockProps> | undefined
-    strong [?]: Component<ChildrenProps> | undefined
-    table [?]: Component<ChildrenProps> | undefined
-    tbody [?]: Component<ChildrenProps> | undefined
-    td [?]: Component<CellProps> | undefined
-    th [?]: Component<CellProps> | undefined
-    thead [?]: Component<ChildrenProps> | undefined
-    tr [?]: Component<ChildrenProps> | undefined
-    u [?]: Component<ChildrenProps> | undefined
-    ul [?]: Component<ChildrenProps> | undefined
+    a [?]: Bun.markdown.Component<Bun.markdown.LinkProps> | undefined
+    blockquote [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    br [?]: Bun.markdown.Component<{}> | undefined
+    code [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    del [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    em [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    h1 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h2 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h3 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h4 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h5 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h6 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    hr [?]: Bun.markdown.Component<{}> | undefined
+    html [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    img [?]: Bun.markdown.Component<Bun.markdown.ImageProps> | undefined
+    li [?]: Bun.markdown.Component<Bun.markdown.ListItemProps> | undefined
+    math [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ol [?]: Bun.markdown.Component<Bun.markdown.OrderedListProps> | undefined
+    p [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    pre [?]: Bun.markdown.Component<Bun.markdown.CodeBlockProps> | undefined
+    strong [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    table [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tbody [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    td [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    th [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    thead [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tr [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    u [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ul [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
   interface markdown.HeadingMeta (bun-types/bun.d.ts)
     id [?]: string | undefined
     level: number
@@ -2600,45 +2625,45 @@ namespace markdown (bun-types/bun.d.ts)
     wikiLinks [?]: boolean | undefined
   interface markdown.RenderCallbacks (bun-types/bun.d.ts)
     blockquote [?]: ((children: string) => null | string | undefined) | undefined
-    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: Bun.markdown.CodeBlockMeta | undefined) => null | string | undefined) | undefined
     codespan [?]: ((children: string) => null | string | undefined) | undefined
     emphasis [?]: ((children: string) => null | string | undefined) | undefined
-    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: Bun.markdown.HeadingMeta) => null | string | undefined) | undefined
     hr [?]: ((children: string) => null | string | undefined) | undefined
     html [?]: ((children: string) => null | string | undefined) | undefined
-    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
-    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
-    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
-    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: Bun.markdown.ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: Bun.markdown.LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: Bun.markdown.ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: Bun.markdown.ListItemMeta) => null | string | undefined) | undefined
     paragraph [?]: ((children: string) => null | string | undefined) | undefined
     strikethrough [?]: ((children: string) => null | string | undefined) | undefined
     strong [?]: ((children: string) => null | string | undefined) | undefined
     table [?]: ((children: string) => null | string | undefined) | undefined
     tbody [?]: ((children: string) => null | string | undefined) | undefined
-    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     text [?]: ((text: string) => null | string | undefined) | undefined
-    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     thead [?]: ((children: string) => null | string | undefined) | undefined
     tr [?]: ((children: string) => null | string | undefined) | undefined
   function markdown.ansi (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, theme?: Bun.markdown.AnsiTheme | undefined): string
   function markdown.html (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.markdown.Options | undefined): string
   function markdown.react (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, components?: Bun.markdown.ComponentOverrides | undefined, options?: Bun.markdown.ReactOptions | undefined): unknown
   function markdown.render (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, callbacks?: Bun.markdown.RenderCallbacks | undefined, options?: Bun.markdown.Options | undefined): string
 function mmap (bun-types/bun.d.ts)
-  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+  call (path: Bun.PathLike, opts?: Bun.MMapOptions | undefined): Uint8Array<ArrayBuffer>
 function nanoseconds (bun-types/bun.d.ts)
   call (): number
 function openInEditor (bun-types/bun.d.ts)
-  call (path: string, options?: EditorOptions | undefined): void
+  call (path: string, options?: Bun.EditorOptions | undefined): void
 var password (bun-types/bun.d.ts)
-  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
-  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
-  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
-  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+  hash: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => string
+  verify: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
 function pathToFileURL (bun-types/bun.d.ts)
   call (path: string): URL
 function peek (bun-types/bun.d.ts)
@@ -2647,49 +2672,49 @@ function peek (bun-types/bun.d.ts)
 namespace peek (bun-types/bun.d.ts)
   function peek.status (bun-types/bun.d.ts)
     call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
-var plugin (bun-types/bun.d.ts): BunRegisterPlugin
-var postgres (bun-types/sql.d.ts): SQL
+var plugin (bun-types/bun.d.ts): Bun.BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): Bun.SQL
 function randomUUIDv5 (bun-types/bun.d.ts)
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
 function randomUUIDv7 (bun-types/bun.d.ts)
   call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
   call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
 function readableStreamToArray (bun-types/bun.d.ts)
   call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
 function readableStreamToArrayBuffer (bun-types/bun.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
 function readableStreamToBlob (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<Blob>
 function readableStreamToBytes (bun-types/deprecated.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
 function readableStreamToFormData (bun-types/bun.d.ts)
-  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+  call (stream: ReadableStream<BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
 function readableStreamToJSON (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<any>
 function readableStreamToText (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<string>
-var redis (bun-types/redis.d.ts): RedisClient
+var redis (bun-types/redis.d.ts): Bun.RedisClient
 function resolve (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): Promise<string>
 function resolveSync (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): string
 var revision (bun-types/bun.d.ts): string
-var s3 (bun-types/s3.d.ts): S3Client
+var s3 (bun-types/s3.d.ts): Bun.S3Client
 var secrets (bun-types/bun.d.ts)
   delete: (options: { service: string; name: string; }) => Promise<boolean>
-  get: (options: { service: string; name: string; }) => Promise<string | null>
+  get: (options: { service: string; name: string; }) => Promise<null | string>
   set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
 namespace semver (bun-types/bun.d.ts)
   function semver.order (bun-types/bun.d.ts)
-    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+    call (v1: Bun.StringLike, v2: Bun.StringLike): -1 | 0 | 1
   function semver.satisfies (bun-types/bun.d.ts)
-    call (version: StringLike, range: StringLike): boolean
+    call (version: Bun.StringLike, range: Bun.StringLike): boolean
 function serve (bun-types/serve.d.ts)
-  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+  call <WebSocketData = undefined, R extends string = never>(options: Bun.Serve.Options<WebSocketData, R>): Bun.Server<WebSocketData>
 function sha (bun-types/bun.d.ts)
-  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
-  call (input: StringOrBuffer, encoding: DigestEncoding): string
+  call (input: Bun.StringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>
+  call (input: Bun.StringOrBuffer, encoding: Bun.DigestEncoding): string
 function shrink (bun-types/bun.d.ts)
   call (): void
 function sleep (bun-types/bun.d.ts)
@@ -2697,27 +2722,27 @@ function sleep (bun-types/bun.d.ts)
 function sleepSync (bun-types/bun.d.ts)
   call (ms: number): void
 function sliceAnsi (bun-types/bun.d.ts)
-  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: Bun.SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
 function spawn (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(options: Bun.SpawnOptions.SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Bun.Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnOptions<In, Out, Err> | undefined): Bun.Subprocess<In, Out, Err>
 function spawnSync (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
-var sql (bun-types/sql.d.ts): SQL
-var stderr (bun-types/bun.d.ts): BunFile
-var stdin (bun-types/bun.d.ts): BunFile
-var stdout (bun-types/bun.d.ts): BunFile
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(options: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): Bun.SyncSubprocess<Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> | undefined): Bun.SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): Bun.SQL
+var stderr (bun-types/bun.d.ts): Bun.BunFile
+var stdin (bun-types/bun.d.ts): Bun.BunFile
+var stdout (bun-types/bun.d.ts): Bun.BunFile
 function stringWidth (bun-types/bun.d.ts)
-  call (input: string, options?: StringWidthOptions | undefined): number
+  call (input: string, options?: Bun.StringWidthOptions | undefined): number
 function stripANSI (bun-types/bun.d.ts)
   call (input: string): string
 namespace udp (bun-types/bun.d.ts)
   interface udp.BaseUDPSocket (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2731,17 +2756,17 @@ namespace udp (bun-types/bun.d.ts)
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     connect: { hostname: string; port: number; }
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
-  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    socket [?]: Bun.udp.ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2749,29 +2774,29 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
-    remoteAddress [readonly]: SocketAddress
-    send: (data: Data) => boolean
-    sendMany: (packets: ReadonlyArray<Data>) => number
+    reload: (handler: Bun.udp.ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: Bun.SocketAddress
+    send: (data: Bun.udp.Data) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string
   interface udp.ReceiveFlags (bun-types/bun.d.ts)
     ipv6: boolean
     truncated: boolean
-  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.Socket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2779,27 +2804,27 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: SocketHandler<DataBinaryType>) => void
-    send: (data: Data, port: number, address: string) => boolean
-    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    reload: (handler: Bun.udp.SocketHandler<DataBinaryType>) => void
+    send: (data: Bun.udp.Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data | number>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.SocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.Socket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: SocketHandler<DataBinaryType> | undefined
+    socket [?]: Bun.udp.SocketHandler<DataBinaryType> | undefined
 function udpSocket (bun-types/bun.d.ts)
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.SocketOptions<DataBinaryType>): Promise<Bun.udp.Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.ConnectSocketOptions<DataBinaryType>): Promise<Bun.udp.ConnectedSocket<DataBinaryType>>
 namespace unsafe (bun-types/bun.d.ts)
   function unsafe.arrayBufferToString (bun-types/bun.d.ts)
     call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
@@ -2813,23 +2838,23 @@ namespace unsafe (bun-types/bun.d.ts)
 var version (bun-types/bun.d.ts): string
 var version_with_sha (bun-types/bun.d.ts): string
 function which (bun-types/bun.d.ts)
-  call (command: string, options?: WhichOptions | undefined): null | string
+  call (command: string, options?: Bun.WhichOptions | undefined): null | string
 function wrapAnsi (bun-types/bun.d.ts)
-  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+  call (input: string, columns: number, options?: Bun.WrapAnsiOptions | undefined): string
 function write (bun-types/bun.d.ts)
-  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile | Bun.PathLike | Bun.S3File, input: Array<Bun.BlobPart> | ArrayBufferLike | Blob | Bun.Archive | NodeJS.TypedArray<ArrayBufferLike> | ReadableStream<any> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
 function zstdCompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
 function zstdCompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
 function zstdDecompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
 function zstdDecompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
 
 # module "bun:bundle"
 interface Registry (bun-types/bundle.d.ts)
@@ -2928,17 +2953,17 @@ interface FFITypeToArgsType (bun-types/ffi.d.ts)
   1: number
   10: number
   11: boolean
-  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  12: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null
   13: undefined
-  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  14: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null | string
   15: bigint | number
   16: bigint | number
   17: JSCallback | Pointer
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2960,8 +2985,8 @@ interface FFITypeToReturnsType (bun-types/ffi.d.ts)
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2983,13 +3008,13 @@ type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
 type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
 type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
 function cc (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | Bun.BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
 function dlopen (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(name: Bun.BunFile | URL | string, symbols: Fns): Library<Fns>
 function linkSymbols (bun-types/ffi.d.ts)
   call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
 function ptr (bun-types/ffi.d.ts)
-  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
 namespace read (bun-types/ffi.d.ts)
   function read.f32 (bun-types/ffi.d.ts)
     call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
@@ -3062,7 +3087,7 @@ interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
 function callerSourceOrigin (bun-types/jsc.d.ts)
   call (): null | string
 function deserialize (bun-types/jsc.d.ts)
-  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>): any
 function drainMicrotasks (bun-types/jsc.d.ts)
   call (): void
 function edenGC (bun-types/jsc.d.ts)
@@ -3138,7 +3163,7 @@ class Database (bun-types/sqlite.d.ts)
   [static]
     construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
     MAX_QUERY_CACHE_SIZE [static]: number
-    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    deserialize [static]: { (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
     open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
     prototype: Database
     setCustomSQLite [static]: (path: string) => boolean
@@ -3148,7 +3173,7 @@ interface DatabaseOptions (bun-types/sqlite.d.ts)
   readwrite [?]: boolean | undefined
   safeIntegers [?]: boolean | undefined
   strict [?]: boolean | undefined
-type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+type SQLQueryBindings (bun-types/sqlite.d.ts) = NodeJS.TypedArray<ArrayBufferLike> | Record<string, NodeJS.TypedArray<ArrayBufferLike> | bigint | boolean | null | number | string> | bigint | boolean | null | number | string
 class SQLiteError (bun-types/sqlite.d.ts)
   byteOffset [readonly]: number
   cause [?]: unknown
@@ -3163,7 +3188,7 @@ class SQLiteError (bun-types/sqlite.d.ts)
     construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
     captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
     isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
     prototype: SQLiteError
     stackTraceLimit: number
 class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
@@ -3172,8 +3197,8 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   all: (...params: ParamsType) => Array<ReturnType>
   as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
   columnNames [readonly]: Array<string>
-  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
-  declaredTypes [readonly]: Array<string | null>
+  columnTypes [readonly]: Array<"BLOB" | "FLOAT" | "INTEGER" | "NULL" | "TEXT" | null>
+  declaredTypes [readonly]: Array<null | string>
   finalize: () => void
   get: (...params: ParamsType) => ReturnType | null
   iterate: (...params: ParamsType) => IterableIterator<ReturnType>
@@ -3182,7 +3207,7 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
   run: (...params: ParamsType) => Changes
   toString: () => string
-  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  values: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | bigint | boolean | number | string>>
   [static]
     construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
     prototype: Statement<any, any>
@@ -3259,7 +3284,7 @@ var native (bun-types/sqlite.d.ts): any
 # module "bun:test"
 type AsymmetricMatcher (bun-types/test.d.ts) = any
 interface AsymmetricMatchers (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3267,7 +3292,7 @@ interface AsymmetricMatchers (bun-types/test.d.ts)
   stringContaining: (str: String | string) => any
   stringMatching: (regex: RegExp | String | string) => any
 interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3293,7 +3318,7 @@ interface Expect (bun-types/test.d.ts)
   call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
   call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
   call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   assertions: (neededAssertions: number) => void
@@ -3360,13 +3385,13 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3380,7 +3405,7 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3446,13 +3471,13 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3466,7 +3491,7 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3483,9 +3508,9 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toThrowError: (expected?: unknown) => void
   toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
   toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
-type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
 interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
-  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  call (label: string, fn: (...args: __internal.IsTuple<T> extends true ? [...table: __internal.Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
   concurrent: Test<T>
   concurrentIf: (condition: boolean) => Test<T>
   each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
@@ -3521,23 +3546,23 @@ var expectTypeOf (bun-types/test.d.ts)
   call <Actual>(): PositiveExpectTypeOf<Actual>
 var it (bun-types/test.d.ts): Test<[]>
 namespace jest (bun-types/test.d.ts)
-  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
-  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
-  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
-  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
-  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
-  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
-  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = JestMock.Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | JestMock.ClassLike> (bun-types/test.d.ts) = T extends JestMock.ClassLike ? JestMock.SpiedClass<T> : T extends JestMock.FunctionLike ? JestMock.SpiedFunction<T> : never
+  type jest.SpiedClass<T extends JestMock.ClassLike> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<(arg: T) => void>
   function jest.advanceTimersByTime (bun-types/test.d.ts)
-    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.clearAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.clearAllTimers (bun-types/test.d.ts)
     call (): void
   function jest.fn (bun-types/test.d.ts)
-    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): jest.Mock<T>
   function jest.getTimerCount (bun-types/test.d.ts)
     call (): number
   function jest.isFakeTimers (bun-types/test.d.ts)
@@ -3547,19 +3572,19 @@ namespace jest (bun-types/test.d.ts)
   function jest.restoreAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.runAllTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.runOnlyPendingTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.setSystemTime (bun-types/test.d.ts)
     call (now?: Date | number | undefined): void
   function jest.setTimeout (bun-types/test.d.ts)
     call (milliseconds: number): void
   function jest.spyOn (bun-types/test.d.ts)
-    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): jest.Mock<Extract<T[K], (...args: Array<any>) => any>>
   function jest.useFakeTimers (bun-types/test.d.ts)
-    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.useRealTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var mock (bun-types/test.d.ts)
   call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
   clearAllMocks: () => void
@@ -3575,24 +3600,118 @@ function spyOn (bun-types/test.d.ts)
   call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
 test -> it
 var vi (bun-types/test.d.ts)
-  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   clearAllMocks: () => void
   clearAllTimers: () => void
-  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => jest.Mock<T>
   getTimerCount: () => number
   isFakeTimers: () => boolean
   mock: (id: string, factory: () => any) => Promise<void> | void
   resetAllMocks: () => void
   restoreAllMocks: () => void
-  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
-  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var xdescribe (bun-types/test.d.ts): Describe<[]>
 var xit (bun-types/test.d.ts): Test<[]>
 xtest -> xit
+
+# module "node:fs/promises"
+function exists (bun-types/overrides.d.ts)
+  call (path: Bun.PathLike): Promise<boolean>
+
+# module "node:tls"
+interface BunConnectionOptions (bun-types/overrides.d.ts)
+  ALPNCallback [?]: ((arg: { servername: string; protocols: Array<string>; }) => string | undefined) | undefined
+  ALPNProtocols [?]: NodeJS.ArrayBufferView<ArrayBufferLike> | ReadonlyArray<string> | undefined
+  SNICallback [?]: ((servername: string, cb: (err: Error | null, ctx?: SecureContext | undefined) => void) => void) | undefined
+  allowPartialTrustChain [?]: boolean | undefined
+  ca [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  cert [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientCertEngine [?]: string | undefined
+  crl [?]: Array<Buffer<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | string | undefined
+  dhparam [?]: Buffer<ArrayBufferLike> | string | undefined
+  ecdhCurve [?]: string | undefined
+  enableTrace [?]: boolean | undefined
+  honorCipherOrder [?]: boolean | undefined
+  host [?]: string | undefined
+  key [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | KeyObject | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  lookup [?]: LookupFunction | undefined
+  maxVersion [?]: SecureVersion | undefined
+  minDHSize [?]: number | undefined
+  minVersion [?]: SecureVersion | undefined
+  passphrase [?]: string | undefined
+  path [?]: string | undefined
+  pfx [?]: Array<Buffer<ArrayBufferLike> | PxfObject | string> | Buffer<ArrayBufferLike> | string | undefined
+  port [?]: number | undefined
+  privateKeyEngine [?]: string | undefined
+  privateKeyIdentifier [?]: string | undefined
+  pskCallback [?]: ((hint: null | string) => PSKCallbackNegotation | null) | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  requestOCSP [?]: boolean | undefined
+  secureContext [?]: SecureContext | undefined
+  secureOptions [?]: number | undefined
+  secureProtocol [?]: string | undefined
+  servername [?]: string | undefined
+  session [?]: Buffer<ArrayBufferLike> | undefined
+  sessionIdContext [?]: string | undefined
+  sessionTimeout [?]: number | undefined
+  sigalgs [?]: string | undefined
+  socket [?]: Stream.Duplex | undefined
+  ticketKeys [?]: Buffer<ArrayBufferLike> | undefined
+  timeout [?]: number | undefined
+function connect (@types/node/tls.d.ts, bun-types/overrides.d.ts)
+  call (options: ConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, host?: string | undefined, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (options: BunConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+
+# module "stream/web"
+interface ReadableStream<R = any> (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  construct new (underlyingSource: UnderlyingByteSource, strategy?: undefined | { highWaterMark?: number | undefined; }): ReadableStream<NodeJS.NonSharedUint8Array>
+  construct new <R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  from: <R = any>(iterable: AsyncIterable<R> | Iterable<R>) => ReadableStream<R>
+  prototype: ReadableStream<any>
+
+# module "url"
+interface URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  construct new (init?: Array<Array<string>> | Record<string, string> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
 
 # globals
 interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
@@ -3603,11 +3722,11 @@ var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/glo
   prototype: AbortController
 interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
   aborted [readonly]: boolean
-  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
   dispatchEvent: (event: Event) => boolean
   onabort: ((this: AbortSignal, ev: Event) => any) | null
   reason [readonly]: any
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   throwIfAborted: () => void
 var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
   construct new (): AbortSignal
@@ -3648,7 +3767,7 @@ interface ArrayConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es
   construct new <T>(...items: Array<T>): Array<T>
   [Symbol.species] [readonly]: ArrayConstructor
   from: { <T>(arrayLike: ArrayLike<T>): Array<T>; <T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>; <T>(iterable: ArrayLike<T> | Iterable<T>): Array<T>; <T, U>(iterable: ArrayLike<T> | Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U> }
-  fromAsync: { <T>(iterableOrArrayLike: ArrayLike<T | PromiseLike<T>> | AsyncIterable<T> | Iterable<T | PromiseLike<T>>): Promise<Array<T>>; <T, U>(iterableOrArrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Array<Awaited<U>>>; <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
+  fromAsync: { <T>(iterableOrArrayLike: ArrayLike<PromiseLike<T> | T> | AsyncIterable<T> | Iterable<PromiseLike<T> | T>): Promise<Array<T>>; <T, U>(iterableOrArrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn: (value: Awaited<T>, index: number) => U, thisArg?: any): Promise<Array<Awaited<U>>>; <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
   isArray: (arg: any) => arg is any[]
   of: <T>(...items: Array<T>) => Array<T>
   prototype [readonly]: Array<any>
@@ -3656,14 +3775,14 @@ interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   size [readonly]: number
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
 var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
-  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  construct new (blobParts?: Array<Bun.BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
   prototype: Blob
 interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   type [?]: string | undefined
@@ -3692,25 +3811,25 @@ class BuildMessage (bun-types/globals.d.ts)
     prototype: BuildMessage
 Bun -> module "bun"
 interface BunFetchRequestInit (bun-types/globals.d.ts)
-  body [?]: BodyInit | null | undefined
+  body [?]: Bun.BodyInit | null | undefined
   cache [?]: RequestCache | undefined
   compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
   credentials [?]: RequestCredentials | undefined
   decompress [?]: boolean | undefined
   dispatcher [?]: Dispatcher | undefined
   duplex [?]: "half" | undefined
-  headers [?]: HeadersInit | undefined
+  headers [?]: Bun.HeadersInit | undefined
   integrity [?]: string | undefined
   keepalive [?]: boolean | undefined
   maxRedirects [?]: number | undefined
   method [?]: string | undefined
   mode [?]: RequestMode | undefined
   protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
-  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: Bun.HeadersInit | undefined; }
   redirect [?]: RequestRedirect | undefined
   referrer [?]: string | undefined
   referrerPolicy [?]: ReferrerPolicy | undefined
-  s3 [?]: S3Options | undefined
+  s3 [?]: Bun.S3Options | undefined
   signal [?]: AbortSignal | null | undefined
   timeout [?]: boolean | number | undefined
   tls [?]: BunFetchRequestInitTLS | undefined
@@ -3718,17 +3837,17 @@ interface BunFetchRequestInit (bun-types/globals.d.ts)
   verbose [?]: boolean | undefined
   window [?]: null | undefined
 interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -3764,16 +3883,16 @@ interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts
   type [readonly]: string
   wasClean [readonly]: boolean
 var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  construct new (type: string, eventInitDict?: Bun.CloseEventInit | undefined): CloseEvent
   prototype: CloseEvent
 interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
-  writable [readonly]: WritableStream<BufferSource>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
+  construct new (format: Bun.CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
   prototype: CompressionStream
 interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
-  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  Console [readonly]: { new (stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
   [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
   assert: (condition?: boolean | undefined, ...data: Array<any>) => void
   clear: () => void
@@ -3797,14 +3916,14 @@ interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
   timeStamp: (label?: string | undefined) => void
   trace: (...data: Array<any>) => void
   warn: (...data: Array<any>) => void
-  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+  write: (...data: Array<ArrayBuffer | ArrayBufferView<ArrayBufferLike> | string>) => number
 interface ConsoleOptions (bun-types/globals.d.ts)
   colorMode [?]: "auto" | boolean | undefined
   groupIndentation [?]: number | undefined
   ignoreErrors [?]: boolean | undefined
   inspectOptions [?]: InspectOptions | undefined
-  stderr [?]: Writable | undefined
-  stdout: Writable
+  stderr [?]: Stream.Writable | undefined
+  stdout: Stream.Writable
 interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   highWaterMark [readonly]: number
   size [readonly]: QueuingStrategySize<any>
@@ -3815,21 +3934,21 @@ interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   getRandomValues: <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T) => T
   randomUUID: () => `${string}-${string}-${string}-${string}-${string}`
   subtle [readonly]: SubtleCrypto
-  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+  timingSafeEqual: (a: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>) => boolean
 var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): Crypto
   prototype: Crypto
 interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
-  algorithm [readonly]: KeyAlgorithm
+  algorithm [readonly]: webcrypto.KeyAlgorithm
   extractable [readonly]: boolean
-  type [readonly]: KeyType
-  usages [readonly]: Array<KeyUsage>
+  type [readonly]: webcrypto.KeyType
+  usages [readonly]: Array<webcrypto.KeyUsage>
 var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): CryptoKey
   prototype: CryptoKey
 interface CryptoKeyPair (bun-types/globals.d.ts)
-  privateKey: CryptoKey
-  publicKey: CryptoKey
+  privateKey: webcrypto.CryptoKey
+  publicKey: webcrypto.CryptoKey
 interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -3851,7 +3970,7 @@ interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/d
   timeStamp [readonly]: number
   type [readonly]: string
 var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
-  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  construct new <T>(type: string, eventInitDict?: Bun.CustomEventInit<T> | undefined): CustomEvent<T>
   prototype: CustomEvent<any>
 interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
   ABORT_ERR [readonly]: 20
@@ -3913,10 +4032,10 @@ var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecate
   WRONG_DOCUMENT_ERR [readonly]: 4
   prototype: DOMException
 interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
-  writable [readonly]: WritableStream<BufferSource>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
+  construct new (format: Bun.CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
   prototype: DecompressionStream
 interface Dict<T> (bun-types/globals.d.ts)
   index [string]: T | undefined
@@ -3943,7 +4062,7 @@ interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, li
   construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
   captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
   isError: { (error: unknown): error is Error; (value: unknown): value is Error }
-  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
   prototype [readonly]: Error
   stackTraceLimit: number
 interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
@@ -3970,7 +4089,7 @@ interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts
   timeStamp [readonly]: number
   type [readonly]: string
 var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  construct new (type: string, eventInitDict?: Bun.ErrorEventInit | undefined): ErrorEvent
   prototype: ErrorEvent
 interface ErrorOptions (bun-types/globals.d.ts, lib.es2022.error.d.ts)
   cause [?]: unknown
@@ -3993,7 +4112,7 @@ interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
   timeStamp [readonly]: number
   type [readonly]: string
 var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  construct new (type: string, eventInitDict?: Bun.EventInit | undefined): Event
   AT_TARGET [readonly]: 2
   BUBBLING_PHASE [readonly]: 3
   CAPTURING_PHASE [readonly]: 1
@@ -4027,9 +4146,9 @@ var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
 interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   withCredentials [?]: boolean | undefined
 interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
-  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
   dispatchEvent: (event: Event) => boolean
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
 var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
   construct new (): EventTarget
   prototype: EventTarget
@@ -4059,7 +4178,7 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified [readonly]: number
   name [readonly]: string
@@ -4068,15 +4187,15 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   text: () => Promise<string>
   type [readonly]: string
 var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
-  construct new (parts: Array<BlobPart>, name: string, options?: BlobPropertyBag & { lastModified?: number | Date | undefined; } | undefined): File
+  construct new (parts: Array<Bun.BlobPart>, name: string, options?: (BlobPropertyBag & { lastModified?: number | Date | undefined; }) | undefined): File
   prototype: File
 interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
   delete: (name: string) => void
   entries: () => IterableIterator<[string, string]>
-  forEach: (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
-  get: (name: string) => FormDataEntryValue | null
-  getAll: (name: string) => Array<FormDataEntryValue>
+  forEach: (callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
+  get: (name: string) => Bun.FormDataEntryValue | null
+  getAll: (name: string) => Array<Bun.FormDataEntryValue>
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
   set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
@@ -4085,19 +4204,19 @@ var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   construct new (): FormData
   prototype: FormData
 class HTMLRewriter (bun-types/html-rewriter.d.ts)
-  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
-  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
-  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  on: (selector: string, handlers: HTMLRewriterTypes.HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: Bun.BufferSource): ArrayBuffer }
   [static]
     construct new (): HTMLRewriter
     prototype: HTMLRewriter
 namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Comment
-    before: (content: string, options?: ContentOptions | undefined) => Comment
-    remove: () => Comment
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    remove: () => HTMLRewriterTypes.Comment
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
     text: string
   type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
   interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
@@ -4105,52 +4224,52 @@ namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
     name [readonly]: null | string
     publicId [readonly]: null | string
-    remove: () => Doctype
+    remove: () => HTMLRewriterTypes.Doctype
     removed [readonly]: boolean
     systemId [readonly]: null | string
   interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
-    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.DocumentEnd
   interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Element
-    append: (content: string, options?: ContentOptions | undefined) => Element
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     attributes [readonly]: IterableIterator<[string, string]>
-    before: (content: string, options?: ContentOptions | undefined) => Element
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     canHaveContent [readonly]: boolean
     getAttribute: (name: string) => null | string
     hasAttribute: (name: string) => boolean
     namespaceURI [readonly]: string
-    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
-    prepend: (content: string, options?: ContentOptions | undefined) => Element
-    remove: () => Element
-    removeAndKeepContent: () => Element
-    removeAttribute: (name: string) => Element
+    onEndTag: (handler: (tag: HTMLRewriterTypes.EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    remove: () => HTMLRewriterTypes.Element
+    removeAndKeepContent: () => HTMLRewriterTypes.Element
+    removeAttribute: (name: string) => HTMLRewriterTypes.Element
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Element
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     selfClosing [readonly]: boolean
-    setAttribute: (name: string, value: string) => Element
-    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    setAttribute: (name: string, value: string) => HTMLRewriterTypes.Element
+    setInnerContent: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     tagName: string
   interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => EndTag
-    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
     name: string
-    remove: () => EndTag
+    remove: () => HTMLRewriterTypes.EndTag
   interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
-    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: HTMLRewriterTypes.Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: HTMLRewriterTypes.DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    element [?]: ((element: Element) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: HTMLRewriterTypes.Element) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Text
-    before: (content: string, options?: ContentOptions | undefined) => Text
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     lastInTextNode [readonly]: boolean
-    remove: () => Text
+    remove: () => HTMLRewriterTypes.Text
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Text
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     text [readonly]: string
 interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
@@ -4168,18 +4287,18 @@ interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
   values [readonly]: () => SpecIterableIterator<string>
 var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (init?: HeadersInit | undefined): Headers
+  construct new (init?: Bun.HeadersInit | undefined): Headers
   prototype: Headers
 interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.es5.d.ts)
   dir [readonly]: string
   dirname: string
-  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  env [readonly]: Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
   file [readonly]: string
   filename: string
-  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: Bun.HMREvent, callback: () => void): void; off(event: Bun.HMREvent, callback: () => void): void; }
   main: boolean
   path [readonly]: string
-  require: Require
+  require: NodeJS.Require
   resolve: (specifier: string, parent?: URL | string | undefined) => string
   resolveSync: (moduleId: string, parent?: string | undefined) => string
   url: string
@@ -4220,7 +4339,7 @@ interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/g
   timeStamp [readonly]: number
   type [readonly]: string
 var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<any>
+  construct new <T>(type: string, eventInitDict?: Bun.MessageEventInit<T> | undefined): MessageEvent<any>
   prototype: MessageEvent<any>
 interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
   addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
@@ -4260,160 +4379,14 @@ var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
   construct new (): Navigator
   prototype: Navigator
 namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
-  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
-  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
-  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.asyncDispose]: () => PromiseLike<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
-    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
-    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
-  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
-  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
-  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
-  interface NodeJS.CallSite (@types/node/globals.d.ts)
-    getColumnNumber: () => null | number
-    getEnclosingColumnNumber: () => null | number
-    getEnclosingLineNumber: () => null | number
-    getEvalOrigin: () => string | undefined
-    getFileName: () => null | string
-    getFunction: () => Function | undefined
-    getFunctionName: () => null | string
-    getLineNumber: () => null | number
-    getMethodName: () => null | string
-    getPosition: () => number
-    getPromiseIndex: () => null | number
-    getScriptHash: () => string
-    getScriptNameOrSourceURL: () => null | string
-    getThis: () => unknown
-    getTypeName: () => null | string
-    isAsync: () => boolean
-    isConstructor: () => boolean
-    isEval: () => boolean
-    isNative: () => boolean
-    isPromiseAll: () => boolean
-    isToplevel: () => boolean
-  interface NodeJS.CpuUsage (@types/node/process.d.ts)
-    system: number
-    user: number
-  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined
-  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
-  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
-    code [?]: string | undefined
-    ctor [?]: Function | undefined
-    detail [?]: string | undefined
-    type [?]: string | undefined
-  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
-    cause [?]: unknown
-    code [?]: string | undefined
-    errno [?]: number | undefined
-    message: string
-    name: string
-    path [?]: string | undefined
-    stack [?]: string | undefined
-    syscall [?]: string | undefined
-  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
-    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
-    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    setMaxListeners: (n: number) => EventEmitter<T>
-  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
-  interface NodeJS.GCFunction (@types/node/globals.d.ts)
-    call (minor?: boolean | undefined): void
-    call (options: GCOptions & { execution: "async"; }): Promise<void>
-    call (options: GCOptions): void
-  interface NodeJS.GCOptions (@types/node/globals.d.ts)
-    execution [?]: "async" | "sync" | undefined
-    filename [?]: string | undefined
-    flavor [?]: "last-resort" | "regular" | undefined
-    type [?]: "major" | "major-snapshot" | "minor" | undefined
-  interface NodeJS.HRTime (@types/node/process.d.ts)
-    call (time?: [number, number] | undefined): [number, number]
-    bigint: () => bigint
-  interface NodeJS.Immediate (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    _onImmediate: (...args: Array<any>) => void
-    hasRef: () => boolean
-    ref: () => Immediate
-    unref: () => Immediate
-  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
-    [Symbol.toStringTag] [readonly]: string
-    drop: (count: number) => IteratorObject<T, undefined, unknown>
-    every: (predicate: (value: T, index: number) => unknown) => boolean
-    filter: { <S>(predicate: (value: T, index: number) => value is S): IteratorObject<S, undefined, unknown>; (predicate: (value: T, index: number) => unknown): IteratorObject<T, undefined, unknown> }
-    find: { <S>(predicate: (value: T, index: number) => value is S): S | undefined; (predicate: (value: T, index: number) => unknown): T | undefined }
-    flatMap: <U>(callback: (value: T, index: number) => Iterable<U, unknown, undefined> | Iterator<U, unknown, undefined>) => IteratorObject<U, undefined, unknown>
-    forEach: (callbackfn: (value: T, index: number) => void) => void
-    map: <U>(callbackfn: (value: T, index: number) => U) => IteratorObject<U, undefined, unknown>
-    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
-    reduce: { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T): T; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number) => T, initialValue: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number) => U, initialValue: U): U }
-    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
-    some: (predicate: (value: T, index: number) => unknown) => boolean
-    take: (limit: number) => IteratorObject<T, undefined, unknown>
-    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
-    toArray: () => Array<T>
-  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
-    arrayBuffers: number
-    external: number
-    heapTotal: number
-    heapUsed: number
-    rss: number
-  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
-    call (): MemoryUsage
-    rss: () => number
-  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
-  interface NodeJS.Module (@types/node/module.d.ts)
-    children: Array<Module>
-    exports: any
-    filename: string
-    id: string
-    isPreloading: boolean
-    loaded: boolean
-    parent: Module | null | undefined
-    path: string
-    paths: Array<string>
-    require: (id: string) => any
-  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
-  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
-  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
-  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
-  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
-  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
-  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
-  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
-  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
-  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
-  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
   interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
     [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
     _exiting: boolean
     abort: () => never
-    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
     allowedNodeEnvironmentFlags: ReadonlySet<string>
-    arch [readonly]: Architecture
+    arch [readonly]: NodeJS.Architecture
     argv: Array<string>
     argv0: string
     assert: (value: unknown, message?: Error | string | undefined) => asserts value
@@ -4422,24 +4395,24 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     browser: boolean
     channel [?]: Control | undefined
     chdir: (directory: string) => void
-    config [readonly]: ProcessConfig
+    config [readonly]: NodeJS.ProcessConfig
     connected: boolean
     constrainedMemory: () => number
-    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     cwd: () => string
     debugPort: number
     disconnect [?]: (() => void) | undefined
     dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
     emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
-    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
-    env: ProcessEnv
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: NodeJS.EmitWarningOptions | undefined): void }
+    env: NodeJS.ProcessEnv
     eventNames: () => Array<string | symbol>
     execArgv: Array<string>
     execPath: string
-    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: NodeJS.ProcessEnv | undefined) => never) | undefined
     exit: (code?: null | number | string | undefined) => never
     exitCode: null | number | string | undefined
-    features [readonly]: ProcessFeatures
+    features [readonly]: NodeJS.ProcessFeatures
     finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
     getActiveResourcesInfo: () => Array<string>
     getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
@@ -4450,48 +4423,48 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     getgroups [?]: (() => Array<number>) | undefined
     getuid [?]: (() => number) | undefined
     hasUncaughtExceptionCaptureCallback: () => boolean
-    hrtime: HRTime
+    hrtime: NodeJS.HRTime
     isBun: true
     kill: (pid: number, signal?: number | string | undefined) => true
     listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
     listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     loadEnvFile: (path?: PathLike | undefined) => void
-    mainModule [?]: Module | undefined
-    memoryUsage: MemoryUsageFn
+    mainModule [?]: NodeJS.Module | undefined
+    memoryUsage: NodeJS.MemoryUsageFn
     nextTick: (callback: Function, ...args: Array<any>) => void
     noDeprecation [?]: boolean | undefined
-    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    permission: ProcessPermission
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    permission: NodeJS.ProcessPermission
     pid [readonly]: number
-    platform [readonly]: Platform
+    platform [readonly]: NodeJS.Platform
     ppid [readonly]: number
-    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     reallyExit: (code?: number | undefined) => never
     ref: (maybeRefable: any) => void
-    release [readonly]: ProcessRelease
-    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
-    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    report: ProcessReport
-    resourceUsage: () => ResourceUsage
+    release [readonly]: NodeJS.ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): NodeJS.Process; (eventName?: string | symbol | undefined): NodeJS.Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    report: NodeJS.ProcessReport
+    resourceUsage: () => NodeJS.ResourceUsage
     revision: string
     send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
-    setMaxListeners: (n: number) => Process
+    setMaxListeners: (n: number) => NodeJS.Process
     setSourceMapsEnabled: (value: boolean) => void
     setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
     setegid [?]: ((id: number | string) => void) | undefined
     seteuid [?]: ((id: number | string) => void) | undefined
     setgid [?]: ((id: number | string) => void) | undefined
-    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<number | string>) => void) | undefined
     setuid [?]: ((id: number | string) => void) | undefined
     sourceMapsEnabled [readonly]: boolean
-    stderr: WriteStream & { fd: 2; }
-    stdin: ReadStream & { fd: 0; }
-    stdout: WriteStream & { fd: 1; }
-    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    stderr: NodeJS.WriteStream & { fd: 2; }
+    stdin: NodeJS.ReadStream & { fd: 0; }
+    stdout: NodeJS.WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     throwDeprecation: boolean
     title: string
     traceDeprecation: boolean
@@ -4500,45 +4473,11 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     unref: (maybeRefable: any) => void
     uptime: () => number
     version [readonly]: string
-    versions [readonly]: ProcessVersions
-  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
-    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
-    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+    versions [readonly]: NodeJS.ProcessVersions
   interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     NODE_ENV [?]: string | undefined
     TZ [?]: string | undefined
-  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
-    cached_builtins [readonly]: boolean
-    debug [readonly]: boolean
-    inspector [readonly]: boolean
-    ipv6 [readonly]: boolean
-    require_module [readonly]: boolean
-    tls [readonly]: boolean
-    tls_alpn [readonly]: boolean
-    tls_ocsp [readonly]: boolean
-    tls_sni [readonly]: boolean
-    typescript [readonly]: "strip" | false
-    uv [readonly]: boolean
-  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
-    has: (scope: string, reference?: string | undefined) => boolean
-  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
-    headersUrl [?]: string | undefined
-    libUrl [?]: string | undefined
-    lts [?]: string | undefined
-    name: string
-    sourceUrl [?]: string | undefined
-  interface NodeJS.ProcessReport (@types/node/process.d.ts)
-    compact: boolean
-    directory: string
-    excludeEnv: boolean
-    filename: string
-    getReport: (err?: Error | undefined) => object
-    reportOnFatalError: boolean
-    reportOnSignal: boolean
-    reportOnUncaughtException: boolean
-    signal: Signals
-    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
   interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     ares: string
@@ -4550,404 +4489,14 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     uv: string
     v8: string
     zlib: string
-  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined [readonly]
-  interface NodeJS.ReadStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    closed [readonly]: boolean
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    destroy: (error?: Error | undefined) => ReadStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    isPaused: () => boolean
-    isRaw: boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    pause: () => ReadStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => ReadStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
-    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    resetAndDestroy: () => ReadStream
-    resume: () => ReadStream
-    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
-    setMaxListeners: (n: number) => ReadStream
-    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
-    setRawMode: (mode: boolean) => ReadStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
-    setTypeOfService: (tos: number) => ReadStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => ReadStream
-    unref: () => ReadStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => ReadStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    pause: () => ReadWriteStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    resume: () => ReadWriteStream
-    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
-    setMaxListeners: (n: number) => ReadWriteStream
-    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadWriteStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    pause: () => ReadableStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    resume: () => ReadableStream
-    setEncoding: (encoding: BufferEncoding) => ReadableStream
-    setMaxListeners: (n: number) => ReadableStream
-    unpipe: (destination?: WritableStream | undefined) => ReadableStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadableStream
-  interface NodeJS.RefCounted (@types/node/globals.d.ts)
-    ref: () => RefCounted
-    unref: () => RefCounted
-  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
-  interface NodeJS.Require (@types/node/module.d.ts)
-    call (id: string): any
-    cache: Dict<Module>
-    extensions: RequireExtensions
-    main: Module | undefined
-    resolve: RequireResolve
-  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
-    index [string]: ((module: Module, filename: string) => any) | undefined
-    .js: (module: Module, filename: string) => any
-    .json: (module: Module, filename: string) => any
-    .node: (module: Module, filename: string) => any
-  interface NodeJS.RequireResolve (@types/node/module.d.ts)
-    call (request: string, options?: RequireResolveOptions | undefined): string
-    paths: (request: string) => Array<string> | null
-  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
-    paths [?]: Array<string> | undefined
-  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
-    fsRead: number
-    fsWrite: number
-    involuntaryContextSwitches: number
-    ipcReceived: number
-    ipcSent: number
-    majorPageFault: number
-    maxRSS: number
-    minorPageFault: number
-    sharedMemorySize: number
-    signalsCount: number
-    swappedOut: number
-    systemCPUTime: number
-    unsharedDataSize: number
-    unsharedStackSize: number
-    userCPUTime: number
-    voluntaryContextSwitches: number
-  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
-  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
-  interface NodeJS.Socket (@types/node/process.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    isTTY [?]: true | undefined
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    pause: () => Socket
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    resume: () => Socket
-    setEncoding: (encoding: BufferEncoding) => Socket
-    setMaxListeners: (n: number) => Socket
-    unpipe: (destination?: WritableStream | undefined) => Socket
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => Socket
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.Timeout (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.toPrimitive]: () => number
-    _onTimeout: (...args: Array<any>) => void
-    close: () => Timeout
-    hasRef: () => boolean
-    ref: () => Timeout
-    refresh: () => Timeout
-    unref: () => Timeout
-  interface NodeJS.Timer (@types/node/timers.d.ts)
-    [Symbol.toPrimitive]: () => number
-    hasRef: () => boolean
-    ref: () => Timer
-    refresh: () => Timer
-    unref: () => Timer
-  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
-  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
-  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
-  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
-  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
-  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
-  interface NodeJS.WritableStream (@types/node/stream.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    setMaxListeners: (n: number) => WritableStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.WriteStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
-    clearScreenDown: (callback?: (() => void) | undefined) => boolean
-    closed [readonly]: boolean
-    columns: number
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
-    destroy: (error?: Error | undefined) => WriteStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
-    getColorDepth: (env?: object | undefined) => number
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    getWindowSize: () => [number, number]
-    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
-    isPaused: () => boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
-    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    pause: () => WriteStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => WriteStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
-    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    resetAndDestroy: () => WriteStream
-    resume: () => WriteStream
-    rows: number
-    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
-    setMaxListeners: (n: number) => WriteStream
-    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
-    setTypeOfService: (tos: number) => WriteStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => WriteStream
-    unref: () => WriteStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => WriteStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
 interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
-  children: Array<Module>
+  children: Array<NodeJS.Module>
   exports: any
   filename: string
   id: string
   isPreloading: boolean
   loaded: boolean
-  parent: Module | null | undefined
+  parent: NodeJS.Module | null | undefined
   path: string
   paths: Array<string>
   require: (id: string) => any
@@ -5056,11 +4605,11 @@ interface Position (bun-types/globals.d.ts)
 interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts, lib.es2021.promise.d.ts, lib.es2024.promise.d.ts, lib.es2025.promise.d.ts)
   construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
   [Symbol.species] [readonly]: PromiseConstructor
-  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>> }
+  all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  any: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>> }
   prototype [readonly]: Promise<any>
-  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
   reject: <T = never>(reason?: any) => Promise<T>
   resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
   try: { <T, U extends Array<unknown>>(callbackFn: (...args: U) => PromiseLike<T> | T, ...args: U): Promise<Awaited<T>>; <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A): Promise<T> }
@@ -5078,7 +4627,7 @@ interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bu
   byobRequest [readonly]: ReadableStreamBYOBRequest | null
   close: () => void
   desiredSize [readonly]: null | number
-  enqueue: (chunk: NonSharedArrayBufferView) => void
+  enqueue: (chunk: NodeJS.NonSharedArrayBufferView) => void
   error: (e?: any) => void
 var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableByteStreamController
@@ -5097,21 +4646,21 @@ interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-typ
   text: () => Promise<string>
   values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
 var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
-  construct new <R = any>(underlyingSource?: DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: Bun.UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: Bun.DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
   prototype: ReadableStream<any>
 interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
-  read: <T extends NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  read: <T extends NodeJS.NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
   releaseLock: () => void
 var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableStreamBYOBReader
   prototype: ReadableStreamBYOBReader
 interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   respond: (bytesWritten: number) => void
-  respondWithNewView: (view: NonSharedArrayBufferView) => void
-  view [readonly]: NonSharedArrayBufferView | null
+  respondWithNewView: (view: NodeJS.NonSharedArrayBufferView) => void
+  view [readonly]: NodeJS.NonSharedArrayBufferView | null
 var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableStreamBYOBRequest
   prototype: ReadableStreamBYOBRequest
@@ -5132,8 +4681,8 @@ interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
 interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
-  read: () => Promise<ReadableStreamDefaultReadResult<R>>
-  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  read: () => Promise<Bun.ReadableStreamDefaultReadResult<R>>
+  readMany: () => Bun.ReadableStreamDefaultReadManyResult<R> | Promise<Bun.ReadableStreamDefaultReadManyResult<R>>
   releaseLock: () => void
 var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
@@ -5143,7 +4692,7 @@ interface ReadableStreamDirectController (bun-types/globals.d.ts)
   end: () => Promise<number> | number
   flush: (wait?: boolean | undefined) => Promise<number> | number
   start: () => void
-  write: (data: BufferSource | string) => Promise<number> | number
+  write: (data: Bun.BufferSource | string) => Promise<number> | number
 interface ReadableStreamGenericReader (bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
@@ -5191,7 +4740,7 @@ interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   destination [readonly]: RequestDestination
   duplex [readonly]: "half"
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   integrity [readonly]: string
   json [readonly]: () => Promise<unknown>
   keepalive [readonly]: boolean
@@ -5210,12 +4759,12 @@ var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   construct new (requestInfo: Request, init?: RequestInit | undefined): Request
   prototype: Request
 interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  body [?]: BodyInit | null | undefined
+  body [?]: Bun.BodyInit | null | undefined
   cache [?]: RequestCache | undefined
   credentials [?]: RequestCredentials | undefined
   dispatcher [?]: Dispatcher | undefined
   duplex [?]: "half" | undefined
-  headers [?]: HeadersInit | undefined
+  headers [?]: Bun.HeadersInit | undefined
   integrity [?]: string | undefined
   keepalive [?]: boolean | undefined
   method [?]: string | undefined
@@ -5247,7 +4796,7 @@ interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
   clone: () => Response
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   json [readonly]: () => Promise<unknown>
   ok [readonly]: boolean
   redirected [readonly]: boolean
@@ -5258,7 +4807,7 @@ interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   type [readonly]: ResponseType
   url [readonly]: string
 var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  construct new (body?: Bun.BodyInit | null | undefined, init?: ResponseInit | undefined): Response
   error: () => Response
   json: (body?: any, init?: ResponseInit | number | undefined) => Response
   redirect: { (url: string, status?: number | undefined): Response; (url: string, init?: ResponseInit | undefined): Response }
@@ -5286,53 +4835,53 @@ interface StreamPipeOptions (bun-types/globals.d.ts)
   preventClose [?]: boolean | undefined
   signal [?]: AbortSignal | undefined
 interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
-  decapsulateBits: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource) => Promise<ArrayBuffer>
-  decapsulateKey: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<CryptoKey>
-  decrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  deriveBits: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
-  deriveKey: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>) => Promise<CryptoKey>
-  digest: (algorithm: AlgorithmIdentifier | CShakeParams | KangarooTwelveParams | TurboShakeParams, data: BufferSource) => Promise<ArrayBuffer>
-  encapsulateBits: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey) => Promise<EncapsulatedBits>
-  encapsulateKey: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<EncapsulatedKey>
-  encrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
-  generateKey: { (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | KmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
-  getPublicKey: (key: CryptoKey, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
-  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey> }
-  sign: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  unwrapKey: (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
-  verify: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
-  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+  decapsulateBits: (decapsulationAlgorithm: webcrypto.AlgorithmIdentifier, decapsulationKey: webcrypto.CryptoKey, ciphertext: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  decapsulateKey: (decapsulationAlgorithm: webcrypto.AlgorithmIdentifier, decapsulationKey: webcrypto.CryptoKey, ciphertext: NodeJS.BufferSource, sharedKeyAlgorithm: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, usages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  decrypt: (algorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.Argon2Params | webcrypto.EcdhKeyDeriveParams | webcrypto.HkdfParams | webcrypto.Pbkdf2Params, baseKey: webcrypto.CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.Argon2Params | webcrypto.EcdhKeyDeriveParams | webcrypto.HkdfParams | webcrypto.Pbkdf2Params, baseKey: webcrypto.CryptoKey, derivedKeyType: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  digest: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.CShakeParams | webcrypto.KangarooTwelveParams | webcrypto.TurboShakeParams, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  encapsulateBits: (encapsulationAlgorithm: webcrypto.AlgorithmIdentifier, encapsulationKey: webcrypto.CryptoKey) => Promise<webcrypto.EncapsulatedBits>
+  encapsulateKey: (encapsulationAlgorithm: webcrypto.AlgorithmIdentifier, encapsulationKey: webcrypto.CryptoKey, sharedKeyAlgorithm: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, usages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.EncapsulatedKey>
+  encrypt: (algorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: webcrypto.CryptoKey): Promise<webcrypto.JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: webcrypto.CryptoKey): Promise<ArrayBuffer>; (format: webcrypto.KeyFormat, key: webcrypto.CryptoKey): Promise<ArrayBuffer | webcrypto.JsonWebKey> }
+  generateKey: { (algorithm: webcrypto.EcKeyGenParams | webcrypto.RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKeyPair>; (algorithm: webcrypto.AesKeyGenParams | webcrypto.HmacKeyGenParams | webcrypto.KmacKeyGenParams | webcrypto.Pbkdf2Params, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey>; (algorithm: webcrypto.AlgorithmIdentifier, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey | webcrypto.CryptoKeyPair> }
+  getPublicKey: (key: webcrypto.CryptoKey, keyUsages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  importKey: { (format: "jwk", keyData: webcrypto.JsonWebKey, algorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: NodeJS.BufferSource, algorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey> }
+  sign: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.ContextParams | webcrypto.EcdsaParams | webcrypto.KmacParams | webcrypto.RsaPssParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: (format: webcrypto.KeyFormat, wrappedKey: NodeJS.BufferSource, unwrappingKey: webcrypto.CryptoKey, unwrapAlgorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, unwrappedKeyAlgorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  verify: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.ContextParams | webcrypto.EcdsaParams | webcrypto.KmacParams | webcrypto.RsaPssParams, key: webcrypto.CryptoKey, signature: NodeJS.BufferSource, data: NodeJS.BufferSource) => Promise<boolean>
+  wrapKey: (format: webcrypto.KeyFormat, key: webcrypto.CryptoKey, wrappingKey: webcrypto.CryptoKey, wrapAlgorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams) => Promise<ArrayBuffer>
 var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): SubtleCrypto
   prototype: SubtleCrypto
 interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  decode: (input?: NodeJS.AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
   encoding [readonly]: string
   fatal [readonly]: boolean
   ignoreBOM [readonly]: boolean
 var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
+  construct new (encoding?: Bun.Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
   prototype: TextDecoder
 interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   encoding [readonly]: string
   fatal [readonly]: boolean
   ignoreBOM [readonly]: boolean
   readable [readonly]: ReadableStream<string>
-  writable [readonly]: WritableStream<BufferSource>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): TextDecoderStream
   prototype: TextDecoderStream
 interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  encode: (input?: string | undefined) => NonSharedUint8Array
-  encodeInto: (src?: string | undefined, dest?: BufferSource | undefined) => TextEncoderEncodeIntoResult
+  encode: (input?: string | undefined) => NodeJS.NonSharedUint8Array
+  encodeInto: (src?: string | undefined, dest?: Bun.BufferSource | undefined) => TextEncoderEncodeIntoResult
   encoding [readonly]: string
 var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
+  construct new (encoding?: Bun.Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
   prototype: TextEncoder
 interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   encoding [readonly]: string
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
   writable [readonly]: WritableStream<string>
 var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): TextEncoderStream
@@ -5358,10 +4907,10 @@ var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-
   construct new (): TransformStreamDefaultController<any>
   prototype: TransformStreamDefaultController<any>
 interface Transformer<I = any, O = any> (bun-types/globals.d.ts)
-  flush [?]: TransformerFlushCallback<O> | undefined
+  flush [?]: Bun.TransformerFlushCallback<O> | undefined
   readableType [?]: undefined
-  start [?]: TransformerStartCallback<O> | undefined
-  transform [?]: TransformerTransformCallback<I, O> | undefined
+  start [?]: Bun.TransformerStartCallback<O> | undefined
+  transform [?]: Bun.TransformerTransformCallback<I, O> | undefined
   writableType [?]: undefined
 interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
   hash: string
@@ -5400,7 +4949,7 @@ interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d
   toJSON: () => Record<string, string>
   values: () => URLSearchParamsIterator<string>
 var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
-  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, string | ReadonlyArray<string>> | URLSearchParams | string | undefined): URLSearchParams
+  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, ReadonlyArray<string> | string> | URLSearchParams | string | undefined): URLSearchParams
   prototype: URLSearchParams
 interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es2022.array.d.ts, lib.es2023.array.d.ts, lib.es5.d.ts, lib.esnext.typedarrays.d.ts)
   index [number]: number
@@ -5440,7 +4989,7 @@ interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bu
   subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
   toBase64: { (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string; (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }): string }
   toHex: { (): string; (): string }
-  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: Intl.NumberFormatOptions | undefined): string }
   toReversed: () => Uint8Array<ArrayBuffer>
   toSorted: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<ArrayBuffer>
   toString: () => string
@@ -5469,54 +5018,54 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     name: string
     stack [?]: string | undefined
   var WebAssembly.CompileError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): CompileError
-    construct new (message?: string | undefined): CompileError
-    prototype: CompileError
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
+    call (message?: string | undefined): WebAssembly.CompileError
+    construct new (message?: string | undefined): WebAssembly.CompileError
+    prototype: WebAssembly.CompileError
+  interface WebAssembly.Global<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
   var WebAssembly.Global (bun-types/wasm.d.ts)
-    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
-    prototype: Global<keyof ValueTypeMap>
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    construct new <T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap>(descriptor: WebAssembly.GlobalDescriptor<T>, v?: WebAssembly.ValueTypeMap[T] | undefined): WebAssembly.Global<T>
+    prototype: WebAssembly.Global<keyof WebAssembly.ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   var WebAssembly.Instance (bun-types/wasm.d.ts)
-    construct new (module: Module, importObject?: Imports | undefined): Instance
-    prototype: Instance
+    construct new (module: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): WebAssembly.Instance
+    prototype: WebAssembly.Instance
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.LinkError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): LinkError
-    construct new (message?: string | undefined): LinkError
-    prototype: LinkError
+    call (message?: string | undefined): WebAssembly.LinkError
+    construct new (message?: string | undefined): WebAssembly.LinkError
+    prototype: WebAssembly.LinkError
   interface WebAssembly.Memory (bun-types/wasm.d.ts)
     buffer [readonly]: ArrayBuffer
     grow: (delta: number) => number
   var WebAssembly.Memory (bun-types/wasm.d.ts)
-    construct new (descriptor: MemoryDescriptor): Memory
-    prototype: Memory
+    construct new (descriptor: WebAssembly.MemoryDescriptor): WebAssembly.Memory
+    prototype: WebAssembly.Memory
   interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
     initial: number
     maximum [?]: number | undefined
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   var WebAssembly.Module (bun-types/wasm.d.ts)
-    construct new (bytes: BufferSource): Module
-    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
-    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
-    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
-    prototype: Module
+    construct new (bytes: Bun.BufferSource): WebAssembly.Module
+    customSections: (moduleObject: WebAssembly.Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleExportDescriptor>
+    imports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleImportDescriptor>
+    prototype: WebAssembly.Module
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
@@ -5525,19 +5074,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     name: string
     stack [?]: string | undefined
   var WebAssembly.RuntimeError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): RuntimeError
-    construct new (message?: string | undefined): RuntimeError
-    prototype: RuntimeError
+    call (message?: string | undefined): WebAssembly.RuntimeError
+    construct new (message?: string | undefined): WebAssembly.RuntimeError
+    prototype: WebAssembly.RuntimeError
   interface WebAssembly.Table (bun-types/wasm.d.ts)
     get: (index: number) => any
     grow: (delta: number, value?: any) => number
     length [readonly]: number
     set: (index: number, value?: any) => void
   var WebAssembly.Table (bun-types/wasm.d.ts)
-    construct new (descriptor: TableDescriptor, value?: any): Table
-    prototype: Table
+    construct new (descriptor: WebAssembly.TableDescriptor, value?: any): WebAssembly.Table
+    prototype: WebAssembly.Table
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
@@ -5549,48 +5098,48 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
   function WebAssembly.compile (bun-types/wasm.d.ts)
-    call (bytes: BufferSource): Promise<Module>
+    call (bytes: Bun.BufferSource): Promise<WebAssembly.Module>
   function WebAssembly.compileStreaming (bun-types/wasm.d.ts)
-    call (source: PromiseLike<Response> | Response): Promise<Module>
+    call (source: PromiseLike<Response> | Response): Promise<WebAssembly.Module>
   function WebAssembly.instantiate (bun-types/wasm.d.ts)
-    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+    call (bytes: Bun.BufferSource, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (moduleObject: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.Instance>
   function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts)
-    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
   function WebAssembly.validate (bun-types/wasm.d.ts)
-    call (bytes: BufferSource): boolean
+    call (bytes: Bun.BufferSource): boolean
 interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
 var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (url: URL | string, options?: WebSocketOptions | undefined): WebSocket
+  construct new (url: URL | string, options?: Bun.WebSocketOptions | undefined): WebSocket
   construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
@@ -5598,19 +5147,19 @@ var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   OPEN [readonly]: 1
   prototype: WebSocket
 interface Worker (bun-types/globals.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
 var Worker (bun-types/globals.d.ts)
-  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  construct new (scriptURL: URL | string, options?: Bun.WorkerOptions | undefined): Worker
   data: any
   prototype: Worker
 interface WorkerOptions (bun-types/globals.d.ts)
@@ -5621,14 +5170,14 @@ interface WorkerOptions (bun-types/globals.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   abort: (reason?: any) => Promise<void>
   close: () => Promise<void>
   getWriter: () => WritableStreamDefaultWriter<W>
   locked [readonly]: boolean
 var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  construct new <W = any>(underlyingSink?: Bun.UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
   prototype: WritableStream<any>
 interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   error: (e?: any) => void
@@ -5648,18 +5197,18 @@ var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types
   prototype: WritableStreamDefaultWriter<any>
 function addEventListener (bun-types/globals.d.ts)
   call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
 function alert (bun-types/globals.d.ts)
   call (message?: string | undefined): void
 function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (immediate: Immediate | undefined): void
+  call (immediate: NodeJS.Immediate | undefined): void
 function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function confirm (bun-types/globals.d.ts)
   call (message?: string | undefined): boolean
 var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts): Console
@@ -5677,35 +5226,31 @@ var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts): 
 var onmessage (bun-types/index.d.ts): never
 var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts): Performance
 function postMessage (bun-types/globals.d.ts)
-  call (message: any, transfer?: Array<Transferable> | undefined): void
+  call (message: any, transfer?: Array<Bun.Transferable> | undefined): void
 function prompt (bun-types/globals.d.ts)
   call (message?: string | undefined, _default?: string | undefined): null | string
 function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (callback: (...args: Array<any>) => void): void
   call (callback: () => void): void
 function removeEventListener (bun-types/globals.d.ts)
-  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void
 function reportError (bun-types/globals.d.ts)
   call (error: any): void
-var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): NodeJS.Require
 function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  call (handler: Bun.TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Immediate
   __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
 function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
   __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
-  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T>(value: T, options?: Bun.StructuredSerializeOptions | undefined): T
   call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/no-lib.txt
+++ b/test/integration/bun-types/inventory/no-lib.txt
@@ -5,39 +5,64 @@
 # undici-types: 8.3.0
 
 # module "*.html"
+export = Bun.HTMLBundle
 
 # module "*.json5"
+export = any
 
 # module "*.jsonc"
+export = any
 
 # module "*.toml"
+export = any
 
 # module "*.txt"
+export = string
 
 # module "*.xml"
+export = Bun.XML.Document
 
 # module "*.yaml"
+export = any
 
 # module "*.yml"
+export = any
 
 # module "*/bun.lock"
+export = Bun.BunLockFile
+
+# module "buffer"
+interface Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  arrayBuffer: { (): Promise<ArrayBuffer>; (): Promise<ArrayBuffer> }
+  bytes: { (): Promise<NodeJS.NonSharedUint8Array>; (): Promise<Uint8Array<ArrayBuffer>> }
+  formData: () => Promise<FormData>
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
+  json: () => Promise<any>
+  size [readonly]: number
+  slice: (start?: number | undefined, end?: number | undefined, contentType?: string | undefined) => Blob
+  stream: { (): ReadableStream<NodeJS.NonSharedUint8Array>; (): ReadableStream<Uint8Array<ArrayBuffer>> }
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/buffer.d.ts, bun-types/overrides.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
 
 # module "bun"
-type $ (bun-types/shell.d.ts) = typeof $
+type $ (bun-types/shell.d.ts) = typeof Bun.$
 function $ (bun-types/shell.d.ts)
-  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
-  Shell: new () => typeof $
-  ShellError: typeof ShellError
-  ShellPromise: typeof ShellPromise
+  call (strings: TemplateStringsArray, ...expressions: Array<Bun.ShellExpression>): Bun.$.ShellPromise
+  Shell: new () => typeof Bun.$
+  ShellError: typeof Bun.$.ShellError
+  ShellPromise: typeof Bun.$.ShellPromise
   braces: (pattern: string) => Array<string>
-  cwd: (newCwd?: string | undefined) => typeof $
-  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  cwd: (newCwd?: string | undefined) => typeof Bun.$
+  env: (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => typeof Bun.$
   escape: (input: string) => string
-  nothrow: () => typeof $
-  throws: (shouldThrow: boolean) => typeof $
+  nothrow: () => typeof Bun.$
+  throws: (shouldThrow: boolean) => typeof Bun.$
 namespace $ (bun-types/shell.d.ts)
   var $.Shell (bun-types/shell.d.ts)
-    construct new (): typeof $
+    construct new (): typeof Bun.$
   class $.ShellError (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
     blob: () => Blob
@@ -52,12 +77,12 @@ namespace $ (bun-types/shell.d.ts)
     stdout [readonly]: Buffer<ArrayBufferLike>
     text: (encoding?: BufferEncoding | undefined) => string
     [static]
-      construct new (message?: string | undefined): ShellError
-      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      construct new (message?: string | undefined): Bun.$.ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): Bun.$.ShellError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: ShellError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.$.ShellError
       stackTraceLimit: number
   interface $.ShellOutput (bun-types/shell.d.ts)
     arrayBuffer: () => ArrayBuffer
@@ -72,25 +97,25 @@ namespace $ (bun-types/shell.d.ts)
     [Symbol.toStringTag] [readonly]: string
     arrayBuffer: () => Promise<ArrayBuffer>
     blob: () => Promise<Blob>
-    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
-    cwd: (newCwd: string) => ShellPromise
-    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
-    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<Bun.$.ShellOutput | TResult>
+    cwd: (newCwd: string) => Bun.$.ShellPromise
+    env: (newEnv: NodeJS.Dict<string> | Record<string, string | undefined> | undefined) => Bun.$.ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<Bun.$.ShellOutput>
     json: () => Promise<any>
     lines: () => AsyncIterable<string>
-    nothrow: () => ShellPromise
-    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    nothrow: () => Bun.$.ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => Bun.$.ShellPromise
     stdin: WritableStream<any>
     text: (encoding?: BufferEncoding | undefined) => Promise<string>
-    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    throws: (shouldThrow: boolean) => ShellPromise
+    then: <TResult1 = Bun.$.ShellOutput, TResult2 = never>(onfulfilled?: ((value: Bun.$.ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => Bun.$.ShellPromise
     [static]
-      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      construct new (executor: (resolve: (value: Bun.$.ShellOutput | PromiseLike<Bun.$.ShellOutput>) => void, reject: (reason?: any) => void) => void): Bun.$.ShellPromise
       [Symbol.species] [readonly]: PromiseConstructor
-      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
-      prototype: ShellPromise
-      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      prototype: Bun.$.ShellPromise
+      race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
       reject: <T = never>(reason?: any) => Promise<T>
       resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
       try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
@@ -98,19 +123,19 @@ namespace $ (bun-types/shell.d.ts)
   function $.braces (bun-types/shell.d.ts)
     call (pattern: string): Array<string>
   function $.cwd (bun-types/shell.d.ts)
-    call (newCwd?: string | undefined): typeof $
+    call (newCwd?: string | undefined): typeof Bun.$
   function $.env (bun-types/shell.d.ts)
-    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+    call (newEnv?: NodeJS.Dict<string> | Record<string, string | undefined> | undefined): typeof Bun.$
   function $.escape (bun-types/shell.d.ts)
     call (input: string): string
   function $.nothrow (bun-types/shell.d.ts)
-    call (): typeof $
+    call (): typeof Bun.$
   function $.throws (bun-types/shell.d.ts)
-    call (shouldThrow: boolean): typeof $
+    call (shouldThrow: boolean): typeof Bun.$
 interface AbstractWorker (bun-types/bun.d.ts)
-  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: Bun.AbstractWorker, ev: Bun.AbstractWorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
 interface AbstractWorkerEventMap (bun-types/bun.d.ts)
   error: ErrorEvent
 interface AddEventListenerOptions (bun-types/bun.d.ts)
@@ -122,16 +147,16 @@ type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips
 class Archive (bun-types/bun.d.ts)
   blob: () => Promise<Blob>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
-  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  extract: (path: string, options?: Bun.ArchiveExtractOptions | undefined) => Promise<number>
   files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
   [static]
-    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
-    prototype: Archive
-    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+    construct new (data: Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined): Bun.Archive
+    prototype: Bun.Archive
+    write [static]: (path: string, data: Bun.Archive | Bun.ArchiveInput, options?: Bun.ArchiveOptions | undefined) => Promise<void>
 type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
 interface ArchiveExtractOptions (bun-types/bun.d.ts)
   glob [?]: ReadonlyArray<string> | string | undefined
-type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+type ArchiveInput (bun-types/bun.d.ts) = ArrayBufferLike | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Record<string, Bun.BlobPart>
 interface ArchiveOptions (bun-types/bun.d.ts)
   compress [?]: "gzip" | undefined
   level [?]: number | undefined
@@ -139,25 +164,25 @@ class ArrayBufferSink (bun-types/bun.d.ts)
   end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
   flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
   start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
   [static]
-    construct new (): ArrayBufferSink
-    prototype: ArrayBufferSink
-type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+    construct new (): Bun.ArrayBufferSink
+    prototype: Bun.ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = DataView<TArrayBuffer> | NodeJS.TypedArray<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "ACLITEM" | "BIGINT" | "BIT" | "BOOLEAN" | "BOX" | "BYTEA" | "CHAR" | "CID" | "CIDR" | "CIRCLE" | "DATE" | "DOUBLE PRECISION" | "INET" | "INT" | "INT2VECTOR" | "INTEGER" | "INTERVAL" | "JSON" | "JSONB" | "JSONPATH" | "LINE" | "LSEG" | "MACADDR" | "MACADDR8" | "MONEY" | "NAME" | "NUMERIC" | "OID" | "PATH" | "PG_DATABASE" | "POINT" | "POLYGON" | "REAL" | "SMALLINT" | "TEXT" | "TID" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "TIMETZ" | "VARBIT" | "VARCHAR" | "XID" | "XML" | (string & {})
 type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
-type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+type BinaryType (bun-types/bun.d.ts) = keyof Bun.BinaryTypeList
 interface BinaryTypeList (bun-types/bun.d.ts)
   arraybuffer: ArrayBuffer
   buffer: Buffer<ArrayBufferLike>
   uint8array: Uint8Array<ArrayBuffer>
-type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
-type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
-type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
-type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string
+type BlobPart (bun-types/bun.d.ts) = Blob | Bun.BufferSource | string
+type BodyInit (bun-types/fetch.d.ts) = (() => AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any>) | AsyncGenerator<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string, any, any> | AsyncIterable<ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | string> | Bun.Image | Bun.XMLHttpRequestBodyInit | ReadableStream<any>
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
 namespace Build (bun-types/bun.d.ts)
-  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
-  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Architecture (bun-types/bun.d.ts) = "aarch64" | "arm64" | "x64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-aarch64" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-darwin-arm64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-linux-aarch64" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-modern" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-linux-aarch64-musl" | "bun-linux-arm64" | "bun-linux-arm64-baseline" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-glibc" | "bun-linux-arm64-modern" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-arm64-musl" | "bun-linux-x64" | "bun-linux-x64-baseline" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-modern" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-x64-musl" | "bun-windows-aarch64" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
   type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
   type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
 interface BuildArtifact (bun-types/bun.d.ts)
@@ -165,13 +190,13 @@ interface BuildArtifact (bun-types/bun.d.ts)
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
   hash: null | string
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
-  loader: Loader
+  loader: Bun.Loader
   path: string
   size [readonly]: number
-  sourcemap: BuildArtifact | null
+  sourcemap: Bun.BuildArtifact | null
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
@@ -180,7 +205,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   banner [?]: string | undefined
   bytecode [?]: boolean | undefined
   bytecodeDepth [?]: number | undefined
-  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  compile [?]: Bun.Build.CompileTarget | Bun.CompileBuildOptions | boolean | undefined
   conditions [?]: Array<string> | string | undefined
   define [?]: Record<string, string> | undefined
   deprecatedNamespaceObjectSetters [?]: boolean | undefined
@@ -190,12 +215,12 @@ interface BuildConfig (bun-types/bun.d.ts)
   env [?]: "disable" | "inline" | `${string}*` | undefined
   external [?]: Array<string> | undefined
   features [?]: Array<string> | undefined
-  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  files [?]: Record<string, ArrayBufferLike | Blob | NodeJS.TypedArray<ArrayBufferLike> | string> | undefined
   footer [?]: string | undefined
   format [?]: "cjs" | "esm" | "iife" | undefined
   ignoreDCEAnnotations [?]: boolean | undefined
   jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
-  loader [?]: undefined | { [x: string]: Loader; }
+  loader [?]: undefined | { [x: string]: Bun.Loader; }
   metafile [?]: boolean | undefined
   minChunkSize [?]: number | undefined
   minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
@@ -204,7 +229,7 @@ interface BuildConfig (bun-types/bun.d.ts)
   optimizeImports [?]: Array<string> | undefined
   outdir [?]: string | undefined
   packages [?]: "bundle" | "external" | undefined
-  plugins [?]: Array<BunPlugin> | undefined
+  plugins [?]: Array<Bun.BunPlugin> | undefined
   publicPath [?]: string | undefined
   reactCompiler [?]: boolean | undefined
   reactCompilerOutputMode [?]: "client" | "ssr" | undefined
@@ -213,17 +238,17 @@ interface BuildConfig (bun-types/bun.d.ts)
   sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
   splitRequire [?]: boolean | undefined
   splitting [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   throw [?]: boolean | undefined
   treeShaking [?]: boolean | undefined
   tsconfig [?]: string | undefined
 interface BuildMetafile (bun-types/bun.d.ts)
-  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
-  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: Bun.ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: Bun.ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
 interface BuildOutput (bun-types/bun.d.ts)
   logs: Array<BuildMessage | ResolveMessage>
-  metafile [?]: BuildMetafile | undefined
-  outputs: Array<BuildArtifact>
+  metafile [?]: Bun.BuildMetafile | undefined
+  outputs: Array<Bun.BuildArtifact>
   success: boolean
 interface BunFile (bun-types/bun.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
@@ -231,29 +256,29 @@ interface BunFile (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface BunInspectOptions (bun-types/bun.d.ts)
   colors [?]: boolean | undefined
   compact [?]: boolean | undefined
   depth [?]: number | undefined
   sorted [?]: boolean | undefined
-type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: Bun.BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: Bun.BunLockFilePackageArray; }; }
 type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
-type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
-type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
-type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, info: Bun.BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Bun.BunLockFilePackageInfo] | [pkg: string, info: Pick<Bun.BunLockFileBasePackageInfo, "bin" | "binDir">] | [pkg: string, registry: string, info: Bun.BunLockFilePackageInfo, integrity: string] | [pkg: string]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = Bun.BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
 interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -280,10 +305,10 @@ interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.t
   type [readonly]: string
 interface BunPlugin (bun-types/bun.d.ts)
   name: string
-  setup: (build: PluginBuilder) => Promise<void> | void
-  target [?]: Target | undefined
+  setup: (build: Bun.PluginBuilder) => Promise<void> | void
+  target [?]: Bun.Target | undefined
 interface BunRegisterPlugin (bun-types/bun.d.ts)
-  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  call <T extends Bun.BunPlugin>(options: T): ReturnType<T["setup"]>
   clearAll: () => void
 interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   arrayBuffer [readonly]: () => Promise<ArrayBuffer>
@@ -292,19 +317,19 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   bodyUsed [readonly]: boolean
   bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
   cache [readonly]: RequestCache
-  clone: () => BunRequest<T>
-  cookies [readonly]: CookieMap
+  clone: () => Bun.BunRequest<T>
+  cookies [readonly]: Bun.CookieMap
   credentials [readonly]: RequestCredentials
   destination [readonly]: RequestDestination
   duplex [readonly]: "half"
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   integrity [readonly]: string
   json [readonly]: () => Promise<unknown>
   keepalive [readonly]: boolean
   method [readonly]: string
   mode [readonly]: RequestMode
-  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  params [readonly]: { [Key in keyof Bun.Serve.ExtractRouteParams<T>]: Bun.Serve.ExtractRouteParams<T>[Key]; }
   redirect [readonly]: RequestRedirect
   referrer [readonly]: string
   referrerPolicy [readonly]: ReferrerPolicy
@@ -314,17 +339,17 @@ interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
   url [readonly]: string
 namespace CSRF (bun-types/bun.d.ts)
   function CSRF.generate (bun-types/bun.d.ts)
-    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+    call (secret?: string | undefined, options?: Bun.CSRFGenerateOptions | undefined): string
   function CSRF.verify (bun-types/bun.d.ts)
-    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+    call (token: string, options?: Bun.CSRFVerifyOptions | undefined): boolean
 type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
 interface CSRFGenerateOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   expiresIn [?]: number | undefined
   sessionId [?]: string | undefined
 interface CSRFVerifyOptions (bun-types/bun.d.ts)
-  algorithm [?]: CSRFAlgorithm | undefined
+  algorithm [?]: Bun.CSRFAlgorithm | undefined
   encoding [?]: "base64" | "base64url" | "hex" | undefined
   maxAge [?]: number | undefined
   secret [?]: string | undefined
@@ -336,7 +361,7 @@ interface CloseEventInit (bun-types/bun.d.ts)
   composed [?]: boolean | undefined
   reason [?]: string | undefined
   wasClean [?]: boolean | undefined
-type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+type ColorInput (bun-types/bun.d.ts) = Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | [number, number, number, number] | [number, number, number] | number | string | { r: number; g: number; b: number; a?: number | undefined; } | { toString(): string; }
 interface CompileBuildOptions (bun-types/bun.d.ts)
   assets [?]: Array<string> | undefined
   autoloadBunfig [?]: boolean | undefined
@@ -346,9 +371,9 @@ interface CompileBuildOptions (bun-types/bun.d.ts)
   execArgv [?]: Array<string> | undefined
   executablePath [?]: string | undefined
   outfile [?]: string | undefined
-  target [?]: CompileTarget | undefined
+  target [?]: Bun.Build.CompileTarget | undefined
   windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
-type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+type CompressionFormat (bun-types/bun.d.ts) = "brotli" | "deflate" | "deflate-raw" | "gzip" | "zstd"
 class Cookie (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | undefined
@@ -358,19 +383,19 @@ class Cookie (bun-types/bun.d.ts)
   name [readonly]: string
   partitioned: boolean
   path: string
-  sameSite: CookieSameSite
+  sameSite: Bun.CookieSameSite
   secure: boolean
   serialize: () => string
-  toJSON: () => CookieInit
+  toJSON: () => Bun.CookieInit
   toString: () => string
   value: string
   [static]
-    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
-    construct new (cookieString: string): Cookie
-    construct new (cookieObject?: CookieInit | undefined): Cookie
-    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
-    parse [static]: (cookieString: string) => Cookie
-    prototype: Cookie
+    construct new (name: string, value: string, options?: Bun.CookieInit | undefined): Bun.Cookie
+    construct new (cookieString: string): Bun.Cookie
+    construct new (cookieObject?: Bun.CookieInit | undefined): Bun.Cookie
+    from [static]: (name: string, value: string, options?: Bun.CookieInit | undefined) => Bun.Cookie
+    parse [static]: (cookieString: string) => Bun.Cookie
+    prototype: Bun.Cookie
 interface CookieInit (bun-types/bun.d.ts)
   domain [?]: string | undefined
   expires [?]: Date | number | string | undefined
@@ -379,26 +404,26 @@ interface CookieInit (bun-types/bun.d.ts)
   name [?]: string | undefined
   partitioned [?]: boolean | undefined
   path [?]: string | undefined
-  sameSite [?]: CookieSameSite | undefined
+  sameSite [?]: Bun.CookieSameSite | undefined
   secure [?]: boolean | undefined
   value [?]: string | undefined
 class CookieMap (bun-types/bun.d.ts)
   [Symbol.iterator]: () => IterableIterator<[string, string]>
-  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  delete: { (name: string): void; (options: Bun.CookieStoreDeleteOptions): void; (name: string, options: Omit<Bun.CookieStoreDeleteOptions, "name">): void }
   entries: () => IterableIterator<[string, string]>
-  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  forEach: (callback: (value: string, key: string, map: Bun.CookieMap) => void) => void
   get: (name: string) => null | string
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
-  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  set: { (name: string, value: string, options?: Bun.CookieInit | undefined): void; (options: Bun.CookieInit): void }
   size [readonly]: number
   toJSON: () => Record<string, string>
   toSetCookieHeaders: () => Array<string>
   values: () => IterableIterator<string>
   [static]
-    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
-    prototype: CookieMap
-type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): Bun.CookieMap
+    prototype: Bun.CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "lax" | "none" | "strict"
 interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
   domain [?]: null | string | undefined
   name: string
@@ -413,30 +438,30 @@ interface CronController (bun-types/bun.d.ts)
 interface CronJob (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   cron [readonly]: string
-  ref: () => CronJob
-  stop: () => CronJob
-  unref: () => CronJob
+  ref: () => Bun.CronJob
+  stop: () => Bun.CronJob
+  unref: () => Bun.CronJob
 interface CronOptions (bun-types/bun.d.ts)
   tz [?]: string | undefined
-type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+type CronWithAutocomplete (bun-types/bun.d.ts) = "@annually" | "@daily" | "@hourly" | "@midnight" | "@monthly" | "@weekly" | "@yearly" | (string & {}) | `${string} ${string} ${string} ${string} ${string}`
 class CryptoHashInterface<T> (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => T
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => T
   [static]
-    construct new <T>(): CryptoHashInterface<T>
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHashInterface<any>
+    construct new <T>(): Bun.CryptoHashInterface<T>
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHashInterface<any>
 class CryptoHasher (bun-types/bun.d.ts)
-  algorithm [readonly]: SupportedCryptoAlgorithms
+  algorithm [readonly]: Bun.SupportedCryptoAlgorithms
   byteLength [readonly]: number
-  copy: () => CryptoHasher
-  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
-  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  copy: () => Bun.CryptoHasher
+  digest: { (encoding: Bun.DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (input: Bun.BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => Bun.CryptoHasher
   [static]
-    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
-    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
-    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: CryptoHasher
+    construct new (algorithm: Bun.SupportedCryptoAlgorithms, hmacKey?: NodeJS.TypedArray<ArrayBufferLike> | string | undefined): Bun.CryptoHasher
+    algorithms [readonly static]: Array<Bun.SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, hashInto: NodeJS.TypedArray<ArrayBufferLike>): NodeJS.TypedArray<ArrayBufferLike>; (algorithm: Bun.SupportedCryptoAlgorithms, input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.CryptoHasher
 interface CustomEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -447,9 +472,9 @@ interface DNSLookup (bun-types/bun.d.ts)
   family: 4 | 6
   ttl: number
 type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
-type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "base64" | "base64url" | "hex" | "latin1" | "ucs2" | "utf16le" | "utf8"
 interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
   pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
   type: "direct"
 type DisconnectListener (bun-types/bun.d.ts) = () => void
@@ -457,7 +482,7 @@ interface EditorOptions (bun-types/bun.d.ts)
   column [?]: number | undefined
   editor [?]: "subl" | "vscode" | undefined
   line [?]: number | undefined
-type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+type Encoding (bun-types/bun.d.ts) = "866" | "ansi_x3.4-1968" | "arabic" | "ascii" | "asmo-708" | "big5" | "big5-hkscs" | "chinese" | "cn-big5" | "cp1250" | "cp1251" | "cp1252" | "cp1253" | "cp1254" | "cp1255" | "cp1256" | "cp1257" | "cp1258" | "cp819" | "cp866" | "csbig5" | "cseuckr" | "cseucpkdfmtjapanese" | "csgb2312" | "csibm866" | "csiso2022jp" | "csiso58gb231280" | "csiso88596e" | "csiso88596i" | "csiso88598e" | "csiso88598i" | "csisolatin1" | "csisolatin2" | "csisolatin3" | "csisolatin4" | "csisolatin5" | "csisolatin6" | "csisolatin9" | "csisolatinarabic" | "csisolatincyrillic" | "csisolatingreek" | "csisolatinhebrew" | "cskoi8r" | "csksc56011987" | "csmacintosh" | "csshiftjis" | "csunicode" | "cyrillic" | "dos-874" | "ecma-114" | "ecma-118" | "elot_928" | "euc-jp" | "euc-kr" | "gb18030" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "greek" | "greek8" | "hebrew" | "ibm819" | "ibm866" | "iso-10646-ucs-2" | "iso-2022-jp" | "iso-8859-1" | "iso-8859-10" | "iso-8859-11" | "iso-8859-13" | "iso-8859-14" | "iso-8859-15" | "iso-8859-16" | "iso-8859-2" | "iso-8859-3" | "iso-8859-4" | "iso-8859-5" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-8859-7" | "iso-8859-8" | "iso-8859-8-e" | "iso-8859-8-i" | "iso-8859-9" | "iso-ir-100" | "iso-ir-101" | "iso-ir-109" | "iso-ir-110" | "iso-ir-126" | "iso-ir-127" | "iso-ir-138" | "iso-ir-144" | "iso-ir-148" | "iso-ir-149" | "iso-ir-157" | "iso-ir-58" | "iso8859-1" | "iso8859-10" | "iso8859-11" | "iso8859-13" | "iso8859-14" | "iso8859-15" | "iso8859-2" | "iso8859-3" | "iso8859-4" | "iso8859-5" | "iso8859-6" | "iso8859-7" | "iso8859-8" | "iso8859-9" | "iso88591" | "iso885910" | "iso885911" | "iso885913" | "iso885914" | "iso885915" | "iso88592" | "iso88593" | "iso88594" | "iso88595" | "iso88596" | "iso88597" | "iso88598" | "iso88599" | "iso_8859-1" | "iso_8859-15" | "iso_8859-1:1987" | "iso_8859-2" | "iso_8859-2:1987" | "iso_8859-3" | "iso_8859-3:1988" | "iso_8859-4" | "iso_8859-4:1988" | "iso_8859-5" | "iso_8859-5:1988" | "iso_8859-6" | "iso_8859-6:1987" | "iso_8859-7" | "iso_8859-7:1987" | "iso_8859-8" | "iso_8859-8:1988" | "iso_8859-9" | "iso_8859-9:1989" | "koi" | "koi8" | "koi8-r" | "koi8-ru" | "koi8-u" | "koi8_r" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "l1" | "l2" | "l3" | "l4" | "l5" | "l6" | "l9" | "latin1" | "latin2" | "latin3" | "latin4" | "latin5" | "latin6" | "logical" | "mac" | "macintosh" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "sun_eu_greek" | "tis-620" | "ucs-2" | "unicode" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "unicodefeff" | "unicodefffe" | "us-ascii" | "utf-16" | "utf-16be" | "utf-16le" | "utf-8" | "utf8" | "visual" | "windows-1250" | "windows-1251" | "windows-1252" | "windows-1253" | "windows-1254" | "windows-1255" | "windows-1256" | "windows-1257" | "windows-1258" | "windows-31j" | "windows-874" | "windows-949" | "x-cp1250" | "x-cp1251" | "x-cp1252" | "x-cp1253" | "x-cp1254" | "x-cp1255" | "x-cp1256" | "x-cp1257" | "x-cp1258" | "x-euc-jp" | "x-gbk" | "x-mac-cyrillic" | "x-mac-roman" | "x-mac-ukrainian" | "x-sjis" | "x-unicode20utf8" | "x-user-defined" | "x-x-big5"
 interface Env (bun-types/bun.d.ts)
   NODE_ENV [?]: string | undefined
   TZ [?]: string | undefined
@@ -478,7 +503,7 @@ interface ErrorLike (bun-types/bun.d.ts)
   name: string
   stack [?]: string | undefined
   syscall [?]: string | undefined
-type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+type Errorlike (bun-types/deprecated.d.ts) = Bun.ErrorLike
 interface EventInit (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -489,31 +514,31 @@ interface EventListenerObject (bun-types/bun.d.ts)
   handleEvent: (object: Event) => void
 interface EventListenerOptions (bun-types/bun.d.ts)
   capture [?]: boolean | undefined
-type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = Bun.EventListener | Bun.EventListenerObject
 interface EventMap (bun-types/bun.d.ts)
-  fetch: FetchEvent
-  message: BunMessageEvent<any>
-  messageerror: BunMessageEvent<any>
+  fetch: Bun.FetchEvent
+  message: Bun.BunMessageEvent<any>
+  messageerror: Bun.BunMessageEvent<any>
 interface EventSource (bun-types/bun.d.ts)
-  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): Bun.EventSource
   CLOSED [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
-  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: Bun.BunMessageEvent<any>) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   close: () => void
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: EventSource, ev: Event) => any) | null
-  onmessage: ((this: EventSource, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: EventSource, ev: Event) => any) | null
+  onerror: ((this: Bun.EventSource, ev: Event) => any) | null
+  onmessage: ((this: Bun.EventSource, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.EventSource, ev: Event) => any) | null
   readyState [readonly]: number
   ref: () => void
-  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.EventSourceEventMap>(type: K, listener: (this: Bun.EventSource, ev: Bun.EventSourceEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: Bun.EventSource, event: Bun.BunMessageEvent<any>) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   unref: () => void
   url [readonly]: string
   withCredentials [readonly]: boolean
 interface EventSourceEventMap (bun-types/bun.d.ts)
   error: Event
-  message: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
   open: Event
 type ExitListener (bun-types/bun.d.ts) = (code: number) => void
 type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
@@ -521,8 +546,8 @@ interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   fd: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface FetchEvent (bun-types/bun.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -551,47 +576,47 @@ interface FileBlob (bun-types/bun.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified: number
   name [? readonly]: string | undefined
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.BunFile; (begin?: number | undefined, contentType?: string | undefined): Bun.BunFile; (contentType?: string | undefined): Bun.BunFile }
   stat: () => Promise<Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
-  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+  write: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => Bun.FileSink
 interface FileSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
   ref: () => void
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
 class FileSystemRouter (bun-types/bun.d.ts)
   assetPrefix [readonly]: string
-  match: (input: Request | Response | string) => MatchedRoute | null
+  match: (input: Request | Response | string) => Bun.MatchedRoute | null
   origin [readonly]: string
   reload: () => void
   routes [readonly]: Record<string, string>
   style [readonly]: string
   [static]
-    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
-    prototype: FileSystemRouter
-type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): Bun.FileSystemRouter
+    prototype: Bun.FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = File | string
 interface GenericTransformStream (bun-types/bun.d.ts)
   readable [readonly]: ReadableStream<any>
   writable [readonly]: WritableStream<any>
 class Glob (bun-types/bun.d.ts)
   match: (str: string) => boolean
-  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
-  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  scan: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: Bun.GlobScanOptions | string | undefined) => IterableIterator<string>
   [static]
-    construct new (pattern: string): Glob
-    prototype: Glob
+    construct new (pattern: string): Bun.Glob
+    prototype: Bun.Glob
 interface GlobScanOptions (bun-types/bun.d.ts)
   absolute [?]: boolean | undefined
   cwd [?]: string | undefined
@@ -599,25 +624,25 @@ interface GlobScanOptions (bun-types/bun.d.ts)
   followSymlinks [?]: boolean | undefined
   onlyFiles [?]: boolean | undefined
   throwErrorOnBrokenSymlink [?]: boolean | undefined
-type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
-type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+type HMREvent (bun-types/devserver.d.ts) = "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:beforeUpdate" | "bun:error" | "bun:invalidate" | "bun:ws:connect" | "bun:ws:disconnect" | (string & {})
+type HMREventNames (bun-types/devserver.d.ts) = "afterUpdate" | "beforeFullReload" | "beforePrune" | "beforeUpdate" | "error" | "invalidate" | "ws:connect" | "ws:disconnect"
 interface HTMLBundle (bun-types/bun.d.ts)
-  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Bun.Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
   index: string
 interface Hash (bun-types/bun.d.ts)
-  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
-  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
-  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
-type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Record<string, string | ReadonlyArray<string>> | Headers
+  adler32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Headers | Record<string, ReadonlyArray<string> | string>
 interface HeapSnapshot (bun-types/bun.d.ts)
   edgeNames: Array<string>
   edgeTypes: Array<string>
@@ -627,56 +652,56 @@ interface HeapSnapshot (bun-types/bun.d.ts)
   type: string
   version: number
 class Image (bun-types/bun.d.ts)
-  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  avif: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   blob: () => Promise<Blob>
   buffer: () => Promise<Buffer<ArrayBufferLike>>
   bytes: () => Promise<Uint8Array<ArrayBufferLike>>
   dataurl: () => Promise<string>
-  flip: () => Image
-  flop: () => Image
-  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  flip: () => Bun.Image
+  flop: () => Bun.Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Bun.Image
   height [readonly]: number
-  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
-  metadata: () => Promise<Metadata>
-  modulate: (options: ModulateOptions) => Image
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Bun.Image
+  metadata: () => Promise<Bun.Image.Metadata>
+  modulate: (options: Bun.Image.ModulateOptions) => Bun.Image
   placeholder: (as?: "dataurl" | undefined) => Promise<string>
-  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
-  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
-  rotate: (degrees: number) => Image
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Bun.Image
+  resize: (width: number, height?: number | undefined, options?: Bun.Image.ResizeOptions | undefined) => Bun.Image
+  rotate: (degrees: number) => Bun.Image
   toBase64: () => Promise<string>
   toBuffer: () => Promise<Buffer<ArrayBufferLike>>
-  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Bun.Image
   width [readonly]: number
-  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  write: (dest: Bun.BunFile | Bun.PathLike | Bun.S3File | number) => Promise<number>
   [static]
-    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    construct new (input: ArrayBuffer | Blob | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.Image.ConstructorOptions | undefined): Bun.Image
     backend [static]: "bun" | "system"
     clipboardChangeCount [static]: () => number
-    fromClipboard [static]: () => Image | null
+    fromClipboard [static]: () => Bun.Image | null
     hasClipboardImage [static]: () => boolean
-    prototype: Image
+    prototype: Bun.Image
   interface Image.ConstructorOptions (bun-types/bun.d.ts)
     autoOrient [?]: boolean | undefined
     maxPixels [?]: number | undefined
-  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
-  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
-  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "bilinear" | "box" | "cubic" | "lanczos2" | "lanczos3" | "linear" | "mitchell" | "mks2013" | "mks2021" | "nearest"
+  type Image.Format (bun-types/bun.d.ts) = "avif" | "bmp" | "gif" | "heic" | "jpeg" | "png" | "tiff" | "webp"
   interface Image.Metadata (bun-types/bun.d.ts)
-    format: Format
+    format: Bun.Image.Format
     height: number
     width: number
   interface Image.ModulateOptions (bun-types/bun.d.ts)
     brightness [?]: number | undefined
     saturation [?]: number | undefined
   interface Image.ResizeOptions (bun-types/bun.d.ts)
-    filter [?]: Filter | undefined
+    filter [?]: Bun.Image.Filter | undefined
     fit [?]: "fill" | "inside" | undefined
     withoutEnlargement [?]: boolean | undefined
   var Image.backend (bun-types/bun.d.ts): "bun" | "system"
 interface Import (bun-types/bun.d.ts)
-  kind: ImportKind
+  kind: Bun.ImportKind
   path: string
-type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+type ImportKind (bun-types/bun.d.ts) = "dynamic-import" | "entry-point-build" | "entry-point-run" | "import-rule" | "import-statement" | "internal" | "require-call" | "require-resolve" | "url-token"
 namespace JSON5 (bun-types/bun.d.ts)
   function JSON5.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -692,30 +717,30 @@ namespace JSONL (bun-types/bun.d.ts)
     read: number
     values: Array<unknown>
   function JSONL.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Array<unknown>
   function JSONL.parseChunk (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): Bun.JSONL.ParseChunkResult
 type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
 interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
   level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
   library [?]: "libdeflate" | undefined
-type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+type Loader (bun-types/bun.d.ts) = "css" | "file" | "html" | "js" | "json" | "jsonc" | "jsx" | "napi" | "text" | "toml" | "ts" | "tsx" | "wasm" | "xml" | "yaml"
 class MD4 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD4
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD4
   [static]
-    construct new (): MD4
+    construct new (): Bun.MD4
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD4
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD4
 class MD5 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => MD5
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.MD5
   [static]
-    construct new (): MD5
+    construct new (): Bun.MD5
     byteLength [readonly static]: 16
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: MD5
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.MD5
 interface MMapOptions (bun-types/bun.d.ts)
   offset [?]: number | undefined
   shared [?]: boolean | undefined
@@ -730,8 +755,8 @@ interface MatchedRoute (bun-types/bun.d.ts)
   pathname [readonly]: string
   query [readonly]: Record<string, string>
   src [readonly]: string
-type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
-type MessageEvent<T = any> (bun-types/bun.d.ts) = BunMessageEvent<T>
+type MaybePromise<T> (bun-types/bun.d.ts) = Promise<T> | T
+type MessageEvent<T = any> (bun-types/bun.d.ts) = Bun.BunMessageEvent<T>
 interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   bubbles [?]: boolean | undefined
   cancelable [?]: boolean | undefined
@@ -742,8 +767,8 @@ interface MessageEventInit<T = any> (bun-types/bun.d.ts)
   source [?]: null | undefined
 type MessageEventSource (bun-types/bun.d.ts) = undefined
 type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
-type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
-type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: Bun.MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "reject" | "resolve"
 interface NetworkSink (bun-types/s3.d.ts)
   end: (error?: Error | undefined) => Promise<number> | number
   flush: () => Promise<number> | number
@@ -751,38 +776,38 @@ interface NetworkSink (bun-types/s3.d.ts)
   start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
   stat: () => Promise<Stats>
   unref: () => void
-  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
-type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
-type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+  write: (chunk: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
 type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
-type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+type OnEndCallback (bun-types/bun.d.ts) = (result: Bun.BuildOutput) => void | Promise<void>
 interface OnLoadArgs (bun-types/bun.d.ts)
   defer: () => Promise<void>
-  loader: Loader
+  loader: Bun.Loader
   namespace: string
   path: string
-type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
-type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+type OnLoadCallback (bun-types/bun.d.ts) = (args: Bun.OnLoadArgs) => Bun.OnLoadResult | Promise<Bun.OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = Bun.OnLoadResultObject | Bun.OnLoadResultSourceCode | undefined | void
 interface OnLoadResultObject (bun-types/bun.d.ts)
   exports: Record<string, unknown>
   loader: "object"
 interface OnLoadResultSourceCode (bun-types/bun.d.ts)
-  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
-  loader [?]: Loader | undefined
+  contents: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Bun.Loader | undefined
 interface OnResolveArgs (bun-types/bun.d.ts)
   importer: string
-  kind: ImportKind
+  kind: Bun.ImportKind
   namespace: string
   path: string
   resolveDir: string
-type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+type OnResolveCallback (bun-types/bun.d.ts) = (args: Bun.OnResolveArgs) => Bun.OnResolveResult | Promise<Bun.OnResolveResult | null | undefined> | null | undefined
 interface OnResolveResult (bun-types/bun.d.ts)
   external [?]: boolean | undefined
   namespace [?]: string | undefined
   path: string
 type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
 namespace Password (bun-types/bun.d.ts)
-  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "argon2d" | "argon2i" | "argon2id" | "bcrypt"
   interface Password.Argon2Algorithm (bun-types/bun.d.ts)
     algorithm: "argon2d" | "argon2i" | "argon2id"
     memoryCost [?]: number | undefined
@@ -790,243 +815,243 @@ namespace Password (bun-types/bun.d.ts)
   interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
     algorithm: "bcrypt"
     cost [?]: number | undefined
-type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
-type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
-type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+type PathLike (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | URL | string
+type PipedSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "cygwin" | "darwin" | "freebsd" | "haiku" | "linux" | "netbsd" | "openbsd" | "sunos" | "win32"
 interface PluginBuilder (bun-types/bun.d.ts)
-  config: BuildConfig & { plugins: Array<BunPlugin>; }
-  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
-  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
-  onEnd: (callback: OnEndCallback) => PluginBuilder
-  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
-  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
-  onStart: (callback: OnStartCallback) => PluginBuilder
+  config: Bun.BuildConfig & { plugins: Array<Bun.BunPlugin>; }
+  module: (specifier: string, callback: () => Bun.OnLoadResult | Promise<Bun.OnLoadResult>) => Bun.PluginBuilder
+  onBeforeParse: (constraints: Bun.PluginConstraints, callback: Bun.OnBeforeParseCallback) => Bun.PluginBuilder
+  onEnd: (callback: Bun.OnEndCallback) => Bun.PluginBuilder
+  onLoad: (constraints: Bun.PluginConstraints, callback: Bun.OnLoadCallback) => Bun.PluginBuilder
+  onResolve: (constraints: Bun.PluginConstraints, callback: Bun.OnResolveCallback) => Bun.PluginBuilder
+  onStart: (callback: Bun.OnStartCallback) => Bun.PluginBuilder
 interface PluginConstraints (bun-types/bun.d.ts)
   filter: RegExp
   namespace [?]: string | undefined
-type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined
 type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
 interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
   done: boolean
   size: number
   value: Array<T>
-type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadDoneResult | ReadableStreamDefaultReadValueResult<T>
 type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
-type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
-type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+type ReadableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = Bun.SyncSubprocess<"pipe", "pipe">
 class RedisClient (bun-types/redis.d.ts)
-  append: (key: KeyLike, value: KeyLike) => Promise<number>
-  bitcount: (key: KeyLike) => Promise<number>
-  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
-  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
-  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
-  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
-  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
-  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  append: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  bitcount: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  bitfield: (key: Bun.RedisClient.KeyLike, ...operations: Array<number | string>) => Promise<Array<null | number>>
+  bitop: { (operation: "NOT" | "not", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  bitpos: (key: Bun.RedisClient.KeyLike, bit: 0 | 1, ...options: Array<number | string>) => Promise<number>
+  blmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<null | string>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpop: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string] | null>
+  brpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, timeout: number) => Promise<null | string>
   bufferedAmount [readonly]: number
-  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
-  client: (...args: Array<string | number>) => Promise<any>
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<[string, string, number] | null>
+  client: (...args: Array<number | string>) => Promise<any>
   close: () => void
-  command: (...args: Array<string | number>) => Promise<any>
-  config: (...args: Array<string | number>) => Promise<any>
+  command: (...args: Array<number | string>) => Promise<any>
+  config: (...args: Array<number | string>) => Promise<any>
   connect: () => Promise<void>
   connected [readonly]: boolean
-  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  copy: { (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike): Promise<number>; (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, replace: "REPLACE"): Promise<number> }
   dbsize: () => Promise<number>
-  debug: (...args: Array<string | number>) => Promise<any>
-  decr: (key: KeyLike) => Promise<number>
-  decrby: (key: KeyLike, decrement: number) => Promise<number>
-  del: (...keys: Array<KeyLike>) => Promise<number>
-  dump: (key: KeyLike) => Promise<string | null>
-  duplicate: () => Promise<RedisClient>
+  debug: (...args: Array<number | string>) => Promise<any>
+  decr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  decrby: (key: Bun.RedisClient.KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  dump: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  duplicate: () => Promise<Bun.RedisClient>
   echo: (message: string) => Promise<string>
-  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
-  exists: (key: KeyLike) => Promise<boolean>
-  expire: (key: KeyLike, seconds: number) => Promise<number>
-  expireat: (key: KeyLike, timestamp: number) => Promise<number>
-  expiretime: (key: KeyLike) => Promise<number>
-  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
+  exists: (key: Bun.RedisClient.KeyLike) => Promise<boolean>
+  expire: (key: Bun.RedisClient.KeyLike, seconds: number) => Promise<number>
+  expireat: (key: Bun.RedisClient.KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<number | string>) => Promise<any>
   flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
   flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
-  function: (...args: Array<KeyLike>) => Promise<any>
-  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
-  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
-  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
-  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
-  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
-  get: (key: KeyLike) => Promise<string | null>
-  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
-  getbit: (key: KeyLike, offset: number) => Promise<number>
-  getdel: (key: KeyLike) => Promise<string | null>
-  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
-  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
-  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
-  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
-  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
-  hgetall: (key: KeyLike) => Promise<Record<string, string>>
-  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
-  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
-  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
-  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
-  hkeys: (key: KeyLike) => Promise<Array<string>>
-  hlen: (key: KeyLike) => Promise<number>
-  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
-  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
-  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
-  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
-  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
-  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
-  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
-  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
-  hstrlen: (key: KeyLike, field: string) => Promise<number>
-  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
-  hvals: (key: KeyLike) => Promise<Array<string>>
-  incr: (key: KeyLike) => Promise<number>
-  incrby: (key: KeyLike, increment: number) => Promise<number>
-  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  function: (...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  geoadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  geodist: { (key: Bun.RedisClient.KeyLike, member1: string, member2: string): Promise<null | string>; (key: Bun.RedisClient.KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<null | string> }
+  geohash: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<null | string>>
+  geopos: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<unknown>>
+  geosearchstore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  get: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getBuffer: (key: Bun.RedisClient.KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: Bun.RedisClient.KeyLike, offset: number) => Promise<number>
+  getdel: (key: Bun.RedisClient.KeyLike) => Promise<null | string>
+  getex: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<null | string>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST"): Promise<null | string> }
+  getrange: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hdel: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  hexists: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hexpire: { (key: Bun.RedisClient.KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hget: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike) => Promise<null | string>
+  hgetall: (key: Bun.RedisClient.KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  hgetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<null | string>> }
+  hincrby: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: Bun.RedisClient.KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  hlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  hmget: { (key: Bun.RedisClient.KeyLike, ...fields: Array<string>): Promise<Array<null | string>>; (key: Bun.RedisClient.KeyLike, fields: Array<string>): Promise<Array<null | string>> }
+  hmset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<"OK">; (key: Bun.RedisClient.KeyLike, fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<"OK"> }
+  hpersist: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: Bun.RedisClient.KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>>; (key: Bun.RedisClient.KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hpttl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: Bun.RedisClient.KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: Bun.RedisClient.KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: Bun.RedisClient.KeyLike, fields: Record<number | string, Bun.RedisClient.KeyLike | number>): Promise<number>; (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetex: { (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number>; (key: Bun.RedisClient.KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<Bun.RedisClient.KeyLike>): Promise<number> }
+  hsetnx: (key: Bun.RedisClient.KeyLike, field: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<boolean>
+  hstrlen: (key: Bun.RedisClient.KeyLike, field: string) => Promise<number>
+  httl: (key: Bun.RedisClient.KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  hvals: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  incr: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  incrby: (key: Bun.RedisClient.KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: Bun.RedisClient.KeyLike, increment: number | string) => Promise<string>
   info: (...sections: Array<string>) => Promise<string>
   keys: (pattern: string) => Promise<Array<string>>
   lastsave: () => Promise<number>
-  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
-  lindex: (key: KeyLike, index: number) => Promise<string | null>
-  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
-  llen: (key: KeyLike) => Promise<number>
-  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
-  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
-  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
-  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
-  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
-  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
-  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
-  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
-  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
-  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
-  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
-  onclose: ((this: RedisClient, error: Error) => void) | null
-  onconnect: ((this: RedisClient) => void) | null
-  persist: (key: KeyLike) => Promise<number>
-  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
-  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
-  pexpiretime: (key: KeyLike) => Promise<number>
-  pfadd: (key: KeyLike, element: string) => Promise<number>
-  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
-  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
-  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
-  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
-  pttl: (key: KeyLike) => Promise<number>
+  lcs: (key1: Bun.RedisClient.KeyLike, key2: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<any>
+  lindex: (key: Bun.RedisClient.KeyLike, index: number) => Promise<null | string>
+  linsert: (key: Bun.RedisClient.KeyLike, position: "AFTER" | "BEFORE", pivot: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike) => Promise<number>
+  llen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  lmove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<null | string>
+  lmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: Bun.RedisClient.KeyLike, element: Bun.RedisClient.KeyLike, ...options: Array<number | string>) => Promise<Array<number> | null | number>
+  lpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  lpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  lrange: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: Bun.RedisClient.KeyLike, count: number, element: Bun.RedisClient.KeyLike) => Promise<number>
+  lset: (key: Bun.RedisClient.KeyLike, index: number, element: Bun.RedisClient.KeyLike) => Promise<string>
+  ltrim: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | string>>
+  mset: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<Bun.RedisClient.KeyLike>) => Promise<any>
+  onclose: ((this: Bun.RedisClient, error: Error) => void) | null
+  onconnect: ((this: Bun.RedisClient) => void) | null
+  persist: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pexpire: (key: Bun.RedisClient.KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: Bun.RedisClient.KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  pfadd: (key: Bun.RedisClient.KeyLike, element: string) => Promise<number>
+  pfcount: (key: Bun.RedisClient.KeyLike, ...moreKeys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  pfmerge: (destkey: Bun.RedisClient.KeyLike, ...sourcekeys: Array<Bun.RedisClient.KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: Bun.RedisClient.KeyLike): Promise<string> }
+  psetex: (key: Bun.RedisClient.KeyLike, milliseconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  pttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
   publish: (channel: string, message: string) => Promise<number>
-  randomkey: () => Promise<string | null>
-  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
-  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
-  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
-  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
-  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
-  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
-  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
-  scard: (key: KeyLike) => Promise<number>
+  randomkey: () => Promise<null | string>
+  rename: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<"OK">
+  renamenx: (key: Bun.RedisClient.KeyLike, newkey: Bun.RedisClient.KeyLike) => Promise<number>
+  rpop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike) => Promise<null | string>
+  rpush: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...rest: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  rpushx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sadd: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<number | string>): Promise<[string, Array<string>]> }
+  scard: (key: Bun.RedisClient.KeyLike) => Promise<number>
   script: (...args: Array<string>) => Promise<any>
-  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sdiff: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   send: (command: string, args: Array<string>) => Promise<any>
-  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
-  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
-  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
-  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
-  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
-  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
-  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
-  sismember: (key: KeyLike, member: string) => Promise<boolean>
-  smembers: (key: KeyLike) => Promise<Array<string>>
-  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
-  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
-  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
-  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  spublish: (channel: KeyLike, message: string) => Promise<number>
-  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
-  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
-  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
-  strlen: (key: KeyLike) => Promise<number>
-  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
-  substr: (key: KeyLike, start: number, end: number) => Promise<string>
-  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
-  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  set: { (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, nx: "NX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, xx: "XX"): Promise<"OK" | null>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, get: "GET"): Promise<null | string>; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike, ...options: Array<string>): Promise<null | string> }
+  setbit: (key: Bun.RedisClient.KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: Bun.RedisClient.KeyLike, seconds: number, value: Bun.RedisClient.KeyLike) => Promise<"OK">
+  setnx: (key: Bun.RedisClient.KeyLike, value: Bun.RedisClient.KeyLike) => Promise<number>
+  setrange: (key: Bun.RedisClient.KeyLike, offset: number, value: Bun.RedisClient.KeyLike) => Promise<number>
+  sinter: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: Bun.RedisClient.KeyLike, ...args: Array<Bun.RedisClient.KeyLike | number>) => Promise<number>
+  sinterstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  sismember: (key: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  smembers: (key: Bun.RedisClient.KeyLike) => Promise<Array<string>>
+  smismember: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<number>>
+  smove: (source: Bun.RedisClient.KeyLike, destination: Bun.RedisClient.KeyLike, member: string) => Promise<boolean>
+  sort: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<Array<null | string> | number>
+  spop: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: Bun.RedisClient.KeyLike, message: string) => Promise<number>
+  srandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: Bun.RedisClient.KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...args: Array<number | string>) => Promise<[string, Array<string>]>
+  strlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<number>; (channels: Array<string>, listener: Bun.RedisClient.StringPubSubListener): Promise<number> }
+  substr: (key: Bun.RedisClient.KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: Bun.RedisClient.KeyLike, key: Bun.RedisClient.KeyLike, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
   time: () => Promise<[string, string]>
-  touch: (...keys: Array<KeyLike>) => Promise<number>
-  ttl: (key: KeyLike) => Promise<number>
-  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
-  unlink: (...keys: Array<KeyLike>) => Promise<number>
-  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  touch: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  ttl: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  type: (key: Bun.RedisClient.KeyLike) => Promise<"hash" | "list" | "none" | "set" | "stream" | "string" | "zset">
+  unlink: (...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: Bun.RedisClient.StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
   wait: (numreplicas: number, timeout: number) => Promise<number>
-  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
-  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
-  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
-  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
-  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
-  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
-  xlen: (key: KeyLike) => Promise<number>
-  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
-  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xread: (...args: Array<string | number>) => Promise<any>
-  xreadgroup: (...args: Array<string | number>) => Promise<any>
-  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
-  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
-  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
-  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
-  zcard: (key: KeyLike) => Promise<number>
-  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
-  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
-  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
-  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
-  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
-  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
-  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
-  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
-  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
-  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
-  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
-  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
-  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
-  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
-  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
-  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
-  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
-  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
-  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
-  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
-  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
-  zscore: (key: KeyLike, member: string) => Promise<number | null>
-  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
-  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  xack: (key: Bun.RedisClient.KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<null | string>
+  xautoclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<number | string>) => Promise<any>
+  xclaim: (key: Bun.RedisClient.KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<number | string>) => Promise<any>
+  xdel: (key: Bun.RedisClient.KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<number | string>) => Promise<any>
+  xlen: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  xpending: (key: Bun.RedisClient.KeyLike, group: string, ...args: Array<number | string>) => Promise<any>
+  xrange: (key: Bun.RedisClient.KeyLike, start: string, end: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<number | string>) => Promise<any>
+  xreadgroup: (...args: Array<number | string>) => Promise<any>
+  xrevrange: (key: Bun.RedisClient.KeyLike, end: string, start: string, ...options: Array<number | string>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: Bun.RedisClient.KeyLike, lastId: string, ...options: Array<number | string>) => Promise<"OK">
+  xtrim: (key: Bun.RedisClient.KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<number | string>) => Promise<number>
+  zadd: (key: Bun.RedisClient.KeyLike, ...args: Array<number | string>) => Promise<number>
+  zcard: (key: Bun.RedisClient.KeyLike) => Promise<number>
+  zcount: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: Bun.RedisClient.KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zincrby: (key: Bun.RedisClient.KeyLike, increment: number, member: Bun.RedisClient.KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<Bun.RedisClient.KeyLike>): Promise<number>; (numkeys: number, ...args: Array<Bun.RedisClient.KeyLike | number>): Promise<number> }
+  zinterstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
+  zlexcount: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<number | string>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<Array<null | number>>
+  zpopmax: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: Bun.RedisClient.KeyLike): Promise<[] | [string, number]>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: Bun.RedisClient.KeyLike): Promise<null | string>; (key: Bun.RedisClient.KeyLike, count: number): Promise<Array<string> | null>; (key: Bun.RedisClient.KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: Bun.RedisClient.KeyLike, min: string, max: string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: string, max: string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangebyscore: { (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<number | string>): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrangestore: (destination: Bun.RedisClient.KeyLike, source: Bun.RedisClient.KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: Bun.RedisClient.KeyLike, member: Bun.RedisClient.KeyLike, ...members: Array<Bun.RedisClient.KeyLike>) => Promise<number>
+  zremrangebylex: (key: Bun.RedisClient.KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: Bun.RedisClient.KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: Bun.RedisClient.KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: Bun.RedisClient.KeyLike, start: number, stop: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: Bun.RedisClient.KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: Bun.RedisClient.KeyLike, max: number | string, min: number | string, ...options: Array<number | string>): Promise<Array<string>> }
+  zrevrank: { (key: Bun.RedisClient.KeyLike, member: string): Promise<null | number>; (key: Bun.RedisClient.KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: Bun.RedisClient.KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: Bun.RedisClient.KeyLike, member: string) => Promise<null | number>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<number | string>): Promise<Array<string>> }
+  zunionstore: (destination: Bun.RedisClient.KeyLike, numkeys: number, ...args: Array<number | string>) => Promise<number>
   [static]
-    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
-    prototype: RedisClient
-  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+    construct new (url?: string | undefined, options?: Bun.RedisOptions | undefined): Bun.RedisClient
+    prototype: Bun.RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = Blob | Bun.ArrayBufferView<ArrayBufferLike> | string
   type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
 interface RedisOptions (bun-types/redis.d.ts)
   autoReconnect [?]: boolean | undefined
@@ -1035,34 +1060,34 @@ interface RedisOptions (bun-types/redis.d.ts)
   enableOfflineQueue [?]: boolean | undefined
   idleTimeout [?]: number | undefined
   maxRetries [?]: number | undefined
-  tls [?]: TLSOptions | boolean | undefined
+  tls [?]: Bun.TLSOptions | boolean | undefined
 type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
 interface ReservedSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
   [Symbol.dispose]: () => void
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
   release: () => void
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 interface ResourceUsage (bun-types/bun.d.ts)
   contextSwitches: { voluntary: number; involuntary: number; }
   cpuTime: { user: number; system: number; total: number; }
@@ -1073,27 +1098,27 @@ interface ResourceUsage (bun-types/bun.d.ts)
   signalCount: number
   swapCount: number
 class S3Client (bun-types/s3.d.ts)
-  delete: (path: string, options?: S3Options | undefined) => Promise<void>
-  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
-  file: (path: string, options?: S3Options | undefined) => S3File
-  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
-  size: (path: string, options?: S3Options | undefined) => Promise<number>
-  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
-  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  delete: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+  list: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+  presign: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+  unlink: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+  write: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
   [static]
-    construct new (options?: S3Options | undefined): S3Client
-    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
-    file [static]: (path: string, options?: S3Options | undefined) => S3File
-    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
-    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
-    prototype: S3Client
-    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
-    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
-    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
-    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+    construct new (options?: Bun.S3Options | undefined): Bun.S3Client
+    delete [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: Bun.S3Options | undefined) => Bun.S3File
+    list [static]: (input?: Bun.S3ListObjectsOptions | null | undefined, options?: Pick<Bun.S3Options, "accessKeyId" | "bucket" | "endpoint" | "region" | "secretAccessKey" | "sessionToken"> | undefined) => Promise<Bun.S3ListObjectsResponse>
+    presign [static]: (path: string, options?: Bun.S3FilePresignOptions | undefined) => string
+    prototype: Bun.S3Client
+    size [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<Bun.S3Stats>
+    unlink [static]: (path: string, options?: Bun.S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
 interface S3File (bun-types/s3.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bucket [? readonly]: string | undefined
@@ -1101,20 +1126,20 @@ interface S3File (bun-types/s3.d.ts)
   delete: () => Promise<void>
   exists: () => Promise<boolean>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   name [? readonly]: string | undefined
-  presign: (options?: S3FilePresignOptions | undefined) => string
+  presign: (options?: Bun.S3FilePresignOptions | undefined) => string
   readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
   size [readonly]: number
-  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
-  stat: () => Promise<S3Stats>
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): Bun.S3File; (begin?: number | undefined, contentType?: string | undefined): Bun.S3File; (contentType?: string | undefined): Bun.S3File }
+  stat: () => Promise<Bun.S3Stats>
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
   unlink: () => Promise<void>
-  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
-  writer: (options?: S3Options | undefined) => NetworkSink
+  write: (data: ArrayBuffer | Blob | Bun.Archive | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | Bun.S3File | Request | Response | SharedArrayBuffer | string, options?: Bun.S3Options | undefined) => Promise<number>
+  writer: (options?: Bun.S3Options | undefined) => Bun.NetworkSink
 interface S3FilePresignOptions (bun-types/s3.d.ts)
   accessKeyId [?]: string | undefined
   acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
@@ -1180,89 +1205,89 @@ interface S3Stats (bun-types/s3.d.ts)
   size: number
   type: string
 class SHA1 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA1
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA1
   [static]
-    construct new (): SHA1
+    construct new (): Bun.SHA1
     byteLength [readonly static]: 20
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA1
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA1
 class SHA224 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA224
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA224
   [static]
-    construct new (): SHA224
+    construct new (): Bun.SHA224
     byteLength [readonly static]: 28
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA224
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA224
 class SHA256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA256
   [static]
-    construct new (): SHA256
+    construct new (): Bun.SHA256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA256
 class SHA384 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA384
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA384
   [static]
-    construct new (): SHA384
+    construct new (): Bun.SHA384
     byteLength [readonly static]: 48
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA384
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA384
 class SHA512 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512
   [static]
-    construct new (): SHA512
+    construct new (): Bun.SHA512
     byteLength [readonly static]: 64
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512
 class SHA512_256 (bun-types/bun.d.ts)
-  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
-  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  digest: { (encoding: Bun.DigestEncoding): string; (hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike> }
+  update: (data: Bun.BlobOrStringOrBuffer) => Bun.SHA512_256
   [static]
-    construct new (): SHA512_256
+    construct new (): Bun.SHA512_256
     byteLength [readonly static]: 32
-    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
-    prototype: SHA512_256
+    hash [static]: { (input: Bun.BlobOrStringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>; (input: Bun.BlobOrStringOrBuffer, encoding: Bun.DigestEncoding): string }
+    prototype: Bun.SHA512_256
 class SQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   [static]
-    construct new (connectionString: URL | string): SQL
-    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
-    construct new (options?: Options | undefined): SQL
-    MySQLError: typeof MySQLError
-    PostgresError: typeof PostgresError
-    SQLError: typeof SQLError
-    SQLiteError: typeof SQLiteError
-    prototype: SQL
+    construct new (connectionString: URL | string): Bun.SQL
+    construct new (connectionString: URL | string, options: Omit<Bun.SQL.PostgresOrMySQLOptions, "filename" | "url"> | Omit<Bun.SQL.SQLiteOptions, "filename" | "url">): Bun.SQL
+    construct new (options?: Bun.SQL.Options | undefined): Bun.SQL
+    MySQLError: typeof Bun.SQL.MySQLError
+    PostgresError: typeof Bun.SQL.PostgresError
+    SQLError: typeof Bun.SQL.SQLError
+    SQLiteError: typeof Bun.SQL.SQLiteError
+    prototype: Bun.SQL
   type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
-  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
-  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => Bun.MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? Bun.SQL.AwaitPromisesArray<T> : Awaited<T>
   interface SQL.Helper<T> (bun-types/sql.d.ts)
     columns [readonly]: Array<keyof T>
     value [readonly]: Array<T>
@@ -1279,13 +1304,13 @@ class SQL (bun-types/sql.d.ts)
     sqlState [? readonly]: string | undefined
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): Bun.SQL.MySQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: MySQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.MySQLError
       stackTraceLimit: number
-  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  type SQL.Options (bun-types/sql.d.ts) = Bun.SQL.PostgresOrMySQLOptions | Bun.SQL.SQLiteOptions
   class SQL.PostgresError (bun-types/sql.d.ts)
     cause [?]: unknown
     code [readonly]: string
@@ -1309,11 +1334,11 @@ class SQL (bun-types/sql.d.ts)
     table [? readonly]: string | undefined
     where [? readonly]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): Bun.SQL.PostgresError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: PostgresError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.PostgresError
       stackTraceLimit: number
   interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
     adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
@@ -1321,7 +1346,7 @@ class SQL (bun-types/sql.d.ts)
     bigint [?]: boolean | undefined
     connectTimeout [?]: number | undefined
     connect_timeout [?]: number | undefined
-    connection [?]: Record<string, string | number | boolean> | undefined
+    connection [?]: Record<string, boolean | number | string> | undefined
     connectionTimeout [?]: number | undefined
     connection_timeout [?]: number | undefined
     database [?]: string | undefined
@@ -1335,39 +1360,39 @@ class SQL (bun-types/sql.d.ts)
     max_lifetime [?]: number | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
-    pass [?]: (() => MaybePromise<string>) | string | undefined
-    password [?]: (() => MaybePromise<string>) | string | undefined
+    pass [?]: (() => Bun.MaybePromise<string>) | string | undefined
+    password [?]: (() => Bun.MaybePromise<string>) | string | undefined
     path [?]: string | undefined
     port [?]: number | string | undefined
     prepare [?]: boolean | undefined
-    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
-    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | Bun.BunFile | Bun.TLSOptions | boolean | undefined
     url [?]: URL | string | undefined
     user [?]: string | undefined
     username [?]: string | undefined
   interface SQL.Query<T> (bun-types/sql.d.ts)
     [Symbol.toStringTag] [readonly]: string
     active: boolean
-    cancel: () => Query<T>
+    cancel: () => Bun.SQL.Query<T>
     cancelled: boolean
     catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
-    execute: () => Query<T>
+    execute: () => Bun.SQL.Query<T>
     finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
-    raw: () => Query<T>
-    simple: () => Query<T>
+    raw: () => Bun.SQL.Query<T>
+    simple: () => Bun.SQL.Query<T>
     then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
-    values: () => Query<T>
+    values: () => Bun.SQL.Query<T>
   class SQL.SQLError (bun-types/sql.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string): SQLError
+      construct new (message: string): Bun.SQL.SQLError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLError
       stackTraceLimit: number
   class SQL.SQLiteError (bun-types/sql.d.ts)
     byteOffset [? readonly]: number | undefined
@@ -1378,55 +1403,55 @@ class SQL (bun-types/sql.d.ts)
     name: string
     stack [?]: string | undefined
     [static]
-      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): Bun.SQL.SQLiteError
       captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
       isError: (value: unknown) => value is Error
-      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
-      prototype: SQLiteError
+      prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
+      prototype: Bun.SQL.SQLiteError
       stackTraceLimit: number
   interface SQL.SQLiteOptions (bun-types/sql.d.ts)
     adapter [?]: "sqlite" | undefined
     create [?]: boolean | undefined
-    filename [?]: ":memory:" | URL | string & {} | undefined
+    filename [?]: ":memory:" | (string & {}) | URL | undefined
     onclose [?]: ((err: Error | null) => void) | undefined
     onconnect [?]: ((err: Error | null) => void) | undefined
     readonly [?]: boolean | undefined
     readwrite [?]: boolean | undefined
     safeIntegers [?]: boolean | undefined
     strict [?]: boolean | undefined
-  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SQLArrayParameter (bun-types/sql.d.ts)
-  arrayType: ArrayType
+  arrayType: Bun.ArrayType
   serializedValues: string
-type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
-type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
-type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
-type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+type SQLOptions (bun-types/deprecated.d.ts) = Bun.SQL.Options
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Bun.SQL.Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.SavepointSQL) => Bun.MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: Bun.TransactionSQL) => Bun.MaybePromise<T>
 interface SavepointSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 namespace Security (bun-types/security.d.ts)
   interface Security.Advisory (bun-types/security.d.ts)
     description: null | string
@@ -1439,29 +1464,29 @@ namespace Security (bun-types/security.d.ts)
     tarball: string
     version: string
   interface Security.Scanner (bun-types/security.d.ts)
-    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    scan: (info: { packages: Array<Bun.Security.Package>; }) => Promise<Array<Bun.Security.Advisory>>
     version: "1"
 namespace Serve (bun-types/serve.d.ts)
-  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = Bun.BunFile | Bun.HTMLBundle | Bun.Serve.DirectoryRouteOptions | Response | false
   interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
   type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
   interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
     dir: string
     statCache [?]: boolean | undefined
-  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
-  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
-  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
-  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
-  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & Bun.Serve.ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes?: Bun.Serve.Routes<WebSocketData, R> | undefined; } | { fetch?(this: Bun.Server<WebSocketData>, req: Request, server: Bun.Server<WebSocketData>): Bun.MaybePromise<Response>; routes: Bun.Serve.Routes<WebSocketData, R>; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = Bun.Serve.FetchOrRoutesWithWebSocket<WebSocketData, R>
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => Bun.MaybePromise<Res>
   interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
-    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | (string & {}) | undefined
     http1 [?]: boolean | undefined
     http2 [?]: boolean | undefined
     http3 [?]: boolean | undefined
@@ -1471,18 +1496,18 @@ namespace Serve (bun-types/serve.d.ts)
     maxRequestBodySize [?]: number | undefined
     port [?]: number | string | undefined
     reusePort [?]: boolean | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
-  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
-  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
-  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = Bun.Serve.Options<WebSocketData, R>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: Bun.Serve.BaseRouteValue | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined> | Partial<Record<Bun.Serve.HTTPMethod, Response | Bun.Serve.Handler<Bun.BunRequest<Path>, Bun.Server<WebSocketData>, void | Response | undefined>>>; }
   interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
-    development [?]: Development | undefined
-    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    development [?]: Bun.Serve.Development | undefined
+    error [?]: ((this: Bun.Server<WebSocketData>, error: Bun.ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
     id [?]: null | string | undefined
     maxRequestBodySize [?]: number | undefined
-    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    tls [?]: Array<Bun.TLSOptions> | Bun.TLSOptions | undefined
     unix [?]: string | undefined
-type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = Bun.ServeOptions<T, R>
 interface Server<WebSocketData> (bun-types/serve.d.ts)
   [Symbol.dispose]: () => void
   closeIdleConnections: () => number
@@ -1494,41 +1519,41 @@ interface Server<WebSocketData> (bun-types/serve.d.ts)
   pendingWebSockets [readonly]: number
   port [readonly]: number | undefined
   protocol [readonly]: "http" | "https" | null
-  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  publish: (topic: string, data: ArrayBuffer | Blob | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, compress?: boolean | undefined) => number
   ref: () => void
-  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
-  requestIP: (request: Request) => SocketAddress | null
+  reload: <R extends string>(options: Bun.Serve.Options<WebSocketData, R>) => Bun.Server<WebSocketData>
+  requestIP: (request: Request) => Bun.SocketAddress | null
   stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
   subscriberCount: (topic: string) => number
   timeout: (request: Request, seconds: number) => void
   unref: () => void
-  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: Bun.HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: Bun.HeadersInit | undefined; data: WebSocketData; }]) => boolean
   url [readonly]: URL
 interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
   binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
   close: (code?: number | undefined, reason?: string | undefined) => void
-  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  cork: <T = unknown>(callback: (ws: Bun.ServerWebSocket<T>) => T) => T
   data: T
   getBufferedAmount: () => number
   isSubscribed: (topic: string) => boolean
-  ping: (data?: Blob | BufferSource | string | undefined) => number
-  pong: (data?: Blob | BufferSource | string | undefined) => number
-  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  ping: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  pong: (data?: Blob | Bun.BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   publishText: (topic: string, data: string, compress?: boolean | undefined) => number
-  readyState [readonly]: WebSocketReadyState
+  readyState [readonly]: Bun.WebSocketReadyState
   remoteAddress [readonly]: string
-  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
-  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  send: (data: Blob | Bun.BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | Bun.BufferSource, compress?: boolean | undefined) => number
   sendText: (data: string, compress?: boolean | undefined) => number
   subscribe: (topic: string) => boolean
   subscriptions [readonly]: Array<string>
   terminate: () => void
   unsubscribe: (topic: string) => boolean
 type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
-type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellExpression (bun-types/shell.d.ts) = Array<Bun.ShellExpression> | BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | Blob | Bun.BunFile | Bun.Subprocess<Bun.SpawnOptions.Writable, Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | ReadableStream<any> | ReadableStream<any> | Request | Response | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | null | number | string | undefined | { raw: string; } | { toString(): string; }
 type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
-type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+type SignalsListener (bun-types/bun.d.ts) = (signal: NodeJS.Signals) => void
 interface SliceAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   ellipsis [?]: string | undefined
@@ -1540,8 +1565,8 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   close: () => void
   data: Data
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1558,14 +1583,14 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1575,154 +1600,154 @@ interface Socket<Data = undefined> (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface SocketAddress (bun-types/bun.d.ts)
   address: string
   family: "IPv4" | "IPv6"
   port: number
-interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
-  binaryType [?]: keyof BinaryTypeList | undefined
-  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
-  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
-  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
-  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
-  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
-  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof Bun.BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof Bun.BinaryTypeList | undefined
+  close [?]: ((socket: Bun.Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Bun.Socket<Data>, data: Bun.BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Bun.Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Bun.Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Bun.Socket<Data>) => Promise<void> | void) | undefined
 interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
+  socket: Bun.SocketHandler<Data, "buffer">
 namespace Spawn (bun-types/bun.d.ts)
-  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
-  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
-  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
-  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
-  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  type Spawn.OptionsObject<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = Bun.SpawnOptions.BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | null | number | undefined
+  type Spawn.ReadableToIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | Bun.BunFile | Bun.ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     lazy [?]: boolean | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
-    terminal [?]: Terminal | TerminalOptions | undefined
+    terminal [?]: Bun.Terminal | Bun.TerminalOptions | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+  interface Spawn.SpawnSyncOptions<In extends Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
     argv0 [?]: string | undefined
     cgroup [?]: number | string | undefined
     cwd [?]: string | undefined
     detached [?]: boolean | undefined
     env [?]: Record<string, string | undefined> | undefined
     gid [?]: number | undefined
-    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    ipc [?]: ((message: any, subprocess: Bun.Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
     killSignal [?]: number | string | undefined
     maxBuffer [?]: number | undefined
     onDisconnect [?]: (() => Promise<void> | void) | undefined
-    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Bun.Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: Bun.ErrorLike | undefined) => Promise<void> | void) | undefined
     serialization [?]: "advanced" | "json" | undefined
     signal [?]: AbortSignal | undefined
     stderr [?]: Err | undefined
     stdin [?]: In | undefined
-    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdio [?]: [In, Out, Err, ...(Bun.SpawnOptions.Readable | "socket-fd")[]] | undefined
     stdout [?]: Out | undefined
     timeout [?]: number | undefined
     uid [?]: number | undefined
     windowsHide [?]: boolean | undefined
     windowsVerbatimArguments [?]: boolean | undefined
-  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
-  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
-  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = "ignore" | "inherit" | "pipe" | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Bun.BunFile | ReadableStream<any> | Request | Response | null | number | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = Bun.FileSink | number | undefined
+  type Spawn.WritableToIO<X extends Bun.SpawnOptions.Writable> (bun-types/bun.d.ts) = X extends "pipe" ? Bun.FileSink : X extends number | Bun.BunFile | Blob | Bun.ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
 SpawnOptions -> Spawn
 type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
-type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type StringOrBuffer (bun-types/bun.d.ts) = ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike> | string
 interface StringWidthOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   countAnsiEscapeCodes [?]: boolean | undefined
   perCodePoint [?]: boolean | undefined
 interface StructuredSerializeOptions (bun-types/bun.d.ts)
-  transfer [?]: Array<Transferable> | undefined
-interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  transfer [?]: Array<Bun.Transferable> | undefined
+interface Subprocess<In extends Bun.SpawnOptions.Writable = Bun.SpawnOptions.Writable, Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => PromiseLike<void>
   disconnect: () => void
   exitCode [readonly]: null | number
   exited [readonly]: Promise<number>
-  kill: (exitCode?: Signals | number | undefined) => void
+  kill: (exitCode?: NodeJS.Signals | number | undefined) => void
   killed [readonly]: boolean
   pid [readonly]: number
-  readable [readonly]: ReadableToIO<Out>
+  readable [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
   ref: () => void
-  resourceUsage: () => ResourceUsage | undefined
+  resourceUsage: () => Bun.ResourceUsage | undefined
   send: (message: any) => void
-  signalCode [readonly]: Signals | null
-  stderr [readonly]: ReadableToIO<Err>
-  stdin [readonly]: WritableToIO<In>
+  signalCode [readonly]: NodeJS.Signals | null
+  stderr [readonly]: Bun.SpawnOptions.ReadableToIO<Err>
+  stdin [readonly]: Bun.SpawnOptions.WritableToIO<In>
   stdio [readonly]: [null, null, null, ...(number | null)[]]
-  stdout [readonly]: ReadableToIO<Out>
-  terminal [readonly]: Terminal | undefined
+  stdout [readonly]: Bun.SpawnOptions.ReadableToIO<Out>
+  terminal [readonly]: Bun.Terminal | undefined
   unref: () => void
-type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
-interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha256" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "sha384" | "sha512" | "sha512-224" | "sha512-256" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable, Err extends Bun.SpawnOptions.Readable = Bun.SpawnOptions.Readable> (bun-types/bun.d.ts)
   exitCode: number
   exitedDueToMaxBuffer [?]: boolean | undefined
   exitedDueToTimeout [?]: boolean | undefined
   pid: number
-  resourceUsage: ResourceUsage
+  resourceUsage: Bun.ResourceUsage
   signalCode [?]: string | undefined
-  stderr: ReadableToSyncIO<Err>
-  stdout: ReadableToSyncIO<Out>
+  stderr: Bun.SpawnOptions.ReadableToSyncIO<Err>
+  stdout: Bun.SpawnOptions.ReadableToSyncIO<Out>
   success: boolean
 interface SystemError (bun-types/bun.d.ts)
   cause [?]: unknown
@@ -1741,8 +1766,8 @@ interface TCPSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1759,14 +1784,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1776,14 +1801,14 @@ interface TCPSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
@@ -1792,36 +1817,36 @@ interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
   ipv6Only [?]: boolean | undefined
   port: number
   reusePort [?]: boolean | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
   exclusive [?]: boolean | undefined
   hostname: string
   port: number
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
 interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   hostname [readonly]: string
   port [readonly]: number
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unref: () => void
 interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -1837,8 +1862,8 @@ interface TLSSocket (bun-types/bun.d.ts)
   close: () => void
   data: undefined
   disableRenegotiation: () => void
-  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
-  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  end: { (data?: Bun.BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: Bun.BufferSource | string | undefined): void }
   flush: () => void
   getAuthorizationError: () => Error | null
   getCertificate: () => PeerCertificate | null | object
@@ -1855,14 +1880,14 @@ interface TLSSocket (bun-types/bun.d.ts)
   getTLSVersion: () => string
   getX509Certificate: () => X509Certificate | undefined
   isSessionReused: () => boolean
-  listener [? readonly]: SocketListener<undefined> | undefined
+  listener [? readonly]: Bun.SocketListener<undefined> | undefined
   localAddress [readonly]: string
   localFamily [readonly]: "IPv4" | "IPv6"
   localPort [readonly]: number
   pause: () => void
   readyState [readonly]: -1 | -2 | 0 | 1 | 2
   ref: () => void
-  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<undefined>, "socket">) => void
   remoteAddress [readonly]: string
   remoteFamily [readonly]: "IPv4" | "IPv6"
   remotePort [readonly]: number
@@ -1872,27 +1897,27 @@ interface TLSSocket (bun-types/bun.d.ts)
   setMaxSendFragment: (size: number) => boolean
   setNoDelay: (noDelay?: boolean | undefined) => boolean
   setServername: (name: string) => void
-  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | Bun.BufferSource | string) => void
   setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
   shutdown: (halfClose?: boolean | undefined) => void
   terminate: () => void
   timeout: (seconds: number) => void
   unref: () => void
-  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
-  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+  upgradeTLS: <Data>(options: Bun.TLSUpgradeOptions<Data>) => [raw: Bun.Socket<Data>, tls: Bun.Socket<Data>]
+  write: (data: Bun.BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
 interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls: TLSOptions | boolean
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls: Bun.TLSOptions | boolean
 namespace TOML (bun-types/bun.d.ts)
   function TOML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): object
   function TOML.stringify (bun-types/bun.d.ts)
     call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
 interface TSConfig (bun-types/bun.d.ts)
   compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
   extends [?]: string | undefined
-type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+type Target (bun-types/bun.d.ts) = "browser" | "bun" | "node"
 class Terminal (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => Promise<void>
   close: () => void
@@ -1905,43 +1930,43 @@ class Terminal (bun-types/bun.d.ts)
   resize: (cols: number, rows: number) => void
   setRawMode: (enabled: boolean) => void
   unref: () => void
-  write: (data: BufferSource | string) => number
+  write: (data: Bun.BufferSource | string) => number
   [static]
-    construct new (options: TerminalOptions): Terminal
-    prototype: Terminal
+    construct new (options: Bun.TerminalOptions): Bun.Terminal
+    prototype: Bun.Terminal
 interface TerminalOptions (bun-types/bun.d.ts)
   cols [?]: number | undefined
-  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
-  drain [?]: ((terminal: Terminal) => void) | undefined
-  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  data [?]: ((terminal: Bun.Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Bun.Terminal) => void) | undefined
+  exit [?]: ((terminal: Bun.Terminal, exitCode: number, signal: null | string) => void) | undefined
   name [?]: string | undefined
   rows [?]: number | undefined
 type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
 interface TransactionSQL (bun-types/sql.d.ts)
-  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
-  call <T = any>(string: string): Query<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
-  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
-  call <T>(value: T & {}): Helper<T>
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Bun.SQL.Query<T>
+  call <T = any>(string: string): Bun.SQL.Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Bun.SQL.Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Bun.SQL.Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Bun.SQL.Helper<T>
   [Symbol.asyncDispose]: () => PromiseLike<void>
-  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
-  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  array: (values: Array<any>, typeNameOrTypeID?: Bun.ArrayType | number | undefined) => Bun.SQLArrayParameter
+  begin: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
   commitDistributed: (name: string) => Promise<void>
-  connect: () => Promise<SQL>
-  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  connect: () => Promise<Bun.SQL>
+  distributed: <T>(name: string, fn: Bun.SQL.TransactionContextCallback<T>) => Promise<Bun.SQL.ContextCallbackResult<T>>
   end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
-  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
   flush: () => void
-  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<Bun.SQL.ListenSubscription>
   notify: (channel: string, payload?: string | undefined) => Promise<void>
-  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
-  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  options: Bun.__internal.Merge<Bun.SQL.PostgresOrMySQLOptions, Bun.SQL.SQLiteOptions> | Bun.__internal.Merge<Bun.SQL.SQLiteOptions, Bun.SQL.PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<Bun.ReservedSQL>
   rollbackDistributed: (name: string) => Promise<void>
-  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
-  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
-  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  savepoint: { <T>(name: string, fn: Bun.SQL.SavepointContextCallback<T>): Promise<T>; <T>(fn: Bun.SQL.SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>>; <T>(options: string, fn: Bun.SQL.TransactionContextCallback<T>): Promise<Bun.SQL.ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Bun.SQL.Query<T>
 type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
 interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
   call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
@@ -1950,13 +1975,13 @@ interface TransformerStartCallback<O> (bun-types/bun.d.ts)
 interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
   call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
 class Transpiler (bun-types/bun.d.ts)
-  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
-  scanImports: (code: StringOrBuffer) => Array<Import>
-  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
-  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  scan: (code: Bun.StringOrBuffer) => { exports: Array<string>; imports: Array<Bun.Import>; }
+  scanImports: (code: Bun.StringOrBuffer) => Array<Bun.Import>
+  transform: (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: Bun.StringOrBuffer, loader: Bun.JavaScriptLoader, ctx: object): string; (code: Bun.StringOrBuffer, ctx: object): string; (code: Bun.StringOrBuffer, loader?: Bun.JavaScriptLoader | undefined): string }
   [static]
-    construct new (options?: TranspilerOptions | undefined): Transpiler
-    prototype: Transpiler
+    construct new (options?: Bun.TranspilerOptions | undefined): Bun.Transpiler
+    prototype: Bun.Transpiler
 interface TranspilerOptions (bun-types/bun.d.ts)
   allowBunRuntime [?]: boolean | undefined
   autoImportJSX [?]: boolean | undefined
@@ -1965,23 +1990,23 @@ interface TranspilerOptions (bun-types/bun.d.ts)
   exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
   inline [?]: boolean | undefined
   jsxOptimizationInline [?]: boolean | undefined
-  loader [?]: JavaScriptLoader | undefined
+  loader [?]: Bun.JavaScriptLoader | undefined
   logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
-  macro [?]: MacroMap | undefined
+  macro [?]: Bun.MacroMap | undefined
   minifyWhitespace [?]: boolean | undefined
   replMode [?]: boolean | undefined
-  target [?]: Target | undefined
+  target [?]: Bun.Target | undefined
   treeShaking [?]: boolean | undefined
   trimUnusedImports [?]: boolean | undefined
-  tsconfig [?]: TSConfig | string | undefined
-type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  tsconfig [?]: Bun.TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: Bun.UncaughtExceptionOrigin) => void
 type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
 interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
-  abort [?]: UnderlyingSinkAbortCallback | undefined
-  close [?]: UnderlyingSinkCloseCallback | undefined
-  start [?]: UnderlyingSinkStartCallback | undefined
+  abort [?]: Bun.UnderlyingSinkAbortCallback | undefined
+  close [?]: Bun.UnderlyingSinkCloseCallback | undefined
+  start [?]: Bun.UnderlyingSinkStartCallback | undefined
   type [?]: "bytes" | "default" | undefined
-  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+  write [?]: Bun.UnderlyingSinkWriteCallback<W> | undefined
 interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
@@ -1991,30 +2016,30 @@ interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
 interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
   call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
 interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
-  cancel [?]: UnderlyingSourceCancelCallback | undefined
-  pull [?]: UnderlyingSourcePullCallback<R> | undefined
-  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  cancel [?]: Bun.UnderlyingSourceCancelCallback | undefined
+  pull [?]: Bun.UnderlyingSourcePullCallback<R> | undefined
+  start [?]: Bun.UnderlyingSourceStartCallback<R> | undefined
   type [?]: undefined
 interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
   call (reason?: any): PromiseLike<void> | void
 interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+  call (controller: Bun.ReadableStreamController<R>): PromiseLike<void> | void
 interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
-  call (controller: ReadableStreamController<R>): any
+  call (controller: Bun.ReadableStreamController<R>): any
 type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
 interface UnixSocketListener<Data> (bun-types/bun.d.ts)
   [Symbol.dispose]: () => void
   data: Data
   ref: () => void
-  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  reload: (options: Pick<Bun.SocketOptions<Data>, "socket">) => void
   stop: (closeActiveConnections?: boolean | undefined) => void
   unix [readonly]: string
   unref: () => void
 interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
   allowHalfOpen [?]: boolean | undefined
   data [?]: Data | undefined
-  socket: SocketHandler<Data, "buffer">
-  tls [?]: TLSOptions | boolean | undefined
+  socket: Bun.SocketHandler<Data, "buffer">
+  tls [?]: Bun.TLSOptions | boolean | undefined
   unix: string
 type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
 namespace WebAssembly (bun-types/wasm.d.ts)
@@ -2023,19 +2048,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     message: string
     name: string
     stack [?]: string | undefined
-  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
-  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.Global<keyof Bun.WebAssembly.ValueTypeMap> | Bun.WebAssembly.Memory | Bun.WebAssembly.Table | Function
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ExportValue; }
+  interface WebAssembly.Global<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
-  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
-  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = Bun.WebAssembly.ExportValue | number
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ModuleImports; }
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2050,13 +2075,13 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
-  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: Bun.WebAssembly.ImportValue; }
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
@@ -2068,11 +2093,11 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     length [readonly]: number
     set: (index: number, value?: any) => void
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
-  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof Bun.WebAssembly.ValueTypeMap
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
     anyfunc: Function
     externref: any
@@ -2082,70 +2107,70 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
 interface WebSocket (bun-types/bun.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
-type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+type WebSocketCompressor (bun-types/serve.d.ts) = "128KB" | "16KB" | "256KB" | "32KB" | "3KB" | "4KB" | "64KB" | "8KB" | "dedicated" | "disable" | "shared"
 interface WebSocketEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: Event
-  message: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
   open: Event
 interface WebSocketHandler<T> (bun-types/serve.d.ts)
   backpressureLimit [?]: number | undefined
-  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  close [?]: ((ws: Bun.ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
   closeOnBackpressureLimit [?]: boolean | undefined
   data [?]: T | undefined
-  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  drain [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
   idleTimeout [?]: number | undefined
   maxPayloadLength [?]: number | undefined
-  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
-  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
-  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
-  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
-  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  message: (ws: Bun.ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: Bun.ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | Bun.WebSocketCompressor | undefined; decompress?: boolean | Bun.WebSocketCompressor | undefined; }
+  ping [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: Bun.ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
   publishToSelf [?]: boolean | undefined
   sendPings [?]: boolean | undefined
-type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptions (bun-types/bun.d.ts) = Bun.WebSocketOptions
 type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
 type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
-type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocol?: string | undefined; } | { protocols?: string | Array<string> | undefined; }
 type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
-type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: Bun.TLSOptions | undefined; }
 type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
 class WebView (bun-types/bun.d.ts)
   [Symbol.asyncDispose]: () => void
   [Symbol.dispose]: () => void
-  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: BunMessageEvent<T>) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: Bun.BunMessageEvent<T>) => void, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   back: () => Promise<void>
   cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
-  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  click: { (x: number, y: number, options?: Bun.WebView.ClickOptions | undefined): Promise<void>; (selector: string, options?: Bun.WebView.ClickSelectorOptions | undefined): Promise<void> }
   close: () => void
   dispatchEvent: (event: Event) => boolean
   evaluate: <T = unknown>(script: string) => Promise<T>
@@ -2154,66 +2179,66 @@ class WebView (bun-types/bun.d.ts)
   navigate: (url: string) => Promise<void>
   onNavigated: ((url: string, title: string) => void) | null
   onNavigationFailed: ((error: Error) => void) | null
-  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  press: (key: (string & {}) | Bun.WebView.VirtualKey, options?: Bun.WebView.PressOptions | undefined) => Promise<void>
   reload: () => Promise<void>
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   resize: (width: number, height: number) => Promise<void>
   screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
   scroll: (dx: number, dy: number) => Promise<void>
-  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  scrollTo: (selector: string, options?: Bun.WebView.ScrollToOptions | undefined) => Promise<void>
   title [readonly]: string
   type: (text: string) => Promise<void>
   url [readonly]: string
   [static]
-    construct new (options?: ConstructorOptions | undefined): WebView
+    construct new (options?: Bun.WebView.ConstructorOptions | undefined): Bun.WebView
     closeAll [static]: () => void
-    prototype: WebView
-  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+    prototype: Bun.WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "chrome" | "webkit" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
   interface WebView.ClickOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
     button [?]: "left" | "middle" | "right" | undefined
     clickCount [?]: 1 | 2 | 3 | undefined
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
     timeout [?]: number | undefined
-  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = ((type: string, ...args: Array<unknown>) => void) | Console
   interface WebView.ConstructorOptions (bun-types/bun.d.ts)
-    backend [?]: Backend | undefined
-    console [?]: ConsoleCapture | undefined
+    backend [?]: Bun.WebView.Backend | undefined
+    console [?]: Bun.WebView.ConsoleCapture | undefined
     dataStore [?]: "ephemeral" | undefined | { directory: string; }
     headless [?]: boolean | undefined
     height [?]: number | undefined
     url [?]: string | undefined
     width [?]: number | undefined
-  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  type WebView.Modifier (bun-types/bun.d.ts) = "Alt" | "Control" | "Meta" | "Shift"
   interface WebView.PressOptions (bun-types/bun.d.ts)
-    modifiers [?]: Array<Modifier> | undefined
+    modifiers [?]: Array<Bun.WebView.Modifier> | undefined
   interface WebView.ScrollToOptions (bun-types/bun.d.ts)
     block [?]: "center" | "end" | "nearest" | "start" | undefined
     timeout [?]: number | undefined
-  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "Backspace" | "Delete" | "End" | "Enter" | "Escape" | "Home" | "PageDown" | "PageUp" | "Space" | "Tab"
 interface WhichOptions (bun-types/bun.d.ts)
   PATH [?]: string | undefined
   cwd [?]: string | undefined
 interface Worker (bun-types/bun.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
 interface WorkerEventMap (bun-types/bun.d.ts)
   close: CloseEvent
   error: ErrorEvent
-  message: BunMessageEvent<any>
-  messageerror: BunMessageEvent<any>
+  message: Bun.BunMessageEvent<any>
+  messageerror: Bun.BunMessageEvent<any>
   open: Event
 interface WorkerOptions (bun-types/bun.d.ts)
   argv [?]: Array<any> | undefined
@@ -2223,44 +2248,44 @@ interface WorkerOptions (bun-types/bun.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
 interface WrapAnsiOptions (bun-types/bun.d.ts)
   ambiguousIsNarrow [?]: boolean | undefined
   hard [?]: boolean | undefined
   trim [?]: boolean | undefined
   wordWrap [?]: boolean | undefined
-type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+type WritableSubprocess (bun-types/bun.d.ts) = Bun.Subprocess<"pipe", any, any>
 namespace XML (bun-types/bun.d.ts)
   interface XML.Comment (bun-types/bun.d.ts)
     comment: string
   interface XML.Document (bun-types/bun.d.ts)
-    index [string]: Value
+    index [string]: Bun.XML.Value
   interface XML.Element (bun-types/bun.d.ts)
-    index [string]: Array<Value> | Value
+    index [string]: Array<Bun.XML.Value> | Bun.XML.Value
   interface XML.Node (bun-types/bun.d.ts)
     attributes: Record<string, string>
-    children: Array<string | Comment | Node | ProcessingInstruction>
+    children: Array<Bun.XML.Comment | Bun.XML.Node | Bun.XML.ProcessingInstruction | string>
     name: string
   interface XML.NodeInput (bun-types/bun.d.ts)
-    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
-    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    attributes [?]: null | undefined | { [name: string]: Bun.XML.Scalar | null | undefined; }
+    children [?]: Array<Bun.XML.Comment | Bun.XML.NodeInput | Bun.XML.ProcessingInstruction | Bun.XML.Scalar | null | undefined> | null | undefined
     name: string
   interface XML.ParseOptions (bun-types/bun.d.ts)
     compact [?]: boolean | undefined
   interface XML.ProcessingInstruction (bun-types/bun.d.ts)
     data: string
     target: string
-  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
-  type XML.Value (bun-types/bun.d.ts) = string | Element
+  type XML.Scalar (bun-types/bun.d.ts) = Date | bigint | boolean | number | string
+  type XML.Value (bun-types/bun.d.ts) = Bun.XML.Element | string
   function XML.parse (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
-    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: (Bun.XML.ParseOptions & { compact?: true | undefined; }) | undefined): Bun.XML.Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options: Bun.XML.ParseOptions & { compact: false; }): Bun.XML.Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.XML.ParseOptions | undefined): Bun.XML.Document | Bun.XML.Node
   function XML.stringify (bun-types/bun.d.ts)
-    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: Bun.XML.Document | Bun.XML.NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
     call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
-type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = Blob | Bun.BufferSource | FormData | URLSearchParams | string
 namespace YAML (bun-types/bun.d.ts)
   function YAML.parse (bun-types/bun.d.ts)
     call (input: string): unknown
@@ -2292,9 +2317,9 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     timeStamp [readonly]: number
     type [readonly]: string
   interface __internal.BunEventTarget (bun-types/globals.d.ts)
-    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
     dispatchEvent: (event: Event) => boolean
-    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+    removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
     [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
     append [readonly]: (name: string, value: string) => void
@@ -2322,7 +2347,7 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     destination [readonly]: RequestDestination
     duplex [readonly]: "half"
     formData [readonly]: () => Promise<FormData>
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     integrity [readonly]: string
     json [readonly]: () => Promise<unknown>
     keepalive [readonly]: boolean
@@ -2343,7 +2368,7 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
     clone: () => Response
     formData [readonly]: () => Promise<FormData>
-    headers: BunHeadersOverride
+    headers: Bun.__internal.BunHeadersOverride
     json [readonly]: () => Promise<unknown>
     ok [readonly]: boolean
     redirected [readonly]: boolean
@@ -2353,16 +2378,16 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
     textStream: () => ReadableStream<string>
     type [readonly]: ResponseType
     url [readonly]: string
-  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Bun.__internal.Merge<T, Exclude<Else, T>> : never
   type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
   type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
   type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = false
   type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = BroadcastChannel
-  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = BunEvent
-  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = BunEventTarget
-  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = WebSocket
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = Bun.__internal.BunEvent
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = Bun.__internal.BunEventTarget
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = Bun.WebSocket
   type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = EventSource
-  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = SubtleCrypto
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = webcrypto.SubtleCrypto
   type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = MessagePort
   type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = ReadableStream<T>
   type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = CompressionStream
@@ -2383,48 +2408,48 @@ namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/global
   type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = ReadableStreamBYOBRequest
   type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = Headers
   type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = Request
-  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: BodyInit | null | undefined; headers?: HeadersInit | undefined; }
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: Bun.BodyInit | null | undefined; headers?: Bun.HeadersInit | undefined; }
   type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = Response
   type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = ResponseInit
   type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = Performance
-  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Worker
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Bun.Worker
   type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
   type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
-  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
-  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = webcrypto.CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = webcrypto.CryptoKeyPair
   type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = Otherwise
   type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
-  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Bun.__internal.Without<A, B> | Bun.__internal.Without<B, A>
 function allocUnsafe (bun-types/bun.d.ts)
   call (size: number): Uint8Array<ArrayBuffer>
 var argv (bun-types/bun.d.ts): Array<string>
 function build (bun-types/bun.d.ts)
-  call (config: BuildConfig): Promise<BuildOutput>
+  call (config: Bun.BuildConfig): Promise<Bun.BuildOutput>
 function color (bun-types/bun.d.ts)
-  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
-  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
-  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
-  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
-  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
-  call (input: ColorInput, outputFormat: "number"): null | number
+  call (input: Bun.ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: Bun.ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: Bun.ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: Bun.ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: Bun.ColorInput, outputFormat: "number"): null | number
 function concatArrayBuffers (bun-types/bun.d.ts)
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
-  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
 function connect (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: Bun.TCPSocketConnectOptions<Data>): Promise<Bun.Socket<Data>>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Promise<Bun.Socket<Data>>
 var cron (bun-types/bun.d.ts)
-  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
-  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
-  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  call (schedule: Bun.CronWithAutocomplete, handler: (this: Bun.CronJob) => unknown, options?: Bun.CronOptions | undefined): Bun.CronJob
+  call (path: string, schedule: Bun.CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: Bun.CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: Bun.CronOptions | undefined) => Date | null
   remove: (title: string) => Promise<void>
 function deepEquals (bun-types/bun.d.ts)
   call (a: any, b: any, strict?: boolean | undefined): boolean
 function deepMatch (bun-types/bun.d.ts)
   call (subset: unknown, a: unknown): boolean
 function deflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 namespace dns (bun-types/bun.d.ts)
   var dns.ADDRCONFIG (bun-types/bun.d.ts): number
   var dns.ALL (bun-types/bun.d.ts): number
@@ -2432,50 +2457,50 @@ namespace dns (bun-types/bun.d.ts)
   function dns.getCacheStats (bun-types/bun.d.ts)
     call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
   function dns.lookup (bun-types/bun.d.ts)
-    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<Bun.DNSLookup>>
   function dns.prefetch (bun-types/bun.d.ts)
     call (hostname: string, port?: number | undefined): void
 var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
 var enableANSIColors (bun-types/bun.d.ts): boolean
-var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+var env (bun-types/bun.d.ts): Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
 function escapeHTML (bun-types/bun.d.ts)
   call (input: boolean | number | object | string): string
 var fetch (bun-types/bun.d.ts): typeof fetch
 function file (bun-types/bun.d.ts)
-  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
-  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
-  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+  call (path: URL | string, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): Bun.BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): Bun.BunFile
 function fileURLToPath (bun-types/bun.d.ts)
   call (url: URL | string): string
 function gc (bun-types/bun.d.ts)
   call (force?: boolean | undefined): void
 function generateHeapSnapshot (bun-types/bun.d.ts)
-  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format?: "jsc" | undefined): Bun.HeapSnapshot
   call (format: "v8"): string
   call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
 function gunzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function gzipSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
-var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: ArrayBuffer | Bun.ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | number | undefined) => bigint | number) & Bun.Hash
 function indexOfLine (bun-types/bun.d.ts)
-  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+  call (buffer: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
 function inflateSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: Bun.LibdeflateCompressionOptions | Bun.ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
 function inspect (bun-types/bun.d.ts)
-  call (arg: any, options?: BunInspectOptions | undefined): string
-  custom: typeof custom
+  call (arg: any, options?: Bun.BunInspectOptions | undefined): string
+  custom: typeof inspect.custom
   table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
 namespace inspect (bun-types/bun.d.ts)
-  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  var inspect.custom (bun-types/bun.d.ts): typeof inspect.custom
   function inspect.table (bun-types/bun.d.ts)
     call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
     call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
 var isMainThread (bun-types/bun.d.ts): boolean
 var isStandaloneExecutable (bun-types/bun.d.ts): boolean
 function listen (bun-types/bun.d.ts)
-  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
-  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+  call <Data = undefined>(options: Bun.TCPSocketListenOptions<Data>): Bun.TCPSocketListener<Data>
+  call <Data = undefined>(options: Bun.UnixSocketOptions<Data>): Bun.UnixSocketListener<Data>
 var main (bun-types/bun.d.ts): string
 namespace markdown (bun-types/bun.d.ts)
   interface markdown.AnsiTheme (bun-types/bun.d.ts)
@@ -2496,37 +2521,37 @@ namespace markdown (bun-types/bun.d.ts)
   interface markdown.CodeBlockProps (bun-types/bun.d.ts)
     children: Array<unknown>
     language [?]: string | undefined
-  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = ((props: P) => any) | (new (props: P) => any) | string
   interface markdown.ComponentOverrides (bun-types/bun.d.ts)
-    a [?]: Component<LinkProps> | undefined
-    blockquote [?]: Component<ChildrenProps> | undefined
-    br [?]: Component<{}> | undefined
-    code [?]: Component<ChildrenProps> | undefined
-    del [?]: Component<ChildrenProps> | undefined
-    em [?]: Component<ChildrenProps> | undefined
-    h1 [?]: Component<HeadingProps> | undefined
-    h2 [?]: Component<HeadingProps> | undefined
-    h3 [?]: Component<HeadingProps> | undefined
-    h4 [?]: Component<HeadingProps> | undefined
-    h5 [?]: Component<HeadingProps> | undefined
-    h6 [?]: Component<HeadingProps> | undefined
-    hr [?]: Component<{}> | undefined
-    html [?]: Component<ChildrenProps> | undefined
-    img [?]: Component<ImageProps> | undefined
-    li [?]: Component<ListItemProps> | undefined
-    math [?]: Component<ChildrenProps> | undefined
-    ol [?]: Component<OrderedListProps> | undefined
-    p [?]: Component<ChildrenProps> | undefined
-    pre [?]: Component<CodeBlockProps> | undefined
-    strong [?]: Component<ChildrenProps> | undefined
-    table [?]: Component<ChildrenProps> | undefined
-    tbody [?]: Component<ChildrenProps> | undefined
-    td [?]: Component<CellProps> | undefined
-    th [?]: Component<CellProps> | undefined
-    thead [?]: Component<ChildrenProps> | undefined
-    tr [?]: Component<ChildrenProps> | undefined
-    u [?]: Component<ChildrenProps> | undefined
-    ul [?]: Component<ChildrenProps> | undefined
+    a [?]: Bun.markdown.Component<Bun.markdown.LinkProps> | undefined
+    blockquote [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    br [?]: Bun.markdown.Component<{}> | undefined
+    code [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    del [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    em [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    h1 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h2 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h3 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h4 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h5 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    h6 [?]: Bun.markdown.Component<Bun.markdown.HeadingProps> | undefined
+    hr [?]: Bun.markdown.Component<{}> | undefined
+    html [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    img [?]: Bun.markdown.Component<Bun.markdown.ImageProps> | undefined
+    li [?]: Bun.markdown.Component<Bun.markdown.ListItemProps> | undefined
+    math [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ol [?]: Bun.markdown.Component<Bun.markdown.OrderedListProps> | undefined
+    p [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    pre [?]: Bun.markdown.Component<Bun.markdown.CodeBlockProps> | undefined
+    strong [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    table [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tbody [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    td [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    th [?]: Bun.markdown.Component<Bun.markdown.CellProps> | undefined
+    thead [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    tr [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    u [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
+    ul [?]: Bun.markdown.Component<Bun.markdown.ChildrenProps> | undefined
   interface markdown.HeadingMeta (bun-types/bun.d.ts)
     id [?]: string | undefined
     level: number
@@ -2598,45 +2623,45 @@ namespace markdown (bun-types/bun.d.ts)
     wikiLinks [?]: boolean | undefined
   interface markdown.RenderCallbacks (bun-types/bun.d.ts)
     blockquote [?]: ((children: string) => null | string | undefined) | undefined
-    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: Bun.markdown.CodeBlockMeta | undefined) => null | string | undefined) | undefined
     codespan [?]: ((children: string) => null | string | undefined) | undefined
     emphasis [?]: ((children: string) => null | string | undefined) | undefined
-    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: Bun.markdown.HeadingMeta) => null | string | undefined) | undefined
     hr [?]: ((children: string) => null | string | undefined) | undefined
     html [?]: ((children: string) => null | string | undefined) | undefined
-    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
-    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
-    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
-    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: Bun.markdown.ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: Bun.markdown.LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: Bun.markdown.ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: Bun.markdown.ListItemMeta) => null | string | undefined) | undefined
     paragraph [?]: ((children: string) => null | string | undefined) | undefined
     strikethrough [?]: ((children: string) => null | string | undefined) | undefined
     strong [?]: ((children: string) => null | string | undefined) | undefined
     table [?]: ((children: string) => null | string | undefined) | undefined
     tbody [?]: ((children: string) => null | string | undefined) | undefined
-    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     text [?]: ((text: string) => null | string | undefined) | undefined
-    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: Bun.markdown.CellMeta | undefined) => null | string | undefined) | undefined
     thead [?]: ((children: string) => null | string | undefined) | undefined
     tr [?]: ((children: string) => null | string | undefined) | undefined
   function markdown.ansi (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, theme?: Bun.markdown.AnsiTheme | undefined): string
   function markdown.html (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: Bun.markdown.Options | undefined): string
   function markdown.react (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, components?: Bun.markdown.ComponentOverrides | undefined, options?: Bun.markdown.ReactOptions | undefined): unknown
   function markdown.render (bun-types/bun.d.ts)
-    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, callbacks?: Bun.markdown.RenderCallbacks | undefined, options?: Bun.markdown.Options | undefined): string
 function mmap (bun-types/bun.d.ts)
-  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+  call (path: Bun.PathLike, opts?: Bun.MMapOptions | undefined): Uint8Array<ArrayBuffer>
 function nanoseconds (bun-types/bun.d.ts)
   call (): number
 function openInEditor (bun-types/bun.d.ts)
-  call (path: string, options?: EditorOptions | undefined): void
+  call (path: string, options?: Bun.EditorOptions | undefined): void
 var password (bun-types/bun.d.ts)
-  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
-  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
-  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
-  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+  hash: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm | undefined) => string
+  verify: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: Bun.StringOrBuffer, hash: Bun.StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
 function pathToFileURL (bun-types/bun.d.ts)
   call (path: string): URL
 function peek (bun-types/bun.d.ts)
@@ -2645,49 +2670,49 @@ function peek (bun-types/bun.d.ts)
 namespace peek (bun-types/bun.d.ts)
   function peek.status (bun-types/bun.d.ts)
     call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
-var plugin (bun-types/bun.d.ts): BunRegisterPlugin
-var postgres (bun-types/sql.d.ts): SQL
+var plugin (bun-types/bun.d.ts): Bun.BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): Bun.SQL
 function randomUUIDv5 (bun-types/bun.d.ts)
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
-  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: Bun.BufferSource | string, namespace: Bun.BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
 function randomUUIDv7 (bun-types/bun.d.ts)
   call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
   call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
 function readableStreamToArray (bun-types/bun.d.ts)
   call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
 function readableStreamToArrayBuffer (bun-types/bun.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
 function readableStreamToBlob (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<Blob>
 function readableStreamToBytes (bun-types/deprecated.d.ts)
-  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+  call (stream: ReadableStream<ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
 function readableStreamToFormData (bun-types/bun.d.ts)
-  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+  call (stream: ReadableStream<BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
 function readableStreamToJSON (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<any>
 function readableStreamToText (bun-types/deprecated.d.ts)
   call (stream: ReadableStream<any>): Promise<string>
-var redis (bun-types/redis.d.ts): RedisClient
+var redis (bun-types/redis.d.ts): Bun.RedisClient
 function resolve (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): Promise<string>
 function resolveSync (bun-types/bun.d.ts)
   call (moduleId: string, parent: string): string
 var revision (bun-types/bun.d.ts): string
-var s3 (bun-types/s3.d.ts): S3Client
+var s3 (bun-types/s3.d.ts): Bun.S3Client
 var secrets (bun-types/bun.d.ts)
   delete: (options: { service: string; name: string; }) => Promise<boolean>
-  get: (options: { service: string; name: string; }) => Promise<string | null>
+  get: (options: { service: string; name: string; }) => Promise<null | string>
   set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
 namespace semver (bun-types/bun.d.ts)
   function semver.order (bun-types/bun.d.ts)
-    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+    call (v1: Bun.StringLike, v2: Bun.StringLike): -1 | 0 | 1
   function semver.satisfies (bun-types/bun.d.ts)
-    call (version: StringLike, range: StringLike): boolean
+    call (version: Bun.StringLike, range: Bun.StringLike): boolean
 function serve (bun-types/serve.d.ts)
-  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+  call <WebSocketData = undefined, R extends string = never>(options: Bun.Serve.Options<WebSocketData, R>): Bun.Server<WebSocketData>
 function sha (bun-types/bun.d.ts)
-  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
-  call (input: StringOrBuffer, encoding: DigestEncoding): string
+  call (input: Bun.StringOrBuffer, hashInto?: NodeJS.TypedArray<ArrayBufferLike> | undefined): NodeJS.TypedArray<ArrayBufferLike>
+  call (input: Bun.StringOrBuffer, encoding: Bun.DigestEncoding): string
 function shrink (bun-types/bun.d.ts)
   call (): void
 function sleep (bun-types/bun.d.ts)
@@ -2695,27 +2720,27 @@ function sleep (bun-types/bun.d.ts)
 function sleepSync (bun-types/bun.d.ts)
   call (ms: number): void
 function sliceAnsi (bun-types/bun.d.ts)
-  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: Bun.SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
 function spawn (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(options: Bun.SpawnOptions.SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Bun.Subprocess<In, Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "inherit">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnOptions<In, Out, Err> | undefined): Bun.Subprocess<In, Out, Err>
 function spawnSync (bun-types/bun.d.ts)
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
-  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
-var sql (bun-types/sql.d.ts): SQL
-var stderr (bun-types/bun.d.ts): BunFile
-var stdin (bun-types/bun.d.ts): BunFile
-var stdout (bun-types/bun.d.ts): BunFile
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(options: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): Bun.SyncSubprocess<Out, Err>
+  call <In extends Bun.SpawnOptions.Writable = "ignore", Out extends Bun.SpawnOptions.Readable = "pipe", Err extends Bun.SpawnOptions.Readable = "pipe">(cmds: Array<string>, options?: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Err> | undefined): Bun.SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): Bun.SQL
+var stderr (bun-types/bun.d.ts): Bun.BunFile
+var stdin (bun-types/bun.d.ts): Bun.BunFile
+var stdout (bun-types/bun.d.ts): Bun.BunFile
 function stringWidth (bun-types/bun.d.ts)
-  call (input: string, options?: StringWidthOptions | undefined): number
+  call (input: string, options?: Bun.StringWidthOptions | undefined): number
 function stripANSI (bun-types/bun.d.ts)
   call (input: string): string
 namespace udp (bun-types/bun.d.ts)
   interface udp.BaseUDPSocket (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2729,17 +2754,17 @@ namespace udp (bun-types/bun.d.ts)
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     connect: { hostname: string; port: number; }
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
-  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    socket [?]: Bun.udp.ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2747,29 +2772,29 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
-    remoteAddress [readonly]: SocketAddress
-    send: (data: Data) => boolean
-    sendMany: (packets: ReadonlyArray<Data>) => number
+    reload: (handler: Bun.udp.ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: Bun.SocketAddress
+    send: (data: Bun.udp.Data) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string
   interface udp.ReceiveFlags (bun-types/bun.d.ts)
     ipv6: boolean
     truncated: boolean
-  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.Socket<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
     addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
-    address [readonly]: SocketAddress
-    binaryType [readonly]: keyof BinaryTypeList
+    address [readonly]: Bun.SocketAddress
+    binaryType [readonly]: keyof Bun.BinaryTypeList
     close: () => void
     closed [readonly]: boolean
     dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
@@ -2777,27 +2802,27 @@ namespace udp (bun-types/bun.d.ts)
     hostname [readonly]: string
     port [readonly]: number
     ref: () => void
-    reload: (handler: SocketHandler<DataBinaryType>) => void
-    send: (data: Data, port: number, address: string) => boolean
-    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    reload: (handler: Bun.udp.SocketHandler<DataBinaryType>) => void
+    send: (data: Bun.udp.Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<Bun.udp.Data | number>) => number
     setBroadcast: (enabled: boolean) => boolean
     setMulticastInterface: (interfaceAddress: string) => boolean
     setMulticastLoopback: (enabled: boolean) => boolean
     setMulticastTTL: (ttl: number) => number
     setTTL: (ttl: number) => number
     unref: () => void
-  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
-    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
-    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
-    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
-  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+  interface udp.SocketHandler<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Bun.udp.Socket<DataBinaryType>, data: Bun.BinaryTypeList[DataBinaryType], port: number, address: string, flags: Bun.udp.ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Bun.udp.Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Bun.udp.Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof Bun.BinaryTypeList> (bun-types/bun.d.ts)
     binaryType [?]: DataBinaryType | undefined
     hostname [?]: string | undefined
     port [?]: number | undefined
-    socket [?]: SocketHandler<DataBinaryType> | undefined
+    socket [?]: Bun.udp.SocketHandler<DataBinaryType> | undefined
 function udpSocket (bun-types/bun.d.ts)
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
-  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.SocketOptions<DataBinaryType>): Promise<Bun.udp.Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof Bun.BinaryTypeList = "buffer">(options: Bun.udp.ConnectSocketOptions<DataBinaryType>): Promise<Bun.udp.ConnectedSocket<DataBinaryType>>
 namespace unsafe (bun-types/bun.d.ts)
   function unsafe.arrayBufferToString (bun-types/bun.d.ts)
     call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
@@ -2811,23 +2836,23 @@ namespace unsafe (bun-types/bun.d.ts)
 var version (bun-types/bun.d.ts): string
 var version_with_sha (bun-types/bun.d.ts): string
 function which (bun-types/bun.d.ts)
-  call (command: string, options?: WhichOptions | undefined): null | string
+  call (command: string, options?: Bun.WhichOptions | undefined): null | string
 function wrapAnsi (bun-types/bun.d.ts)
-  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+  call (input: string, columns: number, options?: Bun.WrapAnsiOptions | undefined): string
 function write (bun-types/bun.d.ts)
-  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
-  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
-  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile | Bun.PathLike | Bun.S3File, input: Array<Bun.BlobPart> | ArrayBufferLike | Blob | Bun.Archive | NodeJS.TypedArray<ArrayBufferLike> | ReadableStream<any> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: Bun.BunFile, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: Bun.PathLike, input: Bun.BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
 function zstdCompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
 function zstdCompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
 function zstdDecompress (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
 function zstdDecompressSync (bun-types/bun.d.ts)
-  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
 
 # module "bun:bundle"
 interface Registry (bun-types/bundle.d.ts)
@@ -2926,17 +2951,17 @@ interface FFITypeToArgsType (bun-types/ffi.d.ts)
   1: number
   10: number
   11: boolean
-  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  12: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null
   13: undefined
-  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  14: NodeJS.TypedArray<ArrayBufferLike> | Pointer | bigint | null | string
   15: bigint | number
   16: bigint | number
   17: JSCallback | Pointer
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2958,8 +2983,8 @@ interface FFITypeToReturnsType (bun-types/ffi.d.ts)
   18: unknown
   19: unknown
   2: number
-  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
-  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  20: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>
   3: number
   4: number
   5: number
@@ -2981,13 +3006,13 @@ type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
 type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
 type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
 function cc (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | Bun.BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
 function dlopen (bun-types/ffi.d.ts)
-  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+  call <Fns extends Record<string, FFIFunction>>(name: Bun.BunFile | URL | string, symbols: Fns): Library<Fns>
 function linkSymbols (bun-types/ffi.d.ts)
   call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
 function ptr (bun-types/ffi.d.ts)
-  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
 namespace read (bun-types/ffi.d.ts)
   function read.f32 (bun-types/ffi.d.ts)
     call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
@@ -3060,7 +3085,7 @@ interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
 function callerSourceOrigin (bun-types/jsc.d.ts)
   call (): null | string
 function deserialize (bun-types/jsc.d.ts)
-  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | NodeJS.TypedArray<ArrayBufferLike>): any
 function drainMicrotasks (bun-types/jsc.d.ts)
   call (): void
 function edenGC (bun-types/jsc.d.ts)
@@ -3136,7 +3161,7 @@ class Database (bun-types/sqlite.d.ts)
   [static]
     construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
     MAX_QUERY_CACHE_SIZE [static]: number
-    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    deserialize [static]: { (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | NodeJS.TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
     open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
     prototype: Database
     setCustomSQLite [static]: (path: string) => boolean
@@ -3146,7 +3171,7 @@ interface DatabaseOptions (bun-types/sqlite.d.ts)
   readwrite [?]: boolean | undefined
   safeIntegers [?]: boolean | undefined
   strict [?]: boolean | undefined
-type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+type SQLQueryBindings (bun-types/sqlite.d.ts) = NodeJS.TypedArray<ArrayBufferLike> | Record<string, NodeJS.TypedArray<ArrayBufferLike> | bigint | boolean | null | number | string> | bigint | boolean | null | number | string
 class SQLiteError (bun-types/sqlite.d.ts)
   byteOffset [readonly]: number
   cause [?]: unknown
@@ -3160,7 +3185,7 @@ class SQLiteError (bun-types/sqlite.d.ts)
     construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
     captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
     isError: (value: unknown) => value is Error
-    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
     prototype: SQLiteError
     stackTraceLimit: number
 class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
@@ -3169,8 +3194,8 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   all: (...params: ParamsType) => Array<ReturnType>
   as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
   columnNames [readonly]: Array<string>
-  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
-  declaredTypes [readonly]: Array<string | null>
+  columnTypes [readonly]: Array<"BLOB" | "FLOAT" | "INTEGER" | "NULL" | "TEXT" | null>
+  declaredTypes [readonly]: Array<null | string>
   finalize: () => void
   get: (...params: ParamsType) => ReturnType | null
   iterate: (...params: ParamsType) => IterableIterator<ReturnType>
@@ -3179,7 +3204,7 @@ class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings>
   raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
   run: (...params: ParamsType) => Changes
   toString: () => string
-  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  values: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | bigint | boolean | number | string>>
   [static]
     construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
     prototype: Statement<any, any>
@@ -3256,7 +3281,7 @@ var native (bun-types/sqlite.d.ts): any
 # module "bun:test"
 type AsymmetricMatcher (bun-types/test.d.ts) = any
 interface AsymmetricMatchers (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3264,7 +3289,7 @@ interface AsymmetricMatchers (bun-types/test.d.ts)
   stringContaining: (str: String | string) => any
   stringMatching: (regex: RegExp | String | string) => any
 interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   closeTo: (num: number, numDigits?: number | undefined) => any
@@ -3290,7 +3315,7 @@ interface Expect (bun-types/test.d.ts)
   call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
   call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
   call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
-  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  any: (constructor: ((...args: Array<any>) => any) | (new (...args: Array<any>) => any)) => any
   anything: () => any
   arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
   assertions: (neededAssertions: number) => void
@@ -3357,13 +3382,13 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3377,7 +3402,7 @@ interface Matchers<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3443,13 +3468,13 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toBeValidDate: () => void
   toBeWithin: (start: number, end: number) => void
   toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAllValues: (expected: Array<unknown>) => void
-  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainAnyValues: (expected: Array<unknown>) => void
   toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
-  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
-  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainKey: { (expected: __internal.IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: __internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<__internal.IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<__internal.IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
   toContainValue: (expected: unknown) => void
   toContainValues: (expected: Array<unknown>) => void
   toEndWith: (expected: string) => void
@@ -3463,7 +3488,7 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toHaveLastReturnedWith: (expected: unknown) => void
   toHaveLength: (length: number) => void
   toHaveNthReturnedWith: (n: number, expected: unknown) => void
-  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveProperty: (keyPath: Array<number | string> | number | string, value?: unknown) => void
   toHaveReturned: () => void
   toHaveReturnedTimes: (times: number) => void
   toHaveReturnedWith: (expected: unknown) => void
@@ -3480,9 +3505,9 @@ interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
   toThrowError: (expected?: unknown) => void
   toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
   toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
-type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
 interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
-  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  call (label: string, fn: (...args: __internal.IsTuple<T> extends true ? [...table: __internal.Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
   concurrent: Test<T>
   concurrentIf: (condition: boolean) => Test<T>
   each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
@@ -3518,23 +3543,23 @@ var expectTypeOf (bun-types/test.d.ts)
   call <Actual>(): PositiveExpectTypeOf<Actual>
 var it (bun-types/test.d.ts): Test<[]>
 namespace jest (bun-types/test.d.ts)
-  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
-  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
-  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
-  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
-  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
-  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
-  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = JestMock.Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | JestMock.ClassLike> (bun-types/test.d.ts) = T extends JestMock.ClassLike ? JestMock.SpiedClass<T> : T extends JestMock.FunctionLike ? JestMock.SpiedFunction<T> : never
+  type jest.SpiedClass<T extends JestMock.ClassLike> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = JestMock.MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = JestMock.MockInstance<(arg: T) => void>
   function jest.advanceTimersByTime (bun-types/test.d.ts)
-    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.clearAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.clearAllTimers (bun-types/test.d.ts)
     call (): void
   function jest.fn (bun-types/test.d.ts)
-    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): jest.Mock<T>
   function jest.getTimerCount (bun-types/test.d.ts)
     call (): number
   function jest.isFakeTimers (bun-types/test.d.ts)
@@ -3544,19 +3569,19 @@ namespace jest (bun-types/test.d.ts)
   function jest.restoreAllMocks (bun-types/test.d.ts)
     call (): void
   function jest.runAllTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.runOnlyPendingTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.setSystemTime (bun-types/test.d.ts)
     call (now?: Date | number | undefined): void
   function jest.setTimeout (bun-types/test.d.ts)
     call (milliseconds: number): void
   function jest.spyOn (bun-types/test.d.ts)
-    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): jest.Mock<Extract<T[K], (...args: Array<any>) => any>>
   function jest.useFakeTimers (bun-types/test.d.ts)
-    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   function jest.useRealTimers (bun-types/test.d.ts)
-    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var mock (bun-types/test.d.ts)
   call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
   clearAllMocks: () => void
@@ -3572,24 +3597,118 @@ function spyOn (bun-types/test.d.ts)
   call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
 test -> it
 var vi (bun-types/test.d.ts)
-  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   clearAllMocks: () => void
   clearAllTimers: () => void
-  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => jest.Mock<T>
   getTimerCount: () => number
   isFakeTimers: () => boolean
   mock: (id: string, factory: () => any) => Promise<void> | void
   resetAllMocks: () => void
   restoreAllMocks: () => void
-  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
   spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
-  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
-  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => jest.Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
 var xdescribe (bun-types/test.d.ts): Describe<[]>
 var xit (bun-types/test.d.ts): Test<[]>
 xtest -> xit
+
+# module "node:fs/promises"
+function exists (bun-types/overrides.d.ts)
+  call (path: Bun.PathLike): Promise<boolean>
+
+# module "node:tls"
+interface BunConnectionOptions (bun-types/overrides.d.ts)
+  ALPNCallback [?]: ((arg: { servername: string; protocols: Array<string>; }) => string | undefined) | undefined
+  ALPNProtocols [?]: NodeJS.ArrayBufferView<ArrayBufferLike> | ReadonlyArray<string> | undefined
+  SNICallback [?]: ((servername: string, cb: (err: Error | null, ctx?: SecureContext | undefined) => void) => void) | undefined
+  allowPartialTrustChain [?]: boolean | undefined
+  ca [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  cert [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientCertEngine [?]: string | undefined
+  crl [?]: Array<Buffer<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | string | undefined
+  dhparam [?]: Buffer<ArrayBufferLike> | string | undefined
+  ecdhCurve [?]: string | undefined
+  enableTrace [?]: boolean | undefined
+  honorCipherOrder [?]: boolean | undefined
+  host [?]: string | undefined
+  key [?]: Array<Buffer<ArrayBufferLike> | Bun.BunFile | KeyObject | NodeJS.TypedArray<ArrayBufferLike> | string> | Buffer<ArrayBufferLike> | Bun.BunFile | NodeJS.TypedArray<ArrayBufferLike> | string | undefined
+  lookup [?]: LookupFunction | undefined
+  maxVersion [?]: SecureVersion | undefined
+  minDHSize [?]: number | undefined
+  minVersion [?]: SecureVersion | undefined
+  passphrase [?]: string | undefined
+  path [?]: string | undefined
+  pfx [?]: Array<Buffer<ArrayBufferLike> | PxfObject | string> | Buffer<ArrayBufferLike> | string | undefined
+  port [?]: number | undefined
+  privateKeyEngine [?]: string | undefined
+  privateKeyIdentifier [?]: string | undefined
+  pskCallback [?]: ((hint: null | string) => PSKCallbackNegotation | null) | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  requestOCSP [?]: boolean | undefined
+  secureContext [?]: SecureContext | undefined
+  secureOptions [?]: number | undefined
+  secureProtocol [?]: string | undefined
+  servername [?]: string | undefined
+  session [?]: Buffer<ArrayBufferLike> | undefined
+  sessionIdContext [?]: string | undefined
+  sessionTimeout [?]: number | undefined
+  sigalgs [?]: string | undefined
+  socket [?]: Stream.Duplex | undefined
+  ticketKeys [?]: Buffer<ArrayBufferLike> | undefined
+  timeout [?]: number | undefined
+function connect (@types/node/tls.d.ts, bun-types/overrides.d.ts)
+  call (options: ConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, host?: string | undefined, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (port: number, options?: ConnectionOptions | undefined, secureConnectListener?: (() => void) | undefined): TLSSocket
+  call (options: BunConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
+
+# module "stream/web"
+interface ReadableStream<R = any> (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/stream/web.d.ts, bun-types/overrides.d.ts)
+  construct new (underlyingSource: UnderlyingByteSource, strategy?: undefined | { highWaterMark?: number | undefined; }): ReadableStream<NodeJS.NonSharedUint8Array>
+  construct new <R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  from: <R = any>(iterable: AsyncIterable<R> | Iterable<R>) => ReadableStream<R>
+  prototype: ReadableStream<any>
+
+# module "url"
+interface URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/url.d.ts, bun-types/overrides.d.ts)
+  construct new (init?: Array<Array<string>> | Record<string, string> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
 
 # globals
 interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
@@ -3600,11 +3719,11 @@ var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/glo
   prototype: AbortController
 interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
   aborted [readonly]: boolean
-  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
   dispatchEvent: (event: Event) => boolean
   onabort: ((this: AbortSignal, ev: Event) => any) | null
   reason [readonly]: any
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
   throwIfAborted: () => void
 var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
   construct new (): AbortSignal
@@ -3647,14 +3766,14 @@ interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   size [readonly]: number
   stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
   text: () => Promise<string>
   type [readonly]: string
 var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
-  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  construct new (blobParts?: Array<Bun.BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
   prototype: Blob
 interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   type [?]: string | undefined
@@ -3683,25 +3802,25 @@ class BuildMessage (bun-types/globals.d.ts)
     prototype: BuildMessage
 Bun -> module "bun"
 interface BunFetchRequestInit (bun-types/globals.d.ts)
-  body [?]: BodyInit | null | undefined
+  body [?]: Bun.BodyInit | null | undefined
   cache [?]: RequestCache | undefined
   compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
   credentials [?]: RequestCredentials | undefined
   decompress [?]: boolean | undefined
   dispatcher [?]: Dispatcher | undefined
   duplex [?]: "half" | undefined
-  headers [?]: HeadersInit | undefined
+  headers [?]: Bun.HeadersInit | undefined
   integrity [?]: string | undefined
   keepalive [?]: boolean | undefined
   maxRedirects [?]: number | undefined
   method [?]: string | undefined
   mode [?]: RequestMode | undefined
   protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
-  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: Bun.HeadersInit | undefined; }
   redirect [?]: RequestRedirect | undefined
   referrer [?]: string | undefined
   referrerPolicy [?]: ReferrerPolicy | undefined
-  s3 [?]: S3Options | undefined
+  s3 [?]: Bun.S3Options | undefined
   signal [?]: AbortSignal | null | undefined
   timeout [?]: boolean | number | undefined
   tls [?]: BunFetchRequestInitTLS | undefined
@@ -3709,17 +3828,17 @@ interface BunFetchRequestInit (bun-types/globals.d.ts)
   verbose [?]: boolean | undefined
   window [?]: null | undefined
 interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
-  ALPNProtocols [?]: BufferSource | string | undefined
-  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  ALPNProtocols [?]: Bun.BufferSource | string | undefined
+  ca [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   caFile [?]: string | undefined
-  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  cert [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   certFile [?]: string | undefined
   checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
   ciphers [?]: string | undefined
   clientRenegotiationLimit [?]: number | undefined
   clientRenegotiationWindow [?]: number | undefined
   dhParamsFile [?]: string | undefined
-  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  key [?]: Array<Bun.BufferSource | Bun.BunFile | string> | Bun.BufferSource | Bun.BunFile | string | undefined
   keyFile [?]: string | undefined
   lowMemoryMode [?]: boolean | undefined
   passphrase [?]: string | undefined
@@ -3755,16 +3874,16 @@ interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts
   type [readonly]: string
   wasClean [readonly]: boolean
 var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  construct new (type: string, eventInitDict?: Bun.CloseEventInit | undefined): CloseEvent
   prototype: CloseEvent
 interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
-  writable [readonly]: WritableStream<BufferSource>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
+  construct new (format: Bun.CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
   prototype: CompressionStream
 interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
-  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  Console [readonly]: { new (stdout: NodeJS.WritableStream, stderr?: NodeJS.WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
   [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
   assert: (condition?: boolean | undefined, ...data: Array<any>) => void
   clear: () => void
@@ -3788,14 +3907,14 @@ interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
   timeStamp: (label?: string | undefined) => void
   trace: (...data: Array<any>) => void
   warn: (...data: Array<any>) => void
-  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+  write: (...data: Array<ArrayBuffer | ArrayBufferView<ArrayBufferLike> | string>) => number
 interface ConsoleOptions (bun-types/globals.d.ts)
   colorMode [?]: "auto" | boolean | undefined
   groupIndentation [?]: number | undefined
   ignoreErrors [?]: boolean | undefined
   inspectOptions [?]: InspectOptions | undefined
-  stderr [?]: Writable | undefined
-  stdout: Writable
+  stderr [?]: Stream.Writable | undefined
+  stdout: Stream.Writable
 interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   highWaterMark [readonly]: number
   size [readonly]: QueuingStrategySize<any>
@@ -3806,21 +3925,21 @@ interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   getRandomValues: <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T) => T
   randomUUID: () => `${string}-${string}-${string}-${string}-${string}`
   subtle [readonly]: SubtleCrypto
-  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+  timingSafeEqual: (a: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | NodeJS.ArrayBufferView<ArrayBufferLike>) => boolean
 var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): Crypto
   prototype: Crypto
 interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
-  algorithm [readonly]: KeyAlgorithm
+  algorithm [readonly]: webcrypto.KeyAlgorithm
   extractable [readonly]: boolean
-  type [readonly]: KeyType
-  usages [readonly]: Array<KeyUsage>
+  type [readonly]: webcrypto.KeyType
+  usages [readonly]: Array<webcrypto.KeyUsage>
 var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): CryptoKey
   prototype: CryptoKey
 interface CryptoKeyPair (bun-types/globals.d.ts)
-  privateKey: CryptoKey
-  publicKey: CryptoKey
+  privateKey: webcrypto.CryptoKey
+  publicKey: webcrypto.CryptoKey
 interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
   bubbles [readonly]: boolean
   cancelBubble: boolean
@@ -3842,7 +3961,7 @@ interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/d
   timeStamp [readonly]: number
   type [readonly]: string
 var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
-  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  construct new <T>(type: string, eventInitDict?: Bun.CustomEventInit<T> | undefined): CustomEvent<T>
   prototype: CustomEvent<any>
 interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
   ABORT_ERR [readonly]: 20
@@ -3904,10 +4023,10 @@ var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecate
   WRONG_DOCUMENT_ERR [readonly]: 4
   prototype: DOMException
 interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
-  writable [readonly]: WritableStream<BufferSource>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
+  construct new (format: Bun.CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
   prototype: DecompressionStream
 interface Dict<T> (bun-types/globals.d.ts)
   index [string]: T | undefined
@@ -3932,7 +4051,7 @@ interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, li
   construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
   captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
   isError: (value: unknown) => value is Error
-  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prepareStackTrace: (err: Error, stackTraces: Array<NodeJS.CallSite>) => any
   prototype [readonly]: Error
   stackTraceLimit: number
 interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
@@ -3959,7 +4078,7 @@ interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts
   timeStamp [readonly]: number
   type [readonly]: string
 var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  construct new (type: string, eventInitDict?: Bun.ErrorEventInit | undefined): ErrorEvent
   prototype: ErrorEvent
 interface ErrorOptions (bun-types/globals.d.ts)
   cause [?]: unknown
@@ -3982,7 +4101,7 @@ interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
   timeStamp [readonly]: number
   type [readonly]: string
 var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
-  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  construct new (type: string, eventInitDict?: Bun.EventInit | undefined): Event
   AT_TARGET [readonly]: 2
   BUBBLING_PHASE [readonly]: 3
   CAPTURING_PHASE [readonly]: 1
@@ -4016,9 +4135,9 @@ var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
 interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   withCredentials [?]: boolean | undefined
 interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
-  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  addEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined) => void
   dispatchEvent: (event: Event) => boolean
-  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  removeEventListener: (type: string, listener: Bun.EventListener | Bun.EventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined) => void
 var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
   construct new (): EventTarget
   prototype: EventTarget
@@ -4048,7 +4167,7 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   arrayBuffer: () => Promise<ArrayBuffer>
   bytes: () => Promise<Uint8Array<ArrayBuffer>>
   formData: () => Promise<FormData>
-  image: (options?: ConstructorOptions | undefined) => Image
+  image: (options?: Bun.Image.ConstructorOptions | undefined) => Bun.Image
   json: () => Promise<any>
   lastModified [readonly]: number
   name [readonly]: string
@@ -4057,15 +4176,15 @@ interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
   text: () => Promise<string>
   type [readonly]: string
 var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
-  construct new (parts: Array<BlobPart>, name: string, options?: BlobPropertyBag & { lastModified?: number | Date | undefined; } | undefined): File
+  construct new (parts: Array<Bun.BlobPart>, name: string, options?: (BlobPropertyBag & { lastModified?: number | Date | undefined; }) | undefined): File
   prototype: File
 interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
   delete: (name: string) => void
   entries: () => IterableIterator<[string, string]>
-  forEach: (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
-  get: (name: string) => FormDataEntryValue | null
-  getAll: (name: string) => Array<FormDataEntryValue>
+  forEach: (callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
+  get: (name: string) => Bun.FormDataEntryValue | null
+  getAll: (name: string) => Array<Bun.FormDataEntryValue>
   has: (name: string) => boolean
   keys: () => IterableIterator<string>
   set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
@@ -4074,19 +4193,19 @@ var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   construct new (): FormData
   prototype: FormData
 class HTMLRewriter (bun-types/html-rewriter.d.ts)
-  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
-  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
-  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  on: (selector: string, handlers: HTMLRewriterTypes.HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: Bun.BufferSource): ArrayBuffer }
   [static]
     construct new (): HTMLRewriter
     prototype: HTMLRewriter
 namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Comment
-    before: (content: string, options?: ContentOptions | undefined) => Comment
-    remove: () => Comment
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
+    remove: () => HTMLRewriterTypes.Comment
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Comment
     text: string
   type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
   interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
@@ -4094,52 +4213,52 @@ namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
   interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
     name [readonly]: null | string
     publicId [readonly]: null | string
-    remove: () => Doctype
+    remove: () => HTMLRewriterTypes.Doctype
     removed [readonly]: boolean
     systemId [readonly]: null | string
   interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
-    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.DocumentEnd
   interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Element
-    append: (content: string, options?: ContentOptions | undefined) => Element
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    append: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     attributes [readonly]: IterableIterator<[string, string]>
-    before: (content: string, options?: ContentOptions | undefined) => Element
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     canHaveContent [readonly]: boolean
     getAttribute: (name: string) => null | string
     hasAttribute: (name: string) => boolean
     namespaceURI [readonly]: string
-    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
-    prepend: (content: string, options?: ContentOptions | undefined) => Element
-    remove: () => Element
-    removeAndKeepContent: () => Element
-    removeAttribute: (name: string) => Element
+    onEndTag: (handler: (tag: HTMLRewriterTypes.EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
+    remove: () => HTMLRewriterTypes.Element
+    removeAndKeepContent: () => HTMLRewriterTypes.Element
+    removeAttribute: (name: string) => HTMLRewriterTypes.Element
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Element
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     selfClosing [readonly]: boolean
-    setAttribute: (name: string, value: string) => Element
-    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    setAttribute: (name: string, value: string) => HTMLRewriterTypes.Element
+    setInnerContent: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Element
     tagName: string
   interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => EndTag
-    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.EndTag
     name: string
-    remove: () => EndTag
+    remove: () => HTMLRewriterTypes.EndTag
   interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
-    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: HTMLRewriterTypes.Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: HTMLRewriterTypes.DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
-    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
-    element [?]: ((element: Element) => Promise<void> | void) | undefined
-    text [?]: ((text: Text) => Promise<void> | void) | undefined
+    comments [?]: ((comment: HTMLRewriterTypes.Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: HTMLRewriterTypes.Element) => Promise<void> | void) | undefined
+    text [?]: ((text: HTMLRewriterTypes.Text) => Promise<void> | void) | undefined
   interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
-    after: (content: string, options?: ContentOptions | undefined) => Text
-    before: (content: string, options?: ContentOptions | undefined) => Text
+    after: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
+    before: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     lastInTextNode [readonly]: boolean
-    remove: () => Text
+    remove: () => HTMLRewriterTypes.Text
     removed [readonly]: boolean
-    replace: (content: string, options?: ContentOptions | undefined) => Text
+    replace: (content: string, options?: HTMLRewriterTypes.ContentOptions | undefined) => HTMLRewriterTypes.Text
     text [readonly]: string
 interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
@@ -4157,18 +4276,18 @@ interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
   values [readonly]: () => SpecIterableIterator<string>
 var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (init?: HeadersInit | undefined): Headers
+  construct new (init?: Bun.HeadersInit | undefined): Headers
   prototype: Headers
 interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.es5.d.ts)
   dir [readonly]: string
   dirname: string
-  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  env [readonly]: Bun.Env & NodeJS.ProcessEnv & ImportMetaEnv
   file [readonly]: string
   filename: string
-  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: Bun.HMREvent, callback: () => void): void; off(event: Bun.HMREvent, callback: () => void): void; }
   main: boolean
   path [readonly]: string
-  require: Require
+  require: NodeJS.Require
   resolve: (specifier: string, parent?: URL | string | undefined) => string
   resolveSync: (moduleId: string, parent?: string | undefined) => string
   url: string
@@ -4209,7 +4328,7 @@ interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/g
   timeStamp [readonly]: number
   type [readonly]: string
 var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<any>
+  construct new <T>(type: string, eventInitDict?: Bun.MessageEventInit<T> | undefined): MessageEvent<any>
   prototype: MessageEvent<any>
 interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
   addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
@@ -4249,148 +4368,14 @@ var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
   construct new (): Navigator
   prototype: Navigator
 namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
-  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
-  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
-  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
-  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.asyncDispose]: () => PromiseLike<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
-    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
-    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
-  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
-  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
-  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
-  interface NodeJS.CallSite (@types/node/globals.d.ts)
-    getColumnNumber: () => null | number
-    getEnclosingColumnNumber: () => null | number
-    getEnclosingLineNumber: () => null | number
-    getEvalOrigin: () => string | undefined
-    getFileName: () => null | string
-    getFunction: () => Function | undefined
-    getFunctionName: () => null | string
-    getLineNumber: () => null | number
-    getMethodName: () => null | string
-    getPosition: () => number
-    getPromiseIndex: () => null | number
-    getScriptHash: () => string
-    getScriptNameOrSourceURL: () => null | string
-    getThis: () => unknown
-    getTypeName: () => null | string
-    isAsync: () => boolean
-    isConstructor: () => boolean
-    isEval: () => boolean
-    isNative: () => boolean
-    isPromiseAll: () => boolean
-    isToplevel: () => boolean
-  interface NodeJS.CpuUsage (@types/node/process.d.ts)
-    system: number
-    user: number
-  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined
-  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
-  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
-    code [?]: string | undefined
-    ctor [?]: Function | undefined
-    detail [?]: string | undefined
-    type [?]: string | undefined
-  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
-    cause [?]: unknown
-    code [?]: string | undefined
-    errno [?]: number | undefined
-    message: string
-    name: string
-    path [?]: string | undefined
-    stack [?]: string | undefined
-    syscall [?]: string | undefined
-  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
-    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
-    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
-    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
-    setMaxListeners: (n: number) => EventEmitter<T>
-  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
-  interface NodeJS.GCFunction (@types/node/globals.d.ts)
-    call (minor?: boolean | undefined): void
-    call (options: GCOptions & { execution: "async"; }): Promise<void>
-    call (options: GCOptions): void
-  interface NodeJS.GCOptions (@types/node/globals.d.ts)
-    execution [?]: "async" | "sync" | undefined
-    filename [?]: string | undefined
-    flavor [?]: "last-resort" | "regular" | undefined
-    type [?]: "major" | "major-snapshot" | "minor" | undefined
-  interface NodeJS.HRTime (@types/node/process.d.ts)
-    call (time?: [number, number] | undefined): [number, number]
-    bigint: () => bigint
-  interface NodeJS.Immediate (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    _onImmediate: (...args: Array<any>) => void
-    hasRef: () => boolean
-    ref: () => Immediate
-    unref: () => Immediate
-  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
-    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
-    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
-    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
-  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
-    arrayBuffers: number
-    external: number
-    heapTotal: number
-    heapUsed: number
-    rss: number
-  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
-    call (): MemoryUsage
-    rss: () => number
-  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
-  interface NodeJS.Module (@types/node/module.d.ts)
-    children: Array<Module>
-    exports: any
-    filename: string
-    id: string
-    isPreloading: boolean
-    loaded: boolean
-    parent: Module | null | undefined
-    path: string
-    paths: Array<string>
-    require: (id: string) => any
-  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
-  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
-  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
-  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
-  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
-  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
-  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
-  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
-  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
-  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
-  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
-  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
-  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
-  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
   interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
     [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
     _exiting: boolean
     abort: () => never
-    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
     allowedNodeEnvironmentFlags: ReadonlySet<string>
-    arch [readonly]: Architecture
+    arch [readonly]: NodeJS.Architecture
     argv: Array<string>
     argv0: string
     assert: (value: unknown, message?: Error | string | undefined) => asserts value
@@ -4399,24 +4384,24 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     browser: boolean
     channel [?]: Control | undefined
     chdir: (directory: string) => void
-    config [readonly]: ProcessConfig
+    config [readonly]: NodeJS.ProcessConfig
     connected: boolean
     constrainedMemory: () => number
-    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     cwd: () => string
     debugPort: number
     disconnect [?]: (() => void) | undefined
     dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
     emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
-    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
-    env: ProcessEnv
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: NodeJS.EmitWarningOptions | undefined): void }
+    env: NodeJS.ProcessEnv
     eventNames: () => Array<string | symbol>
     execArgv: Array<string>
     execPath: string
-    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: NodeJS.ProcessEnv | undefined) => never) | undefined
     exit: (code?: null | number | string | undefined) => never
     exitCode: null | number | string | undefined
-    features [readonly]: ProcessFeatures
+    features [readonly]: NodeJS.ProcessFeatures
     finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
     getActiveResourcesInfo: () => Array<string>
     getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
@@ -4427,48 +4412,48 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     getgroups [?]: (() => Array<number>) | undefined
     getuid [?]: (() => number) | undefined
     hasUncaughtExceptionCaptureCallback: () => boolean
-    hrtime: HRTime
+    hrtime: NodeJS.HRTime
     isBun: true
     kill: (pid: number, signal?: number | string | undefined) => true
     listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
     listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     loadEnvFile: (path?: PathLike | undefined) => void
-    mainModule [?]: Module | undefined
-    memoryUsage: MemoryUsageFn
+    mainModule [?]: NodeJS.Module | undefined
+    memoryUsage: NodeJS.MemoryUsageFn
     nextTick: (callback: Function, ...args: Array<any>) => void
     noDeprecation [?]: boolean | undefined
-    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    permission: ProcessPermission
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    permission: NodeJS.ProcessPermission
     pid [readonly]: number
-    platform [readonly]: Platform
+    platform [readonly]: NodeJS.Platform
     ppid [readonly]: number
-    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
-    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process }
     rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
     reallyExit: (code?: number | undefined) => never
     ref: (maybeRefable: any) => void
-    release [readonly]: ProcessRelease
-    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
-    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
-    report: ProcessReport
-    resourceUsage: () => ResourceUsage
+    release [readonly]: NodeJS.ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): NodeJS.Process; (eventName?: string | symbol | undefined): NodeJS.Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): NodeJS.Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): NodeJS.Process; (event: string | symbol, listener: (...args: Array<any>) => void): NodeJS.Process }
+    report: NodeJS.ProcessReport
+    resourceUsage: () => NodeJS.ResourceUsage
     revision: string
     send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
-    setMaxListeners: (n: number) => Process
+    setMaxListeners: (n: number) => NodeJS.Process
     setSourceMapsEnabled: (value: boolean) => void
     setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
     setegid [?]: ((id: number | string) => void) | undefined
     seteuid [?]: ((id: number | string) => void) | undefined
     setgid [?]: ((id: number | string) => void) | undefined
-    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<number | string>) => void) | undefined
     setuid [?]: ((id: number | string) => void) | undefined
     sourceMapsEnabled [readonly]: boolean
-    stderr: WriteStream & { fd: 2; }
-    stdin: ReadStream & { fd: 0; }
-    stdout: WriteStream & { fd: 1; }
-    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    stderr: NodeJS.WriteStream & { fd: 2; }
+    stdin: NodeJS.ReadStream & { fd: 0; }
+    stdout: NodeJS.WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: NodeJS.CpuUsage | undefined) => NodeJS.CpuUsage
     throwDeprecation: boolean
     title: string
     traceDeprecation: boolean
@@ -4477,45 +4462,11 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     unref: (maybeRefable: any) => void
     uptime: () => number
     version [readonly]: string
-    versions [readonly]: ProcessVersions
-  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
-    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
-    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+    versions [readonly]: NodeJS.ProcessVersions
   interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     NODE_ENV [?]: string | undefined
     TZ [?]: string | undefined
-  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
-    cached_builtins [readonly]: boolean
-    debug [readonly]: boolean
-    inspector [readonly]: boolean
-    ipv6 [readonly]: boolean
-    require_module [readonly]: boolean
-    tls [readonly]: boolean
-    tls_alpn [readonly]: boolean
-    tls_ocsp [readonly]: boolean
-    tls_sni [readonly]: boolean
-    typescript [readonly]: "strip" | false
-    uv [readonly]: boolean
-  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
-    has: (scope: string, reference?: string | undefined) => boolean
-  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
-    headersUrl [?]: string | undefined
-    libUrl [?]: string | undefined
-    lts [?]: string | undefined
-    name: string
-    sourceUrl [?]: string | undefined
-  interface NodeJS.ProcessReport (@types/node/process.d.ts)
-    compact: boolean
-    directory: string
-    excludeEnv: boolean
-    filename: string
-    getReport: (err?: Error | undefined) => object
-    reportOnFatalError: boolean
-    reportOnSignal: boolean
-    reportOnUncaughtException: boolean
-    signal: Signals
-    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
   interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
     index [string]: string | undefined
     ares: string
@@ -4527,404 +4478,14 @@ namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/
     uv: string
     v8: string
     zlib: string
-  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
-    index [string]: T | undefined [readonly]
-  interface NodeJS.ReadStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    closed [readonly]: boolean
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    destroy: (error?: Error | undefined) => ReadStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    isPaused: () => boolean
-    isRaw: boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    pause: () => ReadStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => ReadStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
-    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
-    resetAndDestroy: () => ReadStream
-    resume: () => ReadStream
-    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
-    setMaxListeners: (n: number) => ReadStream
-    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
-    setRawMode: (mode: boolean) => ReadStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
-    setTypeOfService: (tos: number) => ReadStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => ReadStream
-    unref: () => ReadStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => ReadStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    pause: () => ReadWriteStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
-    resume: () => ReadWriteStream
-    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
-    setMaxListeners: (n: number) => ReadWriteStream
-    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadWriteStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    pause: () => ReadableStream
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
-    resume: () => ReadableStream
-    setEncoding: (encoding: BufferEncoding) => ReadableStream
-    setMaxListeners: (n: number) => ReadableStream
-    unpipe: (destination?: WritableStream | undefined) => ReadableStream
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => ReadableStream
-  interface NodeJS.RefCounted (@types/node/globals.d.ts)
-    ref: () => RefCounted
-    unref: () => RefCounted
-  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
-  interface NodeJS.Require (@types/node/module.d.ts)
-    call (id: string): any
-    cache: Dict<Module>
-    extensions: RequireExtensions
-    main: Module | undefined
-    resolve: RequireResolve
-  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
-    index [string]: ((module: Module, filename: string) => any) | undefined
-    .js: (module: Module, filename: string) => any
-    .json: (module: Module, filename: string) => any
-    .node: (module: Module, filename: string) => any
-  interface NodeJS.RequireResolve (@types/node/module.d.ts)
-    call (request: string, options?: RequireResolveOptions | undefined): string
-    paths: (request: string) => Array<string> | null
-  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
-    paths [?]: Array<string> | undefined
-  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
-    fsRead: number
-    fsWrite: number
-    involuntaryContextSwitches: number
-    ipcReceived: number
-    ipcSent: number
-    majorPageFault: number
-    maxRSS: number
-    minorPageFault: number
-    sharedMemorySize: number
-    signalsCount: number
-    swappedOut: number
-    systemCPUTime: number
-    unsharedDataSize: number
-    unsharedStackSize: number
-    userCPUTime: number
-    voluntaryContextSwitches: number
-  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
-  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
-  interface NodeJS.Socket (@types/node/process.d.ts)
-    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    isPaused: () => boolean
-    isTTY [?]: true | undefined
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    pause: () => Socket
-    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
-    readable: boolean
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
-    resume: () => Socket
-    setEncoding: (encoding: BufferEncoding) => Socket
-    setMaxListeners: (n: number) => Socket
-    unpipe: (destination?: WritableStream | undefined) => Socket
-    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
-    wrap: (oldStream: ReadableStream) => Socket
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.Timeout (@types/node/timers.d.ts)
-    [Symbol.dispose]: () => void
-    [Symbol.toPrimitive]: () => number
-    _onTimeout: (...args: Array<any>) => void
-    close: () => Timeout
-    hasRef: () => boolean
-    ref: () => Timeout
-    refresh: () => Timeout
-    unref: () => Timeout
-  interface NodeJS.Timer (@types/node/timers.d.ts)
-    [Symbol.toPrimitive]: () => number
-    hasRef: () => boolean
-    ref: () => Timer
-    refresh: () => Timer
-    unref: () => Timer
-  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
-  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
-  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
-  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
-  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
-  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
-  interface NodeJS.WritableStream (@types/node/stream.d.ts)
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
-    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
-    eventNames: () => Array<string | symbol>
-    getMaxListeners: () => number
-    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
-    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
-    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
-    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
-    setMaxListeners: (n: number) => WritableStream
-    writable: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
-  interface NodeJS.WriteStream (@types/node/process.d.ts)
-    [Symbol.asyncDispose]: () => Promise<void>
-    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
-    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
-    [Symbol.toAsyncStreamable]: () => ByteReadableStream
-    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
-    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
-    _final: (callback: (error?: Error | null | undefined) => void) => void
-    _read: (size: number) => void
-    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
-    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
-    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    address: () => AddressInfo | {}
-    allowHalfOpen: boolean
-    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
-    bufferSize [readonly]: number
-    bytesRead [readonly]: number
-    bytesWritten [readonly]: number
-    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
-    clearScreenDown: (callback?: (() => void) | undefined) => boolean
-    closed [readonly]: boolean
-    columns: number
-    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
-    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
-    connecting [readonly]: boolean
-    cork: () => void
-    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
-    destroy: (error?: Error | undefined) => WriteStream
-    destroySoon: () => void
-    destroyed [readonly]: boolean
-    drop: (limit: number, options?: Abortable | undefined) => Readable
-    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
-    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
-    errored [readonly]: Error | null
-    eventNames: () => Array<string | symbol>
-    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
-    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
-    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
-    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
-    getColorDepth: (env?: object | undefined) => number
-    getMaxListeners: () => number
-    getTypeOfService: () => number
-    getWindowSize: () => [number, number]
-    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
-    isPaused: () => boolean
-    isTTY: boolean
-    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
-    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
-    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    localAddress [? readonly]: string | undefined
-    localFamily [? readonly]: string | undefined
-    localPort [? readonly]: number | undefined
-    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
-    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
-    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    pause: () => WriteStream
-    pending [readonly]: boolean
-    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
-    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
-    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
-    read: (size?: number | undefined) => any
-    readable: boolean
-    readableAborted [readonly]: boolean
-    readableDidRead [readonly]: boolean
-    readableEncoding [readonly]: BufferEncoding | null
-    readableEnded [readonly]: boolean
-    readableFlowing: boolean | null
-    readableHighWaterMark [readonly]: number
-    readableLength [readonly]: number
-    readableObjectMode [readonly]: boolean
-    readyState [readonly]: SocketReadyState
-    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
-    ref: () => WriteStream
-    remoteAddress [readonly]: string | undefined
-    remoteFamily [readonly]: string | undefined
-    remotePort [readonly]: number | undefined
-    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
-    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
-    resetAndDestroy: () => WriteStream
-    resume: () => WriteStream
-    rows: number
-    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
-    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
-    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
-    setMaxListeners: (n: number) => WriteStream
-    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
-    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
-    setTypeOfService: (tos: number) => WriteStream
-    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
-    take: (limit: number, options?: Abortable | undefined) => Readable
-    timeout [? readonly]: number | undefined
-    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
-    uncork: () => void
-    unpipe: (destination?: WritableStream | undefined) => WriteStream
-    unref: () => WriteStream
-    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
-    wrap: (stream: ReadableStream) => WriteStream
-    writable: boolean
-    writableAborted [readonly]: boolean
-    writableCorked [readonly]: number
-    writableEnded [readonly]: boolean
-    writableFinished [readonly]: boolean
-    writableHighWaterMark [readonly]: number
-    writableLength [readonly]: number
-    writableNeedDrain [readonly]: boolean
-    writableObjectMode [readonly]: boolean
-    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
 interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
-  children: Array<Module>
+  children: Array<NodeJS.Module>
   exports: any
   filename: string
   id: string
   isPreloading: boolean
   loaded: boolean
-  parent: Module | null | undefined
+  parent: NodeJS.Module | null | undefined
   path: string
   paths: Array<string>
   require: (id: string) => any
@@ -5033,10 +4594,10 @@ interface Position (bun-types/globals.d.ts)
 interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts)
   construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
   [Symbol.species] [readonly]: PromiseConstructor
-  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
-  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  all: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<PromiseLike<T> | T>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
   prototype [readonly]: Promise<any>
-  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  race: { <T>(values: Iterable<PromiseLike<T> | T>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
   reject: <T = never>(reason?: any) => Promise<T>
   resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
   try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
@@ -5054,7 +4615,7 @@ interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bu
   byobRequest [readonly]: ReadableStreamBYOBRequest | null
   close: () => void
   desiredSize [readonly]: null | number
-  enqueue: (chunk: NonSharedArrayBufferView) => void
+  enqueue: (chunk: NodeJS.NonSharedArrayBufferView) => void
   error: (e?: any) => void
 var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableByteStreamController
@@ -5073,21 +4634,21 @@ interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-typ
   text: () => Promise<string>
   values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
 var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
-  construct new <R = any>(underlyingSource?: DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: Bun.UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: Bun.DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
   prototype: ReadableStream<any>
 interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
-  read: <T extends NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  read: <T extends NodeJS.NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
   releaseLock: () => void
 var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableStreamBYOBReader
   prototype: ReadableStreamBYOBReader
 interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   respond: (bytesWritten: number) => void
-  respondWithNewView: (view: NonSharedArrayBufferView) => void
-  view [readonly]: NonSharedArrayBufferView | null
+  respondWithNewView: (view: NodeJS.NonSharedArrayBufferView) => void
+  view [readonly]: NodeJS.NonSharedArrayBufferView | null
 var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): ReadableStreamBYOBRequest
   prototype: ReadableStreamBYOBRequest
@@ -5108,8 +4669,8 @@ interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
 interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
-  read: () => Promise<ReadableStreamDefaultReadResult<R>>
-  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  read: () => Promise<Bun.ReadableStreamDefaultReadResult<R>>
+  readMany: () => Bun.ReadableStreamDefaultReadManyResult<R> | Promise<Bun.ReadableStreamDefaultReadManyResult<R>>
   releaseLock: () => void
 var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
@@ -5119,7 +4680,7 @@ interface ReadableStreamDirectController (bun-types/globals.d.ts)
   end: () => Promise<number> | number
   flush: (wait?: boolean | undefined) => Promise<number> | number
   start: () => void
-  write: (data: BufferSource | string) => Promise<number> | number
+  write: (data: Bun.BufferSource | string) => Promise<number> | number
 interface ReadableStreamGenericReader (bun-types/globals.d.ts)
   cancel: (reason?: any) => Promise<void>
   closed [readonly]: Promise<void>
@@ -5167,7 +4728,7 @@ interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   destination [readonly]: RequestDestination
   duplex [readonly]: "half"
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   integrity [readonly]: string
   json [readonly]: () => Promise<unknown>
   keepalive [readonly]: boolean
@@ -5186,12 +4747,12 @@ var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   construct new (requestInfo: Request, init?: RequestInit | undefined): Request
   prototype: Request
 interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  body [?]: BodyInit | null | undefined
+  body [?]: Bun.BodyInit | null | undefined
   cache [?]: RequestCache | undefined
   credentials [?]: RequestCredentials | undefined
   dispatcher [?]: Dispatcher | undefined
   duplex [?]: "half" | undefined
-  headers [?]: HeadersInit | undefined
+  headers [?]: Bun.HeadersInit | undefined
   integrity [?]: string | undefined
   keepalive [?]: boolean | undefined
   method [?]: string | undefined
@@ -5223,7 +4784,7 @@ interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
   clone: () => Response
   formData [readonly]: () => Promise<FormData>
-  headers: BunHeadersOverride
+  headers: Bun.__internal.BunHeadersOverride
   json [readonly]: () => Promise<unknown>
   ok [readonly]: boolean
   redirected [readonly]: boolean
@@ -5234,7 +4795,7 @@ interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   type [readonly]: ResponseType
   url [readonly]: string
 var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  construct new (body?: Bun.BodyInit | null | undefined, init?: ResponseInit | undefined): Response
   error: () => Response
   json: (body?: any, init?: ResponseInit | number | undefined) => Response
   redirect: { (url: string, status?: number | undefined): Response; (url: string, init?: ResponseInit | undefined): Response }
@@ -5260,53 +4821,53 @@ interface StreamPipeOptions (bun-types/globals.d.ts)
   preventClose [?]: boolean | undefined
   signal [?]: AbortSignal | undefined
 interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
-  decapsulateBits: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource) => Promise<ArrayBuffer>
-  decapsulateKey: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<CryptoKey>
-  decrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  deriveBits: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
-  deriveKey: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>) => Promise<CryptoKey>
-  digest: (algorithm: AlgorithmIdentifier | CShakeParams | KangarooTwelveParams | TurboShakeParams, data: BufferSource) => Promise<ArrayBuffer>
-  encapsulateBits: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey) => Promise<EncapsulatedBits>
-  encapsulateKey: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<EncapsulatedKey>
-  encrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
-  generateKey: { (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | KmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
-  getPublicKey: (key: CryptoKey, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
-  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey> }
-  sign: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
-  unwrapKey: (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
-  verify: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
-  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+  decapsulateBits: (decapsulationAlgorithm: webcrypto.AlgorithmIdentifier, decapsulationKey: webcrypto.CryptoKey, ciphertext: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  decapsulateKey: (decapsulationAlgorithm: webcrypto.AlgorithmIdentifier, decapsulationKey: webcrypto.CryptoKey, ciphertext: NodeJS.BufferSource, sharedKeyAlgorithm: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, usages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  decrypt: (algorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.Argon2Params | webcrypto.EcdhKeyDeriveParams | webcrypto.HkdfParams | webcrypto.Pbkdf2Params, baseKey: webcrypto.CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.Argon2Params | webcrypto.EcdhKeyDeriveParams | webcrypto.HkdfParams | webcrypto.Pbkdf2Params, baseKey: webcrypto.CryptoKey, derivedKeyType: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  digest: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.CShakeParams | webcrypto.KangarooTwelveParams | webcrypto.TurboShakeParams, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  encapsulateBits: (encapsulationAlgorithm: webcrypto.AlgorithmIdentifier, encapsulationKey: webcrypto.CryptoKey) => Promise<webcrypto.EncapsulatedBits>
+  encapsulateKey: (encapsulationAlgorithm: webcrypto.AlgorithmIdentifier, encapsulationKey: webcrypto.CryptoKey, sharedKeyAlgorithm: webcrypto.AesDerivedKeyParams | webcrypto.AlgorithmIdentifier | webcrypto.HmacImportParams | webcrypto.KmacImportParams, extractable: boolean, usages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.EncapsulatedKey>
+  encrypt: (algorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: webcrypto.CryptoKey): Promise<webcrypto.JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: webcrypto.CryptoKey): Promise<ArrayBuffer>; (format: webcrypto.KeyFormat, key: webcrypto.CryptoKey): Promise<ArrayBuffer | webcrypto.JsonWebKey> }
+  generateKey: { (algorithm: webcrypto.EcKeyGenParams | webcrypto.RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKeyPair>; (algorithm: webcrypto.AesKeyGenParams | webcrypto.HmacKeyGenParams | webcrypto.KmacKeyGenParams | webcrypto.Pbkdf2Params, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey>; (algorithm: webcrypto.AlgorithmIdentifier, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey | webcrypto.CryptoKeyPair> }
+  getPublicKey: (key: webcrypto.CryptoKey, keyUsages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  importKey: { (format: "jwk", keyData: webcrypto.JsonWebKey, algorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: NodeJS.BufferSource, algorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>): Promise<webcrypto.CryptoKey> }
+  sign: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.ContextParams | webcrypto.EcdsaParams | webcrypto.KmacParams | webcrypto.RsaPssParams, key: webcrypto.CryptoKey, data: NodeJS.BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: (format: webcrypto.KeyFormat, wrappedKey: NodeJS.BufferSource, unwrappingKey: webcrypto.CryptoKey, unwrapAlgorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams, unwrappedKeyAlgorithm: webcrypto.AesKeyAlgorithm | webcrypto.AlgorithmIdentifier | webcrypto.EcKeyImportParams | webcrypto.HmacImportParams | webcrypto.KmacImportParams | webcrypto.RsaHashedImportParams, extractable: boolean, keyUsages: Array<webcrypto.KeyUsage>) => Promise<webcrypto.CryptoKey>
+  verify: (algorithm: webcrypto.AlgorithmIdentifier | webcrypto.ContextParams | webcrypto.EcdsaParams | webcrypto.KmacParams | webcrypto.RsaPssParams, key: webcrypto.CryptoKey, signature: NodeJS.BufferSource, data: NodeJS.BufferSource) => Promise<boolean>
+  wrapKey: (format: webcrypto.KeyFormat, key: webcrypto.CryptoKey, wrappingKey: webcrypto.CryptoKey, wrapAlgorithm: webcrypto.AeadParams | webcrypto.AesCbcParams | webcrypto.AesCtrParams | webcrypto.AlgorithmIdentifier | webcrypto.RsaOaepParams) => Promise<ArrayBuffer>
 var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
   construct new (): SubtleCrypto
   prototype: SubtleCrypto
 interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  decode: (input?: NodeJS.AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
   encoding [readonly]: string
   fatal [readonly]: boolean
   ignoreBOM [readonly]: boolean
 var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
+  construct new (encoding?: Bun.Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
   prototype: TextDecoder
 interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   encoding [readonly]: string
   fatal [readonly]: boolean
   ignoreBOM [readonly]: boolean
   readable [readonly]: ReadableStream<string>
-  writable [readonly]: WritableStream<BufferSource>
+  writable [readonly]: WritableStream<NodeJS.BufferSource>
 var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): TextDecoderStream
   prototype: TextDecoderStream
 interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  encode: (input?: string | undefined) => NonSharedUint8Array
-  encodeInto: (src?: string | undefined, dest?: BufferSource | undefined) => TextEncoderEncodeIntoResult
+  encode: (input?: string | undefined) => NodeJS.NonSharedUint8Array
+  encodeInto: (src?: string | undefined, dest?: Bun.BufferSource | undefined) => TextEncoderEncodeIntoResult
   encoding [readonly]: string
 var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
-  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
+  construct new (encoding?: Bun.Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
   prototype: TextEncoder
 interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   encoding [readonly]: string
-  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  readable [readonly]: ReadableStream<NodeJS.NonSharedUint8Array>
   writable [readonly]: WritableStream<string>
 var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   construct new (): TextEncoderStream
@@ -5332,10 +4893,10 @@ var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-
   construct new (): TransformStreamDefaultController<any>
   prototype: TransformStreamDefaultController<any>
 interface Transformer<I = any, O = any> (bun-types/globals.d.ts)
-  flush [?]: TransformerFlushCallback<O> | undefined
+  flush [?]: Bun.TransformerFlushCallback<O> | undefined
   readableType [?]: undefined
-  start [?]: TransformerStartCallback<O> | undefined
-  transform [?]: TransformerTransformCallback<I, O> | undefined
+  start [?]: Bun.TransformerStartCallback<O> | undefined
+  transform [?]: Bun.TransformerTransformCallback<I, O> | undefined
   writableType [?]: undefined
 interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
   hash: string
@@ -5374,7 +4935,7 @@ interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d
   toJSON: () => Record<string, string>
   values: () => URLSearchParamsIterator<string>
 var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
-  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, string | ReadonlyArray<string>> | URLSearchParams | string | undefined): URLSearchParams
+  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, ReadonlyArray<string> | string> | URLSearchParams | string | undefined): URLSearchParams
   prototype: URLSearchParams
 interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es5.d.ts)
   index [number]: number
@@ -5411,7 +4972,7 @@ interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bu
   subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
   toBase64: (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }) => string
   toHex: () => string
-  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: Intl.NumberFormatOptions | undefined): string }
   toString: () => string
   valueOf: () => Uint8Array<TArrayBuffer>
   values: () => ArrayIterator<number>
@@ -5437,54 +4998,54 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     name: string
     stack [?]: string | undefined
   var WebAssembly.CompileError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): CompileError
-    construct new (message?: string | undefined): CompileError
-    prototype: CompileError
-  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
-    value: ValueTypeMap[T]
-    valueOf: () => ValueTypeMap[T]
+    call (message?: string | undefined): WebAssembly.CompileError
+    construct new (message?: string | undefined): WebAssembly.CompileError
+    prototype: WebAssembly.CompileError
+  interface WebAssembly.Global<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
+    value: Bun.WebAssembly.ValueTypeMap[T]
+    valueOf: () => Bun.WebAssembly.ValueTypeMap[T]
   var WebAssembly.Global (bun-types/wasm.d.ts)
-    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
-    prototype: Global<keyof ValueTypeMap>
-  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    construct new <T extends keyof Bun.WebAssembly.ValueTypeMap = keyof Bun.WebAssembly.ValueTypeMap>(descriptor: WebAssembly.GlobalDescriptor<T>, v?: WebAssembly.ValueTypeMap[T] | undefined): WebAssembly.Global<T>
+    prototype: WebAssembly.Global<keyof WebAssembly.ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof WebAssembly.ValueTypeMap = keyof WebAssembly.ValueTypeMap> (bun-types/wasm.d.ts)
     mutable [?]: boolean | undefined
     value: T
   interface WebAssembly.Instance (bun-types/wasm.d.ts)
-    exports [readonly]: Exports
+    exports [readonly]: Bun.WebAssembly.Exports
   var WebAssembly.Instance (bun-types/wasm.d.ts)
-    construct new (module: Module, importObject?: Imports | undefined): Instance
-    prototype: Instance
+    construct new (module: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): WebAssembly.Instance
+    prototype: WebAssembly.Instance
   interface WebAssembly.LinkError (bun-types/wasm.d.ts)
     cause [?]: unknown
     message: string
     name: string
     stack [?]: string | undefined
   var WebAssembly.LinkError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): LinkError
-    construct new (message?: string | undefined): LinkError
-    prototype: LinkError
+    call (message?: string | undefined): WebAssembly.LinkError
+    construct new (message?: string | undefined): WebAssembly.LinkError
+    prototype: WebAssembly.LinkError
   interface WebAssembly.Memory (bun-types/wasm.d.ts)
     buffer [readonly]: ArrayBuffer
     grow: (delta: number) => number
   var WebAssembly.Memory (bun-types/wasm.d.ts)
-    construct new (descriptor: MemoryDescriptor): Memory
-    prototype: Memory
+    construct new (descriptor: WebAssembly.MemoryDescriptor): WebAssembly.Memory
+    prototype: WebAssembly.Memory
   interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
     initial: number
     maximum [?]: number | undefined
     shared [?]: boolean | undefined
   interface WebAssembly.Module (bun-types/wasm.d.ts)
   var WebAssembly.Module (bun-types/wasm.d.ts)
-    construct new (bytes: BufferSource): Module
-    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
-    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
-    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
-    prototype: Module
+    construct new (bytes: Bun.BufferSource): WebAssembly.Module
+    customSections: (moduleObject: WebAssembly.Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleExportDescriptor>
+    imports: (moduleObject: WebAssembly.Module) => Array<WebAssembly.ModuleImportDescriptor>
+    prototype: WebAssembly.Module
   interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     name: string
   interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
-    kind: ImportExportKind
+    kind: Bun.WebAssembly.ImportExportKind
     module: string
     name: string
   interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
@@ -5493,19 +5054,19 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     name: string
     stack [?]: string | undefined
   var WebAssembly.RuntimeError (bun-types/wasm.d.ts)
-    call (message?: string | undefined): RuntimeError
-    construct new (message?: string | undefined): RuntimeError
-    prototype: RuntimeError
+    call (message?: string | undefined): WebAssembly.RuntimeError
+    construct new (message?: string | undefined): WebAssembly.RuntimeError
+    prototype: WebAssembly.RuntimeError
   interface WebAssembly.Table (bun-types/wasm.d.ts)
     get: (index: number) => any
     grow: (delta: number, value?: any) => number
     length [readonly]: number
     set: (index: number, value?: any) => void
   var WebAssembly.Table (bun-types/wasm.d.ts)
-    construct new (descriptor: TableDescriptor, value?: any): Table
-    prototype: Table
+    construct new (descriptor: WebAssembly.TableDescriptor, value?: any): WebAssembly.Table
+    prototype: WebAssembly.Table
   interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
-    element: TableKind
+    element: Bun.WebAssembly.TableKind
     initial: number
     maximum [?]: number | undefined
   interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
@@ -5517,48 +5078,48 @@ namespace WebAssembly (bun-types/wasm.d.ts)
     i64: bigint
     v128: never
   interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
-    instance: Instance
-    module: Module
+    instance: Bun.WebAssembly.Instance
+    module: Bun.WebAssembly.Module
   function WebAssembly.compile (bun-types/wasm.d.ts)
-    call (bytes: BufferSource): Promise<Module>
+    call (bytes: Bun.BufferSource): Promise<WebAssembly.Module>
   function WebAssembly.compileStreaming (bun-types/wasm.d.ts)
-    call (source: PromiseLike<Response> | Response): Promise<Module>
+    call (source: PromiseLike<Response> | Response): Promise<WebAssembly.Module>
   function WebAssembly.instantiate (bun-types/wasm.d.ts)
-    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
-    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+    call (bytes: Bun.BufferSource, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    call (moduleObject: WebAssembly.Module, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.Instance>
   function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts)
-    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (source: PromiseLike<Response> | Response, importObject?: Bun.WebAssembly.Imports | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>
   function WebAssembly.validate (bun-types/wasm.d.ts)
-    call (bytes: BufferSource): boolean
+    call (bytes: Bun.BufferSource): boolean
 interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
   CONNECTING [readonly]: 0
   OPEN [readonly]: 1
   URL [readonly]: string
-  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   binaryType: "arraybuffer" | "nodebuffer"
   bufferedAmount [readonly]: number
   close: (code?: number | undefined, reason?: string | undefined) => void
   dispatchEvent: (event: Event) => boolean
   extensions [readonly]: string
   isPaused [readonly]: boolean
-  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-  onerror: ((this: WebSocket, ev: Event) => any) | null
-  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
-  onopen: ((this: WebSocket, ev: Event) => any) | null
+  onclose: ((this: Bun.WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: Bun.WebSocket, ev: Event) => any) | null
+  onmessage: ((this: Bun.WebSocket, ev: Bun.BunMessageEvent<any>) => any) | null
+  onopen: ((this: Bun.WebSocket, ev: Event) => any) | null
   pause: () => boolean
-  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
-  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  ping: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string | undefined) => void
   protocol [readonly]: string
   readyState [readonly]: 0 | 1 | 2 | 3
-  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WebSocketEventMap>(type: K, listener: (this: Bun.WebSocket, ev: Bun.WebSocketEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   resume: () => boolean
-  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  send: (data: ArrayBufferLike | Bun.ArrayBufferView<ArrayBufferLike> | string) => void
   terminate: () => void
   url [readonly]: string
 var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
-  construct new (url: URL | string, options?: WebSocketOptions | undefined): WebSocket
+  construct new (url: URL | string, options?: Bun.WebSocketOptions | undefined): WebSocket
   construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
   CLOSED [readonly]: 3
   CLOSING [readonly]: 2
@@ -5566,19 +5127,19 @@ var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
   OPEN [readonly]: 1
   prototype: WebSocket
 interface Worker (bun-types/globals.d.ts)
-  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.AddEventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.AddEventListenerOptions | boolean | undefined): void }
   dispatchEvent: (event: Event) => boolean
-  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
-  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
-  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  onerror: ((this: Bun.AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Bun.Worker, ev: Bun.BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Bun.Transferable>): void; (message: any, options?: Bun.StructuredSerializeOptions | undefined): void }
   ref: () => void
-  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeEventListener: { <K extends keyof Bun.WorkerEventMap>(type: K, listener: (this: Bun.Worker, ev: Bun.WorkerEventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void; (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void }
   terminate: () => void
   threadId: number
   unref: () => void
 var Worker (bun-types/globals.d.ts)
-  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  construct new (scriptURL: URL | string, options?: Bun.WorkerOptions | undefined): Worker
   data: any
   prototype: Worker
 interface WorkerOptions (bun-types/globals.d.ts)
@@ -5589,14 +5150,14 @@ interface WorkerOptions (bun-types/globals.d.ts)
   preload [?]: Array<string> | string | undefined
   ref [?]: boolean | undefined
   smol [?]: boolean | undefined
-  type [?]: WorkerType | undefined
+  type [?]: Bun.WorkerType | undefined
 interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   abort: (reason?: any) => Promise<void>
   close: () => Promise<void>
   getWriter: () => WritableStreamDefaultWriter<W>
   locked [readonly]: boolean
 var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
-  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  construct new <W = any>(underlyingSink?: Bun.UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
   prototype: WritableStream<any>
 interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
   error: (e?: any) => void
@@ -5616,18 +5177,18 @@ var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types
   prototype: WritableStreamDefaultWriter<any>
 function addEventListener (bun-types/globals.d.ts)
   call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
 function alert (bun-types/globals.d.ts)
   call (message?: string | undefined): void
 function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (immediate: Immediate | undefined): void
+  call (immediate: NodeJS.Immediate | undefined): void
 function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (id?: Timer | number | undefined): void
-  call (timeout: Timeout | number | string | undefined): void
+  call (timeout: NodeJS.Timeout | number | string | undefined): void
 function confirm (bun-types/globals.d.ts)
   call (message?: string | undefined): boolean
 var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts): Console
@@ -5645,35 +5206,31 @@ var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts): 
 var onmessage (bun-types/index.d.ts): never
 var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts): Performance
 function postMessage (bun-types/globals.d.ts)
-  call (message: any, transfer?: Array<Transferable> | undefined): void
+  call (message: any, transfer?: Array<Bun.Transferable> | undefined): void
 function prompt (bun-types/globals.d.ts)
   call (message?: string | undefined, _default?: string | undefined): null | string
 function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
   call (callback: (...args: Array<any>) => void): void
   call (callback: () => void): void
 function removeEventListener (bun-types/globals.d.ts)
-  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
-  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: Bun.EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: Bun.EventListenerOrEventListenerObject, options?: Bun.EventListenerOptions | boolean | undefined): void
 function reportError (bun-types/globals.d.ts)
   call (error: any): void
-var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): NodeJS.Require
 function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  call (handler: Bun.TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Immediate
   __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
 function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
-  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  call (handler: Bun.TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): NodeJS.Timeout
   __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
 namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
-  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
-    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
 function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
-  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T>(value: T, options?: Bun.StructuredSerializeOptions | undefined): T
   call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T

--- a/test/integration/bun-types/inventory/no-lib.txt
+++ b/test/integration/bun-types/inventory/no-lib.txt
@@ -1,0 +1,5679 @@
+# bun-types inventory: preset no-lib
+# lib: (none)
+# typescript: 6.0.2
+# @types/node: 26.2.0
+# undici-types: 8.3.0
+
+# module "*.html"
+
+# module "*.json5"
+
+# module "*.jsonc"
+
+# module "*.toml"
+
+# module "*.txt"
+
+# module "*.xml"
+
+# module "*.yaml"
+
+# module "*.yml"
+
+# module "*/bun.lock"
+
+# module "bun"
+type $ (bun-types/shell.d.ts) = typeof $
+function $ (bun-types/shell.d.ts)
+  call (strings: TemplateStringsArray, ...expressions: Array<ShellExpression>): ShellPromise
+  Shell: new () => typeof $
+  ShellError: typeof ShellError
+  ShellPromise: typeof ShellPromise
+  braces: (pattern: string) => Array<string>
+  cwd: (newCwd?: string | undefined) => typeof $
+  env: (newEnv?: Dict<string> | Record<string, string | undefined> | undefined) => typeof $
+  escape: (input: string) => string
+  nothrow: () => typeof $
+  throws: (shouldThrow: boolean) => typeof $
+namespace $ (bun-types/shell.d.ts)
+  var $.Shell (bun-types/shell.d.ts)
+    construct new (): typeof $
+  class $.ShellError (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    cause [?]: unknown
+    exitCode [readonly]: number
+    json: () => any
+    message: string
+    name: string
+    stack [?]: string | undefined
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+    [static]
+      construct new (message?: string | undefined): ShellError
+      construct new (message?: string | undefined, options?: ErrorOptions | undefined): ShellError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: ShellError
+      stackTraceLimit: number
+  interface $.ShellOutput (bun-types/shell.d.ts)
+    arrayBuffer: () => ArrayBuffer
+    blob: () => Blob
+    bytes: () => Uint8Array<ArrayBuffer>
+    exitCode [readonly]: number
+    json: () => any
+    stderr [readonly]: Buffer<ArrayBufferLike>
+    stdout [readonly]: Buffer<ArrayBufferLike>
+    text: (encoding?: BufferEncoding | undefined) => string
+  class $.ShellPromise (bun-types/shell.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    arrayBuffer: () => Promise<ArrayBuffer>
+    blob: () => Promise<Blob>
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<ShellOutput | TResult>
+    cwd: (newCwd: string) => ShellPromise
+    env: (newEnv: Dict<string> | Record<string, string | undefined> | undefined) => ShellPromise
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<ShellOutput>
+    json: () => Promise<any>
+    lines: () => AsyncIterable<string>
+    nothrow: () => ShellPromise
+    quiet: (isQuiet?: boolean | undefined) => ShellPromise
+    stdin: WritableStream<any>
+    text: (encoding?: BufferEncoding | undefined) => Promise<string>
+    then: <TResult1 = ShellOutput, TResult2 = never>(onfulfilled?: ((value: ShellOutput) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    throws: (shouldThrow: boolean) => ShellPromise
+    [static]
+      construct new (executor: (resolve: (value: PromiseLike<ShellOutput> | ShellOutput) => void, reject: (reason?: any) => void) => void): ShellPromise
+      [Symbol.species] [readonly]: PromiseConstructor
+      all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+      allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+      prototype: ShellPromise
+      race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+      reject: <T = never>(reason?: any) => Promise<T>
+      resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+      try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
+      withResolvers: <T>() => { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; }
+  function $.braces (bun-types/shell.d.ts)
+    call (pattern: string): Array<string>
+  function $.cwd (bun-types/shell.d.ts)
+    call (newCwd?: string | undefined): typeof $
+  function $.env (bun-types/shell.d.ts)
+    call (newEnv?: Dict<string> | Record<string, string | undefined> | undefined): typeof $
+  function $.escape (bun-types/shell.d.ts)
+    call (input: string): string
+  function $.nothrow (bun-types/shell.d.ts)
+    call (): typeof $
+  function $.throws (bun-types/shell.d.ts)
+    call (shouldThrow: boolean): typeof $
+interface AbstractWorker (bun-types/bun.d.ts)
+  addEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  removeEventListener: { <K extends "error">(type: K, listener: (this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+interface AbstractWorkerEventMap (bun-types/bun.d.ts)
+  error: ErrorEvent
+interface AddEventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+type Architecture (bun-types/deprecated.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc" | "ppc64" | "s390" | "s390x" | "x64"
+class Archive (bun-types/bun.d.ts)
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  extract: (path: string, options?: ArchiveExtractOptions | undefined) => Promise<number>
+  files: (glob?: ReadonlyArray<string> | string | undefined) => Promise<Map<string, File>>
+  [static]
+    construct new (data: ArchiveInput, options?: ArchiveOptions | undefined): Archive
+    prototype: Archive
+    write [static]: (path: string, data: Archive | ArchiveInput, options?: ArchiveOptions | undefined) => Promise<void>
+type ArchiveCompression (bun-types/bun.d.ts) = "gzip"
+interface ArchiveExtractOptions (bun-types/bun.d.ts)
+  glob [?]: ReadonlyArray<string> | string | undefined
+type ArchiveInput (bun-types/bun.d.ts) = Blob | ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | Record<string, BlobPart>
+interface ArchiveOptions (bun-types/bun.d.ts)
+  compress [?]: "gzip" | undefined
+  level [?]: number | undefined
+class ArrayBufferSink (bun-types/bun.d.ts)
+  end: () => ArrayBuffer | Uint8Array<ArrayBuffer>
+  flush: () => ArrayBuffer | Uint8Array<ArrayBuffer> | number
+  start: (options?: undefined | { asUint8Array?: boolean | undefined; highWaterMark?: number | undefined; stream?: boolean | undefined; }) => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  [static]
+    construct new (): ArrayBufferSink
+    prototype: ArrayBufferSink
+type ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/bun.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+type ArrayType (bun-types/sql.d.ts) = "BOOLEAN" | "BYTEA" | "CHAR" | "NAME" | "TEXT" | "VARCHAR" | "SMALLINT" | "INT2VECTOR" | "INTEGER" | "INT" | "BIGINT" | "REAL" | "DOUBLE PRECISION" | "NUMERIC" | "MONEY" | "OID" | "TID" | "XID" | "CID" | "JSON" | "JSONB" | "JSONPATH" | "XML" | "POINT" | "LSEG" | "PATH" | "BOX" | "POLYGON" | "LINE" | "CIRCLE" | "CIDR" | "MACADDR" | "INET" | "MACADDR8" | "DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ" | "INTERVAL" | "TIMETZ" | "BIT" | "VARBIT" | "ACLITEM" | "PG_DATABASE" | (string & {})
+type BeforeExitListener (bun-types/bun.d.ts) = (code: number) => void
+type BinaryType (bun-types/bun.d.ts) = keyof BinaryTypeList
+interface BinaryTypeList (bun-types/bun.d.ts)
+  arraybuffer: ArrayBuffer
+  buffer: Buffer<ArrayBufferLike>
+  uint8array: Uint8Array<ArrayBuffer>
+type BlobOrStringOrBuffer (bun-types/bun.d.ts) = string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>
+type BlobPart (bun-types/bun.d.ts) = string | Blob | BufferSource
+type BodyInit (bun-types/fetch.d.ts) = ReadableStream<any> | XMLHttpRequestBodyInit | AsyncIterable<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>> | AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any> | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>, any, any>) | Image
+type BufferSource (bun-types/bun.d.ts) = ArrayBufferLike | TypedArray<ArrayBufferLike> | DataView<ArrayBufferLike>
+namespace Build (bun-types/bun.d.ts)
+  type Build.Architecture (bun-types/bun.d.ts) = "arm64" | "x64" | "aarch64"
+  type Build.CompileTarget (bun-types/bun.d.ts) = "bun-darwin-arm64" | "bun-darwin-x64" | "bun-darwin-aarch64" | "bun-darwin-arm64-baseline" | "bun-darwin-arm64-modern" | "bun-darwin-x64-baseline" | "bun-darwin-x64-modern" | "bun-darwin-aarch64-baseline" | "bun-darwin-aarch64-modern" | "bun-linux-arm64" | "bun-linux-x64" | "bun-linux-aarch64" | "bun-linux-arm64-glibc" | "bun-linux-arm64-musl" | "bun-linux-x64-glibc" | "bun-linux-x64-musl" | "bun-linux-aarch64-glibc" | "bun-linux-aarch64-musl" | "bun-linux-arm64-baseline" | "bun-linux-arm64-modern" | "bun-linux-x64-baseline" | "bun-linux-x64-modern" | "bun-linux-aarch64-baseline" | "bun-linux-aarch64-modern" | "bun-linux-arm64-baseline-glibc" | "bun-linux-arm64-baseline-musl" | "bun-linux-arm64-modern-glibc" | "bun-linux-arm64-modern-musl" | "bun-linux-x64-baseline-glibc" | "bun-linux-x64-baseline-musl" | "bun-linux-x64-modern-glibc" | "bun-linux-x64-modern-musl" | "bun-linux-aarch64-baseline-glibc" | "bun-linux-aarch64-baseline-musl" | "bun-linux-aarch64-modern-glibc" | "bun-linux-aarch64-modern-musl" | "bun-windows-arm64" | "bun-windows-x64" | "bun-windows-aarch64" | "bun-windows-x64-baseline" | "bun-windows-x64-modern"
+  type Build.Libc (bun-types/bun.d.ts) = "glibc" | "musl"
+  type Build.SIMD (bun-types/bun.d.ts) = "baseline" | "modern"
+interface BuildArtifact (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  hash: null | string
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  kind: "asset" | "bytecode" | "chunk" | "entry-point" | "sourcemap"
+  loader: Loader
+  path: string
+  size [readonly]: number
+  sourcemap: BuildArtifact | null
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+interface BuildConfig (bun-types/bun.d.ts)
+  allowUnresolved [?]: Array<string> | undefined
+  banner [?]: string | undefined
+  bytecode [?]: boolean | undefined
+  bytecodeDepth [?]: number | undefined
+  compile [?]: CompileBuildOptions | CompileTarget | boolean | undefined
+  conditions [?]: Array<string> | string | undefined
+  define [?]: Record<string, string> | undefined
+  deprecatedNamespaceObjectSetters [?]: boolean | undefined
+  drop [?]: Array<string> | undefined
+  emitDCEAnnotations [?]: boolean | undefined
+  entrypoints: Array<string>
+  env [?]: "disable" | "inline" | `${string}*` | undefined
+  external [?]: Array<string> | undefined
+  features [?]: Array<string> | undefined
+  files [?]: Record<string, string | Blob | ArrayBufferLike | TypedArray<ArrayBufferLike>> | undefined
+  footer [?]: string | undefined
+  format [?]: "cjs" | "esm" | "iife" | undefined
+  ignoreDCEAnnotations [?]: boolean | undefined
+  jsx [?]: undefined | { runtime?: "automatic" | "classic" | undefined; importSource?: string | undefined; factory?: string | undefined; fragment?: string | undefined; sideEffects?: boolean | undefined; development?: boolean | undefined; }
+  loader [?]: undefined | { [x: string]: Loader; }
+  metafile [?]: boolean | undefined
+  minChunkSize [?]: number | undefined
+  minify [?]: boolean | undefined | { whitespace?: boolean | undefined; syntax?: boolean | undefined; identifiers?: boolean | undefined; keepNames?: boolean | undefined; }
+  modulePreload [?]: boolean | undefined
+  naming [?]: string | undefined | { chunk?: string | undefined; entry?: string | undefined; asset?: string | undefined; }
+  optimizeImports [?]: Array<string> | undefined
+  outdir [?]: string | undefined
+  packages [?]: "bundle" | "external" | undefined
+  plugins [?]: Array<BunPlugin> | undefined
+  publicPath [?]: string | undefined
+  reactCompiler [?]: boolean | undefined
+  reactCompilerOutputMode [?]: "client" | "ssr" | undefined
+  reactFastRefresh [?]: boolean | undefined
+  root [?]: string | undefined
+  sourcemap [?]: "external" | "inline" | "linked" | "none" | boolean | undefined
+  splitRequire [?]: boolean | undefined
+  splitting [?]: boolean | undefined
+  target [?]: Target | undefined
+  throw [?]: boolean | undefined
+  treeShaking [?]: boolean | undefined
+  tsconfig [?]: string | undefined
+interface BuildMetafile (bun-types/bun.d.ts)
+  inputs: { [path: string]: { bytes: number; imports: Array<{ path: string; kind: ImportKind; original?: string | undefined; external?: boolean | undefined; with?: Record<string, string> | undefined; }>; format?: "json" | "css" | "esm" | "cjs" | undefined; }; }
+  outputs: { [path: string]: { bytes: number; inputs: { [path: string]: { bytesInOutput: number; }; }; imports: Array<{ path: string; kind: ImportKind; }>; exports: Array<string>; entryPoint?: string | undefined; cssBundle?: string | undefined; }; }
+interface BuildOutput (bun-types/bun.d.ts)
+  logs: Array<BuildMessage | ResolveMessage>
+  metafile [?]: BuildMetafile | undefined
+  outputs: Array<BuildArtifact>
+  success: boolean
+interface BunFile (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface BunInspectOptions (bun-types/bun.d.ts)
+  colors [?]: boolean | undefined
+  compact [?]: boolean | undefined
+  depth [?]: number | undefined
+  sorted [?]: boolean | undefined
+type BunLockFile (bun-types/bun.d.ts) = { lockfileVersion: 0 | 1 | 2; workspaces: { [workspace: string]: BunLockFileWorkspacePackage; }; overrides?: Record<string, string> | undefined; patchedDependencies?: Record<string, string> | undefined; trustedDependencies?: Array<string> | undefined; catalog?: Record<string, string> | undefined; catalogs?: Record<string, Record<string, string>> | undefined; configVersion?: 0 | 1 | undefined; packages: { [pkg: string]: BunLockFilePackageArray; }; }
+type BunLockFileBasePackageInfo (bun-types/bun.d.ts) = { dependencies?: Record<string, string> | undefined; devDependencies?: Record<string, string> | undefined; optionalDependencies?: Record<string, string> | undefined; peerDependencies?: Record<string, string> | undefined; optionalPeers?: Array<string> | undefined; bin?: string | Record<string, string> | undefined; binDir?: string | undefined; }
+type BunLockFilePackageArray (bun-types/bun.d.ts) = [pkg: string, registry: string, info: BunLockFilePackageInfo, integrity: string] | [pkg: string, info: BunLockFilePackageInfo] | [pkg: string] | [pkg: string, info: BunLockFilePackageInfo, bunTag: string] | [pkg: string, info: Pick<BunLockFileBasePackageInfo, "bin" | "binDir">]
+type BunLockFilePackageInfo (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { os?: string | Array<string> | undefined; cpu?: string | Array<string> | undefined; bundled?: true | undefined; }
+type BunLockFileWorkspacePackage (bun-types/bun.d.ts) = BunLockFileBasePackageInfo & { name?: string | undefined; version?: string | undefined; }
+interface BunMessageEvent<T = any> (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+interface BunPlugin (bun-types/bun.d.ts)
+  name: string
+  setup: (build: PluginBuilder) => Promise<void> | void
+  target [?]: Target | undefined
+interface BunRegisterPlugin (bun-types/bun.d.ts)
+  call <T extends BunPlugin>(options: T): ReturnType<T["setup"]>
+  clearAll: () => void
+interface BunRequest<T extends string = string> (bun-types/serve.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  cache [readonly]: RequestCache
+  clone: () => BunRequest<T>
+  cookies [readonly]: CookieMap
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  duplex [readonly]: "half"
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  integrity [readonly]: string
+  json [readonly]: () => Promise<unknown>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  params [readonly]: { [Key in keyof ExtractRouteParams<T>]: ExtractRouteParams<T>[Key]; }
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+namespace CSRF (bun-types/bun.d.ts)
+  function CSRF.generate (bun-types/bun.d.ts)
+    call (secret?: string | undefined, options?: CSRFGenerateOptions | undefined): string
+  function CSRF.verify (bun-types/bun.d.ts)
+    call (token: string, options?: CSRFVerifyOptions | undefined): boolean
+type CSRFAlgorithm (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256"
+interface CSRFGenerateOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  expiresIn [?]: number | undefined
+  sessionId [?]: string | undefined
+interface CSRFVerifyOptions (bun-types/bun.d.ts)
+  algorithm [?]: CSRFAlgorithm | undefined
+  encoding [?]: "base64" | "base64url" | "hex" | undefined
+  maxAge [?]: number | undefined
+  secret [?]: string | undefined
+  sessionId [?]: string | undefined
+interface CloseEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  code [?]: number | undefined
+  composed [?]: boolean | undefined
+  reason [?]: string | undefined
+  wasClean [?]: boolean | undefined
+type ColorInput (bun-types/bun.d.ts) = string | number | Uint8Array<ArrayBuffer> | { r: number; g: number; b: number; a?: number | undefined; } | [number, number, number] | [number, number, number, number] | Uint8ClampedArray<ArrayBuffer> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | { toString(): string; }
+interface CompileBuildOptions (bun-types/bun.d.ts)
+  assets [?]: Array<string> | undefined
+  autoloadBunfig [?]: boolean | undefined
+  autoloadDotenv [?]: boolean | undefined
+  autoloadPackageJson [?]: boolean | undefined
+  autoloadTsconfig [?]: boolean | undefined
+  execArgv [?]: Array<string> | undefined
+  executablePath [?]: string | undefined
+  outfile [?]: string | undefined
+  target [?]: CompileTarget | undefined
+  windows [?]: undefined | { hideConsole?: boolean | undefined; icon?: string | undefined; title?: string | undefined; publisher?: string | undefined; version?: string | undefined; description?: string | undefined; copyright?: string | undefined; }
+type CompressionFormat (bun-types/bun.d.ts) = "gzip" | "deflate" | "deflate-raw" | "brotli" | "zstd"
+class Cookie (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | undefined
+  httpOnly: boolean
+  isExpired: () => boolean
+  maxAge [?]: number | undefined
+  name [readonly]: string
+  partitioned: boolean
+  path: string
+  sameSite: CookieSameSite
+  secure: boolean
+  serialize: () => string
+  toJSON: () => CookieInit
+  toString: () => string
+  value: string
+  [static]
+    construct new (name: string, value: string, options?: CookieInit | undefined): Cookie
+    construct new (cookieString: string): Cookie
+    construct new (cookieObject?: CookieInit | undefined): Cookie
+    from [static]: (name: string, value: string, options?: CookieInit | undefined) => Cookie
+    parse [static]: (cookieString: string) => Cookie
+    prototype: Cookie
+interface CookieInit (bun-types/bun.d.ts)
+  domain [?]: string | undefined
+  expires [?]: Date | number | string | undefined
+  httpOnly [?]: boolean | undefined
+  maxAge [?]: number | undefined
+  name [?]: string | undefined
+  partitioned [?]: boolean | undefined
+  path [?]: string | undefined
+  sameSite [?]: CookieSameSite | undefined
+  secure [?]: boolean | undefined
+  value [?]: string | undefined
+class CookieMap (bun-types/bun.d.ts)
+  [Symbol.iterator]: () => IterableIterator<[string, string]>
+  delete: { (name: string): void; (options: CookieStoreDeleteOptions): void; (name: string, options: Omit<CookieStoreDeleteOptions, "name">): void }
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callback: (value: string, key: string, map: CookieMap) => void) => void
+  get: (name: string) => null | string
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: string, options?: CookieInit | undefined): void; (options: CookieInit): void }
+  size [readonly]: number
+  toJSON: () => Record<string, string>
+  toSetCookieHeaders: () => Array<string>
+  values: () => IterableIterator<string>
+  [static]
+    construct new (init?: Array<Array<string>> | Record<string, string> | string | undefined): CookieMap
+    prototype: CookieMap
+type CookieSameSite (bun-types/bun.d.ts) = "none" | "strict" | "lax"
+interface CookieStoreDeleteOptions (bun-types/bun.d.ts)
+  domain [?]: null | string | undefined
+  name: string
+  path [?]: string | undefined
+interface CookieStoreGetOptions (bun-types/bun.d.ts)
+  name [?]: string | undefined
+  url [?]: string | undefined
+interface CronController (bun-types/bun.d.ts)
+  cron [readonly]: string
+  scheduledTime [readonly]: number
+  type [readonly]: "scheduled"
+interface CronJob (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  cron [readonly]: string
+  ref: () => CronJob
+  stop: () => CronJob
+  unref: () => CronJob
+interface CronOptions (bun-types/bun.d.ts)
+  tz [?]: string | undefined
+type CronWithAutocomplete (bun-types/bun.d.ts) = (string & {}) | "@yearly" | "@annually" | "@monthly" | "@weekly" | "@daily" | "@midnight" | "@hourly" | `${string} ${string} ${string} ${string} ${string}`
+class CryptoHashInterface<T> (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => T
+  [static]
+    construct new <T>(): CryptoHashInterface<T>
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHashInterface<any>
+class CryptoHasher (bun-types/bun.d.ts)
+  algorithm [readonly]: SupportedCryptoAlgorithms
+  byteLength [readonly]: number
+  copy: () => CryptoHasher
+  digest: { (encoding: DigestEncoding): string; (): Buffer<ArrayBufferLike>; (hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike> }
+  update: (input: BlobOrStringOrBuffer, inputEncoding?: BufferEncoding | undefined) => CryptoHasher
+  [static]
+    construct new (algorithm: SupportedCryptoAlgorithms, hmacKey?: TypedArray<ArrayBufferLike> | string | undefined): CryptoHasher
+    algorithms [readonly static]: Array<SupportedCryptoAlgorithms>
+    hash [static]: { (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer): Buffer<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, hashInto: TypedArray<ArrayBufferLike>): TypedArray<ArrayBufferLike>; (algorithm: SupportedCryptoAlgorithms, input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: CryptoHasher
+interface CustomEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  detail [?]: T | undefined
+interface DNSLookup (bun-types/bun.d.ts)
+  address: string
+  family: 4 | 6
+  ttl: number
+type DOMHighResTimeStamp (bun-types/bun.d.ts) = number
+type DigestEncoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "base64url" | "latin1" | "hex"
+interface DirectUnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull: (controller: ReadableStreamDirectController) => PromiseLike<void> | void
+  type: "direct"
+type DisconnectListener (bun-types/bun.d.ts) = () => void
+interface EditorOptions (bun-types/bun.d.ts)
+  column [?]: number | undefined
+  editor [?]: "subl" | "vscode" | undefined
+  line [?]: number | undefined
+type Encoding (bun-types/bun.d.ts) = "ascii" | "utf8" | "utf-8" | "utf-16le" | "ucs-2" | "latin1" | "unicode-1-1-utf-8" | "unicode11utf8" | "unicode20utf8" | "x-unicode20utf8" | "866" | "cp866" | "csibm866" | "ibm866" | "csisolatin2" | "iso-8859-2" | "iso-ir-101" | "iso8859-2" | "iso88592" | "iso_8859-2" | "iso_8859-2:1987" | "l2" | "latin2" | "csisolatin3" | "iso-8859-3" | "iso-ir-109" | "iso8859-3" | "iso88593" | "iso_8859-3" | "iso_8859-3:1988" | "l3" | "latin3" | "csisolatin4" | "iso-8859-4" | "iso-ir-110" | "iso8859-4" | "iso88594" | "iso_8859-4" | "iso_8859-4:1988" | "l4" | "latin4" | "csisolatincyrillic" | "cyrillic" | "iso-8859-5" | "iso-ir-144" | "iso8859-5" | "iso88595" | "iso_8859-5" | "iso_8859-5:1988" | "arabic" | "asmo-708" | "csiso88596e" | "csiso88596i" | "csisolatinarabic" | "ecma-114" | "iso-8859-6" | "iso-8859-6-e" | "iso-8859-6-i" | "iso-ir-127" | "iso8859-6" | "iso88596" | "iso_8859-6" | "iso_8859-6:1987" | "csisolatingreek" | "ecma-118" | "elot_928" | "greek" | "greek8" | "iso-8859-7" | "iso-ir-126" | "iso8859-7" | "iso88597" | "iso_8859-7" | "iso_8859-7:1987" | "sun_eu_greek" | "csiso88598e" | "csisolatinhebrew" | "hebrew" | "iso-8859-8" | "iso-8859-8-e" | "iso-ir-138" | "iso8859-8" | "iso88598" | "iso_8859-8" | "iso_8859-8:1988" | "visual" | "csiso88598i" | "iso-8859-8-i" | "logical" | "csisolatin6" | "iso-8859-10" | "iso-ir-157" | "iso8859-10" | "iso885910" | "l6" | "latin6" | "iso-8859-13" | "iso8859-13" | "iso885913" | "iso-8859-14" | "iso8859-14" | "iso885914" | "csisolatin9" | "iso-8859-15" | "iso8859-15" | "iso885915" | "iso_8859-15" | "l9" | "iso-8859-16" | "cskoi8r" | "koi" | "koi8" | "koi8-r" | "koi8_r" | "koi8-ru" | "koi8-u" | "csmacintosh" | "mac" | "macintosh" | "x-mac-roman" | "dos-874" | "iso-8859-11" | "iso8859-11" | "iso885911" | "tis-620" | "windows-874" | "cp1250" | "windows-1250" | "x-cp1250" | "cp1251" | "windows-1251" | "x-cp1251" | "ansi_x3.4-1968" | "cp1252" | "cp819" | "csisolatin1" | "ibm819" | "iso-8859-1" | "iso-ir-100" | "iso8859-1" | "iso88591" | "iso_8859-1" | "iso_8859-1:1987" | "l1" | "us-ascii" | "windows-1252" | "x-cp1252" | "cp1253" | "windows-1253" | "x-cp1253" | "cp1254" | "csisolatin5" | "iso-8859-9" | "iso-ir-148" | "iso8859-9" | "iso88599" | "iso_8859-9" | "iso_8859-9:1989" | "l5" | "latin5" | "windows-1254" | "x-cp1254" | "cp1255" | "windows-1255" | "x-cp1255" | "cp1256" | "windows-1256" | "x-cp1256" | "cp1257" | "windows-1257" | "x-cp1257" | "cp1258" | "windows-1258" | "x-cp1258" | "x-mac-cyrillic" | "x-mac-ukrainian" | "chinese" | "csgb2312" | "csiso58gb231280" | "gb2312" | "gb_2312" | "gb_2312-80" | "gbk" | "iso-ir-58" | "x-gbk" | "gb18030" | "big5" | "big5-hkscs" | "cn-big5" | "csbig5" | "x-x-big5" | "cseucpkdfmtjapanese" | "euc-jp" | "x-euc-jp" | "csiso2022jp" | "iso-2022-jp" | "csshiftjis" | "ms932" | "ms_kanji" | "shift-jis" | "shift_jis" | "sjis" | "windows-31j" | "x-sjis" | "cseuckr" | "csksc56011987" | "euc-kr" | "iso-ir-149" | "korean" | "ks_c_5601-1987" | "ks_c_5601-1989" | "ksc5601" | "ksc_5601" | "windows-949" | "unicodefffe" | "utf-16be" | "csunicode" | "iso-10646-ucs-2" | "unicode" | "unicodefeff" | "utf-16" | "x-user-defined"
+interface Env (bun-types/bun.d.ts)
+  NODE_ENV [?]: string | undefined
+  TZ [?]: string | undefined
+interface ErrorEventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  colno [?]: number | undefined
+  composed [?]: boolean | undefined
+  error [?]: any
+  filename [?]: string | undefined
+  lineno [?]: number | undefined
+  message [?]: string | undefined
+interface ErrorLike (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+type Errorlike (bun-types/deprecated.d.ts) = ErrorLike
+interface EventInit (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+interface EventListener (bun-types/bun.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (bun-types/bun.d.ts)
+  handleEvent: (object: Event) => void
+interface EventListenerOptions (bun-types/bun.d.ts)
+  capture [?]: boolean | undefined
+type EventListenerOrEventListenerObject (bun-types/bun.d.ts) = EventListener | EventListenerObject
+interface EventMap (bun-types/bun.d.ts)
+  fetch: FetchEvent
+  message: BunMessageEvent<any>
+  messageerror: BunMessageEvent<any>
+interface EventSource (bun-types/bun.d.ts)
+  construct new (url: URL | string, eventSourceInitDict?: EventSourceInit | undefined): EventSource
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: Event) => any) | null
+  onmessage: ((this: EventSource, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: number
+  ref: () => void
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: (this: EventSource, event: BunMessageEvent<any>) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => void
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+interface EventSourceEventMap (bun-types/bun.d.ts)
+  error: Event
+  message: BunMessageEvent<any>
+  open: Event
+type ExitListener (bun-types/bun.d.ts) = (code: number) => void
+type FFIFunctionCallable (bun-types/bun.d.ts) = Function & { readonly __ffi_function_callable: typeof FFIFunctionCallableSymbol; }
+interface FdSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  fd: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface FetchEvent (bun-types/bun.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface FileBlob (bun-types/bun.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified: number
+  name [? readonly]: string | undefined
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): BunFile; (begin?: number | undefined, contentType?: string | undefined): BunFile; (contentType?: string | undefined): BunFile }
+  stat: () => Promise<Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | BunFile | ReadableStream<any> | Request | Response | SharedArrayBuffer | string, options?: undefined | { highWaterMark?: number | undefined; }) => Promise<number>
+  writer: (options?: undefined | { highWaterMark?: number | undefined; }) => FileSink
+interface FileSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+class FileSystemRouter (bun-types/bun.d.ts)
+  assetPrefix [readonly]: string
+  match: (input: Request | Response | string) => MatchedRoute | null
+  origin [readonly]: string
+  reload: () => void
+  routes [readonly]: Record<string, string>
+  style [readonly]: string
+  [static]
+    construct new (options: { dir: string; style: "nextjs"; assetPrefix?: string | undefined; origin?: string | undefined; fileExtensions?: Array<string> | undefined; }): FileSystemRouter
+    prototype: FileSystemRouter
+type FormDataEntryValue (bun-types/bun.d.ts) = string | File
+interface GenericTransformStream (bun-types/bun.d.ts)
+  readable [readonly]: ReadableStream<any>
+  writable [readonly]: WritableStream<any>
+class Glob (bun-types/bun.d.ts)
+  match: (str: string) => boolean
+  scan: (optionsOrCwd?: GlobScanOptions | string | undefined) => AsyncIterableIterator<string>
+  scanSync: (optionsOrCwd?: GlobScanOptions | string | undefined) => IterableIterator<string>
+  [static]
+    construct new (pattern: string): Glob
+    prototype: Glob
+interface GlobScanOptions (bun-types/bun.d.ts)
+  absolute [?]: boolean | undefined
+  cwd [?]: string | undefined
+  dot [?]: boolean | undefined
+  followSymlinks [?]: boolean | undefined
+  onlyFiles [?]: boolean | undefined
+  throwErrorOnBrokenSymlink [?]: boolean | undefined
+type HMREvent (bun-types/devserver.d.ts) = (string & {}) | "bun:error" | "bun:beforeUpdate" | "bun:afterUpdate" | "bun:beforeFullReload" | "bun:beforePrune" | "bun:invalidate" | "bun:ws:disconnect" | "bun:ws:connect"
+type HMREventNames (bun-types/devserver.d.ts) = "error" | "beforeUpdate" | "afterUpdate" | "beforeFullReload" | "beforePrune" | "invalidate" | "ws:disconnect" | "ws:connect"
+interface HTMLBundle (bun-types/bun.d.ts)
+  files [?]: Array<{ input?: string | undefined; path: string; loader: Loader; isEntry: boolean; headers: { [key: string]: string; etag: string; "content-type": string; }; }> | undefined
+  index: string
+interface Hash (bun-types/bun.d.ts)
+  adler32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => number
+  cityHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  crc32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur32v3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  murmur64v2: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  rapidhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  wyhash: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash3: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+  xxHash32: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: number | undefined) => number
+  xxHash64: (data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string, seed?: bigint | undefined) => bigint
+type HeadersInit (bun-types/fetch.d.ts) = Array<Array<string>> | Record<string, string | ReadonlyArray<string>> | Headers
+interface HeapSnapshot (bun-types/bun.d.ts)
+  edgeNames: Array<string>
+  edgeTypes: Array<string>
+  edges: Array<number>
+  nodeClassNames: Array<string>
+  nodes: Array<number>
+  type: string
+  version: number
+class Image (bun-types/bun.d.ts)
+  avif: (options?: undefined | { quality?: number | undefined; }) => Image
+  blob: () => Promise<Blob>
+  buffer: () => Promise<Buffer<ArrayBufferLike>>
+  bytes: () => Promise<Uint8Array<ArrayBufferLike>>
+  dataurl: () => Promise<string>
+  flip: () => Image
+  flop: () => Image
+  heic: (options?: undefined | { quality?: number | undefined; }) => Image
+  height [readonly]: number
+  jpeg: (options?: undefined | { quality?: number | undefined; progressive?: boolean | undefined; }) => Image
+  metadata: () => Promise<Metadata>
+  modulate: (options: ModulateOptions) => Image
+  placeholder: (as?: "dataurl" | undefined) => Promise<string>
+  png: (options?: undefined | { compressionLevel?: number | undefined; palette?: boolean | undefined; colors?: number | undefined; dither?: boolean | undefined; }) => Image
+  resize: (width: number, height?: number | undefined, options?: ResizeOptions | undefined) => Image
+  rotate: (degrees: number) => Image
+  toBase64: () => Promise<string>
+  toBuffer: () => Promise<Buffer<ArrayBufferLike>>
+  webp: (options?: undefined | { quality?: number | undefined; lossless?: boolean | undefined; }) => Image
+  width [readonly]: number
+  write: (dest: BunFile | PathLike | S3File | number) => Promise<number>
+  [static]
+    construct new (input: ArrayBuffer | Blob | TypedArray<ArrayBufferLike> | string, options?: ConstructorOptions | undefined): Image
+    backend [static]: "bun" | "system"
+    clipboardChangeCount [static]: () => number
+    fromClipboard [static]: () => Image | null
+    hasClipboardImage [static]: () => boolean
+    prototype: Image
+  interface Image.ConstructorOptions (bun-types/bun.d.ts)
+    autoOrient [?]: boolean | undefined
+    maxPixels [?]: number | undefined
+  type Image.ErrorCode (bun-types/bun.d.ts) = "ERR_IMAGE_FORMAT_UNSUPPORTED" | "ERR_IMAGE_TOO_MANY_PIXELS" | "ERR_IMAGE_DECODE_FAILED" | "ERR_IMAGE_ENCODE_FAILED" | "ERR_IMAGE_UNKNOWN_FORMAT" | "ERR_INVALID_STATE"
+  type Image.Filter (bun-types/bun.d.ts) = "nearest" | "box" | "bilinear" | "linear" | "cubic" | "mitchell" | "lanczos2" | "lanczos3" | "mks2013" | "mks2021"
+  type Image.Format (bun-types/bun.d.ts) = "jpeg" | "png" | "webp" | "heic" | "avif" | "bmp" | "tiff" | "gif"
+  interface Image.Metadata (bun-types/bun.d.ts)
+    format: Format
+    height: number
+    width: number
+  interface Image.ModulateOptions (bun-types/bun.d.ts)
+    brightness [?]: number | undefined
+    saturation [?]: number | undefined
+  interface Image.ResizeOptions (bun-types/bun.d.ts)
+    filter [?]: Filter | undefined
+    fit [?]: "fill" | "inside" | undefined
+    withoutEnlargement [?]: boolean | undefined
+  var Image.backend (bun-types/bun.d.ts): "bun" | "system"
+interface Import (bun-types/bun.d.ts)
+  kind: ImportKind
+  path: string
+type ImportKind (bun-types/bun.d.ts) = "import-statement" | "require-call" | "require-resolve" | "dynamic-import" | "import-rule" | "url-token" | "internal" | "entry-point-run" | "entry-point-build"
+namespace JSON5 (bun-types/bun.d.ts)
+  function JSON5.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function JSON5.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+namespace JSONC (bun-types/bun.d.ts)
+  function JSONC.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+namespace JSONL (bun-types/bun.d.ts)
+  interface JSONL.ParseChunkResult (bun-types/bun.d.ts)
+    done: boolean
+    error: SyntaxError | null
+    read: number
+    values: Array<unknown>
+  function JSONL.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Array<unknown>
+  function JSONL.parseChunk (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, start?: number | undefined, end?: number | undefined): ParseChunkResult
+type JavaScriptLoader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx"
+interface LibdeflateCompressionOptions (bun-types/bun.d.ts)
+  level [?]: 0 | 1 | 10 | 11 | 12 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "libdeflate" | undefined
+type Loader (bun-types/bun.d.ts) = "js" | "jsx" | "ts" | "tsx" | "json" | "jsonc" | "toml" | "yaml" | "xml" | "file" | "napi" | "wasm" | "text" | "css" | "html"
+class MD4 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD4
+  [static]
+    construct new (): MD4
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD4
+class MD5 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => MD5
+  [static]
+    construct new (): MD5
+    byteLength [readonly static]: 16
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: MD5
+interface MMapOptions (bun-types/bun.d.ts)
+  offset [?]: number | undefined
+  shared [?]: boolean | undefined
+  size [?]: number | undefined
+  sync [?]: boolean | undefined
+type MacroMap (bun-types/bun.d.ts) = { [x: string]: Record<string, string>; }
+interface MatchedRoute (bun-types/bun.d.ts)
+  filePath [readonly]: string
+  kind [readonly]: "catch-all" | "dynamic" | "exact" | "optional-catch-all"
+  name [readonly]: string
+  params [readonly]: Record<string, string>
+  pathname [readonly]: string
+  query [readonly]: Record<string, string>
+  src [readonly]: string
+type MaybePromise<T> (bun-types/bun.d.ts) = T | Promise<T>
+type MessageEvent<T = any> (bun-types/bun.d.ts) = BunMessageEvent<T>
+interface MessageEventInit<T = any> (bun-types/bun.d.ts)
+  bubbles [?]: boolean | undefined
+  cancelable [?]: boolean | undefined
+  composed [?]: boolean | undefined
+  data [?]: T | undefined
+  lastEventId [?]: string | undefined
+  origin [?]: string | undefined
+  source [?]: null | undefined
+type MessageEventSource (bun-types/bun.d.ts) = undefined
+type MessageListener (bun-types/bun.d.ts) = (message: unknown, sendHandle: unknown) => void
+type MultipleResolveListener (bun-types/deprecated.d.ts) = (type: MultipleResolveType, promise: Promise<unknown>, value: unknown) => void
+type MultipleResolveType (bun-types/bun.d.ts) = "resolve" | "reject"
+interface NetworkSink (bun-types/s3.d.ts)
+  end: (error?: Error | undefined) => Promise<number> | number
+  flush: () => Promise<number> | number
+  ref: () => void
+  start: (options?: undefined | { highWaterMark?: number | undefined; }) => void
+  stat: () => Promise<Stats>
+  unref: () => void
+  write: (chunk: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string) => Promise<number> | number
+type NullSubprocess (bun-types/bun.d.ts) = Subprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type NullSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"inherit" | "ignore" | null | undefined, "inherit" | "ignore" | null | undefined>
+type OnBeforeParseCallback (bun-types/bun.d.ts) = { napiModule: unknown; symbol: string; external?: unknown; }
+type OnEndCallback (bun-types/bun.d.ts) = (result: BuildOutput) => void | Promise<void>
+interface OnLoadArgs (bun-types/bun.d.ts)
+  defer: () => Promise<void>
+  loader: Loader
+  namespace: string
+  path: string
+type OnLoadCallback (bun-types/bun.d.ts) = (args: OnLoadArgs) => OnLoadResult | Promise<OnLoadResult>
+type OnLoadResult (bun-types/bun.d.ts) = void | OnLoadResultSourceCode | OnLoadResultObject | undefined
+interface OnLoadResultObject (bun-types/bun.d.ts)
+  exports: Record<string, unknown>
+  loader: "object"
+interface OnLoadResultSourceCode (bun-types/bun.d.ts)
+  contents: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | SharedArrayBuffer | string
+  loader [?]: Loader | undefined
+interface OnResolveArgs (bun-types/bun.d.ts)
+  importer: string
+  kind: ImportKind
+  namespace: string
+  path: string
+  resolveDir: string
+type OnResolveCallback (bun-types/bun.d.ts) = (args: OnResolveArgs) => OnResolveResult | Promise<OnResolveResult | null | undefined> | null | undefined
+interface OnResolveResult (bun-types/bun.d.ts)
+  external [?]: boolean | undefined
+  namespace [?]: string | undefined
+  path: string
+type OnStartCallback (bun-types/bun.d.ts) = () => void | Promise<void>
+namespace Password (bun-types/bun.d.ts)
+  type Password.AlgorithmLabel (bun-types/bun.d.ts) = "bcrypt" | "argon2id" | "argon2d" | "argon2i"
+  interface Password.Argon2Algorithm (bun-types/bun.d.ts)
+    algorithm: "argon2d" | "argon2i" | "argon2id"
+    memoryCost [?]: number | undefined
+    timeCost [?]: number | undefined
+  interface Password.BCryptAlgorithm (bun-types/bun.d.ts)
+    algorithm: "bcrypt"
+    cost [?]: number | undefined
+type PathLike (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike> | URL
+type PipedSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", "pipe", "pipe">
+type Platform (bun-types/deprecated.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+interface PluginBuilder (bun-types/bun.d.ts)
+  config: BuildConfig & { plugins: Array<BunPlugin>; }
+  module: (specifier: string, callback: () => OnLoadResult | Promise<OnLoadResult>) => PluginBuilder
+  onBeforeParse: (constraints: PluginConstraints, callback: OnBeforeParseCallback) => PluginBuilder
+  onEnd: (callback: OnEndCallback) => PluginBuilder
+  onLoad: (constraints: PluginConstraints, callback: OnLoadCallback) => PluginBuilder
+  onResolve: (constraints: PluginConstraints, callback: OnResolveCallback) => PluginBuilder
+  onStart: (callback: OnStartCallback) => PluginBuilder
+interface PluginConstraints (bun-types/bun.d.ts)
+  filter: RegExp
+  namespace [?]: string | undefined
+type ReadableIO (bun-types/deprecated.d.ts) = number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+type ReadableStreamController<T> (bun-types/bun.d.ts) = ReadableStreamDefaultController<T>
+interface ReadableStreamDefaultReadManyResult<T> (bun-types/bun.d.ts)
+  done: boolean
+  size: number
+  value: Array<T>
+type ReadableStreamDefaultReadResult<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReadValueResult<T> | ReadableStreamDefaultReadDoneResult
+type ReadableStreamReader<T> (bun-types/bun.d.ts) = ReadableStreamDefaultReader<T>
+type ReadableSubprocess (bun-types/bun.d.ts) = Subprocess<any, "pipe", "pipe">
+type ReadableSyncSubprocess (bun-types/bun.d.ts) = SyncSubprocess<"pipe", "pipe">
+class RedisClient (bun-types/redis.d.ts)
+  append: (key: KeyLike, value: KeyLike) => Promise<number>
+  bitcount: (key: KeyLike) => Promise<number>
+  bitfield: (key: KeyLike, ...operations: Array<string | number>) => Promise<Array<number | null>>
+  bitop: { (operation: "NOT" | "not", destkey: KeyLike, key: KeyLike): Promise<number>; (operation: "AND" | "ANDOR" | "DIFF" | "DIFF1" | "ONE" | "OR" | "XOR" | "and" | "andor" | "diff" | "diff1" | "one" | "or" | "xor", destkey: KeyLike, key: KeyLike, ...moreKeys: Array<KeyLike>): Promise<number> }
+  bitpos: (key: KeyLike, bit: 0 | 1, ...options: Array<string | number>) => Promise<number>
+  blmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT", timeout: number) => Promise<string | null>
+  blmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  blpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpop: (...args: Array<number | KeyLike>) => Promise<[string, string] | null>
+  brpoplpush: (source: KeyLike, destination: KeyLike, timeout: number) => Promise<string | null>
+  bufferedAmount [readonly]: number
+  bzmpop: (timeout: number, numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  bzpopmax: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  bzpopmin: (...args: Array<number | KeyLike>) => Promise<[string, string, number] | null>
+  client: (...args: Array<string | number>) => Promise<any>
+  close: () => void
+  command: (...args: Array<string | number>) => Promise<any>
+  config: (...args: Array<string | number>) => Promise<any>
+  connect: () => Promise<void>
+  connected [readonly]: boolean
+  copy: { (source: KeyLike, destination: KeyLike): Promise<number>; (source: KeyLike, destination: KeyLike, replace: "REPLACE"): Promise<number> }
+  dbsize: () => Promise<number>
+  debug: (...args: Array<string | number>) => Promise<any>
+  decr: (key: KeyLike) => Promise<number>
+  decrby: (key: KeyLike, decrement: number) => Promise<number>
+  del: (...keys: Array<KeyLike>) => Promise<number>
+  dump: (key: KeyLike) => Promise<string | null>
+  duplicate: () => Promise<RedisClient>
+  echo: (message: string) => Promise<string>
+  eval: (script: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  evalsha: (sha1: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  exists: (key: KeyLike) => Promise<boolean>
+  expire: (key: KeyLike, seconds: number) => Promise<number>
+  expireat: (key: KeyLike, timestamp: number) => Promise<number>
+  expiretime: (key: KeyLike) => Promise<number>
+  fcall: (name: string, numkeys: number, ...keysAndArgs: Array<string | number>) => Promise<any>
+  flushall: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  flushdb: { (): Promise<"OK">; (mode: "ASYNC" | "SYNC" | "async" | "sync"): Promise<"OK"> }
+  function: (...args: Array<KeyLike>) => Promise<any>
+  geoadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  geodist: { (key: KeyLike, member1: string, member2: string): Promise<string | null>; (key: KeyLike, member1: string, member2: string, unit: "FT" | "KM" | "M" | "MI" | "ft" | "km" | "m" | "mi"): Promise<string | null> }
+  geohash: (key: KeyLike, ...members: Array<string>) => Promise<Array<string | null>>
+  geopos: (key: KeyLike, ...members: Array<string>) => Promise<Array<[number, number] | null>>
+  geosearch: (key: KeyLike, ...args: Array<string | number>) => Promise<Array<unknown>>
+  geosearchstore: (destination: KeyLike, source: KeyLike, ...args: Array<string | number>) => Promise<number>
+  get: (key: KeyLike) => Promise<string | null>
+  getBuffer: (key: KeyLike) => Promise<Uint8Array<ArrayBuffer> | null>
+  getbit: (key: KeyLike, offset: number) => Promise<number>
+  getdel: (key: KeyLike) => Promise<string | null>
+  getex: { (key: KeyLike): Promise<string | null>; (key: KeyLike, ex: "EX", seconds: number): Promise<string | null>; (key: KeyLike, px: "PX", milliseconds: number): Promise<string | null>; (key: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<string | null>; (key: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<string | null>; (key: KeyLike, persist: "PERSIST"): Promise<string | null> }
+  getrange: (key: KeyLike, start: number, end: number) => Promise<string>
+  getset: (key: KeyLike, value: KeyLike) => Promise<string | null>
+  hdel: (key: KeyLike, field: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  hexists: (key: KeyLike, field: KeyLike) => Promise<boolean>
+  hexpire: { (key: KeyLike, seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, seconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpireat: { (key: KeyLike, unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeSeconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hget: (key: KeyLike, field: KeyLike) => Promise<string | null>
+  hgetall: (key: KeyLike) => Promise<Record<string, string>>
+  hgetdel: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<string | null>>
+  hgetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>>; (key: KeyLike, persist: "PERSIST", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<string | null>> }
+  hincrby: (key: KeyLike, field: string, increment: number | string) => Promise<number>
+  hincrbyfloat: (key: KeyLike, field: string, increment: number | string) => Promise<string>
+  hkeys: (key: KeyLike) => Promise<Array<string>>
+  hlen: (key: KeyLike) => Promise<number>
+  hmget: { (key: KeyLike, ...fields: Array<string>): Promise<Array<string | null>>; (key: KeyLike, fields: Array<string>): Promise<Array<string | null>> }
+  hmset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<"OK">; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<"OK">; (key: KeyLike, fieldValues: Array<KeyLike>): Promise<"OK"> }
+  hpersist: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpexpire: { (key: KeyLike, milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, milliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpireat: { (key: KeyLike, unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>>; (key: KeyLike, unixTimeMilliseconds: number, condition: "GT" | "LT" | "NX" | "XX", fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>): Promise<Array<number>> }
+  hpexpiretime: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hpttl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hrandfield: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>>; (key: KeyLike, count: number, withValues: "WITHVALUES"): Promise<Array<[string, string]>> }
+  hscan: { (key: KeyLike, cursor: number | string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, count: "COUNT", limit: number): Promise<[string, Array<string>]>; (key: KeyLike, cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", limit: number): Promise<[string, Array<string>]> }
+  hset: { (key: KeyLike, fields: Record<string | number, number | KeyLike>): Promise<number>; (key: KeyLike, field: KeyLike, value: KeyLike, ...rest: Array<KeyLike>): Promise<number> }
+  hsetex: { (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fnx: "FNX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", ex: "EX", seconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", px: "PX", milliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", exat: "EXAT", unixTimeSeconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", pxat: "PXAT", unixTimeMilliseconds: number, fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number>; (key: KeyLike, fxx: "FXX", keepttl: "KEEPTTL", fieldsKeyword: "FIELDS", numfields: number, ...fieldValues: Array<KeyLike>): Promise<number> }
+  hsetnx: (key: KeyLike, field: KeyLike, value: KeyLike) => Promise<boolean>
+  hstrlen: (key: KeyLike, field: string) => Promise<number>
+  httl: (key: KeyLike, fieldsKeyword: "FIELDS", numfields: number, ...fields: Array<KeyLike>) => Promise<Array<number>>
+  hvals: (key: KeyLike) => Promise<Array<string>>
+  incr: (key: KeyLike) => Promise<number>
+  incrby: (key: KeyLike, increment: number) => Promise<number>
+  incrbyfloat: (key: KeyLike, increment: number | string) => Promise<string>
+  info: (...sections: Array<string>) => Promise<string>
+  keys: (pattern: string) => Promise<Array<string>>
+  lastsave: () => Promise<number>
+  lcs: (key1: KeyLike, key2: KeyLike, ...options: Array<string | number>) => Promise<any>
+  lindex: (key: KeyLike, index: number) => Promise<string | null>
+  linsert: (key: KeyLike, position: "AFTER" | "BEFORE", pivot: KeyLike, element: KeyLike) => Promise<number>
+  llen: (key: KeyLike) => Promise<number>
+  lmove: (source: KeyLike, destination: KeyLike, from: "LEFT" | "RIGHT", to: "LEFT" | "RIGHT") => Promise<string | null>
+  lmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<string>] | null>
+  lpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  lpos: (key: KeyLike, element: KeyLike, ...options: Array<string | number>) => Promise<number | Array<number> | null>
+  lpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  lpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  lrange: (key: KeyLike, start: number, stop: number) => Promise<Array<string>>
+  lrem: (key: KeyLike, count: number, element: KeyLike) => Promise<number>
+  lset: (key: KeyLike, index: number, element: KeyLike) => Promise<string>
+  ltrim: (key: KeyLike, start: number, stop: number) => Promise<string>
+  mget: (...keys: Array<KeyLike>) => Promise<Array<string | null>>
+  mset: (...keyValuePairs: Array<KeyLike>) => Promise<"OK">
+  msetnx: (...keyValuePairs: Array<KeyLike>) => Promise<number>
+  object: (subcommand: string, ...args: Array<KeyLike>) => Promise<any>
+  onclose: ((this: RedisClient, error: Error) => void) | null
+  onconnect: ((this: RedisClient) => void) | null
+  persist: (key: KeyLike) => Promise<number>
+  pexpire: (key: KeyLike, milliseconds: number) => Promise<number>
+  pexpireat: (key: KeyLike, millisecondsTimestamp: number) => Promise<number>
+  pexpiretime: (key: KeyLike) => Promise<number>
+  pfadd: (key: KeyLike, element: string) => Promise<number>
+  pfcount: (key: KeyLike, ...moreKeys: Array<KeyLike>) => Promise<number>
+  pfmerge: (destkey: KeyLike, ...sourcekeys: Array<KeyLike>) => Promise<"OK">
+  ping: { (): Promise<"PONG">; (message: KeyLike): Promise<string> }
+  psetex: (key: KeyLike, milliseconds: number, value: KeyLike) => Promise<"OK">
+  pttl: (key: KeyLike) => Promise<number>
+  publish: (channel: string, message: string) => Promise<number>
+  randomkey: () => Promise<string | null>
+  rename: (key: KeyLike, newkey: KeyLike) => Promise<"OK">
+  renamenx: (key: KeyLike, newkey: KeyLike) => Promise<number>
+  rpop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string>> }
+  rpoplpush: (source: KeyLike, destination: KeyLike) => Promise<string | null>
+  rpush: (key: KeyLike, value: KeyLike, ...rest: Array<KeyLike>) => Promise<number>
+  rpushx: (key: KeyLike, value: KeyLike) => Promise<number>
+  sadd: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  scan: { (cursor: number | string): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string): Promise<[string, Array<string>]>; (cursor: number | string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, match: "MATCH", pattern: string, count: "COUNT", hint: number): Promise<[string, Array<string>]>; (cursor: number | string, ...options: Array<string | number>): Promise<[string, Array<string>]> }
+  scard: (key: KeyLike) => Promise<number>
+  script: (...args: Array<string>) => Promise<any>
+  sdiff: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sdiffstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  send: (command: string, args: Array<string>) => Promise<any>
+  set: { (key: KeyLike, value: KeyLike): Promise<"OK">; (key: KeyLike, value: KeyLike, ex: "EX", seconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, px: "PX", milliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, exat: "EXAT", timestampSeconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, pxat: "PXAT", timestampMilliseconds: number): Promise<"OK">; (key: KeyLike, value: KeyLike, nx: "NX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, xx: "XX"): Promise<"OK" | null>; (key: KeyLike, value: KeyLike, get: "GET"): Promise<string | null>; (key: KeyLike, value: KeyLike, keepttl: "KEEPTTL"): Promise<"OK">; (key: KeyLike, value: KeyLike, ...options: Array<string>): Promise<string | null> }
+  setbit: (key: KeyLike, offset: number, value: 0 | 1) => Promise<number>
+  setex: (key: KeyLike, seconds: number, value: KeyLike) => Promise<"OK">
+  setnx: (key: KeyLike, value: KeyLike) => Promise<number>
+  setrange: (key: KeyLike, offset: number, value: KeyLike) => Promise<number>
+  sinter: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sintercard: (numkeys: number, key: KeyLike, ...args: Array<number | KeyLike>) => Promise<number>
+  sinterstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  sismember: (key: KeyLike, member: string) => Promise<boolean>
+  smembers: (key: KeyLike) => Promise<Array<string>>
+  smismember: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number>>
+  smove: (source: KeyLike, destination: KeyLike, member: string) => Promise<boolean>
+  sort: (key: KeyLike, ...args: Array<string | number>) => Promise<number | Array<string | null>>
+  spop: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  spublish: (channel: KeyLike, message: string) => Promise<number>
+  srandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null> }
+  srem: (key: KeyLike, ...members: Array<string>) => Promise<number>
+  sscan: (key: KeyLike, cursor: number | string, ...args: Array<string | number>) => Promise<[string, Array<string>]>
+  strlen: (key: KeyLike) => Promise<number>
+  subscribe: { (channel: string, listener: StringPubSubListener): Promise<number>; (channels: Array<string>, listener: StringPubSubListener): Promise<number> }
+  substr: (key: KeyLike, start: number, end: number) => Promise<string>
+  sunion: (key: KeyLike, ...keys: Array<KeyLike>) => Promise<Array<string>>
+  sunionstore: (destination: KeyLike, key: KeyLike, ...keys: Array<KeyLike>) => Promise<number>
+  time: () => Promise<[string, string]>
+  touch: (...keys: Array<KeyLike>) => Promise<number>
+  ttl: (key: KeyLike) => Promise<number>
+  type: (key: KeyLike) => Promise<"string" | "none" | "list" | "set" | "zset" | "hash" | "stream">
+  unlink: (...keys: Array<KeyLike>) => Promise<number>
+  unsubscribe: { (channel: string): Promise<void>; (channel: string, listener: StringPubSubListener): Promise<void>; (): Promise<void>; (channels: Array<string>): Promise<void> }
+  wait: (numreplicas: number, timeout: number) => Promise<number>
+  xack: (key: KeyLike, group: string, id: string, ...moreIds: Array<string>) => Promise<number>
+  xadd: (key: KeyLike, ...args: Array<string | number>) => Promise<string | null>
+  xautoclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, start: string, ...options: Array<string | number>) => Promise<any>
+  xclaim: (key: KeyLike, group: string, consumer: string, minIdleTime: number, id: string, ...rest: Array<string | number>) => Promise<any>
+  xdel: (key: KeyLike, id: string, ...moreIds: Array<string>) => Promise<number>
+  xgroup: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xinfo: (subcommand: string, ...args: Array<string | number>) => Promise<any>
+  xlen: (key: KeyLike) => Promise<number>
+  xpending: (key: KeyLike, group: string, ...args: Array<string | number>) => Promise<any>
+  xrange: (key: KeyLike, start: string, end: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xread: (...args: Array<string | number>) => Promise<any>
+  xreadgroup: (...args: Array<string | number>) => Promise<any>
+  xrevrange: (key: KeyLike, end: string, start: string, ...options: Array<string | number>) => Promise<Array<[string, Array<string>]>>
+  xsetid: (key: KeyLike, lastId: string, ...options: Array<string | number>) => Promise<"OK">
+  xtrim: (key: KeyLike, strategy: "MAXLEN" | "MINID" | "maxlen" | "minid", threshold: number | string, ...options: Array<string | number>) => Promise<number>
+  zadd: (key: KeyLike, ...args: Array<string | number>) => Promise<number>
+  zcard: (key: KeyLike) => Promise<number>
+  zcount: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zdiff: { (numkeys: number, ...args: [...keys: KeyLike[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...keys: Array<KeyLike>): Promise<Array<string>> }
+  zdiffstore: (destination: KeyLike, numkeys: number, ...keys: Array<KeyLike>) => Promise<number>
+  zincrby: (key: KeyLike, increment: number, member: KeyLike) => Promise<number>
+  zinter: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zintercard: { (numkeys: number, ...keys: Array<KeyLike>): Promise<number>; (numkeys: number, ...args: Array<number | KeyLike>): Promise<number> }
+  zinterstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  zlexcount: (key: KeyLike, min: string, max: string) => Promise<number>
+  zmpop: (numkeys: number, ...args: Array<string | number>) => Promise<[string, Array<[string, number]>] | null>
+  zmscore: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<Array<number | null>>
+  zpopmax: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zpopmin: { (key: KeyLike): Promise<[] | [string, number]>; (key: KeyLike, count: number): Promise<Array<[string, number]>> }
+  zrandmember: { (key: KeyLike): Promise<string | null>; (key: KeyLike, count: number): Promise<Array<string> | null>; (key: KeyLike, count: number, withscores: "WITHSCORES"): Promise<Array<[string, number]> | null> }
+  zrange: { (key: KeyLike, start: number | string, stop: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number | string, stop: number | string, byscore: "BYSCORE"): Promise<Array<string>>; (key: KeyLike, start: string, stop: string, bylex: "BYLEX"): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string, ...options: Array<string>): Promise<Array<string>>; (key: KeyLike, start: number | string, stop: number | string): Promise<Array<string>> }
+  zrangebylex: { (key: KeyLike, min: string, max: string): Promise<Array<string>>; (key: KeyLike, min: string, max: string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: string, max: string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangebyscore: { (key: KeyLike, min: number | string, max: number | string): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, withscores: "WITHSCORES", limit: "LIMIT", offset: number, count: number, ...options: Array<string | number>): Promise<Array<[string, number]>>; (key: KeyLike, min: number | string, max: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrangestore: (destination: KeyLike, source: KeyLike, start: number | string, stop: number | string, ...options: Array<string>) => Promise<number>
+  zrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zrem: (key: KeyLike, member: KeyLike, ...members: Array<KeyLike>) => Promise<number>
+  zremrangebylex: (key: KeyLike, min: string, max: string) => Promise<number>
+  zremrangebyrank: (key: KeyLike, start: number, stop: number) => Promise<number>
+  zremrangebyscore: (key: KeyLike, min: number | string, max: number | string) => Promise<number>
+  zrevrange: { (key: KeyLike, start: number, stop: number): Promise<Array<string>>; (key: KeyLike, start: number, stop: number, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, start: number, stop: number, ...options: Array<string>): Promise<Array<string>> }
+  zrevrangebylex: (key: KeyLike, max: string, min: string, ...options: Array<string>) => Promise<Array<string>>
+  zrevrangebyscore: { (key: KeyLike, max: number | string, min: number | string): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, withscores: "WITHSCORES"): Promise<Array<[string, number]>>; (key: KeyLike, max: number | string, min: number | string, limit: "LIMIT", offset: number, count: number): Promise<Array<string>>; (key: KeyLike, max: number | string, min: number | string, ...options: Array<string | number>): Promise<Array<string>> }
+  zrevrank: { (key: KeyLike, member: string): Promise<number | null>; (key: KeyLike, member: string, withscore: "WITHSCORE"): Promise<[number, number] | null> }
+  zscan: (key: KeyLike, cursor: number | string, ...options: Array<string>) => Promise<[string, Array<string>]>
+  zscore: (key: KeyLike, member: string) => Promise<number | null>
+  zunion: { (numkeys: number, ...args: [...args: (string | number)[], withscores: "WITHSCORES"]): Promise<Array<[string, number]>>; (numkeys: number, ...args: Array<string | number>): Promise<Array<string>> }
+  zunionstore: (destination: KeyLike, numkeys: number, ...args: Array<string | number>) => Promise<number>
+  [static]
+    construct new (url?: string | undefined, options?: RedisOptions | undefined): RedisClient
+    prototype: RedisClient
+  type RedisClient.KeyLike (bun-types/redis.d.ts) = string | Blob | ArrayBufferView<ArrayBufferLike>
+  type RedisClient.StringPubSubListener (bun-types/redis.d.ts) = (message: string, channel: string) => void
+interface RedisOptions (bun-types/redis.d.ts)
+  autoReconnect [?]: boolean | undefined
+  connectionTimeout [?]: number | undefined
+  enableAutoPipelining [?]: boolean | undefined
+  enableOfflineQueue [?]: boolean | undefined
+  idleTimeout [?]: number | undefined
+  maxRetries [?]: number | undefined
+  tls [?]: TLSOptions | boolean | undefined
+type RejectionHandledListener (bun-types/bun.d.ts) = (promise: Promise<unknown>) => void
+interface ReservedSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  [Symbol.dispose]: () => void
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  release: () => void
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+interface ResourceUsage (bun-types/bun.d.ts)
+  contextSwitches: { voluntary: number; involuntary: number; }
+  cpuTime: { user: number; system: number; total: number; }
+  maxRSS: number
+  messages: { sent: number; received: number; }
+  ops: { in: number; out: number; }
+  shmSize: number
+  signalCount: number
+  swapCount: number
+class S3Client (bun-types/s3.d.ts)
+  delete: (path: string, options?: S3Options | undefined) => Promise<void>
+  exists: (path: string, options?: S3Options | undefined) => Promise<boolean>
+  file: (path: string, options?: S3Options | undefined) => S3File
+  list: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+  presign: (path: string, options?: S3FilePresignOptions | undefined) => string
+  size: (path: string, options?: S3Options | undefined) => Promise<number>
+  stat: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+  unlink: (path: string, options?: S3Options | undefined) => Promise<void>
+  write: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  [static]
+    construct new (options?: S3Options | undefined): S3Client
+    delete [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    exists [static]: (path: string, options?: S3Options | undefined) => Promise<boolean>
+    file [static]: (path: string, options?: S3Options | undefined) => S3File
+    list [static]: (input?: S3ListObjectsOptions | null | undefined, options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint"> | undefined) => Promise<S3ListObjectsResponse>
+    presign [static]: (path: string, options?: S3FilePresignOptions | undefined) => string
+    prototype: S3Client
+    size [static]: (path: string, options?: S3Options | undefined) => Promise<number>
+    stat [static]: (path: string, options?: S3Options | undefined) => Promise<S3Stats>
+    unlink [static]: (path: string, options?: S3Options | undefined) => Promise<void>
+    write [static]: (path: string, data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | File | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+interface S3File (bun-types/s3.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bucket [? readonly]: string | undefined
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  delete: () => Promise<void>
+  exists: () => Promise<boolean>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  name [? readonly]: string | undefined
+  presign: (options?: S3FilePresignOptions | undefined) => string
+  readable [readonly]: ReadableStream<Uint8Array<ArrayBuffer>>
+  size [readonly]: number
+  slice: { (begin?: number | undefined, end?: number | undefined, contentType?: string | undefined): S3File; (begin?: number | undefined, contentType?: string | undefined): S3File; (contentType?: string | undefined): S3File }
+  stat: () => Promise<S3Stats>
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+  unlink: () => Promise<void>
+  write: (data: Archive | ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | BunFile | Request | Response | S3File | SharedArrayBuffer | string, options?: S3Options | undefined) => Promise<number>
+  writer: (options?: S3Options | undefined) => NetworkSink
+interface S3FilePresignOptions (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endpoint [?]: string | undefined
+  expiresIn [?]: number | undefined
+  highWaterMark [?]: number | undefined
+  method [?]: "DELETE" | "GET" | "HEAD" | "POST" | "PUT" | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3ListObjectsOptions (bun-types/s3.d.ts)
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  fetchOwner [?]: boolean | undefined
+  maxKeys [?]: number | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3ListObjectsResponse (bun-types/s3.d.ts)
+  commonPrefixes [?]: Array<{ prefix: string; }> | undefined
+  contents [?]: Array<{ checksumAlgorithm?: "CRC32" | "CRC32C" | "SHA1" | "SHA256" | "CRC64NVME" | undefined; checksumType?: "COMPOSITE" | "FULL_OBJECT" | undefined; eTag?: string | undefined; key: string; lastModified?: string | undefined; owner?: { id?: string | undefined; displayName?: string | undefined; } | undefined; restoreStatus?: { isRestoreInProgress?: boolean | undefined; restoreExpiryDate?: string | undefined; } | undefined; size?: number | undefined; storageClass?: "STANDARD" | "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD_IA" | undefined; }> | undefined
+  continuationToken [?]: string | undefined
+  delimiter [?]: string | undefined
+  encodingType [?]: "url" | undefined
+  isTruncated [?]: boolean | undefined
+  keyCount [?]: number | undefined
+  maxKeys [?]: number | undefined
+  name [?]: string | undefined
+  nextContinuationToken [?]: string | undefined
+  prefix [?]: string | undefined
+  startAfter [?]: string | undefined
+interface S3Options (bun-types/s3.d.ts)
+  accessKeyId [?]: string | undefined
+  acl [?]: "authenticated-read" | "aws-exec-read" | "bucket-owner-full-control" | "bucket-owner-read" | "log-delivery-write" | "private" | "public-read" | "public-read-write" | undefined
+  bucket [?]: string | undefined
+  contentDisposition [?]: string | undefined
+  contentEncoding [?]: string | undefined
+  endpoint [?]: string | undefined
+  highWaterMark [?]: number | undefined
+  partSize [?]: number | undefined
+  queueSize [?]: number | undefined
+  region [?]: string | undefined
+  requestPayer [?]: boolean | undefined
+  retry [?]: number | undefined
+  secretAccessKey [?]: string | undefined
+  sessionToken [?]: string | undefined
+  storageClass [?]: "DEEP_ARCHIVE" | "EXPRESS_ONEZONE" | "GLACIER" | "GLACIER_IR" | "INTELLIGENT_TIERING" | "ONEZONE_IA" | "OUTPOSTS" | "REDUCED_REDUNDANCY" | "SNOW" | "STANDARD" | "STANDARD_IA" | undefined
+  type [?]: string | undefined
+  virtualHostedStyle [?]: boolean | undefined
+interface S3Stats (bun-types/s3.d.ts)
+  etag: string
+  lastModified: Date
+  size: number
+  type: string
+class SHA1 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA1
+  [static]
+    construct new (): SHA1
+    byteLength [readonly static]: 20
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA1
+class SHA224 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA224
+  [static]
+    construct new (): SHA224
+    byteLength [readonly static]: 28
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA224
+class SHA256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA256
+  [static]
+    construct new (): SHA256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA256
+class SHA384 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA384
+  [static]
+    construct new (): SHA384
+    byteLength [readonly static]: 48
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA384
+class SHA512 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512
+  [static]
+    construct new (): SHA512
+    byteLength [readonly static]: 64
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512
+class SHA512_256 (bun-types/bun.d.ts)
+  digest: { (encoding: DigestEncoding): string; (hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike> }
+  update: (data: BlobOrStringOrBuffer) => SHA512_256
+  [static]
+    construct new (): SHA512_256
+    byteLength [readonly static]: 32
+    hash [static]: { (input: BlobOrStringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>; (input: BlobOrStringOrBuffer, encoding: DigestEncoding): string }
+    prototype: SHA512_256
+class SQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  [static]
+    construct new (connectionString: URL | string): SQL
+    construct new (connectionString: URL | string, options: Omit<PostgresOrMySQLOptions, "filename" | "url"> | Omit<SQLiteOptions, "filename" | "url">): SQL
+    construct new (options?: Options | undefined): SQL
+    MySQLError: typeof MySQLError
+    PostgresError: typeof PostgresError
+    SQLError: typeof SQLError
+    SQLiteError: typeof SQLiteError
+    prototype: SQL
+  type SQL.AwaitPromisesArray<T extends Array<PromiseLike<any>>> (bun-types/sql.d.ts) = { [K in keyof T]: Awaited<T[K]>; }
+  type SQL.ContextCallback<T, SQL> (bun-types/sql.d.ts) = (sql: SQL) => MaybePromise<T>
+  type SQL.ContextCallbackResult<T> (bun-types/sql.d.ts) = T extends Array<PromiseLike<any>> ? AwaitPromisesArray<T> : Awaited<T>
+  interface SQL.Helper<T> (bun-types/sql.d.ts)
+    columns [readonly]: Array<keyof T>
+    value [readonly]: Array<T>
+  interface SQL.ListenSubscription (bun-types/sql.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    channel [readonly]: string
+    unlisten: () => Promise<void>
+  class SQL.MySQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    errno [? readonly]: number | undefined
+    message: string
+    name: string
+    sqlState [? readonly]: string | undefined
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number | undefined; sqlState: string | undefined; }): MySQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: MySQLError
+      stackTraceLimit: number
+  type SQL.Options (bun-types/sql.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+  class SQL.PostgresError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    code [readonly]: string
+    column [? readonly]: string | undefined
+    constraint [? readonly]: string | undefined
+    dataType [? readonly]: string | undefined
+    detail [? readonly]: string | undefined
+    errno [? readonly]: string | undefined
+    file [? readonly]: string | undefined
+    hint [? readonly]: string | undefined
+    internalPosition [? readonly]: string | undefined
+    internalQuery [? readonly]: string | undefined
+    line [? readonly]: string | undefined
+    message: string
+    name: string
+    position [? readonly]: string | undefined
+    routine [? readonly]: string | undefined
+    schema [? readonly]: string | undefined
+    severity [? readonly]: string | undefined
+    stack [?]: string | undefined
+    table [? readonly]: string | undefined
+    where [? readonly]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno?: string | undefined; detail?: string | undefined; hint?: string | undefined; severity?: string | undefined; position?: string | undefined; internalPosition?: string | undefined; internalQuery?: string | undefined; where?: string | undefined; schema?: string | undefined; table?: string | undefined; column?: string | undefined; dataType?: string | undefined; constraint?: string | undefined; file?: string | undefined; line?: string | undefined; routine?: string | undefined; }): PostgresError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: PostgresError
+      stackTraceLimit: number
+  interface SQL.PostgresOrMySQLOptions (bun-types/sql.d.ts)
+    adapter [?]: "mariadb" | "mysql" | "postgres" | undefined
+    allowPublicKeyRetrieval [?]: boolean | undefined
+    bigint [?]: boolean | undefined
+    connectTimeout [?]: number | undefined
+    connect_timeout [?]: number | undefined
+    connection [?]: Record<string, string | number | boolean> | undefined
+    connectionTimeout [?]: number | undefined
+    connection_timeout [?]: number | undefined
+    database [?]: string | undefined
+    db [?]: string | undefined
+    host [?]: string | undefined
+    hostname [?]: string | undefined
+    idleTimeout [?]: number | undefined
+    idle_timeout [?]: number | undefined
+    max [?]: number | undefined
+    maxLifetime [?]: number | undefined
+    max_lifetime [?]: number | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    pass [?]: (() => MaybePromise<string>) | string | undefined
+    password [?]: (() => MaybePromise<string>) | string | undefined
+    path [?]: string | undefined
+    port [?]: number | string | undefined
+    prepare [?]: boolean | undefined
+    ssl [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    tls [?]: "allow" | "disable" | "prefer" | "require" | "verify-ca" | "verify-full" | BunFile | TLSOptions | boolean | undefined
+    url [?]: URL | string | undefined
+    user [?]: string | undefined
+    username [?]: string | undefined
+  interface SQL.Query<T> (bun-types/sql.d.ts)
+    [Symbol.toStringTag] [readonly]: string
+    active: boolean
+    cancel: () => Query<T>
+    cancelled: boolean
+    catch: <TResult = never>(onrejected?: ((reason: any) => PromiseLike<TResult> | TResult) | null | undefined) => Promise<T | TResult>
+    execute: () => Query<T>
+    finally: (onfinally?: (() => void) | null | undefined) => Promise<T>
+    raw: () => Query<T>
+    simple: () => Query<T>
+    then: <TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => PromiseLike<TResult1> | TResult1) | null | undefined, onrejected?: ((reason: any) => PromiseLike<TResult2> | TResult2) | null | undefined) => Promise<TResult1 | TResult2>
+    values: () => Query<T>
+  class SQL.SQLError (bun-types/sql.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string): SQLError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLError
+      stackTraceLimit: number
+  class SQL.SQLiteError (bun-types/sql.d.ts)
+    byteOffset [? readonly]: number | undefined
+    cause [?]: unknown
+    code [readonly]: string
+    errno [readonly]: number
+    message: string
+    name: string
+    stack [?]: string | undefined
+    [static]
+      construct new (message: string, options: { code: string; errno: number; byteOffset?: number | undefined; }): SQLiteError
+      captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+      isError: (value: unknown) => value is Error
+      prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+      prototype: SQLiteError
+      stackTraceLimit: number
+  interface SQL.SQLiteOptions (bun-types/sql.d.ts)
+    adapter [?]: "sqlite" | undefined
+    create [?]: boolean | undefined
+    filename [?]: ":memory:" | URL | string & {} | undefined
+    onclose [?]: ((err: Error | null) => void) | undefined
+    onconnect [?]: ((err: Error | null) => void) | undefined
+    readonly [?]: boolean | undefined
+    readwrite [?]: boolean | undefined
+    safeIntegers [?]: boolean | undefined
+    strict [?]: boolean | undefined
+  type SQL.SavepointContextCallback<T> (bun-types/sql.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+  type SQL.TransactionContextCallback<T> (bun-types/sql.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SQLArrayParameter (bun-types/sql.d.ts)
+  arrayType: ArrayType
+  serializedValues: string
+type SQLOptions (bun-types/deprecated.d.ts) = SQLiteOptions | PostgresOrMySQLOptions
+type SQLQuery<T = any> (bun-types/deprecated.d.ts) = Query<T>
+type SQLSavepointContextCallback<T> (bun-types/deprecated.d.ts) = (sql: SavepointSQL) => MaybePromise<T>
+type SQLTransactionContextCallback<T> (bun-types/deprecated.d.ts) = (sql: TransactionSQL) => MaybePromise<T>
+interface SavepointSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+namespace Security (bun-types/security.d.ts)
+  interface Security.Advisory (bun-types/security.d.ts)
+    description: null | string
+    level: "fatal" | "warn"
+    package: string
+    url: null | string
+  interface Security.Package (bun-types/security.d.ts)
+    name: string
+    requestedRange: string
+    tarball: string
+    version: string
+  interface Security.Scanner (bun-types/security.d.ts)
+    scan: (info: { packages: Array<Package>; }) => Promise<Array<Advisory>>
+    version: "1"
+namespace Serve (bun-types/serve.d.ts)
+  type Serve.BaseRouteValue (bun-types/serve.d.ts) = false | BunFile | Response | HTMLBundle | DirectoryRouteOptions
+  interface Serve.BaseServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Development (bun-types/serve.d.ts) = boolean | { hmr?: boolean | undefined; console?: boolean | undefined; chromeDevToolsAutomaticWorkspaceFolders?: boolean | undefined; }
+  interface Serve.DirectoryRouteOptions (bun-types/serve.d.ts)
+    dir: string
+    statCache [?]: boolean | undefined
+  type Serve.ExtractRouteParams<T> (bun-types/serve.d.ts) = string extends T ? Record<string, string> : T extends `${string}:${infer Param}/${infer Rest}` ? { [K in Param]: string; } & ExtractRouteParams<Rest> : T extends `${string}:${infer Param}` ? { [K in Param]: string; } : T extends `${string}*` ? {} : {}
+  type Serve.FetchOrRoutes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes: Routes<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<Response>; routes?: Routes<WebSocketData, R> | undefined; }
+  type Serve.FetchOrRoutesWithWebSocket<WebSocketData, R extends string> (bun-types/serve.d.ts) = { websocket: WebSocketHandler<WebSocketData>; } & ({ fetch?(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes: RoutesWithUpgrade<WebSocketData, R>; } | { fetch(this: Server<WebSocketData>, req: Request, server: Server<WebSocketData>): MaybePromise<void | Response | undefined>; routes?: RoutesWithUpgrade<WebSocketData, R> | undefined; })
+  type Serve.HTTPMethod (bun-types/serve.d.ts) = "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "PATCH" | "OPTIONS"
+  type Serve.Handler<Req extends Request, S, Res> (bun-types/serve.d.ts) = (request: Req, server: S) => MaybePromise<Res>
+  interface Serve.HostnamePortServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    hostname [?]: "0.0.0.0" | "127.0.0.1" | "localhost" | string & {} | undefined
+    http1 [?]: boolean | undefined
+    http2 [?]: boolean | undefined
+    http3 [?]: boolean | undefined
+    id [?]: null | string | undefined
+    idleTimeout [?]: number | undefined
+    ipv6Only [?]: boolean | undefined
+    maxRequestBodySize [?]: number | undefined
+    port [?]: number | string | undefined
+    reusePort [?]: boolean | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+  type Serve.Options<WebSocketData, R extends string = string> (bun-types/serve.d.ts) = XOR<HostnamePortServeOptions<WebSocketData>, UnixServeOptions<WebSocketData>> & XOR<FetchOrRoutes<WebSocketData, R>, FetchOrRoutesWithWebSocket<WebSocketData, R>>
+  type Serve.Routes<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, Response> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, Response>>>; }
+  type Serve.RoutesWithUpgrade<WebSocketData, R extends string> (bun-types/serve.d.ts) = { [Path in R]: BaseRouteValue | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined> | Partial<Record<HTTPMethod, Response | Handler<BunRequest<Path>, Server<WebSocketData>, void | Response | undefined>>>; }
+  interface Serve.UnixServeOptions<WebSocketData> (bun-types/serve.d.ts)
+    development [?]: Development | undefined
+    error [?]: ((this: Server<WebSocketData>, error: ErrorLike) => Promise<Response> | Promise<void> | Response | void) | undefined
+    id [?]: null | string | undefined
+    maxRequestBodySize [?]: number | undefined
+    tls [?]: Array<TLSOptions> | TLSOptions | undefined
+    unix [?]: string | undefined
+type ServeOptions<T = undefined, R extends string = never> (bun-types/deprecated.d.ts) = XOR<HostnamePortServeOptions<T>, UnixServeOptions<T>> & XOR<FetchOrRoutes<T, R>, FetchOrRoutesWithWebSocket<T, R>>
+interface Server<WebSocketData> (bun-types/serve.d.ts)
+  [Symbol.dispose]: () => void
+  closeIdleConnections: () => number
+  development [readonly]: boolean
+  fetch: (request: Request | string) => Promise<Response> | Response
+  hostname [readonly]: string | undefined
+  id [readonly]: string
+  pendingRequests [readonly]: number
+  pendingWebSockets [readonly]: number
+  port [readonly]: number | undefined
+  protocol [readonly]: "http" | "https" | null
+  publish: (topic: string, data: ArrayBuffer | ArrayBufferView<ArrayBufferLike> | Blob | SharedArrayBuffer | string, compress?: boolean | undefined) => number
+  ref: () => void
+  reload: <R extends string>(options: Options<WebSocketData, R>) => Server<WebSocketData>
+  requestIP: (request: Request) => SocketAddress | null
+  stop: (closeActiveConnections?: boolean | undefined) => Promise<void>
+  subscriberCount: (topic: string) => number
+  timeout: (request: Request, seconds: number) => void
+  unref: () => void
+  upgrade: (request: Request, ...options: [WebSocketData] extends [undefined] ? [options?: { headers?: HeadersInit | undefined; data?: undefined; } | undefined] : [options: { headers?: HeadersInit | undefined; data: WebSocketData; }]) => boolean
+  url [readonly]: URL
+interface ServerWebSocket<T = undefined> (bun-types/serve.d.ts)
+  binaryType [?]: "arraybuffer" | "blob" | "nodebuffer" | "uint8array" | undefined
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  cork: <T = unknown>(callback: (ws: ServerWebSocket<T>) => T) => T
+  data: T
+  getBufferedAmount: () => number
+  isSubscribed: (topic: string) => boolean
+  ping: (data?: Blob | BufferSource | string | undefined) => number
+  pong: (data?: Blob | BufferSource | string | undefined) => number
+  publish: (topic: string, data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  publishBinary: (topic: string, data: Blob | BufferSource, compress?: boolean | undefined) => number
+  publishText: (topic: string, data: string, compress?: boolean | undefined) => number
+  readyState [readonly]: WebSocketReadyState
+  remoteAddress [readonly]: string
+  send: (data: Blob | BufferSource | string, compress?: boolean | undefined) => number
+  sendBinary: (data: Blob | BufferSource, compress?: boolean | undefined) => number
+  sendText: (data: string, compress?: boolean | undefined) => number
+  subscribe: (topic: string) => boolean
+  subscriptions [readonly]: Array<string>
+  terminate: () => void
+  unsubscribe: (topic: string) => boolean
+type ServerWebSocketSendStatus (bun-types/serve.d.ts) = number
+type ShellExpression (bun-types/shell.d.ts) = string | number | { toString(): string; } | Array<ShellExpression> | { raw: string; } | Subprocess<Writable, Readable, Readable> | BunFile | Blob | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | ReadableStream<any> | Response | Request | ReadableStream<any> | null | undefined
+type ShellFunction (bun-types/deprecated.d.ts) = (input: Uint8Array<ArrayBuffer>) => Uint8Array<ArrayBuffer>
+type SignalsListener (bun-types/bun.d.ts) = (signal: Signals) => void
+interface SliceAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  ellipsis [?]: string | undefined
+interface Socket<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: Data
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface SocketAddress (bun-types/bun.d.ts)
+  address: string
+  family: "IPv4" | "IPv6"
+  port: number
+interface SocketHandler<Data = unknown, DataBinaryType extends keyof BinaryTypeList = "buffer"> (bun-types/bun.d.ts)
+  binaryType [?]: keyof BinaryTypeList | undefined
+  close [?]: ((socket: Socket<Data>, error?: Error | undefined) => Promise<void> | void) | undefined
+  connectError [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  data [?]: ((socket: Socket<Data>, data: BinaryTypeList[DataBinaryType]) => Promise<void> | void) | undefined
+  drain [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  end [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  error [?]: ((socket: Socket<Data>, error: Error) => Promise<void> | void) | undefined
+  handshake [?]: ((socket: Socket<Data>, success: boolean, authorizationError: Error | null) => void) | undefined
+  open [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+  timeout [?]: ((socket: Socket<Data>) => Promise<void> | void) | undefined
+interface SocketListener<Data = undefined> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface SocketOptions<Data = unknown> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+namespace Spawn (bun-types/bun.d.ts)
+  interface Spawn.BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts) = BaseOptions<In, Out, Err>
+  type Spawn.Readable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | ArrayBufferView<ArrayBufferLike> | null | undefined
+  type Spawn.ReadableToIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? ReadableStream<Uint8Array<ArrayBuffer>> : X extends number | BunFile | ArrayBufferView<ArrayBufferLike> ? number : undefined
+  type Spawn.ReadableToSyncIO<X extends Readable> (bun-types/bun.d.ts) = X extends "pipe" | undefined ? Buffer<ArrayBufferLike> : undefined
+  interface Spawn.SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    lazy [?]: boolean | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    terminal [?]: Terminal | TerminalOptions | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  interface Spawn.SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable> (bun-types/bun.d.ts)
+    argv0 [?]: string | undefined
+    cgroup [?]: number | string | undefined
+    cwd [?]: string | undefined
+    detached [?]: boolean | undefined
+    env [?]: Record<string, string | undefined> | undefined
+    gid [?]: number | undefined
+    ipc [?]: ((message: any, subprocess: Subprocess<In, Out, Err>, handle?: unknown) => void) | undefined
+    killSignal [?]: number | string | undefined
+    maxBuffer [?]: number | undefined
+    onDisconnect [?]: (() => Promise<void> | void) | undefined
+    onExit [?]: ((subprocess: Subprocess<In, Out, Err>, exitCode: null | number, signalCode: null | number, error?: ErrorLike | undefined) => Promise<void> | void) | undefined
+    serialization [?]: "advanced" | "json" | undefined
+    signal [?]: AbortSignal | undefined
+    stderr [?]: Err | undefined
+    stdin [?]: In | undefined
+    stdio [?]: [In, Out, Err, ...(Readable | "socket-fd")[]] | undefined
+    stdout [?]: Out | undefined
+    timeout [?]: number | undefined
+    uid [?]: number | undefined
+    windowsHide [?]: boolean | undefined
+    windowsVerbatimArguments [?]: boolean | undefined
+  type Spawn.Writable (bun-types/bun.d.ts) = number | "pipe" | "inherit" | "ignore" | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | ReadableStream<any> | Response | Request | null | undefined
+  type Spawn.WritableIO (bun-types/bun.d.ts) = number | FileSink | undefined
+  type Spawn.WritableToIO<X extends Writable> (bun-types/bun.d.ts) = X extends "pipe" ? FileSink : X extends number | BunFile | Blob | ArrayBufferView<ArrayBufferLike> | Response | Request ? number : undefined
+SpawnOptions -> Spawn
+type StringLike (bun-types/bun.d.ts) = string | { toString(): string; }
+type StringOrBuffer (bun-types/bun.d.ts) = string | ArrayBufferLike | TypedArray<ArrayBufferLike>
+interface StringWidthOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  countAnsiEscapeCodes [?]: boolean | undefined
+  perCodePoint [?]: boolean | undefined
+interface StructuredSerializeOptions (bun-types/bun.d.ts)
+  transfer [?]: Array<Transferable> | undefined
+interface Subprocess<In extends Writable = Writable, Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  disconnect: () => void
+  exitCode [readonly]: null | number
+  exited [readonly]: Promise<number>
+  kill: (exitCode?: Signals | number | undefined) => void
+  killed [readonly]: boolean
+  pid [readonly]: number
+  readable [readonly]: ReadableToIO<Out>
+  ref: () => void
+  resourceUsage: () => ResourceUsage | undefined
+  send: (message: any) => void
+  signalCode [readonly]: Signals | null
+  stderr [readonly]: ReadableToIO<Err>
+  stdin [readonly]: WritableToIO<In>
+  stdio [readonly]: [null, null, null, ...(number | null)[]]
+  stdout [readonly]: ReadableToIO<Out>
+  terminal [readonly]: Terminal | undefined
+  unref: () => void
+type SupportedCryptoAlgorithms (bun-types/bun.d.ts) = "blake2b256" | "blake2b512" | "sha256" | "sha384" | "sha512" | "sha512-256" | "blake2s256" | "md4" | "md5" | "ripemd160" | "sha1" | "sha224" | "sha512-224" | "sha3-224" | "sha3-256" | "sha3-384" | "sha3-512" | "shake128" | "shake256"
+interface SyncSubprocess<Out extends Readable = Readable, Err extends Readable = Readable> (bun-types/bun.d.ts)
+  exitCode: number
+  exitedDueToMaxBuffer [?]: boolean | undefined
+  exitedDueToTimeout [?]: boolean | undefined
+  pid: number
+  resourceUsage: ResourceUsage
+  signalCode [?]: string | undefined
+  stderr: ReadableToSyncIO<Err>
+  stdout: ReadableToSyncIO<Out>
+  success: boolean
+interface SystemError (bun-types/bun.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface TCPSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TCPSocketConnectOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  ipv6Only [?]: boolean | undefined
+  port: number
+  reusePort [?]: boolean | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListenOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  exclusive [?]: boolean | undefined
+  hostname: string
+  port: number
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+interface TCPSocketListener<Data = unknown> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  hostname [readonly]: string
+  port [readonly]: number
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unref: () => void
+interface TLSOptions (bun-types/bun.d.ts, bun-types/deprecated.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface TLSSocket (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  alpnProtocol [readonly]: false | null | string
+  authorized [readonly]: boolean
+  bytesWritten [readonly]: number
+  close: () => void
+  data: undefined
+  disableRenegotiation: () => void
+  end: { (data?: BufferSource | string | undefined, byteOffset?: number | undefined, byteLength?: number | undefined): number; (): void }
+  exportKeyingMaterial: { (length: number, label: string, context: Buffer<ArrayBufferLike>): Buffer<ArrayBufferLike>; (length: number, label: string, context?: BufferSource | string | undefined): void }
+  flush: () => void
+  getAuthorizationError: () => Error | null
+  getCertificate: () => PeerCertificate | null | object
+  getCipher: () => CipherNameAndProtocol
+  getEphemeralKeyInfo: () => EphemeralKeyInfo | null | object
+  getPeerCertificate: () => PeerCertificate
+  getPeerX509Certificate: () => X509Certificate
+  getServername: () => string
+  getSession: () => void
+  getSharedSigalgs: () => Array<string>
+  getTLSFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSPeerFinishedMessage: () => Buffer<ArrayBufferLike> | undefined
+  getTLSTicket: () => Buffer<ArrayBufferLike> | undefined
+  getTLSVersion: () => string
+  getX509Certificate: () => X509Certificate | undefined
+  isSessionReused: () => boolean
+  listener [? readonly]: SocketListener<undefined> | undefined
+  localAddress [readonly]: string
+  localFamily [readonly]: "IPv4" | "IPv6"
+  localPort [readonly]: number
+  pause: () => void
+  readyState [readonly]: -1 | -2 | 0 | 1 | 2
+  ref: () => void
+  reload: (options: Pick<SocketOptions<undefined>, "socket">) => void
+  remoteAddress [readonly]: string
+  remoteFamily [readonly]: "IPv4" | "IPv6"
+  remotePort [readonly]: number
+  renegotiate: () => void
+  resume: () => void
+  setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => boolean
+  setMaxSendFragment: (size: number) => boolean
+  setNoDelay: (noDelay?: boolean | undefined) => boolean
+  setServername: (name: string) => void
+  setSession: (session: Buffer<ArrayBufferLike> | BufferSource | string) => void
+  setVerifyMode: (requestCert: boolean, rejectUnauthorized: boolean) => void
+  shutdown: (halfClose?: boolean | undefined) => void
+  terminate: () => void
+  timeout: (seconds: number) => void
+  unref: () => void
+  upgradeTLS: <Data>(options: TLSUpgradeOptions<Data>) => [raw: Socket<Data>, tls: Socket<Data>]
+  write: (data: BufferSource | string, byteOffset?: number | undefined, byteLength?: number | undefined) => number
+interface TLSUpgradeOptions<Data> (bun-types/bun.d.ts)
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls: TLSOptions | boolean
+namespace TOML (bun-types/bun.d.ts)
+  function TOML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): object
+  function TOML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+interface TSConfig (bun-types/bun.d.ts)
+  compilerOptions [?]: undefined | { paths?: Record<string, Array<string>> | undefined; baseUrl?: string | undefined; jsx?: "preserve" | "react" | "react-jsx" | "react-jsxdev" | undefined; jsxFactory?: string | undefined; jsxFragmentFactory?: string | undefined; jsxImportSource?: string | undefined; useDefineForClassFields?: boolean | undefined; importsNotUsedAsValues?: "error" | "preserve" | "remove" | undefined; moduleSuffixes?: any; }
+  extends [?]: string | undefined
+type Target (bun-types/bun.d.ts) = "bun" | "node" | "browser"
+class Terminal (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => Promise<void>
+  close: () => void
+  closed [readonly]: boolean
+  controlFlags: number
+  inputFlags: number
+  localFlags: number
+  outputFlags: number
+  ref: () => void
+  resize: (cols: number, rows: number) => void
+  setRawMode: (enabled: boolean) => void
+  unref: () => void
+  write: (data: BufferSource | string) => number
+  [static]
+    construct new (options: TerminalOptions): Terminal
+    prototype: Terminal
+interface TerminalOptions (bun-types/bun.d.ts)
+  cols [?]: number | undefined
+  data [?]: ((terminal: Terminal, data: Uint8Array<ArrayBuffer>) => void) | undefined
+  drain [?]: ((terminal: Terminal) => void) | undefined
+  exit [?]: ((terminal: Terminal, exitCode: number, signal: null | string) => void) | undefined
+  name [?]: string | undefined
+  rows [?]: number | undefined
+type TimerHandler (bun-types/bun.d.ts) = (...args: Array<any>) => void
+interface TransactionSQL (bun-types/sql.d.ts)
+  call <T = any>(strings: TemplateStringsArray, ...values: Array<unknown>): Query<T>
+  call <T = any>(string: string): Query<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }>(obj: Array<T> | ReadonlyArray<T> | T): Helper<T>
+  call <T extends { [x: string]: unknown; [x: number]: unknown; [x: symbol]: unknown; }, Keys extends number | string | symbol = keyof T>(obj: Array<T> | ReadonlyArray<T> | T, ...columns: ReadonlyArray<Keys>): Helper<Pick<T, Keys>>
+  call <T>(value: T & {}): Helper<T>
+  [Symbol.asyncDispose]: () => PromiseLike<void>
+  array: (values: Array<any>, typeNameOrTypeID?: ArrayType | number | undefined) => SQLArrayParameter
+  begin: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  beginDistributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  close: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  commitDistributed: (name: string) => Promise<void>
+  connect: () => Promise<SQL>
+  distributed: <T>(name: string, fn: TransactionContextCallback<T>) => Promise<ContextCallbackResult<T>>
+  end: (options?: undefined | { timeout?: number | undefined; }) => Promise<void>
+  file: <T = any>(filename: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+  flush: () => void
+  listen: (channel: string, onnotify: (payload: string) => void, onlisten?: (() => void) | undefined) => Promise<ListenSubscription>
+  notify: (channel: string, payload?: string | undefined) => Promise<void>
+  options: Merge<PostgresOrMySQLOptions, SQLiteOptions> | Merge<SQLiteOptions, PostgresOrMySQLOptions>
+  reserve: (options?: undefined | { signal?: AbortSignal | undefined; }) => Promise<ReservedSQL>
+  rollbackDistributed: (name: string) => Promise<void>
+  savepoint: { <T>(name: string, fn: SavepointContextCallback<T>): Promise<T>; <T>(fn: SavepointContextCallback<T>): Promise<T> }
+  transaction: { <T>(fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>>; <T>(options: string, fn: TransactionContextCallback<T>): Promise<ContextCallbackResult<T>> }
+  unsafe: <T = any>(string: string, values?: Array<any> | Record<string, any> | undefined) => Query<T>
+type Transferable (bun-types/bun.d.ts) = ArrayBuffer | MessagePort
+interface TransformerFlushCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+interface TransformerStartCallback<O> (bun-types/bun.d.ts)
+  call (controller: TransformStreamDefaultController<O>): any
+interface TransformerTransformCallback<I, O> (bun-types/bun.d.ts)
+  call (chunk: I, controller: TransformStreamDefaultController<O>): PromiseLike<void> | void
+class Transpiler (bun-types/bun.d.ts)
+  scan: (code: StringOrBuffer) => { exports: Array<string>; imports: Array<Import>; }
+  scanImports: (code: StringOrBuffer) => Array<Import>
+  transform: (code: StringOrBuffer, loader?: JavaScriptLoader | undefined) => Promise<string>
+  transformSync: { (code: StringOrBuffer, loader: JavaScriptLoader, ctx: object): string; (code: StringOrBuffer, ctx: object): string; (code: StringOrBuffer, loader?: JavaScriptLoader | undefined): string }
+  [static]
+    construct new (options?: TranspilerOptions | undefined): Transpiler
+    prototype: Transpiler
+interface TranspilerOptions (bun-types/bun.d.ts)
+  allowBunRuntime [?]: boolean | undefined
+  autoImportJSX [?]: boolean | undefined
+  deadCodeElimination [?]: boolean | undefined
+  define [?]: Record<string, string> | undefined
+  exports [?]: undefined | { eliminate?: Array<string> | undefined; replace?: Record<string, string> | undefined; }
+  inline [?]: boolean | undefined
+  jsxOptimizationInline [?]: boolean | undefined
+  loader [?]: JavaScriptLoader | undefined
+  logLevel [?]: "debug" | "error" | "info" | "verbose" | "warn" | undefined
+  macro [?]: MacroMap | undefined
+  minifyWhitespace [?]: boolean | undefined
+  replMode [?]: boolean | undefined
+  target [?]: Target | undefined
+  treeShaking [?]: boolean | undefined
+  trimUnusedImports [?]: boolean | undefined
+  tsconfig [?]: TSConfig | string | undefined
+type UncaughtExceptionListener (bun-types/deprecated.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+type UncaughtExceptionOrigin (bun-types/bun.d.ts) = "uncaughtException" | "unhandledRejection"
+interface UnderlyingSink<W = any> (bun-types/bun.d.ts)
+  abort [?]: UnderlyingSinkAbortCallback | undefined
+  close [?]: UnderlyingSinkCloseCallback | undefined
+  start [?]: UnderlyingSinkStartCallback | undefined
+  type [?]: "bytes" | "default" | undefined
+  write [?]: UnderlyingSinkWriteCallback<W> | undefined
+interface UnderlyingSinkAbortCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSinkCloseCallback (bun-types/bun.d.ts)
+  call (): PromiseLike<void> | void
+interface UnderlyingSinkStartCallback (bun-types/bun.d.ts)
+  call (controller: WritableStreamDefaultController): any
+interface UnderlyingSinkWriteCallback<W> (bun-types/bun.d.ts)
+  call (chunk: W, controller: WritableStreamDefaultController): PromiseLike<void> | void
+interface UnderlyingSource<R = any> (bun-types/bun.d.ts)
+  cancel [?]: UnderlyingSourceCancelCallback | undefined
+  pull [?]: UnderlyingSourcePullCallback<R> | undefined
+  start [?]: UnderlyingSourceStartCallback<R> | undefined
+  type [?]: undefined
+interface UnderlyingSourceCancelCallback (bun-types/bun.d.ts)
+  call (reason?: any): PromiseLike<void> | void
+interface UnderlyingSourcePullCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): PromiseLike<void> | void
+interface UnderlyingSourceStartCallback<R> (bun-types/bun.d.ts)
+  call (controller: ReadableStreamController<R>): any
+type UnhandledRejectionListener (bun-types/deprecated.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+interface UnixSocketListener<Data> (bun-types/bun.d.ts)
+  [Symbol.dispose]: () => void
+  data: Data
+  ref: () => void
+  reload: (options: Pick<SocketOptions<Data>, "socket">) => void
+  stop: (closeActiveConnections?: boolean | undefined) => void
+  unix [readonly]: string
+  unref: () => void
+interface UnixSocketOptions<Data = undefined> (bun-types/bun.d.ts)
+  allowHalfOpen [?]: boolean | undefined
+  data [?]: Data | undefined
+  socket: SocketHandler<Data, "buffer">
+  tls [?]: TLSOptions | boolean | undefined
+  unix: string
+type WarningListener (bun-types/bun.d.ts) = (warning: Error) => void
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  type WebAssembly.ExportValue (bun-types/wasm.d.ts) = Function | Global<keyof ValueTypeMap> | Memory | Table
+  type WebAssembly.Exports (bun-types/wasm.d.ts) = { [x: string]: ExportValue; }
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  type WebAssembly.ImportExportKind (bun-types/wasm.d.ts) = "function" | "global" | "memory" | "table" | "tag"
+  type WebAssembly.ImportValue (bun-types/wasm.d.ts) = number | ExportValue
+  type WebAssembly.Imports (bun-types/wasm.d.ts) = { [x: string]: ModuleImports; }
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  type WebAssembly.ModuleImports (bun-types/wasm.d.ts) = { [x: string]: ImportValue; }
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  type WebAssembly.TableKind (bun-types/wasm.d.ts) = "anyfunc" | "externref"
+  type WebAssembly.ValueType (bun-types/wasm.d.ts) = keyof ValueTypeMap
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+interface WebSocket (bun-types/bun.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+type WebSocketCompressor (bun-types/serve.d.ts) = "disable" | "shared" | "dedicated" | "3KB" | "4KB" | "8KB" | "16KB" | "32KB" | "64KB" | "128KB" | "256KB"
+interface WebSocketEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: Event
+  message: BunMessageEvent<any>
+  open: Event
+interface WebSocketHandler<T> (bun-types/serve.d.ts)
+  backpressureLimit [?]: number | undefined
+  close [?]: ((ws: ServerWebSocket<T>, code: number, reason: string) => Promise<void> | void) | undefined
+  closeOnBackpressureLimit [?]: boolean | undefined
+  data [?]: T | undefined
+  drain [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  idleTimeout [?]: number | undefined
+  maxPayloadLength [?]: number | undefined
+  message: (ws: ServerWebSocket<T>, message: Buffer<ArrayBuffer> | string) => Promise<void> | void
+  open [?]: ((ws: ServerWebSocket<T>) => Promise<void> | void) | undefined
+  perMessageDeflate [?]: boolean | undefined | { compress?: boolean | WebSocketCompressor | undefined; decompress?: boolean | WebSocketCompressor | undefined; }
+  ping [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  pong [?]: ((ws: ServerWebSocket<T>, data: Buffer<ArrayBufferLike>) => Promise<void> | void) | undefined
+  publishToSelf [?]: boolean | undefined
+  sendPings [?]: boolean | undefined
+type WebSocketOptions (bun-types/bun.d.ts) = (WebSocketOptionsProtocolsOrProtocol & WebSocketOptionsTLS) & WebSocketOptionsHeaders & WebSocketOptionsProxy & WebSocketOptionsCompression
+type WebSocketOptionsCompression (bun-types/bun.d.ts) = { perMessageDeflate?: boolean | undefined; }
+type WebSocketOptionsHeaders (bun-types/bun.d.ts) = { headers?: OutgoingHttpHeaders | undefined; }
+type WebSocketOptionsProtocolsOrProtocol (bun-types/bun.d.ts) = { protocols?: string | Array<string> | undefined; } | { protocol?: string | undefined; }
+type WebSocketOptionsProxy (bun-types/bun.d.ts) = { proxy?: string | URL | { url: string | URL; headers?: Headers | OutgoingHttpHeaders | undefined; } | undefined; }
+type WebSocketOptionsTLS (bun-types/bun.d.ts) = { tls?: TLSOptions | undefined; }
+type WebSocketReadyState (bun-types/serve.d.ts) = 0 | 1 | 2 | 3
+class WebView (bun-types/bun.d.ts)
+  [Symbol.asyncDispose]: () => void
+  [Symbol.dispose]: () => void
+  addEventListener: { <T = unknown>(type: `${string}.${string}`, listener: (event: BunMessageEvent<T>) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  back: () => Promise<void>
+  cdp: <T = unknown>(method: string, params?: Record<string, unknown> | undefined) => Promise<T>
+  click: { (x: number, y: number, options?: ClickOptions | undefined): Promise<void>; (selector: string, options?: ClickSelectorOptions | undefined): Promise<void> }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  evaluate: <T = unknown>(script: string) => Promise<T>
+  forward: () => Promise<void>
+  loading [readonly]: boolean
+  navigate: (url: string) => Promise<void>
+  onNavigated: ((url: string, title: string) => void) | null
+  onNavigationFailed: ((error: Error) => void) | null
+  press: (key: VirtualKey | string & {}, options?: PressOptions | undefined) => Promise<void>
+  reload: () => Promise<void>
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  resize: (width: number, height: number) => Promise<void>
+  screenshot: { (options?: undefined | { encoding?: "blob" | undefined; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Blob>; (options: { encoding: "buffer"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>; (options: { encoding: "base64"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<string>; (options: { encoding: "shmem"; format?: "jpeg" | "png" | "webp" | undefined; quality?: number | undefined; }): Promise<{ name: string; size: number; }> }
+  scroll: (dx: number, dy: number) => Promise<void>
+  scrollTo: (selector: string, options?: ScrollToOptions | undefined) => Promise<void>
+  title [readonly]: string
+  type: (text: string) => Promise<void>
+  url [readonly]: string
+  [static]
+    construct new (options?: ConstructorOptions | undefined): WebView
+    closeAll [static]: () => void
+    prototype: WebView
+  type WebView.Backend (bun-types/bun.d.ts) = "webkit" | "chrome" | { type: "chrome"; url: string; } | { type: "chrome"; url?: false | undefined; path?: string | undefined; argv?: Array<string> | undefined; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; } | { type: "webkit"; stdout?: "inherit" | "ignore" | undefined; stderr?: "inherit" | "ignore" | undefined; }
+  interface WebView.ClickOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ClickSelectorOptions (bun-types/bun.d.ts)
+    button [?]: "left" | "middle" | "right" | undefined
+    clickCount [?]: 1 | 2 | 3 | undefined
+    modifiers [?]: Array<Modifier> | undefined
+    timeout [?]: number | undefined
+  type WebView.ConsoleCapture (bun-types/bun.d.ts) = Console | ((type: string, ...args: Array<unknown>) => void)
+  interface WebView.ConstructorOptions (bun-types/bun.d.ts)
+    backend [?]: Backend | undefined
+    console [?]: ConsoleCapture | undefined
+    dataStore [?]: "ephemeral" | undefined | { directory: string; }
+    headless [?]: boolean | undefined
+    height [?]: number | undefined
+    url [?]: string | undefined
+    width [?]: number | undefined
+  type WebView.Modifier (bun-types/bun.d.ts) = "Shift" | "Control" | "Alt" | "Meta"
+  interface WebView.PressOptions (bun-types/bun.d.ts)
+    modifiers [?]: Array<Modifier> | undefined
+  interface WebView.ScrollToOptions (bun-types/bun.d.ts)
+    block [?]: "center" | "end" | "nearest" | "start" | undefined
+    timeout [?]: number | undefined
+  type WebView.VirtualKey (bun-types/bun.d.ts) = "Enter" | "Tab" | "Space" | "Backspace" | "Delete" | "Escape" | "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" | "End" | "PageUp" | "PageDown"
+interface WhichOptions (bun-types/bun.d.ts)
+  PATH [?]: string | undefined
+  cwd [?]: string | undefined
+interface Worker (bun-types/bun.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+interface WorkerEventMap (bun-types/bun.d.ts)
+  close: CloseEvent
+  error: ErrorEvent
+  message: BunMessageEvent<any>
+  messageerror: BunMessageEvent<any>
+  open: Event
+interface WorkerOptions (bun-types/bun.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+type WorkerType (bun-types/bun.d.ts) = "classic" | "module"
+interface WrapAnsiOptions (bun-types/bun.d.ts)
+  ambiguousIsNarrow [?]: boolean | undefined
+  hard [?]: boolean | undefined
+  trim [?]: boolean | undefined
+  wordWrap [?]: boolean | undefined
+type WritableSubprocess (bun-types/bun.d.ts) = Subprocess<"pipe", any, any>
+namespace XML (bun-types/bun.d.ts)
+  interface XML.Comment (bun-types/bun.d.ts)
+    comment: string
+  interface XML.Document (bun-types/bun.d.ts)
+    index [string]: Value
+  interface XML.Element (bun-types/bun.d.ts)
+    index [string]: Array<Value> | Value
+  interface XML.Node (bun-types/bun.d.ts)
+    attributes: Record<string, string>
+    children: Array<string | Comment | Node | ProcessingInstruction>
+    name: string
+  interface XML.NodeInput (bun-types/bun.d.ts)
+    attributes [?]: null | undefined | { [name: string]: Scalar | null | undefined; }
+    children [?]: Array<Comment | ProcessingInstruction | NodeInput | Scalar | null | undefined> | null | undefined
+    name: string
+  interface XML.ParseOptions (bun-types/bun.d.ts)
+    compact [?]: boolean | undefined
+  interface XML.ProcessingInstruction (bun-types/bun.d.ts)
+    data: string
+    target: string
+  type XML.Scalar (bun-types/bun.d.ts) = string | number | bigint | boolean | Date
+  type XML.Value (bun-types/bun.d.ts) = string | Element
+  function XML.parse (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions & { compact?: true | undefined; } | undefined): Document
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options: ParseOptions & { compact: false; }): Node
+    call (input: ArrayBufferLike | Blob | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: ParseOptions | undefined): Document | Node
+  function XML.stringify (bun-types/bun.d.ts)
+    call (value: Document | NodeInput, replacer?: null | undefined, space?: number | string | undefined): string
+    call (value: unknown, replacer?: null | undefined, space?: number | string | undefined): string | undefined
+type XMLHttpRequestBodyInit (bun-types/bun.d.ts) = string | Blob | BufferSource | FormData | URLSearchParams
+namespace YAML (bun-types/bun.d.ts)
+  function YAML.parse (bun-types/bun.d.ts)
+    call (input: string): unknown
+  function YAML.stringify (bun-types/bun.d.ts)
+    call (input: unknown, replacer?: null | undefined, space?: number | string | undefined): string
+interface ZlibCompressionOptions (bun-types/bun.d.ts)
+  level [?]: -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  library [?]: "zlib" | undefined
+  memLevel [?]: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | undefined
+  strategy [?]: number | undefined
+  windowBits [?]: -10 | -11 | -12 | -13 | -14 | -15 | -9 | 10 | 11 | 12 | 13 | 14 | 15 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 9 | undefined
+namespace __internal (bun-types/bun.d.ts, bun-types/fetch.d.ts, bun-types/globals.d.ts)
+  interface __internal.BunEvent (bun-types/globals.d.ts)
+    bubbles [readonly]: boolean
+    cancelBubble: boolean
+    cancelable [readonly]: boolean
+    composed [readonly]: boolean
+    composedPath: () => [(EventTarget | undefined)?]
+    currentTarget [readonly]: EventTarget | null
+    defaultPrevented [readonly]: boolean
+    eventPhase [readonly]: number
+    isTrusted [readonly]: boolean
+    preventDefault: () => void
+    returnValue: boolean
+    srcElement [readonly]: EventTarget | null
+    stopImmediatePropagation: () => void
+    stopPropagation: () => void
+    target [readonly]: EventTarget | null
+    timeStamp [readonly]: number
+    type [readonly]: string
+  interface __internal.BunEventTarget (bun-types/globals.d.ts)
+    addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+    dispatchEvent: (event: Event) => boolean
+    removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  interface __internal.BunHeadersOverride (bun-types/fetch.d.ts)
+    [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
+    append [readonly]: (name: string, value: string) => void
+    count [readonly]: number
+    delete [readonly]: (name: string) => void
+    entries [readonly]: () => SpecIterableIterator<[string, string]>
+    forEach [readonly]: (callbackfn: (value: string, key: string, iterable: Headers) => void, thisArg?: unknown) => void
+    get [readonly]: (name: string) => null | string
+    getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+    getSetCookie [readonly]: () => Array<string>
+    has [readonly]: (name: string) => boolean
+    keys [readonly]: () => SpecIterableIterator<string>
+    set [readonly]: (name: string, value: string) => void
+    toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+    values [readonly]: () => SpecIterableIterator<string>
+  interface __internal.BunRequestOverride (bun-types/fetch.d.ts)
+    arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+    blob [readonly]: () => Promise<Blob>
+    body [readonly]: ReadableStream<any> | null
+    bodyUsed [readonly]: boolean
+    bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+    cache [readonly]: RequestCache
+    clone: () => Request
+    credentials [readonly]: RequestCredentials
+    destination [readonly]: RequestDestination
+    duplex [readonly]: "half"
+    formData [readonly]: () => Promise<FormData>
+    headers: BunHeadersOverride
+    integrity [readonly]: string
+    json [readonly]: () => Promise<unknown>
+    keepalive [readonly]: boolean
+    method [readonly]: string
+    mode [readonly]: RequestMode
+    redirect [readonly]: RequestRedirect
+    referrer [readonly]: string
+    referrerPolicy [readonly]: ReferrerPolicy
+    signal [readonly]: AbortSignal
+    text [readonly]: () => Promise<string>
+    textStream: () => ReadableStream<string>
+    url [readonly]: string
+  interface __internal.BunResponseOverride (bun-types/fetch.d.ts)
+    arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+    blob [readonly]: () => Promise<Blob>
+    body [readonly]: ReadableStream<any> | null
+    bodyUsed [readonly]: boolean
+    bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+    clone: () => Response
+    formData [readonly]: () => Promise<FormData>
+    headers: BunHeadersOverride
+    json [readonly]: () => Promise<unknown>
+    ok [readonly]: boolean
+    redirected [readonly]: boolean
+    status [readonly]: number
+    statusText [readonly]: string
+    text [readonly]: () => Promise<string>
+    textStream: () => ReadableStream<string>
+    type [readonly]: ResponseType
+    url [readonly]: string
+  type __internal.DistributedMerge<T, Else = T> (bun-types/bun.d.ts) = T extends T ? Merge<T, Exclude<Else, T>> : never
+  type __internal.DistributedOmit<T, K extends PropertyKey> (bun-types/bun.d.ts) = T extends T ? Omit<T, K> : never
+  type __internal.KeysInBoth<A, B> (bun-types/bun.d.ts) = keyof A extends keyof B ? keyof B & keyof A : never
+  type __internal.LibDomIsLoaded (bun-types/bun.d.ts) = false
+  type __internal.LibEmptyOrBroadcastChannel (bun-types/globals.d.ts) = BroadcastChannel
+  type __internal.LibEmptyOrBunEvent (bun-types/globals.d.ts) = BunEvent
+  type __internal.LibEmptyOrBunEventTarget (bun-types/globals.d.ts) = BunEventTarget
+  type __internal.LibEmptyOrBunWebSocket (bun-types/globals.d.ts) = WebSocket
+  type __internal.LibEmptyOrEventSource (bun-types/globals.d.ts) = EventSource
+  type __internal.LibEmptyOrNodeCryptoWebcryptoSubtleCrypto (bun-types/globals.d.ts) = SubtleCrypto
+  type __internal.LibEmptyOrNodeMessagePort (bun-types/globals.d.ts) = MessagePort
+  type __internal.LibEmptyOrNodeReadableStream<T> (bun-types/globals.d.ts) = ReadableStream<T>
+  type __internal.LibEmptyOrNodeStreamWebCompressionStream (bun-types/globals.d.ts) = CompressionStream
+  type __internal.LibEmptyOrNodeStreamWebDecompressionStream (bun-types/globals.d.ts) = DecompressionStream
+  type __internal.LibEmptyOrNodeStreamWebTextDecoderStream (bun-types/globals.d.ts) = TextDecoderStream
+  type __internal.LibEmptyOrNodeStreamWebTextEncoderStream (bun-types/globals.d.ts) = TextEncoderStream
+  type __internal.LibEmptyOrNodeUtilTextDecoder (bun-types/globals.d.ts) = TextDecoder
+  type __internal.LibEmptyOrNodeUtilTextEncoder (bun-types/globals.d.ts) = TextEncoder
+  type __internal.LibEmptyOrNodeWritableStream<T> (bun-types/globals.d.ts) = WritableStream<T>
+  type __internal.LibEmptyOrPerformanceEntry (bun-types/globals.d.ts) = PerformanceEntry
+  type __internal.LibEmptyOrPerformanceMark (bun-types/globals.d.ts) = PerformanceMark
+  type __internal.LibEmptyOrPerformanceMeasure (bun-types/globals.d.ts) = PerformanceMeasure
+  type __internal.LibEmptyOrPerformanceObserver (bun-types/globals.d.ts) = PerformanceObserver
+  type __internal.LibEmptyOrPerformanceObserverEntryList (bun-types/globals.d.ts) = PerformanceObserverEntryList
+  type __internal.LibEmptyOrPerformanceResourceTiming (bun-types/globals.d.ts) = PerformanceResourceTiming
+  type __internal.LibEmptyOrReadableByteStreamController (bun-types/globals.d.ts) = ReadableByteStreamController
+  type __internal.LibEmptyOrReadableStreamBYOBReader (bun-types/globals.d.ts) = ReadableStreamBYOBReader
+  type __internal.LibEmptyOrReadableStreamBYOBRequest (bun-types/globals.d.ts) = ReadableStreamBYOBRequest
+  type __internal.LibOrFallbackHeaders (bun-types/fetch.d.ts) = Headers
+  type __internal.LibOrFallbackRequest (bun-types/fetch.d.ts) = Request
+  type __internal.LibOrFallbackRequestInit (bun-types/fetch.d.ts) = Omit<RequestInit, "body" | "headers"> & { body?: BodyInit | null | undefined; headers?: HeadersInit | undefined; }
+  type __internal.LibOrFallbackResponse (bun-types/fetch.d.ts) = Response
+  type __internal.LibOrFallbackResponseInit (bun-types/fetch.d.ts) = ResponseInit
+  type __internal.LibPerformanceOrNodePerfHooksPerformance (bun-types/globals.d.ts) = Performance
+  type __internal.LibWorkerOrBunWorker (bun-types/globals.d.ts) = Worker
+  type __internal.Merge<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; } & Omit<B, Extract<keyof B, keyof A>> & Omit<A, Extract<keyof B, keyof A>> & { [Key in Extract<keyof B, keyof A>]: B[Key] | A[Key]; }
+  type __internal.MergeInner<A, B> (bun-types/bun.d.ts) = Omit<A, Extract<keyof A, keyof B>> & Omit<B, Extract<keyof A, keyof B>> & { [Key in Extract<keyof A, keyof B>]: A[Key] | B[Key]; }
+  type __internal.NodeCryptoWebcryptoCryptoKey (bun-types/globals.d.ts) = CryptoKey
+  type __internal.NodeCryptoWebcryptoCryptoKeyPair (bun-types/globals.d.ts) = CryptoKeyPair
+  type __internal.UseLibDomIfAvailable<GlobalThisKeyName extends PropertyKey, Otherwise> (bun-types/bun.d.ts) = Otherwise
+  type __internal.Without<A, B> (bun-types/bun.d.ts) = A & { [Key in Exclude<keyof B, keyof A>]?: undefined; }
+  type __internal.XOR<A, B> (bun-types/bun.d.ts) = Without<A, B> | Without<B, A>
+function allocUnsafe (bun-types/bun.d.ts)
+  call (size: number): Uint8Array<ArrayBuffer>
+var argv (bun-types/bun.d.ts): Array<string>
+function build (bun-types/bun.d.ts)
+  call (config: BuildConfig): Promise<BuildOutput>
+function color (bun-types/bun.d.ts)
+  call (input: ColorInput, outputFormat?: "HEX" | "ansi" | "ansi-16" | "ansi-16m" | "ansi-256" | "css" | "hex" | "hsl" | "lab" | "number" | "rgb" | "rgba" | undefined): null | string
+  call (input: ColorInput, outputFormat: "[rgb]"): [number, number, number] | null
+  call (input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null
+  call (input: ColorInput, outputFormat: "{rgb}"): null | { r: number; g: number; b: number; }
+  call (input: ColorInput, outputFormat: "{rgba}"): null | { r: number; g: number; b: number; a: number; }
+  call (input: ColorInput, outputFormat: "number"): null | number
+function concatArrayBuffers (bun-types/bun.d.ts)
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength?: number | undefined): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: false): ArrayBuffer
+  call (buffers: Array<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>, maxLength: number, asUint8Array: true): Uint8Array<ArrayBuffer>
+function connect (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketConnectOptions<Data>): Promise<Socket<Data>>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): Promise<Socket<Data>>
+var cron (bun-types/bun.d.ts)
+  call (schedule: CronWithAutocomplete, handler: (this: CronJob) => unknown, options?: CronOptions | undefined): CronJob
+  call (path: string, schedule: CronWithAutocomplete, title: string): Promise<void>
+  parse: (expression: CronWithAutocomplete, relativeDate?: Date | number | undefined, options?: CronOptions | undefined) => Date | null
+  remove: (title: string) => Promise<void>
+function deepEquals (bun-types/bun.d.ts)
+  call (a: any, b: any, strict?: boolean | undefined): boolean
+function deepMatch (bun-types/bun.d.ts)
+  call (subset: unknown, a: unknown): boolean
+function deflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+namespace dns (bun-types/bun.d.ts)
+  var dns.ADDRCONFIG (bun-types/bun.d.ts): number
+  var dns.ALL (bun-types/bun.d.ts): number
+  var dns.V4MAPPED (bun-types/bun.d.ts): number
+  function dns.getCacheStats (bun-types/bun.d.ts)
+    call (): { cacheHitsCompleted: number; cacheHitsInflight: number; cacheMisses: number; size: number; errors: number; totalCount: number; }
+  function dns.lookup (bun-types/bun.d.ts)
+    call (hostname: string, options?: undefined | { family?: 0 | 4 | 6 | "IPv4" | "IPv6" | "any" | undefined; socketType?: "udp" | "tcp" | undefined; flags?: number | undefined; port?: number | undefined; backend?: "system" | "libc" | "c-ares" | "getaddrinfo" | undefined; }): Promise<Array<DNSLookup>>
+  function dns.prefetch (bun-types/bun.d.ts)
+    call (hostname: string, port?: number | undefined): void
+var embeddedFiles (bun-types/bun.d.ts): ReadonlyArray<Blob>
+var enableANSIColors (bun-types/bun.d.ts): boolean
+var env (bun-types/bun.d.ts): Env & ProcessEnv & ImportMetaEnv
+function escapeHTML (bun-types/bun.d.ts)
+  call (input: boolean | number | object | string): string
+var fetch (bun-types/bun.d.ts): typeof fetch
+function file (bun-types/bun.d.ts)
+  call (path: URL | string, options?: BlobPropertyBag | undefined): BunFile
+  call (path: ArrayBufferLike | Uint8Array<ArrayBuffer>, options?: BlobPropertyBag | undefined): BunFile
+  call (fileDescriptor: number, options?: BlobPropertyBag | undefined): BunFile
+function fileURLToPath (bun-types/bun.d.ts)
+  call (url: URL | string): string
+function gc (bun-types/bun.d.ts)
+  call (force?: boolean | undefined): void
+function generateHeapSnapshot (bun-types/bun.d.ts)
+  call (format?: "jsc" | undefined): HeapSnapshot
+  call (format: "v8"): string
+  call (format: "v8", encoding: "arraybuffer"): ArrayBuffer
+function gunzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function gzipSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+var hash (bun-types/bun.d.ts): ((data: string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView<ArrayBufferLike>, seed?: number | bigint | undefined) => number | bigint) & Hash
+function indexOfLine (bun-types/bun.d.ts)
+  call (buffer: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, offset?: number | undefined): number
+function inflateSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Uint8Array<ArrayBuffer> | string, options?: LibdeflateCompressionOptions | ZlibCompressionOptions | undefined): Uint8Array<ArrayBuffer>
+function inspect (bun-types/bun.d.ts)
+  call (arg: any, options?: BunInspectOptions | undefined): string
+  custom: typeof custom
+  table: { (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string; (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string }
+namespace inspect (bun-types/bun.d.ts)
+  var inspect.custom (bun-types/bun.d.ts): typeof custom
+  function inspect.table (bun-types/bun.d.ts)
+    call (tabularData: Array<unknown> | object, properties?: Array<string> | undefined, options?: undefined | { colors?: boolean | undefined; }): string
+    call (tabularData: Array<unknown> | object, options?: undefined | { colors?: boolean | undefined; }): string
+var isMainThread (bun-types/bun.d.ts): boolean
+var isStandaloneExecutable (bun-types/bun.d.ts): boolean
+function listen (bun-types/bun.d.ts)
+  call <Data = undefined>(options: TCPSocketListenOptions<Data>): TCPSocketListener<Data>
+  call <Data = undefined>(options: UnixSocketOptions<Data>): UnixSocketListener<Data>
+var main (bun-types/bun.d.ts): string
+namespace markdown (bun-types/bun.d.ts)
+  interface markdown.AnsiTheme (bun-types/bun.d.ts)
+    colors [?]: boolean | undefined
+    columns [?]: number | undefined
+    hyperlinks [?]: boolean | undefined
+    kittyGraphics [?]: boolean | undefined
+    light [?]: boolean | undefined
+  interface markdown.CellMeta (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+  interface markdown.CellProps (bun-types/bun.d.ts)
+    align [?]: "center" | "left" | "right" | undefined
+    children: Array<unknown>
+  interface markdown.ChildrenProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+  interface markdown.CodeBlockMeta (bun-types/bun.d.ts)
+    language [?]: string | undefined
+  interface markdown.CodeBlockProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    language [?]: string | undefined
+  type markdown.Component<P = {}> (bun-types/bun.d.ts) = string | ((props: P) => any) | (new (props: P) => any)
+  interface markdown.ComponentOverrides (bun-types/bun.d.ts)
+    a [?]: Component<LinkProps> | undefined
+    blockquote [?]: Component<ChildrenProps> | undefined
+    br [?]: Component<{}> | undefined
+    code [?]: Component<ChildrenProps> | undefined
+    del [?]: Component<ChildrenProps> | undefined
+    em [?]: Component<ChildrenProps> | undefined
+    h1 [?]: Component<HeadingProps> | undefined
+    h2 [?]: Component<HeadingProps> | undefined
+    h3 [?]: Component<HeadingProps> | undefined
+    h4 [?]: Component<HeadingProps> | undefined
+    h5 [?]: Component<HeadingProps> | undefined
+    h6 [?]: Component<HeadingProps> | undefined
+    hr [?]: Component<{}> | undefined
+    html [?]: Component<ChildrenProps> | undefined
+    img [?]: Component<ImageProps> | undefined
+    li [?]: Component<ListItemProps> | undefined
+    math [?]: Component<ChildrenProps> | undefined
+    ol [?]: Component<OrderedListProps> | undefined
+    p [?]: Component<ChildrenProps> | undefined
+    pre [?]: Component<CodeBlockProps> | undefined
+    strong [?]: Component<ChildrenProps> | undefined
+    table [?]: Component<ChildrenProps> | undefined
+    tbody [?]: Component<ChildrenProps> | undefined
+    td [?]: Component<CellProps> | undefined
+    th [?]: Component<CellProps> | undefined
+    thead [?]: Component<ChildrenProps> | undefined
+    tr [?]: Component<ChildrenProps> | undefined
+    u [?]: Component<ChildrenProps> | undefined
+    ul [?]: Component<ChildrenProps> | undefined
+  interface markdown.HeadingMeta (bun-types/bun.d.ts)
+    id [?]: string | undefined
+    level: number
+  interface markdown.HeadingProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    id [?]: string | undefined
+  interface markdown.ImageMeta (bun-types/bun.d.ts)
+    src: string
+    title [?]: string | undefined
+  interface markdown.ImageProps (bun-types/bun.d.ts)
+    alt [?]: string | undefined
+    src: string
+    title [?]: string | undefined
+  interface markdown.LinkMeta (bun-types/bun.d.ts)
+    href: string
+    title [?]: string | undefined
+  interface markdown.LinkProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    href: string
+    title [?]: string | undefined
+  interface markdown.ListItemMeta (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    depth: number
+    index: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.ListItemProps (bun-types/bun.d.ts)
+    checked [?]: boolean | undefined
+    children: Array<unknown>
+  interface markdown.ListMeta (bun-types/bun.d.ts)
+    depth: number
+    ordered: boolean
+    start [?]: number | undefined
+  interface markdown.Options (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.OrderedListProps (bun-types/bun.d.ts)
+    children: Array<unknown>
+    start: number
+  interface markdown.ReactOptions (bun-types/bun.d.ts)
+    autolinks [?]: boolean | undefined | { url?: boolean | undefined; www?: boolean | undefined; email?: boolean | undefined; }
+    collapseWhitespace [?]: boolean | undefined
+    hardSoftBreaks [?]: boolean | undefined
+    headings [?]: boolean | undefined | { ids?: boolean | undefined; autolink?: boolean | undefined; }
+    latexMath [?]: boolean | undefined
+    noHtmlBlocks [?]: boolean | undefined
+    noHtmlSpans [?]: boolean | undefined
+    noIndentedCodeBlocks [?]: boolean | undefined
+    permissiveAtxHeaders [?]: boolean | undefined
+    reactVersion [?]: 18 | 19 | undefined
+    strikethrough [?]: boolean | undefined
+    tables [?]: boolean | undefined
+    tagFilter [?]: boolean | undefined
+    tasklists [?]: boolean | undefined
+    underline [?]: boolean | undefined
+    wikiLinks [?]: boolean | undefined
+  interface markdown.RenderCallbacks (bun-types/bun.d.ts)
+    blockquote [?]: ((children: string) => null | string | undefined) | undefined
+    code [?]: ((children: string, meta?: CodeBlockMeta | undefined) => null | string | undefined) | undefined
+    codespan [?]: ((children: string) => null | string | undefined) | undefined
+    emphasis [?]: ((children: string) => null | string | undefined) | undefined
+    heading [?]: ((children: string, meta: HeadingMeta) => null | string | undefined) | undefined
+    hr [?]: ((children: string) => null | string | undefined) | undefined
+    html [?]: ((children: string) => null | string | undefined) | undefined
+    image [?]: ((children: string, meta: ImageMeta) => null | string | undefined) | undefined
+    link [?]: ((children: string, meta: LinkMeta) => null | string | undefined) | undefined
+    list [?]: ((children: string, meta: ListMeta) => null | string | undefined) | undefined
+    listItem [?]: ((children: string, meta: ListItemMeta) => null | string | undefined) | undefined
+    paragraph [?]: ((children: string) => null | string | undefined) | undefined
+    strikethrough [?]: ((children: string) => null | string | undefined) | undefined
+    strong [?]: ((children: string) => null | string | undefined) | undefined
+    table [?]: ((children: string) => null | string | undefined) | undefined
+    tbody [?]: ((children: string) => null | string | undefined) | undefined
+    td [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    text [?]: ((text: string) => null | string | undefined) | undefined
+    th [?]: ((children: string, meta?: CellMeta | undefined) => null | string | undefined) | undefined
+    thead [?]: ((children: string) => null | string | undefined) | undefined
+    tr [?]: ((children: string) => null | string | undefined) | undefined
+  function markdown.ansi (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, theme?: AnsiTheme | undefined): string
+  function markdown.html (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: Options | undefined): string
+  function markdown.react (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, components?: ComponentOverrides | undefined, options?: ReactOptions | undefined): unknown
+  function markdown.render (bun-types/bun.d.ts)
+    call (input: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, callbacks?: RenderCallbacks | undefined, options?: Options | undefined): string
+function mmap (bun-types/bun.d.ts)
+  call (path: PathLike, opts?: MMapOptions | undefined): Uint8Array<ArrayBuffer>
+function nanoseconds (bun-types/bun.d.ts)
+  call (): number
+function openInEditor (bun-types/bun.d.ts)
+  call (path: string, options?: EditorOptions | undefined): void
+var password (bun-types/bun.d.ts)
+  hash: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => Promise<string>
+  hashSync: (password: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | Argon2Algorithm | BCryptAlgorithm | undefined) => string
+  verify: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => Promise<boolean>
+  verifySync: (password: StringOrBuffer, hash: StringOrBuffer, algorithm?: "argon2d" | "argon2i" | "argon2id" | "bcrypt" | undefined) => boolean
+function pathToFileURL (bun-types/bun.d.ts)
+  call (path: string): URL
+function peek (bun-types/bun.d.ts)
+  call <T = undefined>(promise: Promise<T> | T): Promise<T> | T
+  status: <T = undefined>(promise: Promise<T> | T) => "fulfilled" | "pending" | "rejected"
+namespace peek (bun-types/bun.d.ts)
+  function peek.status (bun-types/bun.d.ts)
+    call <T = undefined>(promise: Promise<T> | T): "fulfilled" | "pending" | "rejected"
+var plugin (bun-types/bun.d.ts): BunRegisterPlugin
+var postgres (bun-types/sql.d.ts): SQL
+function randomUUIDv5 (bun-types/bun.d.ts)
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding?: "base64" | "base64url" | "hex" | undefined): string
+  call (name: BufferSource | string, namespace: BufferSource | string, encoding: "buffer"): Buffer<ArrayBufferLike>
+function randomUUIDv7 (bun-types/bun.d.ts)
+  call (encoding?: "base64" | "base64url" | "hex" | undefined, timestamp?: Date | number | undefined): string
+  call (encoding: "buffer", timestamp?: Date | number | undefined): Buffer<ArrayBufferLike>
+function readableStreamToArray (bun-types/bun.d.ts)
+  call <T>(stream: ReadableStream<T>): Array<T> | Promise<Array<T>>
+function readableStreamToArrayBuffer (bun-types/bun.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): ArrayBuffer | Promise<ArrayBuffer>
+function readableStreamToBlob (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<Blob>
+function readableStreamToBytes (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<ArrayBufferLike | ArrayBufferView<ArrayBufferLike>>): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+function readableStreamToFormData (bun-types/bun.d.ts)
+  call (stream: ReadableStream<string | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | BigInt64Array<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | DataView<ArrayBufferLike>>, multipartBoundaryExcludingDashes?: BigInt64Array<ArrayBufferLike> | BigUint64Array<ArrayBufferLike> | DataView<ArrayBufferLike> | Float16Array<ArrayBufferLike> | Float32Array<ArrayBufferLike> | Float64Array<ArrayBufferLike> | Int16Array<ArrayBufferLike> | Int32Array<ArrayBufferLike> | Int8Array<ArrayBufferLike> | Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | Uint8Array<ArrayBufferLike> | Uint8ClampedArray<ArrayBufferLike> | string | undefined): Promise<FormData>
+function readableStreamToJSON (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<any>
+function readableStreamToText (bun-types/deprecated.d.ts)
+  call (stream: ReadableStream<any>): Promise<string>
+var redis (bun-types/redis.d.ts): RedisClient
+function resolve (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): Promise<string>
+function resolveSync (bun-types/bun.d.ts)
+  call (moduleId: string, parent: string): string
+var revision (bun-types/bun.d.ts): string
+var s3 (bun-types/s3.d.ts): S3Client
+var secrets (bun-types/bun.d.ts)
+  delete: (options: { service: string; name: string; }) => Promise<boolean>
+  get: (options: { service: string; name: string; }) => Promise<string | null>
+  set: (options: { service: string; name: string; value: string; allowUnrestrictedAccess?: boolean | undefined; }) => Promise<void>
+namespace semver (bun-types/bun.d.ts)
+  function semver.order (bun-types/bun.d.ts)
+    call (v1: StringLike, v2: StringLike): -1 | 0 | 1
+  function semver.satisfies (bun-types/bun.d.ts)
+    call (version: StringLike, range: StringLike): boolean
+function serve (bun-types/serve.d.ts)
+  call <WebSocketData = undefined, R extends string = never>(options: Options<WebSocketData, R>): Server<WebSocketData>
+function sha (bun-types/bun.d.ts)
+  call (input: StringOrBuffer, hashInto?: TypedArray<ArrayBufferLike> | undefined): TypedArray<ArrayBufferLike>
+  call (input: StringOrBuffer, encoding: DigestEncoding): string
+function shrink (bun-types/bun.d.ts)
+  call (): void
+function sleep (bun-types/bun.d.ts)
+  call (ms: Date | number): Promise<void>
+function sleepSync (bun-types/bun.d.ts)
+  call (ms: number): void
+function sliceAnsi (bun-types/bun.d.ts)
+  call (input: string, start?: number | undefined, end?: number | undefined, options?: SliceAnsiOptions | boolean | string | undefined, ambiguousIsNarrow?: boolean | undefined): string
+function spawn (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(options: SpawnOptions<In, Out, Err> & { cmd: Array<string>; }): Subprocess<In, Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "inherit">(cmds: Array<string>, options?: SpawnOptions<In, Out, Err> | undefined): Subprocess<In, Out, Err>
+function spawnSync (bun-types/bun.d.ts)
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(options: SpawnSyncOptions<In, Out, Err> & { cmd: Array<string>; onExit?: undefined; }): SyncSubprocess<Out, Err>
+  call <In extends Writable = "ignore", Out extends Readable = "pipe", Err extends Readable = "pipe">(cmds: Array<string>, options?: SpawnSyncOptions<In, Out, Err> | undefined): SyncSubprocess<Out, Err>
+var sql (bun-types/sql.d.ts): SQL
+var stderr (bun-types/bun.d.ts): BunFile
+var stdin (bun-types/bun.d.ts): BunFile
+var stdout (bun-types/bun.d.ts): BunFile
+function stringWidth (bun-types/bun.d.ts)
+  call (input: string, options?: StringWidthOptions | undefined): number
+function stripANSI (bun-types/bun.d.ts)
+  call (input: string): string
+namespace udp (bun-types/bun.d.ts)
+  interface udp.BaseUDPSocket (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectSocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    connect: { hostname: string; port: number; }
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: ConnectedSocketHandler<DataBinaryType> | undefined
+  interface udp.ConnectedSocket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: ConnectedSocketHandler<DataBinaryType>) => void
+    remoteAddress [readonly]: SocketAddress
+    send: (data: Data) => boolean
+    sendMany: (packets: ReadonlyArray<Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.ConnectedSocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: ConnectedSocket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: ConnectedSocket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: ConnectedSocket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  type udp.Data (bun-types/bun.d.ts) = string | ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  interface udp.ReceiveFlags (bun-types/bun.d.ts)
+    ipv6: boolean
+    truncated: boolean
+  interface udp.Socket<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    addMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    addSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    address [readonly]: SocketAddress
+    binaryType [readonly]: keyof BinaryTypeList
+    close: () => void
+    closed [readonly]: boolean
+    dropMembership: (multicastAddress: string, interfaceAddress?: string | undefined) => boolean
+    dropSourceSpecificMembership: (sourceAddress: string, groupAddress: string, interfaceAddress?: string | undefined) => boolean
+    hostname [readonly]: string
+    port [readonly]: number
+    ref: () => void
+    reload: (handler: SocketHandler<DataBinaryType>) => void
+    send: (data: Data, port: number, address: string) => boolean
+    sendMany: (packets: ReadonlyArray<number | Data>) => number
+    setBroadcast: (enabled: boolean) => boolean
+    setMulticastInterface: (interfaceAddress: string) => boolean
+    setMulticastLoopback: (enabled: boolean) => boolean
+    setMulticastTTL: (ttl: number) => number
+    setTTL: (ttl: number) => number
+    unref: () => void
+  interface udp.SocketHandler<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    data [?]: ((socket: Socket<DataBinaryType>, data: BinaryTypeList[DataBinaryType], port: number, address: string, flags: ReceiveFlags) => Promise<void> | void) | undefined
+    drain [?]: ((socket: Socket<DataBinaryType>) => Promise<void> | void) | undefined
+    error [?]: ((socket: Socket<DataBinaryType>, error: Error) => Promise<void> | void) | undefined
+  interface udp.SocketOptions<DataBinaryType extends keyof BinaryTypeList> (bun-types/bun.d.ts)
+    binaryType [?]: DataBinaryType | undefined
+    hostname [?]: string | undefined
+    port [?]: number | undefined
+    socket [?]: SocketHandler<DataBinaryType> | undefined
+function udpSocket (bun-types/bun.d.ts)
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: SocketOptions<DataBinaryType>): Promise<Socket<DataBinaryType>>
+  call <DataBinaryType extends keyof BinaryTypeList = "buffer">(options: ConnectSocketOptions<DataBinaryType>): Promise<ConnectedSocket<DataBinaryType>>
+namespace unsafe (bun-types/bun.d.ts)
+  function unsafe.arrayBufferToString (bun-types/bun.d.ts)
+    call (buffer: ArrayBufferLike | Uint8Array<ArrayBuffer>): string
+    call (buffer: Uint16Array<ArrayBufferLike>): string
+  function unsafe.gcAggressionLevel (bun-types/bun.d.ts)
+    call (level?: 0 | 1 | 2 | undefined): 0 | 1 | 2
+  function unsafe.memoryFootprint (bun-types/bun.d.ts)
+    call (): number | undefined
+  function unsafe.mimallocDump (bun-types/bun.d.ts)
+    call (): void
+var version (bun-types/bun.d.ts): string
+var version_with_sha (bun-types/bun.d.ts): string
+function which (bun-types/bun.d.ts)
+  call (command: string, options?: WhichOptions | undefined): null | string
+function wrapAnsi (bun-types/bun.d.ts)
+  call (input: string, columns: number, options?: WrapAnsiOptions | undefined): string
+function write (bun-types/bun.d.ts)
+  call (destination: BunFile | PathLike | S3File, input: Archive | Array<BlobPart> | ArrayBufferLike | Blob | ReadableStream<any> | TypedArray<ArrayBufferLike> | string, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: Request | Response, options?: undefined | { createPath?: boolean | undefined; }): Promise<number>
+  call (destination: BunFile, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+  call (destinationPath: PathLike, input: BunFile, options?: undefined | { mode?: number | undefined; createPath?: boolean | undefined; }): Promise<number>
+function zstdCompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Promise<Buffer<ArrayBufferLike>>
+function zstdCompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string, options?: undefined | { level?: number | undefined; }): Buffer<ArrayBufferLike>
+function zstdDecompress (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Promise<Buffer<ArrayBufferLike>>
+function zstdDecompressSync (bun-types/bun.d.ts)
+  call (data: ArrayBuffer | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike> | string): Buffer<ArrayBufferLike>
+
+# module "bun:bundle"
+interface Registry (bun-types/bundle.d.ts)
+function feature (bun-types/bundle.d.ts)
+  call (flag: string): boolean
+
+# module "bun:ffi"
+function CFunction (bun-types/ffi.d.ts)
+  call (fn: FFIFunction & { ptr: number | bigint | Pointer; }): CallableFunction & { close(): void; }
+type CString (bun-types/ffi.d.ts) = string
+var CString (bun-types/ffi.d.ts): CStringConstructor
+interface CStringConstructor (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+  construct new (ptr: Pointer | bigint | null | number, byteOffset?: number | undefined, byteLength?: number | undefined): string
+type ConvertFns<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts) = { [K in keyof Fns]: { (...args: Fns[K]["args"] extends infer A extends ReadonlyArray<FFITypeOrString> ? { [L in keyof A]: FFITypeToArgsType[ToFFIType<A[L]>]; } : [unknown] extends [Fns[K]["args"]] ? [] : never): [unknown] extends [Fns[K]["returns"]] ? undefined : FFITypeToReturnsType[ToFFIType<NonNullable<Fns[K]["returns"]>>]; __ffi_function_callable: typeof FFIFunctionCallableSymbol; }; }
+interface FFIFunction (bun-types/ffi.d.ts)
+  args [? readonly]: ReadonlyArray<FFITypeOrString> | undefined
+  ptr [? readonly]: Pointer | bigint | undefined
+  returns [? readonly]: FFITypeOrString | undefined
+  threadsafe [? readonly]: boolean | undefined
+var FFIFunctionCallableSymbol (bun-types/ffi.d.ts): typeof FFIFunctionCallableSymbol
+enum FFIType (bun-types/ffi.d.ts)
+  char = FFIType.char
+  int8_t = FFIType.int8_t
+  i8 = FFIType.int8_t
+  uint8_t = FFIType.uint8_t
+  u8 = FFIType.uint8_t
+  int16_t = FFIType.int16_t
+  i16 = FFIType.int16_t
+  uint16_t = FFIType.uint16_t
+  u16 = FFIType.uint16_t
+  int32_t = FFIType.int32_t
+  i32 = FFIType.int32_t
+  int = FFIType.int32_t
+  uint32_t = FFIType.uint32_t
+  u32 = FFIType.uint32_t
+  int64_t = FFIType.int64_t
+  i64 = FFIType.int64_t
+  uint64_t = FFIType.uint64_t
+  u64 = FFIType.uint64_t
+  double = FFIType.double
+  f64 = FFIType.double
+  float = FFIType.float
+  f32 = FFIType.float
+  bool = FFIType.bool
+  ptr = FFIType.ptr
+  pointer = FFIType.ptr
+  void = FFIType.void
+  cstring = FFIType.cstring
+  i64_fast = FFIType.i64_fast
+  u64_fast = FFIType.u64_fast
+  function = FFIType.function
+  napi_env = FFIType.napi_env
+  napi_value = FFIType.napi_value
+  buffer = FFIType.buffer
+  buffer_length = FFIType.buffer_length
+type FFITypeOrString (bun-types/ffi.d.ts) = FFIType | keyof FFITypeStringToType
+interface FFITypeStringToType (bun-types/ffi.d.ts)
+  bool: FFIType.bool
+  buffer: FFIType.buffer
+  buffer_bytelength: FFIType.buffer_length
+  buffer_length: FFIType.buffer_length
+  callback: FFIType.ptr
+  char: FFIType.char
+  cstring: FFIType.cstring
+  double: FFIType.double
+  f32: FFIType.float
+  f64: FFIType.double
+  float: FFIType.float
+  function: FFIType.ptr
+  i16: FFIType.int16_t
+  i32: FFIType.int32_t
+  i64: FFIType.int64_t
+  i8: FFIType.int8_t
+  int: FFIType.int32_t
+  int16_t: FFIType.int16_t
+  int32_t: FFIType.int32_t
+  int64_t: FFIType.int64_t
+  int8_t: FFIType.int8_t
+  napi_env: FFIType.napi_env
+  napi_value: FFIType.napi_value
+  pointer: FFIType.ptr
+  ptr: FFIType.ptr
+  u16: FFIType.uint16_t
+  u32: FFIType.uint32_t
+  u64: FFIType.uint64_t
+  u8: FFIType.uint8_t
+  uint16_t: FFIType.uint16_t
+  uint32_t: FFIType.uint32_t
+  uint64_t: FFIType.uint64_t
+  uint8_t: FFIType.uint8_t
+  usize: FFIType.uint64_t
+  void: FFIType.void
+interface FFITypeToArgsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | TypedArray<ArrayBufferLike> | bigint | null
+  13: undefined
+  14: Pointer | TypedArray<ArrayBufferLike> | bigint | null | string
+  15: bigint | number
+  16: bigint | number
+  17: JSCallback | Pointer
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint | number
+  8: bigint | number
+  9: number
+interface FFITypeToReturnsType (bun-types/ffi.d.ts)
+  0: number
+  1: number
+  10: number
+  11: boolean
+  12: Pointer | bigint | null
+  13: undefined
+  14: null | string
+  15: bigint | number
+  16: bigint | number
+  17: Pointer | bigint | null
+  18: unknown
+  19: unknown
+  2: number
+  20: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  21: DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>
+  3: number
+  4: number
+  5: number
+  6: number
+  7: bigint
+  8: bigint
+  9: number
+class JSCallback (bun-types/ffi.d.ts)
+  close: () => void
+  ptr [readonly]: Pointer | null
+  threadsafe [readonly]: boolean
+  [static]
+    construct new (callback: (...args: Array<any>) => any, definition: FFIFunction): JSCallback
+    prototype: JSCallback
+interface Library<Fns extends Readonly<Record<string, FFIFunction>>> (bun-types/ffi.d.ts)
+  close: () => void
+  symbols: ConvertFns<Fns>
+type Pointer (bun-types/ffi.d.ts) = number & { __pointer__: null; }
+type Symbols (bun-types/ffi.d.ts) = { readonly [x: string]: FFIFunction; }
+type ToFFIType<T extends FFITypeOrString> (bun-types/ffi.d.ts) = T extends FFIType ? T : T extends string ? FFITypeStringToType[T] : never
+function cc (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(options: { source: string | BunFile | URL; library?: string | Array<string> | undefined; include?: string | Array<string> | undefined; symbols: Fns; define?: Record<string, string> | undefined; flags?: string | Array<string> | undefined; }): Library<Fns>
+function dlopen (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(name: BunFile | URL | string, symbols: Fns): Library<Fns>
+function linkSymbols (bun-types/ffi.d.ts)
+  call <Fns extends Record<string, FFIFunction>>(symbols: Fns): Library<Fns>
+function ptr (bun-types/ffi.d.ts)
+  call (view: ArrayBufferLike | DataView<ArrayBufferLike> | TypedArray<ArrayBufferLike>, byteOffset?: number | undefined): Pointer
+namespace read (bun-types/ffi.d.ts)
+  function read.f32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.f64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.i64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.i8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.intptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.ptr (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u16 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u32 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+  function read.u64 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): bigint
+  function read.u8 (bun-types/ffi.d.ts)
+    call (ptr: Pointer | bigint | number, byteOffset?: number | undefined): number
+var suffix (bun-types/ffi.d.ts): string
+function toArrayBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): ArrayBuffer
+function toBuffer (bun-types/ffi.d.ts)
+  call (ptr: Pointer | bigint | number, byteOffset?: number | undefined, byteLength?: number | undefined): Buffer<ArrayBufferLike>
+function viewSource (bun-types/ffi.d.ts)
+  call (symbols: Readonly<Record<string, FFIFunction>>, is_callback?: false | undefined): Array<string>
+  call (callback: FFIFunction, is_callback: true): string
+
+# module "bun:jsc"
+interface HeapStats (bun-types/jsc.d.ts)
+  extraMemorySize: number
+  globalObjectCount: number
+  heapCapacity: number
+  heapSize: number
+  objectCount: number
+  objectTypeCounts: Record<string, number>
+  protectedGlobalObjectCount: number
+  protectedObjectCount: number
+  protectedObjectTypeCounts: Record<string, number>
+interface MemoryUsage (bun-types/jsc.d.ts)
+  current: number
+  currentCommit: number
+  pageFaults: number
+  peak: number
+  peakCommit: number
+interface SamplingProfile (bun-types/jsc.d.ts)
+  bytecodes: string
+  functions: string
+  stackTraces: SamplingProfileStackTraces
+interface SamplingProfileStackFrame (bun-types/jsc.d.ts)
+  category: string
+  column: number
+  flags: number
+  inliner [?]: undefined | { name: string; location: string; line: number; column: number; category: string; }
+  line: number
+  location: string
+  name: string
+  sourceID: number
+  sourceURL [?]: string | undefined
+interface SamplingProfileStackTraces (bun-types/jsc.d.ts)
+  interval: number
+  sources: Array<{ sourceID: number; url?: string | undefined; sourceURL?: string | undefined; sourceMappingURL?: string | undefined; }>
+  traces: Array<{ timestamp: number; frames: Array<SamplingProfileStackFrame>; }>
+function callerSourceOrigin (bun-types/jsc.d.ts)
+  call (): null | string
+function deserialize (bun-types/jsc.d.ts)
+  call (value: ArrayBufferLike | Buffer<ArrayBufferLike> | TypedArray<ArrayBufferLike>): any
+function drainMicrotasks (bun-types/jsc.d.ts)
+  call (): void
+function edenGC (bun-types/jsc.d.ts)
+  call (): number
+function estimateShallowMemoryUsageOf (bun-types/jsc.d.ts)
+  call (value: CallableFunction | bigint | object | string | symbol): number
+function fullGC (bun-types/jsc.d.ts)
+  call (): number
+function gcAndSweep (bun-types/jsc.d.ts)
+  call (): number
+function getProtectedObjects (bun-types/jsc.d.ts)
+  call (): Array<any>
+function getRandomSeed (bun-types/jsc.d.ts)
+  call (): number
+function heapSize (bun-types/jsc.d.ts)
+  call (): number
+function heapStats (bun-types/jsc.d.ts)
+  call (): HeapStats
+function isRope (bun-types/jsc.d.ts)
+  call (input: string): boolean
+function jscDescribe (bun-types/jsc.d.ts)
+  call (value: any): string
+function jscDescribeArray (bun-types/jsc.d.ts)
+  call (array: Array<any>): string
+function memoryUsage (bun-types/jsc.d.ts)
+  call (): MemoryUsage
+function noFTL (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function noOSRExitFuzzing (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function numberOfDFGCompiles (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function optimizeNextInvocation (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): void
+function profile (bun-types/jsc.d.ts)
+  call <T extends (...args: Array<any>) => any>(callback: T, sampleInterval?: number | undefined, ...args: Parameters<T>): ReturnType<T> extends Promise<infer U> ? Promise<SamplingProfile> : SamplingProfile
+function releaseWeakRefs (bun-types/jsc.d.ts)
+  call (): void
+function reoptimizationRetryCount (bun-types/jsc.d.ts)
+  call (func: (...args: Array<any>) => any): number
+function serialize (bun-types/jsc.d.ts)
+  call (value: any, options?: undefined | { binaryType?: "arraybuffer" | undefined; }): SharedArrayBuffer
+  call (value: any, options?: undefined | { binaryType: "nodebuffer"; }): Buffer<ArrayBufferLike>
+function setRandomSeed (bun-types/jsc.d.ts)
+  call (value: number): void
+function setTimeZone (bun-types/jsc.d.ts)
+  call (timeZone: string): string
+function startRemoteDebugger (bun-types/jsc.d.ts)
+  call (host?: string | undefined, port?: number | undefined): void
+function startSamplingProfiler (bun-types/jsc.d.ts)
+  call (optionalDirectory?: string | undefined, sampleInterval?: number | undefined): void
+function totalCompileTime (bun-types/jsc.d.ts)
+  call (): number
+
+# module "bun:sqlite"
+interface Changes (bun-types/sqlite.d.ts)
+  changes: number
+  lastInsertRowid: bigint | number
+class Database (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  close: (throwOnError?: boolean | undefined) => void
+  exec: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  fileControl: { (op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number; (zDbName: string, op: number, arg?: ArrayBufferView<ArrayBufferLike> | number | undefined): number }
+  filename [readonly]: string
+  handle [readonly]: number
+  inTransaction: boolean
+  loadExtension: (extension: string, entryPoint?: string | undefined) => void
+  prepare: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string, params?: ParamsType | undefined) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  query: <ReturnType, ParamsType extends Array<SQLQueryBindings> | SQLQueryBindings>(sql: string) => Statement<ReturnType, ParamsType extends Array<any> ? ParamsType : [ParamsType]>
+  run: <ParamsType extends Array<SQLQueryBindings>>(sql: string, ...bindings: Array<ParamsType>) => Changes
+  serialize: (name?: string | undefined) => Buffer<ArrayBufferLike>
+  transaction: <A extends Array<any>, T>(insideTransaction: (...args: A) => T) => { (...args: A): T; deferred: (...args: A) => T; immediate: (...args: A) => T; exclusive: (...args: A) => T; }
+  [static]
+    construct new (filename?: string | undefined, options?: DatabaseOptions | number | undefined): Database
+    MAX_QUERY_CACHE_SIZE [static]: number
+    deserialize [static]: { (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, isReadOnly?: boolean | undefined): Database; (serialized: ArrayBufferLike | TypedArray<ArrayBufferLike>, options?: undefined | { readonly?: boolean | undefined; strict?: boolean | undefined; safeIntegers?: boolean | undefined; }): Database }
+    open [static]: (filename: string, options?: DatabaseOptions | number | undefined) => Database
+    prototype: Database
+    setCustomSQLite [static]: (path: string) => boolean
+interface DatabaseOptions (bun-types/sqlite.d.ts)
+  create [?]: boolean | undefined
+  readonly [?]: boolean | undefined
+  readwrite [?]: boolean | undefined
+  safeIntegers [?]: boolean | undefined
+  strict [?]: boolean | undefined
+type SQLQueryBindings (bun-types/sqlite.d.ts) = string | number | bigint | boolean | TypedArray<ArrayBufferLike> | Record<string, string | number | bigint | boolean | TypedArray<ArrayBufferLike> | null> | null
+class SQLiteError (bun-types/sqlite.d.ts)
+  byteOffset [readonly]: number
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno: number
+  message: string
+  name [readonly]: "SQLiteError"
+  stack [?]: string | undefined
+  [static]
+    construct new (message?: string | undefined): SQLiteError
+    construct new (message?: string | undefined, options?: ErrorOptions | undefined): SQLiteError
+    captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+    isError: (value: unknown) => value is Error
+    prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+    prototype: SQLiteError
+    stackTraceLimit: number
+class Statement<ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>> (bun-types/sqlite.d.ts)
+  [Symbol.dispose]: () => void
+  [Symbol.iterator]: () => IterableIterator<ReturnType>
+  all: (...params: ParamsType) => Array<ReturnType>
+  as: <T = unknown>(Class: new (...args: Array<any>) => T) => Statement<T, ParamsType>
+  columnNames [readonly]: Array<string>
+  columnTypes [readonly]: Array<"TEXT" | "INTEGER" | "FLOAT" | "BLOB" | "NULL" | null>
+  declaredTypes [readonly]: Array<string | null>
+  finalize: () => void
+  get: (...params: ParamsType) => ReturnType | null
+  iterate: (...params: ParamsType) => IterableIterator<ReturnType>
+  native [readonly]: any
+  paramsCount [readonly]: number
+  raw: (...params: ParamsType) => Array<Array<Uint8Array<ArrayBufferLike> | null>>
+  run: (...params: ParamsType) => Changes
+  toString: () => string
+  values: (...params: ParamsType) => Array<Array<string | number | bigint | boolean | Uint8Array<ArrayBufferLike>>>
+  [static]
+    construct new <ReturnType = unknown, ParamsType extends Array<SQLQueryBindings> = Array<any>>(nativeHandle: any): Statement<ReturnType, ParamsType>
+    prototype: Statement<any, any>
+namespace constants (bun-types/sqlite.d.ts)
+  var constants.SQLITE_FCNTL_BEGIN_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_BUSYHANDLER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CHUNK_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_DONE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKPT_START (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_CKSM_FILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_COMMIT_PHASETWO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_DATA_VERSION (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_EXTERNAL_READER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_FILE_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_GET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_HAS_MOVED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_JOURNAL_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LAST_ERRNO (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCKSTATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_LOCK_TIMEOUT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_MMAP_SIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PDB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PERSIST_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_POWERSAFE_OVERWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_PRAGMA (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RBU (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESERVE_BYTES (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_RESET_CACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SET_LOCKPROXYFILE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_HINT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SIZE_LIMIT (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_SYNC_OMITTED (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TEMPFILENAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_TRACE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFSNAME (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_VFS_POINTER (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WAL_BLOCK (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_AV_RETRY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_GET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_WIN32_SET_HANDLE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_FCNTL_ZIPVFS (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_AUTOPROXY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_CREATE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_DELETEONCLOSE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXCLUSIVE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_EXRESCODE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_FULLMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MAIN_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_MEMORY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOFOLLOW (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_NOMUTEX (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_PRIVATECACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READONLY (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_READWRITE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SHAREDCACHE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUBJOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_SUPER_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TEMP_JOURNAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_TRANSIENT_DB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_URI (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_OPEN_WAL (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NORMALIZE (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_NO_VTAB (bun-types/sqlite.d.ts): number
+  var constants.SQLITE_PREPARE_PERSISTENT (bun-types/sqlite.d.ts): number
+default -> Database
+var native (bun-types/sqlite.d.ts): any
+
+# module "bun:test"
+type AsymmetricMatcher (bun-types/test.d.ts) = any
+interface AsymmetricMatchers (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+interface AsymmetricMatchersBuiltin (bun-types/test.d.ts)
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  objectContaining: (obj: object) => any
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+type CustomMatcher<E, P extends Array<any>> (bun-types/test.d.ts) = (this: MatcherContext, expected: E, ...matcherArguments: P) => MatcherResult | Promise<MatcherResult>
+type CustomMatchersDetected (bun-types/test.d.ts) = Omit<Matchers<unknown>, keyof MatchersBuiltin<unknown>> & Omit<AsymmetricMatchers, keyof AsymmetricMatchersBuiltin>
+interface Describe<T extends ReadonlyArray<any>> (bun-types/test.d.ts)
+  call (fn: () => void): void
+  call (label: DescribeLabel, fn: (...args: T) => void): void
+  concurrent: Describe<T>
+  each: { <T extends readonly [any, ...any[]]>(table: ReadonlyArray<T>): Describe<[...T]>; <T extends Array<any>>(table: ReadonlyArray<T>): Describe<[...T]>; <T>(table: Array<T>): Describe<[T]> }
+  if: (condition: boolean) => Describe<T>
+  only: Describe<T>
+  serial: Describe<T>
+  skip: Describe<T>
+  skipIf: (condition: boolean) => Describe<T>
+  todo: Describe<T>
+  todoIf: (condition: boolean) => Describe<T>
+type EqualsFunction (bun-types/test.d.ts) = (a: unknown, b: unknown) => boolean
+interface Expect (bun-types/test.d.ts)
+  call (actual?: undefined, customFailMessage?: string | undefined): Matchers<undefined>
+  call <T = unknown>(actual: T, customFailMessage?: string | undefined): Matchers<T>
+  call <T = unknown>(actual?: T | undefined, customFailMessage?: string | undefined): Matchers<T | undefined>
+  any: (constructor: ((...args: Array<any>) => any) | new (...args: Array<any>) => any) => any
+  anything: () => any
+  arrayContaining: <E = any>(arr: ReadonlyArray<E>) => any
+  assertions: (neededAssertions: number) => void
+  closeTo: (num: number, numDigits?: number | undefined) => any
+  extend: <M>(matchers: ExpectExtendMatchers<M>) => void
+  hasAssertions: () => void
+  not: ExpectNot
+  objectContaining: (obj: object) => any
+  rejectsTo: AsymmetricMatchers
+  resolvesTo: AsymmetricMatchers
+  stringContaining: (str: String | string) => any
+  stringMatching: (regex: RegExp | String | string) => any
+  unreachable: (msg?: Error | string | undefined) => never
+type ExpectExtendMatchers<M> (bun-types/test.d.ts) = { [k in keyof M]: k extends never ? CustomMatcher<unknown, Parameters<CustomMatchersDetected[k]>> : CustomMatcher<unknown, Array<any>>; }
+interface MatcherResult (bun-types/test.d.ts)
+  message [?]: (() => string) | string | undefined
+  pass: boolean
+interface Matchers<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+interface MatchersBuiltin<T = unknown> (bun-types/test.d.ts)
+  fail: (message?: string | undefined) => void
+  lastCalledWith: (...expected: Array<unknown>) => void
+  not: Matchers<unknown>
+  nthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  pass: (message?: string | undefined) => void
+  rejects: Matchers<unknown>
+  resolves: Matchers<Awaited<T>>
+  toBe: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toBeArray: () => void
+  toBeArrayOfSize: (size: number) => void
+  toBeBoolean: () => void
+  toBeCalled: () => void
+  toBeCalledTimes: (expected: number) => void
+  toBeCalledWith: (...expected: Array<unknown>) => void
+  toBeCloseTo: (expected: number, numDigits?: number | undefined) => void
+  toBeDate: () => void
+  toBeDefined: () => void
+  toBeEmpty: () => void
+  toBeEmptyObject: () => void
+  toBeEven: () => void
+  toBeFalse: () => void
+  toBeFalsy: () => void
+  toBeFinite: () => void
+  toBeFunction: () => void
+  toBeGreaterThan: (expected: bigint | number) => void
+  toBeGreaterThanOrEqual: (expected: bigint | number) => void
+  toBeInstanceOf: (value: unknown) => void
+  toBeInteger: () => void
+  toBeLessThan: (expected: bigint | number) => void
+  toBeLessThanOrEqual: (expected: bigint | number) => void
+  toBeNaN: () => void
+  toBeNegative: () => void
+  toBeNil: () => void
+  toBeNull: () => void
+  toBeNumber: () => void
+  toBeObject: () => void
+  toBeOdd: () => void
+  toBeOneOf: { (expected: Iterable<T>): void; <X = T>(expected: NoInfer<Iterable<X>>): void }
+  toBePositive: () => void
+  toBeString: () => void
+  toBeSymbol: () => void
+  toBeTrue: () => void
+  toBeTruthy: () => void
+  toBeTypeOf: (type: "bigint" | "boolean" | "function" | "number" | "object" | "string" | "symbol" | "undefined") => void
+  toBeUndefined: () => void
+  toBeValidDate: () => void
+  toBeWithin: (start: number, end: number) => void
+  toContain: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainAllKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAllValues: (expected: Array<unknown>) => void
+  toContainAnyKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainAnyValues: (expected: Array<unknown>) => void
+  toContainEqual: { (expected: T extends Iterable<infer U> ? U : T): void; <X = T>(expected: NoInfer<X extends Iterable<infer U> ? U : X>): void }
+  toContainKey: { (expected: IfNeverThenElse<keyof T, PropertyKey>): void; <X = T>(expected: IfNeverThenElse<NoInfer<keyof X>, PropertyKey>): void }
+  toContainKeys: { (expected: Array<IfNeverThenElse<keyof T, PropertyKey>>): void; <X = T>(expected: Array<IfNeverThenElse<NoInfer<keyof X>, PropertyKey>>): void }
+  toContainValue: (expected: unknown) => void
+  toContainValues: (expected: Array<unknown>) => void
+  toEndWith: (expected: string) => void
+  toEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toEqualIgnoringWhitespace: (expected: string) => void
+  toHaveBeenCalled: () => void
+  toHaveBeenCalledTimes: (expected: number) => void
+  toHaveBeenCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenLastCalledWith: (...expected: Array<unknown>) => void
+  toHaveBeenNthCalledWith: (n: number, ...expected: Array<unknown>) => void
+  toHaveLastReturnedWith: (expected: unknown) => void
+  toHaveLength: (length: number) => void
+  toHaveNthReturnedWith: (n: number, expected: unknown) => void
+  toHaveProperty: (keyPath: Array<string | number> | number | string, value?: unknown) => void
+  toHaveReturned: () => void
+  toHaveReturnedTimes: (times: number) => void
+  toHaveReturnedWith: (expected: unknown) => void
+  toInclude: (expected: string) => void
+  toIncludeRepeated: (expected: string, times: number) => void
+  toMatch: (expected: RegExp | string) => void
+  toMatchInlineSnapshot: { (value?: string | undefined): void; (propertyMatchers?: object | undefined, value?: string | undefined): void }
+  toMatchObject: (subset: object) => void
+  toMatchSnapshot: { (hint?: string | undefined): void; (propertyMatchers?: object | undefined, hint?: string | undefined): void }
+  toSatisfy: (predicate: (value: T) => boolean) => void
+  toStartWith: (expected: string) => void
+  toStrictEqual: { (expected: T): void; <X = T>(expected: NoInfer<X>): void }
+  toThrow: (expected?: unknown) => void
+  toThrowError: (expected?: unknown) => void
+  toThrowErrorMatchingInlineSnapshot: (value?: string | undefined) => void
+  toThrowErrorMatchingSnapshot: (hint?: string | undefined) => void
+type Mock<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+interface Test<T extends ReadonlyArray<unknown>> (bun-types/test.d.ts)
+  call (label: string, fn: (...args: IsTuple<T> extends true ? [...table: Flatten<T, T>, done: (err?: unknown) => void] : T) => Promise<unknown> | void, options?: TestOptions | number | undefined): void
+  concurrent: Test<T>
+  concurrentIf: (condition: boolean) => Test<T>
+  each: { <T extends readonly [unknown, ...unknown[]]>(table: ReadonlyArray<T>): Test<T>; <T extends Array<unknown>>(table: ReadonlyArray<T>): Test<T>; <T>(table: Array<T>): Test<[T]> }
+  failing: Test<T>
+  failingIf: (condition: boolean) => Test<T>
+  if: (condition: boolean) => Test<T>
+  only: Test<T>
+  serial: Test<T>
+  serialIf: (condition: boolean) => Test<T>
+  skip: Test<T>
+  skipIf: (condition: boolean) => Test<T>
+  todo: Test<T>
+  todoIf: (condition: boolean) => Test<T>
+interface TestOptions (bun-types/test.d.ts)
+  repeats [?]: number | undefined
+  retry [?]: number | undefined
+  timeout [?]: number | undefined
+type Tester (bun-types/test.d.ts) = (this: TesterContext, a: any, b: any, customTesters: Array<Tester>) => boolean | undefined
+interface TesterContext (bun-types/test.d.ts)
+  equals: EqualsFunction
+function afterAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function afterEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeAll (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function beforeEach (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+var describe (bun-types/test.d.ts): Describe<[]>
+var expect (bun-types/test.d.ts): Expect
+var expectTypeOf (bun-types/test.d.ts)
+  call <Actual>(actual: Actual): PositiveExpectTypeOf<Actual>
+  call <Actual>(): PositiveExpectTypeOf<Actual>
+var it (bun-types/test.d.ts): Test<[]>
+namespace jest (bun-types/test.d.ts)
+  type jest.Mock<T extends (...args: Array<any>) => any = (...args: Array<any>) => any> (bun-types/test.d.ts) = Mock<T>
+  type jest.Replaced<T> (bun-types/test.d.ts) = Replaced<T>
+  type jest.Spied<T extends ((...args: Array<any>) => any) | ClassLike> (bun-types/test.d.ts) = T extends ClassLike ? SpiedClass<T> : T extends FunctionLike ? SpiedFunction<T> : never
+  type jest.SpiedClass<T extends ClassLike> (bun-types/test.d.ts) = MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  type jest.SpiedFunction<T extends (...args: Array<any>) => any> (bun-types/test.d.ts) = MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  type jest.SpiedGetter<T> (bun-types/test.d.ts) = MockInstance<() => T>
+  type jest.SpiedSetter<T> (bun-types/test.d.ts) = MockInstance<(arg: T) => void>
+  function jest.advanceTimersByTime (bun-types/test.d.ts)
+    call (milliseconds: number): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.advanceTimersToNextTimer (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.clearAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.clearAllTimers (bun-types/test.d.ts)
+    call (): void
+  function jest.fn (bun-types/test.d.ts)
+    call <T extends (...args: Array<any>) => any>(func?: T | undefined): Mock<T>
+  function jest.getTimerCount (bun-types/test.d.ts)
+    call (): number
+  function jest.isFakeTimers (bun-types/test.d.ts)
+    call (): boolean
+  function jest.resetAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.restoreAllMocks (bun-types/test.d.ts)
+    call (): void
+  function jest.runAllTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.runOnlyPendingTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.setSystemTime (bun-types/test.d.ts)
+    call (now?: Date | number | undefined): void
+  function jest.setTimeout (bun-types/test.d.ts)
+    call (milliseconds: number): void
+  function jest.spyOn (bun-types/test.d.ts)
+    call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+  function jest.useFakeTimers (bun-types/test.d.ts)
+    call (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  function jest.useRealTimers (bun-types/test.d.ts)
+    call (): { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var mock (bun-types/test.d.ts)
+  call <T extends (...args: Array<any>) => any>(Function?: T | undefined): Mock<T>
+  clearAllMocks: () => void
+  module: (id: string, factory: () => any) => Promise<void> | void
+  restore: () => void
+function onTestFinished (bun-types/test.d.ts)
+  call (fn: (() => Promise<unknown> | void) | ((done: (err?: unknown) => void) => void), options?: HookOptions | undefined): void
+function setDefaultTimeout (bun-types/test.d.ts)
+  call (milliseconds: number): void
+function setSystemTime (bun-types/test.d.ts)
+  call (now?: Date | number | undefined): ThisType<void>
+function spyOn (bun-types/test.d.ts)
+  call <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K): Mock<Extract<T[K], (...args: Array<any>) => any>>
+test -> it
+var vi (bun-types/test.d.ts)
+  advanceTimersByTime: (milliseconds: number) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  advanceTimersToNextTimer: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  clearAllMocks: () => void
+  clearAllTimers: () => void
+  fn: <T extends (...args: Array<any>) => any>(func?: T | undefined) => Mock<T>
+  getTimerCount: () => number
+  isFakeTimers: () => boolean
+  mock: (id: string, factory: () => any) => Promise<void> | void
+  resetAllMocks: () => void
+  restoreAllMocks: () => void
+  runAllTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  runOnlyPendingTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  spyOn: <T extends object, K extends number | string | symbol>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>
+  useFakeTimers: (options?: "legacy" | "modern" | undefined | { now?: number | Date | undefined; }) => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+  useRealTimers: () => { fn: <T extends (...args: any[]) => any>(func?: T | undefined) => Mock<T>; spyOn: <T extends object, K extends keyof T>(obj: T, methodOrPropertyValue: K) => Mock<Extract<T[K], (...args: Array<any>) => any>>; mock: (id: string, factory: () => any) => void | Promise<void>; restoreAllMocks: () => void; clearAllMocks: () => void; resetAllMocks: () => void; useFakeTimers: (options?: "modern" | { now?: number | Date | undefined; } | "legacy" | undefined) => any; useRealTimers: () => any; advanceTimersByTime: (milliseconds: number) => any; advanceTimersToNextTimer: () => any; runAllTimers: () => any; runOnlyPendingTimers: () => any; getTimerCount: () => number; clearAllTimers: () => void; isFakeTimers: () => boolean; }
+var xdescribe (bun-types/test.d.ts): Describe<[]>
+var xit (bun-types/test.d.ts): Test<[]>
+xtest -> xit
+
+# globals
+interface AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => void
+  signal [readonly]: AbortSignal
+var AbortController (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  construct new (): AbortController
+  prototype: AbortController
+interface AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  aborted [readonly]: boolean
+  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  onabort: ((this: AbortSignal, ev: Event) => any) | null
+  reason [readonly]: any
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+  throwIfAborted: () => void
+var AbortSignal (@types/node/web-globals/abortcontroller.d.ts, bun-types/globals.d.ts)
+  construct new (): AbortSignal
+  abort: (reason?: any) => AbortSignal
+  any: (signals: Array<AbortSignal>) => AbortSignal
+  prototype: AbortSignal
+  timeout: (ms: number) => AbortSignal
+interface AddEventListenerOptions (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  capture [?]: boolean | undefined
+  once [?]: boolean | undefined
+  passive [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  [Symbol.toStringTag] [readonly]: "ArrayBuffer"
+  byteLength [readonly]: number
+  resize: (byteLength: number) => ArrayBuffer
+  slice: { (begin?: number | undefined, end?: number | undefined): ArrayBuffer; (begin: number, end?: number | undefined): ArrayBuffer }
+var ArrayBuffer (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts): ArrayBufferConstructor
+interface ArrayBufferConstructor (bun-types/globals.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2017.arraybuffer.d.ts, lib.es5.d.ts)
+  construct new (byteLength: number): ArrayBuffer
+  construct new (): ArrayBuffer
+  construct new (byteLength: number, options: { maxByteLength?: number | undefined; }): ArrayBuffer
+  [Symbol.species] [readonly]: ArrayBufferConstructor
+  isView: (arg: any) => arg is ArrayBufferView<ArrayBufferLike>
+  prototype [readonly]: ArrayBuffer
+interface ArrayConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  call (arrayLength?: number | undefined): Array<any>
+  call <T>(arrayLength: number): Array<T>
+  call <T>(...items: Array<T>): Array<T>
+  construct new (arrayLength?: number | undefined): Array<any>
+  construct new <T>(arrayLength: number): Array<T>
+  construct new <T>(...items: Array<T>): Array<T>
+  [Symbol.species] [readonly]: ArrayConstructor
+  from: { <T>(arrayLike: ArrayLike<T>): Array<T>; <T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U>; <T>(iterable: ArrayLike<T> | Iterable<T>): Array<T>; <T, U>(iterable: ArrayLike<T> | Iterable<T>, mapfn: (v: T, k: number) => U, thisArg?: any): Array<U> }
+  fromAsync: { <T>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>): Promise<Array<Awaited<T>>>; <T, U>(arrayLike: ArrayLike<T> | AsyncIterable<T> | Iterable<T>, mapFn?: ((value: T, index: number) => U) | undefined, thisArg?: any): Promise<Array<Awaited<U>>> }
+  isArray: (arg: any) => arg is any[]
+  of: <T>(...items: Array<T>) => Array<T>
+  prototype [readonly]: Array<any>
+interface Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  size [readonly]: number
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+var Blob (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  construct new (blobParts?: Array<BlobPart> | undefined, options?: BlobPropertyBag | undefined): Blob
+  prototype: Blob
+interface BlobPropertyBag (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  type [?]: string | undefined
+interface BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (ev: BroadcastChannelEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  name [readonly]: string
+  onmessage: ((ev: MessageEvent<any>) => void) | null
+  onmessageerror: ((ev: MessageEvent<any>) => void) | null
+  postMessage: (message: any) => void
+  ref: () => BroadcastChannel
+  removeEventListener: { <K extends keyof BroadcastChannelEventMap>(type: K, listener: (ev: BroadcastChannelEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  unref: () => BroadcastChannel
+var BroadcastChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (name: string): BroadcastChannel
+  prototype: BroadcastChannel
+var BuildError (bun-types/deprecated.d.ts): typeof BuildMessage
+class BuildMessage (bun-types/globals.d.ts)
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "BuildMessage"
+  position [readonly]: Position | null
+  [static]
+    construct new (): BuildMessage
+    prototype: BuildMessage
+Bun -> module "bun"
+interface BunFetchRequestInit (bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  compress [?]: "br" | "deflate" | "gzip" | "zstd" | boolean | undefined | { encoding: "gzip" | "deflate" | "zstd" | "br"; level?: number | undefined; }
+  credentials [?]: RequestCredentials | undefined
+  decompress [?]: boolean | undefined
+  dispatcher [?]: Dispatcher | undefined
+  duplex [?]: "half" | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  maxRedirects [?]: number | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  protocol [?]: "h1" | "h2" | "h3" | "http1.1" | "http2" | "http3" | undefined
+  proxy [?]: URL | string | undefined | { url: string | URL; headers?: HeadersInit | undefined; }
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  s3 [?]: S3Options | undefined
+  signal [?]: AbortSignal | null | undefined
+  timeout [?]: boolean | number | undefined
+  tls [?]: BunFetchRequestInitTLS | undefined
+  unix [?]: string | undefined
+  verbose [?]: boolean | undefined
+  window [?]: null | undefined
+interface BunFetchRequestInitTLS (bun-types/globals.d.ts)
+  ALPNProtocols [?]: BufferSource | string | undefined
+  ca [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  caFile [?]: string | undefined
+  cert [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  certFile [?]: string | undefined
+  checkServerIdentity [?]: ((hostname: string, cert: PeerCertificate) => Error | undefined) | undefined
+  ciphers [?]: string | undefined
+  clientRenegotiationLimit [?]: number | undefined
+  clientRenegotiationWindow [?]: number | undefined
+  dhParamsFile [?]: string | undefined
+  key [?]: Array<string | BunFile | BufferSource> | BufferSource | BunFile | string | undefined
+  keyFile [?]: string | undefined
+  lowMemoryMode [?]: boolean | undefined
+  passphrase [?]: string | undefined
+  rejectUnauthorized [?]: boolean | undefined
+  requestCert [?]: boolean | undefined
+  secureOptions [?]: number | undefined
+  serverName [?]: string | undefined
+interface ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<ArrayBufferView<ArrayBufferLike>>
+var ByteLengthQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (init: QueuingStrategyInit): ByteLengthQueuingStrategy
+  prototype: ByteLengthQueuingStrategy
+interface CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  code [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  reason [readonly]: string
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  wasClean [readonly]: boolean
+var CloseEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: CloseEventInit | undefined): CloseEvent
+  prototype: CloseEvent
+interface CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<BufferSource>
+var CompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): CompressionStream
+  prototype: CompressionStream
+interface Console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts)
+  Console [readonly]: { new (stdout: WritableStream, stderr?: WritableStream | undefined, ignoreErrors?: boolean | undefined): Console; new (options: ConsoleOptions): Console; prototype: Console; }
+  [Symbol.asyncIterator]: () => AsyncIterableIterator<string>
+  assert: (condition?: boolean | undefined, ...data: Array<any>) => void
+  clear: () => void
+  count: (label?: string | undefined) => void
+  countReset: (label?: string | undefined) => void
+  debug: (...data: Array<any>) => void
+  dir: (item?: any, options?: any) => void
+  dirxml: (...data: Array<any>) => void
+  error: (...data: Array<any>) => void
+  group: (...data: Array<any>) => void
+  groupCollapsed: (...data: Array<any>) => void
+  groupEnd: () => void
+  info: (...data: Array<any>) => void
+  log: (...data: Array<any>) => void
+  profile: (label?: string | undefined) => void
+  profileEnd: (label?: string | undefined) => void
+  table: (tabularData?: any, properties?: Array<string> | undefined) => void
+  time: (label?: string | undefined) => void
+  timeEnd: (label?: string | undefined) => void
+  timeLog: (label?: string | undefined, ...data: Array<any>) => void
+  timeStamp: (label?: string | undefined) => void
+  trace: (...data: Array<any>) => void
+  warn: (...data: Array<any>) => void
+  write: (...data: Array<string | ArrayBuffer | ArrayBufferView<ArrayBufferLike>>) => number
+interface ConsoleOptions (bun-types/globals.d.ts)
+  colorMode [?]: "auto" | boolean | undefined
+  groupIndentation [?]: number | undefined
+  ignoreErrors [?]: boolean | undefined
+  inspectOptions [?]: InspectOptions | undefined
+  stderr [?]: Writable | undefined
+  stdout: Writable
+interface CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [readonly]: number
+  size [readonly]: QueuingStrategySize<any>
+var CountQueuingStrategy (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (init: QueuingStrategyInit): CountQueuingStrategy
+  prototype: CountQueuingStrategy
+interface Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  getRandomValues: <T extends ArrayBufferView<ArrayBufferLike> | null>(array: T) => T
+  randomUUID: () => `${string}-${string}-${string}-${string}-${string}`
+  subtle [readonly]: SubtleCrypto
+  timingSafeEqual: (a: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>, b: ArrayBufferLike | ArrayBufferView<ArrayBufferLike>) => boolean
+var Crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): Crypto
+  prototype: Crypto
+interface CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  algorithm [readonly]: KeyAlgorithm
+  extractable [readonly]: boolean
+  type [readonly]: KeyType
+  usages [readonly]: Array<KeyUsage>
+var CryptoKey (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): CryptoKey
+  prototype: CryptoKey
+interface CryptoKeyPair (bun-types/globals.d.ts)
+  privateKey: CryptoKey
+  publicKey: CryptoKey
+interface CustomEvent<T = any> (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  detail [readonly]: T
+  eventPhase [readonly]: number
+  initCustomEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, detail?: T | undefined) => void
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var CustomEvent (@types/node/web-globals/events.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  construct new <T>(type: string, eventInitDict?: CustomEventInit<T> | undefined): CustomEvent<T>
+  prototype: CustomEvent<any>
+interface DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  cause [?]: unknown
+  code [readonly]: number
+  message [readonly]: string
+  name [readonly]: string
+  stack [?]: string | undefined
+var DOMException (@types/node/web-globals/domexception.d.ts, bun-types/deprecated.d.ts, bun-types/globals.d.ts)
+  construct new (message?: string | undefined, name?: string | undefined): DOMException
+  ABORT_ERR [readonly]: 20
+  DATA_CLONE_ERR [readonly]: 25
+  DOMSTRING_SIZE_ERR [readonly]: 2
+  HIERARCHY_REQUEST_ERR [readonly]: 3
+  INDEX_SIZE_ERR [readonly]: 1
+  INUSE_ATTRIBUTE_ERR [readonly]: 10
+  INVALID_ACCESS_ERR [readonly]: 15
+  INVALID_CHARACTER_ERR [readonly]: 5
+  INVALID_MODIFICATION_ERR [readonly]: 13
+  INVALID_NODE_TYPE_ERR [readonly]: 24
+  INVALID_STATE_ERR [readonly]: 11
+  NAMESPACE_ERR [readonly]: 14
+  NETWORK_ERR [readonly]: 19
+  NOT_FOUND_ERR [readonly]: 8
+  NOT_SUPPORTED_ERR [readonly]: 9
+  NO_DATA_ALLOWED_ERR [readonly]: 6
+  NO_MODIFICATION_ALLOWED_ERR [readonly]: 7
+  QUOTA_EXCEEDED_ERR [readonly]: 22
+  SECURITY_ERR [readonly]: 18
+  SYNTAX_ERR [readonly]: 12
+  TIMEOUT_ERR [readonly]: 23
+  TYPE_MISMATCH_ERR [readonly]: 17
+  URL_MISMATCH_ERR [readonly]: 21
+  VALIDATION_ERR [readonly]: 16
+  WRONG_DOCUMENT_ERR [readonly]: 4
+  prototype: DOMException
+interface DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<BufferSource>
+var DecompressionStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (format: CompressionFormat, strategy?: undefined | { highWaterMark?: number | undefined; }): DecompressionStream
+  prototype: DecompressionStream
+interface Dict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined
+interface ErrnoException (bun-types/globals.d.ts)
+  cause [?]: unknown
+  code [?]: string | undefined
+  errno [?]: number | undefined
+  message: string
+  name: string
+  path [?]: string | undefined
+  stack [?]: string | undefined
+  syscall [?]: string | undefined
+interface Error (bun-types/globals.d.ts, lib.es5.d.ts)
+  cause [?]: unknown
+  message: string
+  name: string
+  stack [?]: string | undefined
+var Error (bun-types/globals.d.ts, lib.es5.d.ts): ErrorConstructor
+interface ErrorConstructor (@types/node/globals.d.ts, bun-types/globals.d.ts, lib.es5.d.ts)
+  call (message?: string | undefined): Error
+  construct new (message?: string | undefined): Error
+  construct new (message?: string | undefined, options?: ErrorOptions | undefined): Error
+  captureStackTrace: { (targetObject: object, constructorOpt?: Function | undefined): void; (targetObject: object, constructorOpt?: Function | undefined): void }
+  isError: (value: unknown) => value is Error
+  prepareStackTrace: (err: Error, stackTraces: Array<CallSite>) => any
+  prototype [readonly]: Error
+  stackTraceLimit: number
+interface ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  colno [readonly]: number
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  error [readonly]: any
+  eventPhase [readonly]: number
+  filename [readonly]: string
+  isTrusted [readonly]: boolean
+  lineno [readonly]: number
+  message [readonly]: string
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var ErrorEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: ErrorEventInit | undefined): ErrorEvent
+  prototype: ErrorEvent
+interface ErrorOptions (bun-types/globals.d.ts)
+  cause [?]: unknown
+interface Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var Event (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  construct new (type: string, eventInitDict?: EventInit | undefined): Event
+  AT_TARGET [readonly]: 2
+  BUBBLING_PHASE [readonly]: 3
+  CAPTURING_PHASE [readonly]: 1
+  NONE [readonly]: 0
+  prototype: Event
+interface EventListener (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  call (evt: Event): void
+interface EventListenerObject (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  handleEvent: (object: Event) => void
+interface EventMap (bun-types/globals.d.ts)
+  fetch: FetchEvent
+  message: MessageEvent<any>
+  messageerror: MessageEvent<any>
+interface EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  CLOSED [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  addEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: EventSource, ev: ErrorEvent) => any) | null
+  onmessage: ((this: EventSource, ev: MessageEvent<any>) => any) | null
+  onopen: ((this: EventSource, ev: Event) => any) | null
+  readyState [readonly]: 0 | 1 | 2
+  removeEventListener: { <K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  url [readonly]: string
+  withCredentials [readonly]: boolean
+var EventSource (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (): EventSource
+  prototype: EventSource
+interface EventSourceInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  withCredentials [?]: boolean | undefined
+interface EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  addEventListener: (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  removeEventListener: (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined) => void
+var EventTarget (@types/node/web-globals/events.d.ts, bun-types/globals.d.ts)
+  construct new (): EventTarget
+  prototype: EventTarget
+interface FetchEvent (bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  isTrusted [readonly]: boolean
+  preventDefault: () => void
+  request [readonly]: Request
+  respondWith: (response: Promise<Response> | Response) => void
+  returnValue: boolean
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+  url [readonly]: string
+  waitUntil: (promise: Promise<any>) => void
+interface File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  arrayBuffer: () => Promise<ArrayBuffer>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  formData: () => Promise<FormData>
+  image: (options?: ConstructorOptions | undefined) => Image
+  json: () => Promise<any>
+  lastModified [readonly]: number
+  name [readonly]: string
+  size [readonly]: number
+  stream: () => ReadableStream<Uint8Array<ArrayBuffer>>
+  text: () => Promise<string>
+  type [readonly]: string
+var File (@types/node/web-globals/blob.d.ts, bun-types/globals.d.ts)
+  construct new (parts: Array<BlobPart>, name: string, options?: BlobPropertyBag & { lastModified?: number | Date | undefined; } | undefined): File
+  prototype: File
+interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  append: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  delete: (name: string) => void
+  entries: () => IterableIterator<[string, string]>
+  forEach: (callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any) => void
+  get: (name: string) => FormDataEntryValue | null
+  getAll: (name: string) => Array<FormDataEntryValue>
+  has: (name: string) => boolean
+  keys: () => IterableIterator<string>
+  set: { (name: string, value: Blob | string): void; (name: string, value: string): void; (name: string, blobValue: Blob, filename?: string | undefined): void }
+  values: () => IterableIterator<string>
+var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (): FormData
+  prototype: FormData
+class HTMLRewriter (bun-types/html-rewriter.d.ts)
+  on: (selector: string, handlers: HTMLRewriterElementContentHandlers) => HTMLRewriter
+  onDocument: (handlers: HTMLRewriterDocumentContentHandlers) => HTMLRewriter
+  transform: { (input: Response): Response; (input: string): string; (input: BufferSource): ArrayBuffer }
+  [static]
+    construct new (): HTMLRewriter
+    prototype: HTMLRewriter
+namespace HTMLRewriterTypes (bun-types/html-rewriter.d.ts)
+  interface HTMLRewriterTypes.Comment (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Comment
+    before: (content: string, options?: ContentOptions | undefined) => Comment
+    remove: () => Comment
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Comment
+    text: string
+  type HTMLRewriterTypes.Content (bun-types/html-rewriter.d.ts) = string
+  interface HTMLRewriterTypes.ContentOptions (bun-types/html-rewriter.d.ts)
+    html [?]: boolean | undefined
+  interface HTMLRewriterTypes.Doctype (bun-types/html-rewriter.d.ts)
+    name [readonly]: null | string
+    publicId [readonly]: null | string
+    remove: () => Doctype
+    removed [readonly]: boolean
+    systemId [readonly]: null | string
+  interface HTMLRewriterTypes.DocumentEnd (bun-types/html-rewriter.d.ts)
+    append: (content: string, options?: ContentOptions | undefined) => DocumentEnd
+  interface HTMLRewriterTypes.Element (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Element
+    append: (content: string, options?: ContentOptions | undefined) => Element
+    attributes [readonly]: IterableIterator<[string, string]>
+    before: (content: string, options?: ContentOptions | undefined) => Element
+    canHaveContent [readonly]: boolean
+    getAttribute: (name: string) => null | string
+    hasAttribute: (name: string) => boolean
+    namespaceURI [readonly]: string
+    onEndTag: (handler: (tag: EndTag) => Promise<void> | void) => void
+    prepend: (content: string, options?: ContentOptions | undefined) => Element
+    remove: () => Element
+    removeAndKeepContent: () => Element
+    removeAttribute: (name: string) => Element
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Element
+    selfClosing [readonly]: boolean
+    setAttribute: (name: string, value: string) => Element
+    setInnerContent: (content: string, options?: ContentOptions | undefined) => Element
+    tagName: string
+  interface HTMLRewriterTypes.EndTag (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => EndTag
+    before: (content: string, options?: ContentOptions | undefined) => EndTag
+    name: string
+    remove: () => EndTag
+  interface HTMLRewriterTypes.HTMLRewriterDocumentContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    doctype [?]: ((doctype: Doctype) => Promise<void> | void) | undefined
+    end [?]: ((end: DocumentEnd) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.HTMLRewriterElementContentHandlers (bun-types/html-rewriter.d.ts)
+    comments [?]: ((comment: Comment) => Promise<void> | void) | undefined
+    element [?]: ((element: Element) => Promise<void> | void) | undefined
+    text [?]: ((text: Text) => Promise<void> | void) | undefined
+  interface HTMLRewriterTypes.Text (bun-types/html-rewriter.d.ts)
+    after: (content: string, options?: ContentOptions | undefined) => Text
+    before: (content: string, options?: ContentOptions | undefined) => Text
+    lastInTextNode [readonly]: boolean
+    remove: () => Text
+    removed [readonly]: boolean
+    replace: (content: string, options?: ContentOptions | undefined) => Text
+    text [readonly]: string
+interface Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  [Symbol.iterator] [readonly]: () => SpecIterableIterator<[string, string]>
+  append [readonly]: (name: string, value: string) => void
+  count [readonly]: number
+  delete [readonly]: (name: string) => void
+  entries [readonly]: () => SpecIterableIterator<[string, string]>
+  forEach [readonly]: (callbackfn: (value: string, key: string, iterable: Headers) => void, thisArg?: unknown) => void
+  get [readonly]: (name: string) => null | string
+  getAll: (name: "Set-Cookie" | "set-cookie") => Array<string>
+  getSetCookie [readonly]: () => Array<string>
+  has [readonly]: (name: string) => boolean
+  keys [readonly]: () => SpecIterableIterator<string>
+  set [readonly]: (name: string, value: string) => void
+  toJSON: () => Record<string, string> & { "set-cookie"?: Array<string> | undefined; }
+  values [readonly]: () => SpecIterableIterator<string>
+var Headers (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (init?: HeadersInit | undefined): Headers
+  prototype: Headers
+interface ImportMeta (@types/node/web-globals/importmeta.d.ts, bun-types/devserver.d.ts, bun-types/globals.d.ts, lib.es5.d.ts)
+  dir [readonly]: string
+  dirname: string
+  env [readonly]: Env & ProcessEnv & ImportMetaEnv
+  file [readonly]: string
+  filename: string
+  hot: { data: any; accept(): void; accept(cb: (newModule: any) => void): void; accept(specifier: string, callback: (newModule: any) => void): void; accept(specifiers: Array<string>, callback: (newModules: Array<any>) => void): void; dispose(cb: (data: any) => void | Promise<void>): void; decline(): void; on(event: HMREvent, callback: () => void): void; off(event: HMREvent, callback: () => void): void; }
+  main: boolean
+  path [readonly]: string
+  require: Require
+  resolve: (specifier: string, parent?: URL | string | undefined) => string
+  resolveSync: (moduleId: string, parent?: string | undefined) => string
+  url: string
+interface ImportMetaEnv (bun-types/globals.d.ts)
+  index [string]: string | undefined
+var Loader (bun-types/globals.d.ts)
+  dependencyKeysIfEvaluated: (specifier: string) => Array<string>
+  registry: Map<string, { key: string; state: number; fetch: Promise<any>; instantiate: Promise<any>; satisfy: Promise<any>; dependencies: Array<any>; module: { dependenciesMap: Map<string, any>; }; linkError?: any; linkSucceeded: boolean; evaluated: boolean; then?: any; isAsync: boolean; }>
+  resolve: (specifier: string, referrer: string) => string
+interface MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  port1 [readonly]: MessagePort
+  port2 [readonly]: MessagePort
+var MessageChannel (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (): MessageChannel
+  prototype: MessageChannel
+interface MessageEvent<T = any> (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  bubbles [readonly]: boolean
+  cancelBubble: boolean
+  cancelable [readonly]: boolean
+  composed [readonly]: boolean
+  composedPath: () => [(EventTarget | undefined)?]
+  currentTarget [readonly]: EventTarget | null
+  data [readonly]: T
+  defaultPrevented [readonly]: boolean
+  eventPhase [readonly]: number
+  initMessageEvent: (type: string, bubbles?: boolean | undefined, cancelable?: boolean | undefined, data?: any, origin?: string | undefined, lastEventId?: string | undefined, source?: null | undefined) => void
+  isTrusted [readonly]: boolean
+  lastEventId [readonly]: string
+  origin [readonly]: string
+  ports [readonly]: ReadonlyArray<MessagePort>
+  preventDefault: () => void
+  returnValue: boolean
+  source [readonly]: null | undefined
+  srcElement [readonly]: EventTarget | null
+  stopImmediatePropagation: () => void
+  stopPropagation: () => void
+  target [readonly]: EventTarget | null
+  timeStamp [readonly]: number
+  type [readonly]: string
+var MessageEvent (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new <T>(type: string, eventInitDict?: MessageEventInit<T> | undefined): MessageEvent<any>
+  prototype: MessageEvent<any>
+interface MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  addListener: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  close: () => void
+  dispatchEvent: (event: Event) => boolean
+  emit: { (event: "close", ev: Event): boolean; (event: "message", value: any): boolean; (event: "messageerror", error: Error): boolean; (event: string, arg: any): boolean }
+  eventNames: () => Array<string>
+  getMaxListeners: () => number
+  hasRef: () => boolean
+  listenerCount: (type: string) => number
+  off: { (event: "close", listener: (ev: Event) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "message", listener: (value: any) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions | undefined): MessagePort; (event: string, listener: (arg: any) => void, options?: EventListenerOptions | undefined): MessagePort }
+  on: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  once: { (event: "close", listener: (ev: Event) => void): MessagePort; (event: "message", listener: (value: any) => void): MessagePort; (event: "messageerror", listener: (error: Error) => void): MessagePort; (event: string, listener: (arg: any) => void): MessagePort }
+  onclose: ((ev: Event) => void) | null
+  onmessage: ((ev: MessageEvent<any>) => void) | null
+  onmessageerror: ((ev: MessageEvent<any>) => void) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeAllListeners: (type?: string | undefined) => MessagePort
+  removeEventListener: { <K extends keyof MessagePortEventMap>(type: K, listener: (ev: MessagePortEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  removeListener: { (event: "close", listener: (ev: Event) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "message", listener: (value: any) => void, options?: EventListenerOptions | undefined): MessagePort; (event: "messageerror", listener: (error: Error) => void, options?: EventListenerOptions | undefined): MessagePort; (event: string, listener: (arg: any) => void, options?: EventListenerOptions | undefined): MessagePort }
+  setMaxListeners: (n: number) => void
+  start: () => void
+  unref: () => void
+var MessagePort (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  construct new (): MessagePort
+  prototype: MessagePort
+interface Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
+  hardwareConcurrency [readonly]: number
+  language [readonly]: string
+  languages [readonly]: ReadonlyArray<string>
+  locks [readonly]: LockManager
+  platform [readonly]: "Linux x86_64" | "MacIntel" | "Win32"
+  userAgent [readonly]: string
+var Navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts)
+  construct new (): Navigator
+  prototype: Navigator
+namespace NodeJS (@types/node/buffer.d.ts, @types/node/events.d.ts, @types/node/globals.d.ts, @types/node/globals.typedarray.d.ts, @types/node/module.d.ts, @types/node/process.d.ts, @types/node/stream.d.ts, @types/node/timers.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+  type NodeJS.AllowSharedBufferSource (@types/node/globals.d.ts) = ArrayBufferLike | ArrayBufferView<ArrayBufferLike>
+  type NodeJS.Architecture (@types/node/process.d.ts) = "arm" | "arm64" | "ia32" | "mips" | "mipsel" | "ppc64" | "s390x" | "x64" | "loong64" | "riscv64"
+  type NodeJS.ArrayBufferView<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = TypedArray<TArrayBuffer> | DataView<TArrayBuffer>
+  interface NodeJS.AsyncIterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.asyncDispose]: () => PromiseLike<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => Promise<IteratorResult<T, TReturn>>
+    return [?]: ((value?: PromiseLike<TReturn> | TReturn | undefined) => Promise<IteratorResult<T, TReturn>>) | undefined
+    throw [?]: ((e?: any) => Promise<IteratorResult<T, TReturn>>) | undefined
+  type NodeJS.BeforeExitListener (@types/node/process.d.ts) = (code: number) => void
+  type NodeJS.BufferEncoding (@types/node/buffer.d.ts) = "ascii" | "utf8" | "utf-8" | "utf16le" | "utf-16le" | "ucs2" | "ucs-2" | "base64" | "base64url" | "latin1" | "binary" | "hex"
+  type NodeJS.BufferSource (@types/node/globals.d.ts) = ArrayBuffer | NonSharedArrayBufferView
+  interface NodeJS.CallSite (@types/node/globals.d.ts)
+    getColumnNumber: () => null | number
+    getEnclosingColumnNumber: () => null | number
+    getEnclosingLineNumber: () => null | number
+    getEvalOrigin: () => string | undefined
+    getFileName: () => null | string
+    getFunction: () => Function | undefined
+    getFunctionName: () => null | string
+    getLineNumber: () => null | number
+    getMethodName: () => null | string
+    getPosition: () => number
+    getPromiseIndex: () => null | number
+    getScriptHash: () => string
+    getScriptNameOrSourceURL: () => null | string
+    getThis: () => unknown
+    getTypeName: () => null | string
+    isAsync: () => boolean
+    isConstructor: () => boolean
+    isEval: () => boolean
+    isNative: () => boolean
+    isPromiseAll: () => boolean
+    isToplevel: () => boolean
+  interface NodeJS.CpuUsage (@types/node/process.d.ts)
+    system: number
+    user: number
+  interface NodeJS.Dict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined
+  type NodeJS.DisconnectListener (@types/node/process.d.ts) = () => void
+  interface NodeJS.EmitWarningOptions (@types/node/process.d.ts)
+    code [?]: string | undefined
+    ctor [?]: Function | undefined
+    detail [?]: string | undefined
+    type [?]: string | undefined
+  interface NodeJS.ErrnoException (@types/node/globals.d.ts)
+    cause [?]: unknown
+    code [?]: string | undefined
+    errno [?]: number | undefined
+    message: string
+    name: string
+    path [?]: string | undefined
+    stack [?]: string | undefined
+    syscall [?]: string | undefined
+  interface NodeJS.EventEmitter<T extends EventMap<T> = any> (@types/node/events.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: IfEventMap<T, E | keyof EventEmitterEventMap | (keyof T & (string | symbol)), string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    emit: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, ...args: IfEventMap<T, E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>, Array<any>>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener?: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void> | undefined) => number
+    listeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    off: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    on: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    once: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    prependOnceListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    rawListeners: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>) => Array<IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>>
+    removeAllListeners: <E extends string | symbol>(eventName?: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol> | undefined) => EventEmitter<T>
+    removeListener: <E extends string | symbol>(eventName: IfEventMap<T, keyof EventEmitterEventMap | (keyof T & (string | symbol)) | E, string | symbol>, listener: IfEventMap<T, (...args: E extends keyof T ? T[E] : E extends keyof EventEmitterEventMap ? EventEmitterEventMap[E] : Array<any>) => void, (...args: Array<any>) => void>) => EventEmitter<T>
+    setMaxListeners: (n: number) => EventEmitter<T>
+  type NodeJS.ExitListener (@types/node/process.d.ts) = (code: number) => void
+  interface NodeJS.GCFunction (@types/node/globals.d.ts)
+    call (minor?: boolean | undefined): void
+    call (options: GCOptions & { execution: "async"; }): Promise<void>
+    call (options: GCOptions): void
+  interface NodeJS.GCOptions (@types/node/globals.d.ts)
+    execution [?]: "async" | "sync" | undefined
+    filename [?]: string | undefined
+    flavor [?]: "last-resort" | "regular" | undefined
+    type [?]: "major" | "major-snapshot" | "minor" | undefined
+  interface NodeJS.HRTime (@types/node/process.d.ts)
+    call (time?: [number, number] | undefined): [number, number]
+    bigint: () => bigint
+  interface NodeJS.Immediate (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    _onImmediate: (...args: Array<any>) => void
+    hasRef: () => boolean
+    ref: () => Immediate
+    unref: () => Immediate
+  interface NodeJS.Iterator<T, TReturn = undefined, TNext = any> (@types/node/globals.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.iterator]: () => Iterator<T, TReturn, TNext>
+    next: (...__0: [TNext] | []) => IteratorResult<T, TReturn>
+    return [?]: ((value?: TReturn | undefined) => IteratorResult<T, TReturn>) | undefined
+    throw [?]: ((e?: any) => IteratorResult<T, TReturn>) | undefined
+  interface NodeJS.MemoryUsage (@types/node/process.d.ts)
+    arrayBuffers: number
+    external: number
+    heapTotal: number
+    heapUsed: number
+    rss: number
+  interface NodeJS.MemoryUsageFn (@types/node/process.d.ts)
+    call (): MemoryUsage
+    rss: () => number
+  type NodeJS.MessageListener (@types/node/process.d.ts) = (message: string | number | boolean | object | null, sendHandle: SendHandle) => void
+  interface NodeJS.Module (@types/node/module.d.ts)
+    children: Array<Module>
+    exports: any
+    filename: string
+    id: string
+    isPreloading: boolean
+    loaded: boolean
+    parent: Module | null | undefined
+    path: string
+    paths: Array<string>
+    require: (id: string) => any
+  type NodeJS.NonSharedArrayBufferView (@types/node/globals.typedarray.d.ts) = TypedArray<ArrayBuffer> | DataView<ArrayBuffer>
+  type NodeJS.NonSharedBigInt64Array (@types/node/globals.typedarray.d.ts) = BigInt64Array<ArrayBuffer>
+  type NodeJS.NonSharedBigUint64Array (@types/node/globals.typedarray.d.ts) = BigUint64Array<ArrayBuffer>
+  type NodeJS.NonSharedDataView (@types/node/globals.typedarray.d.ts) = DataView<ArrayBuffer>
+  type NodeJS.NonSharedFloat16Array (@types/node/globals.typedarray.d.ts) = Float16Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat32Array (@types/node/globals.typedarray.d.ts) = Float32Array<ArrayBuffer>
+  type NodeJS.NonSharedFloat64Array (@types/node/globals.typedarray.d.ts) = Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedInt16Array (@types/node/globals.typedarray.d.ts) = Int16Array<ArrayBuffer>
+  type NodeJS.NonSharedInt32Array (@types/node/globals.typedarray.d.ts) = Int32Array<ArrayBuffer>
+  type NodeJS.NonSharedInt8Array (@types/node/globals.typedarray.d.ts) = Int8Array<ArrayBuffer>
+  type NodeJS.NonSharedTypedArray (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer> | Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> | Int8Array<ArrayBuffer> | Int16Array<ArrayBuffer> | Int32Array<ArrayBuffer> | BigUint64Array<ArrayBuffer> | BigInt64Array<ArrayBuffer> | Float16Array<ArrayBuffer> | Float32Array<ArrayBuffer> | Float64Array<ArrayBuffer>
+  type NodeJS.NonSharedUint16Array (@types/node/globals.typedarray.d.ts) = Uint16Array<ArrayBuffer>
+  type NodeJS.NonSharedUint32Array (@types/node/globals.typedarray.d.ts) = Uint32Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8Array (@types/node/globals.typedarray.d.ts) = Uint8Array<ArrayBuffer>
+  type NodeJS.NonSharedUint8ClampedArray (@types/node/globals.typedarray.d.ts) = Uint8ClampedArray<ArrayBuffer>
+  type NodeJS.PartialOptions<T> (@types/node/globals.d.ts) = { [K in keyof T]?: T[K] | undefined; }
+  type NodeJS.Platform (@types/node/process.d.ts) = "aix" | "android" | "darwin" | "freebsd" | "haiku" | "linux" | "openbsd" | "sunos" | "win32" | "cygwin" | "netbsd"
+  interface NodeJS.Process (@types/node/process.d.ts, bun-types/deprecated.d.ts, bun-types/overrides.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    _exiting: boolean
+    abort: () => never
+    addListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    addUncaughtExceptionCaptureCallback: (fn: (err: unknown) => boolean) => void
+    allowedNodeEnvironmentFlags: ReadonlySet<string>
+    arch [readonly]: Architecture
+    argv: Array<string>
+    argv0: string
+    assert: (value: unknown, message?: Error | string | undefined) => asserts value
+    availableMemory: () => number
+    binding: { (m: "constants"): { os: typeof constants; fs: typeof constants; crypto: typeof constants; zlib: typeof constants; trace: { TRACE_EVENT_PHASE_BEGIN: number; TRACE_EVENT_PHASE_END: number; TRACE_EVENT_PHASE_COMPLETE: number; TRACE_EVENT_PHASE_INSTANT: number; TRACE_EVENT_PHASE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_ASYNC_STEP_INTO: number; TRACE_EVENT_PHASE_ASYNC_STEP_PAST: number; TRACE_EVENT_PHASE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_BEGIN: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_END: number; TRACE_EVENT_PHASE_NESTABLE_ASYNC_INSTANT: number; TRACE_EVENT_PHASE_FLOW_BEGIN: number; TRACE_EVENT_PHASE_FLOW_STEP: number; TRACE_EVENT_PHASE_FLOW_END: number; TRACE_EVENT_PHASE_METADATA: number; TRACE_EVENT_PHASE_COUNTER: number; TRACE_EVENT_PHASE_SAMPLE: number; TRACE_EVENT_PHASE_CREATE_OBJECT: number; TRACE_EVENT_PHASE_SNAPSHOT_OBJECT: number; TRACE_EVENT_PHASE_DELETE_OBJECT: number; TRACE_EVENT_PHASE_MEMORY_DUMP: number; TRACE_EVENT_PHASE_MARK: number; TRACE_EVENT_PHASE_CLOCK_SYNC: number; TRACE_EVENT_PHASE_ENTER_CONTEXT: number; TRACE_EVENT_PHASE_LEAVE_CONTEXT: number; TRACE_EVENT_PHASE_LINK_IDS: number; }; }; (m: "uv"): { errname(code: number): string; UV_E2BIG: number; UV_EACCES: number; UV_EADDRINUSE: number; UV_EADDRNOTAVAIL: number; UV_EAFNOSUPPORT: number; UV_EAGAIN: number; UV_EAI_ADDRFAMILY: number; UV_EAI_AGAIN: number; UV_EAI_BADFLAGS: number; UV_EAI_BADHINTS: number; UV_EAI_CANCELED: number; UV_EAI_FAIL: number; UV_EAI_FAMILY: number; UV_EAI_MEMORY: number; UV_EAI_NODATA: number; UV_EAI_NONAME: number; UV_EAI_OVERFLOW: number; UV_EAI_PROTOCOL: number; UV_EAI_SERVICE: number; UV_EAI_SOCKTYPE: number; UV_EALREADY: number; UV_EBADF: number; UV_EBUSY: number; UV_ECANCELED: number; UV_ECHARSET: number; UV_ECONNABORTED: number; UV_ECONNREFUSED: number; UV_ECONNRESET: number; UV_EDESTADDRREQ: number; UV_EEXIST: number; UV_EFAULT: number; UV_EFBIG: number; UV_EHOSTUNREACH: number; UV_EINTR: number; UV_EINVAL: number; UV_EIO: number; UV_EISCONN: number; UV_EISDIR: number; UV_ELOOP: number; UV_EMFILE: number; UV_EMSGSIZE: number; UV_ENAMETOOLONG: number; UV_ENETDOWN: number; UV_ENETUNREACH: number; UV_ENFILE: number; UV_ENOBUFS: number; UV_ENODEV: number; UV_ENOENT: number; UV_ENOMEM: number; UV_ENONET: number; UV_ENOPROTOOPT: number; UV_ENOSPC: number; UV_ENOSYS: number; UV_ENOTCONN: number; UV_ENOTDIR: number; UV_ENOTEMPTY: number; UV_ENOTSOCK: number; UV_ENOTSUP: number; UV_EOVERFLOW: number; UV_EPERM: number; UV_EPIPE: number; UV_EPROTO: number; UV_EPROTONOSUPPORT: number; UV_EPROTOTYPE: number; UV_ERANGE: number; UV_EROFS: number; UV_ESHUTDOWN: number; UV_ESPIPE: number; UV_ESRCH: number; UV_ETIMEDOUT: number; UV_ETXTBSY: number; UV_EXDEV: number; UV_UNKNOWN: number; UV_EOF: number; UV_ENXIO: number; UV_EMLINK: number; UV_EHOSTDOWN: number; UV_EREMOTEIO: number; UV_ENOTTY: number; UV_EFTYPE: number; UV_EILSEQ: number; UV_ESOCKTNOSUPPORT: number; UV_ENODATA: number; UV_EUNATCH: number; }; (m: "http_parser"): { methods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "QUERY"]; allMethods: ["DELETE", "GET", "HEAD", "POST", "PUT", "CONNECT", "OPTIONS", "TRACE", "COPY", "LOCK", "MKCOL", "MOVE", "PROPFIND", "PROPPATCH", "SEARCH", "UNLOCK", "BIND", "REBIND", "UNBIND", "ACL", "REPORT", "MKACTIVITY", "CHECKOUT", "MERGE", "M-SEARCH", "NOTIFY", "SUBSCRIBE", "UNSUBSCRIBE", "PATCH", "PURGE", "MKCALENDAR", "LINK", "UNLINK", "SOURCE", "PRI", "DESCRIBE", "ANNOUNCE", "SETUP", "PLAY", "PAUSE", "TEARDOWN", "GET_PARAMETER", "SET_PARAMETER", "REDIRECT", "RECORD", "FLUSH", "QUERY"]; HTTPParser: unknown; ConnectionsList: unknown; }; (m: string): object }
+    browser: boolean
+    channel [?]: Control | undefined
+    chdir: (directory: string) => void
+    config [readonly]: ProcessConfig
+    connected: boolean
+    constrainedMemory: () => number
+    cpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    cwd: () => string
+    debugPort: number
+    disconnect [?]: (() => void) | undefined
+    dlopen: { (module: object, filename: string, flags?: number | undefined): void; (module: { exports: any; }, filename: string, flags?: number | undefined): void }
+    emit: { <E extends keyof ProcessEventMap>(eventName: E, ...args: ProcessEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean; (event: "memoryPressure", level: "critical" | "warning"): boolean }
+    emitWarning: { (warning: Error | string, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, type?: string | undefined, code?: string | undefined, ctor?: Function | undefined): void; (warning: Error | string, options?: EmitWarningOptions | undefined): void }
+    env: ProcessEnv
+    eventNames: () => Array<string | symbol>
+    execArgv: Array<string>
+    execPath: string
+    execve [?]: ((file: string, args?: ReadonlyArray<string> | undefined, env?: ProcessEnv | undefined) => never) | undefined
+    exit: (code?: null | number | string | undefined) => never
+    exitCode: null | number | string | undefined
+    features [readonly]: ProcessFeatures
+    finalization: { register<T extends object>(ref: T, callback: (ref: T, event: "exit") => void): void; registerBeforeExit<T extends object>(ref: T, callback: (ref: T, event: "beforeExit") => void): void; unregister(ref: object): void; }
+    getActiveResourcesInfo: () => Array<string>
+    getBuiltinModule: { <ID extends keyof BuiltInModule>(id: ID): BuiltInModule[ID]; (id: string): object | undefined }
+    getMaxListeners: () => number
+    getegid [?]: (() => number) | undefined
+    geteuid [?]: (() => number) | undefined
+    getgid [?]: (() => number) | undefined
+    getgroups [?]: (() => Array<number>) | undefined
+    getuid [?]: (() => number) | undefined
+    hasUncaughtExceptionCaptureCallback: () => boolean
+    hrtime: HRTime
+    isBun: true
+    kill: (pid: number, signal?: number | string | undefined) => true
+    listenerCount: { <E extends keyof ProcessEventMap>(eventName: E, listener?: ((...args: ProcessEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    loadEnvFile: (path?: PathLike | undefined) => void
+    mainModule [?]: Module | undefined
+    memoryUsage: MemoryUsageFn
+    nextTick: (callback: Function, ...args: Array<any>) => void
+    noDeprecation [?]: boolean | undefined
+    off: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    on: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    once: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    permission: ProcessPermission
+    pid [readonly]: number
+    platform [readonly]: Platform
+    ppid [readonly]: number
+    prependListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    prependOnceListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process }
+    rawListeners: { <E extends keyof ProcessEventMap>(eventName: E): Array<(...args: ProcessEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    reallyExit: (code?: number | undefined) => never
+    ref: (maybeRefable: any) => void
+    release [readonly]: ProcessRelease
+    removeAllListeners: { <E extends keyof ProcessEventMap>(eventName?: E | undefined): Process; (eventName?: string | symbol | undefined): Process }
+    removeListener: { <E extends keyof ProcessEventMap>(eventName: E, listener: (...args: ProcessEventMap[E]) => void): Process; (eventName: string | symbol, listener: (...args: Array<any>) => void): Process; (event: "memoryPressure", listener: (level: "critical" | "warning") => void): Process; (event: string | symbol, listener: (...args: Array<any>) => void): Process }
+    report: ProcessReport
+    resourceUsage: () => ResourceUsage
+    revision: string
+    send [?]: undefined | { (message: any, sendHandle?: SendHandle, options?: MessageOptions | undefined, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, sendHandle: SendHandle, callback?: ((error: Error | null) => void) | undefined): boolean; (message: any, callback: (error: Error | null) => void): boolean }
+    setMaxListeners: (n: number) => Process
+    setSourceMapsEnabled: (value: boolean) => void
+    setUncaughtExceptionCaptureCallback: (cb: ((err: unknown) => void) | null) => void
+    setegid [?]: ((id: number | string) => void) | undefined
+    seteuid [?]: ((id: number | string) => void) | undefined
+    setgid [?]: ((id: number | string) => void) | undefined
+    setgroups [?]: ((groups: ReadonlyArray<string | number>) => void) | undefined
+    setuid [?]: ((id: number | string) => void) | undefined
+    sourceMapsEnabled [readonly]: boolean
+    stderr: WriteStream & { fd: 2; }
+    stdin: ReadStream & { fd: 0; }
+    stdout: WriteStream & { fd: 1; }
+    threadCpuUsage: (previousValue?: CpuUsage | undefined) => CpuUsage
+    throwDeprecation: boolean
+    title: string
+    traceDeprecation: boolean
+    traceProcessWarnings: boolean
+    umask: { (): number; (mask: number | string): number }
+    unref: (maybeRefable: any) => void
+    uptime: () => number
+    version [readonly]: string
+    versions [readonly]: ProcessVersions
+  interface NodeJS.ProcessConfig (@types/node/process.d.ts)
+    target_defaults [readonly]: { readonly cflags: Array<any>; readonly default_configuration: string; readonly defines: Array<string>; readonly include_dirs: Array<string>; readonly libraries: Array<string>; }
+    variables [readonly]: { readonly clang: number; readonly host_arch: string; readonly node_install_npm: boolean; readonly node_install_waf: boolean; readonly node_prefix: string; readonly node_shared_openssl: boolean; readonly node_shared_v8: boolean; readonly node_shared_zlib: boolean; readonly node_use_dtrace: boolean; readonly node_use_etw: boolean; readonly node_use_openssl: boolean; readonly target_arch: string; readonly v8_no_strict_aliasing: number; readonly v8_use_snapshot: boolean; readonly visibility: string; }
+  interface NodeJS.ProcessEnv (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    NODE_ENV [?]: string | undefined
+    TZ [?]: string | undefined
+  interface NodeJS.ProcessFeatures (@types/node/process.d.ts)
+    cached_builtins [readonly]: boolean
+    debug [readonly]: boolean
+    inspector [readonly]: boolean
+    ipv6 [readonly]: boolean
+    require_module [readonly]: boolean
+    tls [readonly]: boolean
+    tls_alpn [readonly]: boolean
+    tls_ocsp [readonly]: boolean
+    tls_sni [readonly]: boolean
+    typescript [readonly]: "strip" | false
+    uv [readonly]: boolean
+  interface NodeJS.ProcessPermission (@types/node/process.d.ts)
+    has: (scope: string, reference?: string | undefined) => boolean
+  interface NodeJS.ProcessRelease (@types/node/process.d.ts)
+    headersUrl [?]: string | undefined
+    libUrl [?]: string | undefined
+    lts [?]: string | undefined
+    name: string
+    sourceUrl [?]: string | undefined
+  interface NodeJS.ProcessReport (@types/node/process.d.ts)
+    compact: boolean
+    directory: string
+    excludeEnv: boolean
+    filename: string
+    getReport: (err?: Error | undefined) => object
+    reportOnFatalError: boolean
+    reportOnSignal: boolean
+    reportOnUncaughtException: boolean
+    signal: Signals
+    writeReport: { (fileName?: string | undefined, err?: Error | undefined): string; (err?: Error | undefined): string }
+  interface NodeJS.ProcessVersions (@types/node/process.d.ts, bun-types/overrides.d.ts)
+    index [string]: string | undefined
+    ares: string
+    bun: string
+    http_parser: string
+    modules: string
+    node: string
+    openssl: string
+    uv: string
+    v8: string
+    zlib: string
+  interface NodeJS.ReadOnlyDict<T> (@types/node/globals.d.ts)
+    index [string]: T | undefined [readonly]
+  interface NodeJS.ReadStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    closed [readonly]: boolean
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): ReadStream; (port: number, host: string, connectionListener?: (() => void) | undefined): ReadStream; (port: number, connectionListener?: (() => void) | undefined): ReadStream; (path: string, connectionListener?: (() => void) | undefined): ReadStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    destroy: (error?: Error | undefined) => ReadStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof SocketEventMap>(eventName: E, ...args: SocketEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): ReadStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): ReadStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): ReadStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    isPaused: () => boolean
+    isRaw: boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof SocketEventMap>(eventName: E, listener?: ((...args: SocketEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    off: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    on: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    once: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    pause: () => ReadStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    prependOnceListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof SocketEventMap>(eventName: E): Array<(...args: SocketEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => ReadStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof SocketEventMap>(eventName?: E | undefined): ReadStream; (eventName?: string | symbol | undefined): ReadStream }
+    removeListener: { <E extends keyof SocketEventMap>(eventName: E, listener: (...args: SocketEventMap[E]) => void): ReadStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): ReadStream }
+    resetAndDestroy: () => ReadStream
+    resume: () => ReadStream
+    setDefaultEncoding: (encoding: BufferEncoding) => ReadStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => ReadStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => ReadStream
+    setMaxListeners: (n: number) => ReadStream
+    setNoDelay: (noDelay?: boolean | undefined) => ReadStream
+    setRawMode: (mode: boolean) => ReadStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => ReadStream
+    setTypeOfService: (tos: number) => ReadStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => ReadStream
+    unref: () => ReadStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => ReadStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadWriteStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): ReadWriteStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): ReadWriteStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): ReadWriteStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    pause: () => ReadWriteStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadWriteStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadWriteStream
+    resume: () => ReadWriteStream
+    setEncoding: (encoding: BufferEncoding) => ReadWriteStream
+    setMaxListeners: (n: number) => ReadWriteStream
+    unpipe: (destination?: WritableStream | undefined) => ReadWriteStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadWriteStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.ReadableStream (@types/node/stream.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    pause: () => ReadableStream
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => ReadableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => ReadableStream
+    resume: () => ReadableStream
+    setEncoding: (encoding: BufferEncoding) => ReadableStream
+    setMaxListeners: (n: number) => ReadableStream
+    unpipe: (destination?: WritableStream | undefined) => ReadableStream
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => ReadableStream
+  interface NodeJS.RefCounted (@types/node/globals.d.ts)
+    ref: () => RefCounted
+    unref: () => RefCounted
+  type NodeJS.RejectionHandledListener (@types/node/process.d.ts) = (promise: Promise<unknown>) => void
+  interface NodeJS.Require (@types/node/module.d.ts)
+    call (id: string): any
+    cache: Dict<Module>
+    extensions: RequireExtensions
+    main: Module | undefined
+    resolve: RequireResolve
+  interface NodeJS.RequireExtensions (@types/node/module.d.ts)
+    index [string]: ((module: Module, filename: string) => any) | undefined
+    .js: (module: Module, filename: string) => any
+    .json: (module: Module, filename: string) => any
+    .node: (module: Module, filename: string) => any
+  interface NodeJS.RequireResolve (@types/node/module.d.ts)
+    call (request: string, options?: RequireResolveOptions | undefined): string
+    paths: (request: string) => Array<string> | null
+  interface NodeJS.RequireResolveOptions (@types/node/module.d.ts)
+    paths [?]: Array<string> | undefined
+  interface NodeJS.ResourceUsage (@types/node/process.d.ts)
+    fsRead: number
+    fsWrite: number
+    involuntaryContextSwitches: number
+    ipcReceived: number
+    ipcSent: number
+    majorPageFault: number
+    maxRSS: number
+    minorPageFault: number
+    sharedMemorySize: number
+    signalsCount: number
+    swappedOut: number
+    systemCPUTime: number
+    unsharedDataSize: number
+    unsharedStackSize: number
+    userCPUTime: number
+    voluntaryContextSwitches: number
+  type NodeJS.Signals (@types/node/process.d.ts) = "SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" | "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" | "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" | "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"
+  type NodeJS.SignalsListener (@types/node/process.d.ts) = (signal: Signals) => void
+  interface NodeJS.Socket (@types/node/process.d.ts)
+    [Symbol.asyncIterator]: () => AsyncIterableIterator<string | Buffer<ArrayBufferLike>>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): Socket; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): Socket; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): Socket }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    isPaused: () => boolean
+    isTTY [?]: true | undefined
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    pause: () => Socket
+    pipe: <T extends WritableStream>(destination: T, options?: undefined | { end?: boolean | undefined; }) => T
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    read: (size?: number | undefined) => Buffer<ArrayBufferLike> | string
+    readable: boolean
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => Socket
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => Socket
+    resume: () => Socket
+    setEncoding: (encoding: BufferEncoding) => Socket
+    setMaxListeners: (n: number) => Socket
+    unpipe: (destination?: WritableStream | undefined) => Socket
+    unshift: (chunk: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined) => void
+    wrap: (oldStream: ReadableStream) => Socket
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.Timeout (@types/node/timers.d.ts)
+    [Symbol.dispose]: () => void
+    [Symbol.toPrimitive]: () => number
+    _onTimeout: (...args: Array<any>) => void
+    close: () => Timeout
+    hasRef: () => boolean
+    ref: () => Timeout
+    refresh: () => Timeout
+    unref: () => Timeout
+  interface NodeJS.Timer (@types/node/timers.d.ts)
+    [Symbol.toPrimitive]: () => number
+    hasRef: () => boolean
+    ref: () => Timer
+    refresh: () => Timer
+    unref: () => Timer
+  type NodeJS.TypedArray<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (@types/node/globals.typedarray.d.ts) = Uint8Array<TArrayBuffer> | Uint8ClampedArray<TArrayBuffer> | Uint16Array<TArrayBuffer> | Uint32Array<TArrayBuffer> | Int8Array<TArrayBuffer> | Int16Array<TArrayBuffer> | Int32Array<TArrayBuffer> | BigUint64Array<TArrayBuffer> | BigInt64Array<TArrayBuffer> | Float16Array<TArrayBuffer> | Float32Array<TArrayBuffer> | Float64Array<TArrayBuffer>
+  type NodeJS.UncaughtExceptionListener (@types/node/process.d.ts) = (error: Error, origin: UncaughtExceptionOrigin) => void
+  type NodeJS.UncaughtExceptionOrigin (@types/node/process.d.ts) = "uncaughtException" | "unhandledRejection"
+  type NodeJS.UnhandledRejectionListener (@types/node/process.d.ts) = (reason: unknown, promise: Promise<unknown>) => void
+  type NodeJS.WarningListener (@types/node/process.d.ts) = (warning: Error) => void
+  type NodeJS.WorkerListener (@types/node/process.d.ts) = (worker: Worker) => void
+  interface NodeJS.WritableStream (@types/node/stream.d.ts)
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    addListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    emit: <E extends string | symbol>(eventName: string | symbol, ...args: Array<any>) => boolean
+    end: { (cb?: (() => void) | undefined): WritableStream; (data: Uint8Array<ArrayBufferLike> | string, cb?: (() => void) | undefined): WritableStream; (str: string, encoding?: BufferEncoding | undefined, cb?: (() => void) | undefined): WritableStream }
+    eventNames: () => Array<string | symbol>
+    getMaxListeners: () => number
+    listenerCount: <E extends string | symbol>(eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined) => number
+    listeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    off: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    on: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    once: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    prependOnceListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    rawListeners: <E extends string | symbol>(eventName: string | symbol) => Array<(...args: Array<any>) => void>
+    removeAllListeners: <E extends string | symbol>(eventName?: string | symbol | undefined) => WritableStream
+    removeListener: <E extends string | symbol>(eventName: string | symbol, listener: (...args: Array<any>) => void) => WritableStream
+    setMaxListeners: (n: number) => WritableStream
+    writable: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+  interface NodeJS.WriteStream (@types/node/process.d.ts)
+    [Symbol.asyncDispose]: () => Promise<void>
+    [Symbol.asyncIterator]: () => AsyncIterator<any, undefined, any>
+    [Symbol.captureRejectionSymbol] [?]: ((error: Error, event: string | symbol, ...args: Array<any>) => void) | undefined
+    [Symbol.toAsyncStreamable]: () => ByteReadableStream
+    _construct [?]: ((callback: (error?: Error | null | undefined) => void) => void) | undefined
+    _destroy: (error: Error | null, callback: (error?: Error | null | undefined) => void) => void
+    _final: (callback: (error?: Error | null | undefined) => void) => void
+    _read: (size: number) => void
+    _write: (chunk: any, encoding: BufferEncoding, callback: (error?: Error | null | undefined) => void) => void
+    _writev [?]: ((chunks: Array<{ chunk: any; encoding: BufferEncoding; }>, callback: (error?: Error | null | undefined) => void) => void) | undefined
+    addListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    address: () => AddressInfo | {}
+    allowHalfOpen: boolean
+    autoSelectFamilyAttemptedAddresses [readonly]: Array<string>
+    bufferSize [readonly]: number
+    bytesRead [readonly]: number
+    bytesWritten [readonly]: number
+    clearLine: (dir: Direction, callback?: (() => void) | undefined) => boolean
+    clearScreenDown: (callback?: (() => void) | undefined) => boolean
+    closed [readonly]: boolean
+    columns: number
+    compose: (stream: ((source: any) => void) | TransformStream<any, any> | WritableStream | WritableStream<any>, options?: Abortable | undefined) => Duplex
+    connect: { (options: SocketConnectOpts, connectionListener?: (() => void) | undefined): WriteStream; (port: number, host: string, connectionListener?: (() => void) | undefined): WriteStream; (port: number, connectionListener?: (() => void) | undefined): WriteStream; (path: string, connectionListener?: (() => void) | undefined): WriteStream }
+    connecting [readonly]: boolean
+    cork: () => void
+    cursorTo: { (x: number, y?: number | undefined, callback?: (() => void) | undefined): boolean; (x: number, callback: () => void): boolean }
+    destroy: (error?: Error | undefined) => WriteStream
+    destroySoon: () => void
+    destroyed [readonly]: boolean
+    drop: (limit: number, options?: Abortable | undefined) => Readable
+    emit: { <E extends keyof WriteStreamEventMap>(eventName: E, ...args: WriteStreamEventMap[E]): boolean; (eventName: string | symbol, ...args: Array<any>): boolean }
+    end: { (callback?: (() => void) | undefined): WriteStream; (buffer: Uint8Array<ArrayBufferLike> | string, callback?: (() => void) | undefined): WriteStream; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, callback?: (() => void) | undefined): WriteStream }
+    errored [readonly]: Error | null
+    eventNames: () => Array<string | symbol>
+    every: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    filter: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: ReadableOperatorOptions | undefined) => Readable
+    find: { <T>(fn: (data: any, options?: Abortable | undefined) => data is T, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<T | undefined>; (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined): Promise<any> }
+    flatMap: (fn: (data: any, options?: Abortable | undefined) => any, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Readable
+    forEach: (fn: (data: any, options?: Abortable | undefined) => Promise<void> | void, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<void>
+    getColorDepth: (env?: object | undefined) => number
+    getMaxListeners: () => number
+    getTypeOfService: () => number
+    getWindowSize: () => [number, number]
+    hasColors: { (count?: number | undefined): boolean; (env?: object | undefined): boolean; (count: number, env?: object | undefined): boolean }
+    isPaused: () => boolean
+    isTTY: boolean
+    iterator: (options?: ReadableIteratorOptions | undefined) => AsyncIterator<any, undefined, any>
+    listenerCount: { <E extends keyof WriteStreamEventMap>(eventName: E, listener?: ((...args: WriteStreamEventMap[E]) => void) | undefined): number; (eventName: string | symbol, listener?: ((...args: Array<any>) => void) | undefined): number }
+    listeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    localAddress [? readonly]: string | undefined
+    localFamily [? readonly]: string | undefined
+    localPort [? readonly]: number | undefined
+    map: (fn: (data: any, options?: Abortable | undefined) => any, options?: ReadableOperatorOptions | undefined) => Readable
+    moveCursor: (dx: number, dy: number, callback?: (() => void) | undefined) => boolean
+    off: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    on: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    once: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    pause: () => WriteStream
+    pending [readonly]: boolean
+    pipe: <T extends WritableStream>(destination: T, options?: PipeOptions | undefined) => T
+    prependListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    prependOnceListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    push: (chunk: any, encoding?: BufferEncoding | undefined) => boolean
+    rawListeners: { <E extends keyof WriteStreamEventMap>(eventName: E): Array<(...args: WriteStreamEventMap[E]) => void>; (eventName: string | symbol): Array<(...args: Array<any>) => void> }
+    read: (size?: number | undefined) => any
+    readable: boolean
+    readableAborted [readonly]: boolean
+    readableDidRead [readonly]: boolean
+    readableEncoding [readonly]: BufferEncoding | null
+    readableEnded [readonly]: boolean
+    readableFlowing: boolean | null
+    readableHighWaterMark [readonly]: number
+    readableLength [readonly]: number
+    readableObjectMode [readonly]: boolean
+    readyState [readonly]: SocketReadyState
+    reduce: { <T>(fn: (previous: any, data: any, options?: Abortable | undefined) => T): Promise<T>; <T>(fn: (previous: T, data: any, options?: Abortable | undefined) => T, initial: T, options?: Abortable | undefined): Promise<T> }
+    ref: () => WriteStream
+    remoteAddress [readonly]: string | undefined
+    remoteFamily [readonly]: string | undefined
+    remotePort [readonly]: number | undefined
+    removeAllListeners: { <E extends keyof WriteStreamEventMap>(eventName?: E | undefined): WriteStream; (eventName?: string | symbol | undefined): WriteStream }
+    removeListener: { <E extends keyof WriteStreamEventMap>(eventName: E, listener: (...args: WriteStreamEventMap[E]) => void): WriteStream; (eventName: string | symbol, listener: (...args: Array<any>) => void): WriteStream }
+    resetAndDestroy: () => WriteStream
+    resume: () => WriteStream
+    rows: number
+    setDefaultEncoding: (encoding: BufferEncoding) => WriteStream
+    setEncoding: (encoding?: BufferEncoding | undefined) => WriteStream
+    setKeepAlive: (enable?: boolean | undefined, initialDelay?: number | undefined) => WriteStream
+    setMaxListeners: (n: number) => WriteStream
+    setNoDelay: (noDelay?: boolean | undefined) => WriteStream
+    setTimeout: (timeout: number, callback?: (() => void) | undefined) => WriteStream
+    setTypeOfService: (tos: number) => WriteStream
+    some: (fn: (data: any, options?: Abortable | undefined) => Promise<boolean> | boolean, options?: Pick<ReadableOperatorOptions, "signal" | "concurrency"> | undefined) => Promise<boolean>
+    take: (limit: number, options?: Abortable | undefined) => Readable
+    timeout [? readonly]: number | undefined
+    toArray: (options?: Abortable | undefined) => Promise<Array<any>>
+    uncork: () => void
+    unpipe: (destination?: WritableStream | undefined) => WriteStream
+    unref: () => WriteStream
+    unshift: (chunk: any, encoding?: BufferEncoding | undefined) => void
+    wrap: (stream: ReadableStream) => WriteStream
+    writable: boolean
+    writableAborted [readonly]: boolean
+    writableCorked [readonly]: number
+    writableEnded [readonly]: boolean
+    writableFinished [readonly]: boolean
+    writableHighWaterMark [readonly]: number
+    writableLength [readonly]: number
+    writableNeedDrain [readonly]: boolean
+    writableObjectMode [readonly]: boolean
+    write: { (buffer: Uint8Array<ArrayBufferLike> | string, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean; (str: Uint8Array<ArrayBufferLike> | string, encoding?: BufferEncoding | undefined, cb?: ((err?: Error | null | undefined) => void) | undefined): boolean }
+interface NodeModule (@types/node/module.d.ts, bun-types/globals.d.ts)
+  children: Array<Module>
+  exports: any
+  filename: string
+  id: string
+  isPreloading: boolean
+  loaded: boolean
+  parent: Module | null | undefined
+  path: string
+  paths: Array<string>
+  require: (id: string) => any
+interface Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  addEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (ev: PerformanceEventMap[K]) => void, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  clearMarks: (markName?: string | undefined) => void
+  clearMeasures: (measureName?: string | undefined) => void
+  clearResourceTimings: (resourceTimingName?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  eventLoopUtilization: (utilization1?: EventLoopUtilization | undefined, utilization2?: EventLoopUtilization | undefined) => EventLoopUtilization
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: EntryType | undefined) => PerformanceEntryList
+  getEntriesByType: (type: EntryType) => PerformanceEntryList
+  mark: (markName: string, markOptions?: PerformanceMarkOptions | undefined) => PerformanceMark
+  markResourceTiming: (timingInfo: FetchTimingInfo, requestedUrl: string, initiatorType: string, global: unknown, cacheMode: string, bodyInfo: unknown, responseStatus: number, deliveryType?: string | undefined) => PerformanceResourceTiming
+  measure: { (measureName: string, startMark?: string | undefined, endMark?: string | undefined): PerformanceMeasure; (measureName: string, options: PerformanceMeasureOptions, endMark?: string | undefined): PerformanceMeasure }
+  nodeTiming [readonly]: PerformanceNodeTiming
+  now: () => number
+  onresourcetimingbufferfull: ((ev: Event) => void) | null
+  removeEventListener: { <K extends "resourcetimingbufferfull">(type: K, listener: (ev: PerformanceEventMap[K]) => void, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListener | EventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  setResourceTimingBufferSize: (maxSize: number) => void
+  timeOrigin [readonly]: number
+  timerify: <T extends (...args: Array<any>) => any>(fn: T, options?: TimerifyOptions | undefined) => T
+  toJSON: () => any
+var Performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): Performance
+  prototype: Performance
+interface PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  duration [readonly]: number
+  entryType [readonly]: EntryType
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceEntry (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceEntry
+  prototype: PerformanceEntry
+interface PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: "mark"
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMark (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceMark
+  prototype: PerformanceMark
+interface PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  detail [readonly]: any
+  duration [readonly]: number
+  entryType [readonly]: "measure"
+  name [readonly]: string
+  startTime [readonly]: number
+  toJSON: () => any
+var PerformanceMeasure (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceMeasure
+  prototype: PerformanceMeasure
+interface PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  disconnect: () => void
+  observe: (options: PerformanceObserverInit) => void
+  takeRecords: () => PerformanceEntryList
+var PerformanceObserver (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceObserver
+  prototype: PerformanceObserver
+interface PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  getEntries: () => PerformanceEntryList
+  getEntriesByName: (name: string, type?: EntryType | undefined) => PerformanceEntryList
+  getEntriesByType: (type: EntryType) => PerformanceEntryList
+var PerformanceObserverEntryList (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceObserverEntryList
+  prototype: PerformanceObserverEntryList
+interface PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  connectEnd [readonly]: number
+  connectStart [readonly]: number
+  decodedBodySize [readonly]: number
+  domainLookupEnd [readonly]: number
+  domainLookupStart [readonly]: number
+  duration [readonly]: number
+  encodedBodySize [readonly]: number
+  entryType [readonly]: "resource"
+  fetchStart [readonly]: number
+  initiatorType [readonly]: string
+  name [readonly]: string
+  nextHopProtocol [readonly]: string
+  redirectEnd [readonly]: number
+  redirectStart [readonly]: number
+  requestStart [readonly]: number
+  responseEnd [readonly]: number
+  responseStart [readonly]: number
+  responseStatus [readonly]: number
+  secureConnectionStart [readonly]: number
+  startTime [readonly]: number
+  toJSON: () => any
+  transferSize [readonly]: number
+  workerStart [readonly]: number
+var PerformanceResourceTiming (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts)
+  construct new (): PerformanceResourceTiming
+  prototype: PerformanceResourceTiming
+interface Position (bun-types/globals.d.ts)
+  column: number
+  file: string
+  length: number
+  line: number
+  lineText: string
+  namespace: string
+  offset: number
+interface PromiseConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2015.promise.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2020.promise.d.ts)
+  construct new <T>(executor: (resolve: (value: PromiseLike<T> | T) => void, reject: (reason?: any) => void) => void): Promise<T>
+  [Symbol.species] [readonly]: PromiseConstructor
+  all: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<Awaited<T>>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: Awaited<T[P]>; }> }
+  allSettled: { <T extends ReadonlyArray<unknown> | []>(values: T): Promise<{ -readonly [P in keyof T]: PromiseSettledResult<Awaited<T[P]>>; }>; <T>(values: Iterable<T | PromiseLike<T>>): Promise<Array<PromiseSettledResult<Awaited<T>>>> }
+  prototype [readonly]: Promise<any>
+  race: { <T>(values: Iterable<T | PromiseLike<T>>): Promise<Awaited<T>>; <T extends ReadonlyArray<unknown> | []>(values: T): Promise<Awaited<T[number]>> }
+  reject: <T = never>(reason?: any) => Promise<T>
+  resolve: { (): Promise<void>; <T>(value: T): Promise<Awaited<T>>; <T>(value: PromiseLike<T> | T): Promise<Awaited<T>> }
+  try: <T, A extends Array<any> = []>(fn: (...args: A) => PromiseLike<T> | T, ...args: A) => Promise<T>
+  withResolvers: <T>() => { promise: Promise<T>; resolve: (value?: T | PromiseLike<T> | undefined) => void; reject: (reason?: any) => void; }
+interface QueuingStrategy<T = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  highWaterMark [?]: number | undefined
+  size [?]: QueuingStrategySize<T> | undefined
+interface QueuingStrategyInit (bun-types/globals.d.ts)
+  highWaterMark: number
+interface QueuingStrategySize<T = any> (bun-types/globals.d.ts)
+  call (chunk?: T | undefined): number
+interface ReadOnlyDict<T> (bun-types/globals.d.ts)
+  index [string]: T | undefined [readonly]
+interface ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  byobRequest [readonly]: ReadableStreamBYOBRequest | null
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk: NonSharedArrayBufferView) => void
+  error: (e?: any) => void
+var ReadableByteStreamController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableByteStreamController
+  prototype: ReadableByteStreamController
+interface ReadableStream<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+  blob: () => Promise<Blob>
+  bytes: () => Promise<Uint8Array<ArrayBuffer>>
+  cancel: (reason?: any) => Promise<void>
+  getReader: { (options: { mode: "byob"; }): ReadableStreamBYOBReader; (): ReadableStreamDefaultReader<R>; (options?: ReadableStreamGetReaderOptions | undefined): ReadableStreamReader<R> }
+  json: () => Promise<any>
+  locked [readonly]: boolean
+  pipeThrough: <T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions | undefined) => ReadableStream<T>
+  pipeTo: (destination: WritableStream<R>, options?: StreamPipeOptions | undefined) => Promise<void>
+  tee: () => [ReadableStream<R>, ReadableStream<R>]
+  text: () => Promise<string>
+  values: (options?: ReadableStreamIteratorOptions | undefined) => ReadableStreamAsyncIterator<R>
+var ReadableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <R = any>(underlyingSource?: UnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  construct new <R = any>(underlyingSource?: DirectUnderlyingSource<R> | undefined, strategy?: QueuingStrategy<R> | undefined): ReadableStream<R>
+  prototype: ReadableStream<any>
+interface ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+  read: <T extends NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>
+  releaseLock: () => void
+var ReadableStreamBYOBReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamBYOBReader
+  prototype: ReadableStreamBYOBReader
+interface ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  respond: (bytesWritten: number) => void
+  respondWithNewView: (view: NonSharedArrayBufferView) => void
+  view [readonly]: NonSharedArrayBufferView | null
+var ReadableStreamBYOBRequest (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamBYOBRequest
+  prototype: ReadableStreamBYOBRequest
+interface ReadableStreamDefaultController<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  close: () => void
+  desiredSize [readonly]: null | number
+  enqueue: (chunk?: R | undefined) => void
+  error: (e?: any) => void
+var ReadableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): ReadableStreamDefaultController<any>
+  prototype: ReadableStreamDefaultController<any>
+interface ReadableStreamDefaultReadDoneResult (bun-types/globals.d.ts)
+  done: true
+  value [?]: undefined
+interface ReadableStreamDefaultReadValueResult<T> (bun-types/globals.d.ts)
+  done: false
+  value: T
+interface ReadableStreamDefaultReader<R = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+  read: () => Promise<ReadableStreamDefaultReadResult<R>>
+  readMany: () => Promise<ReadableStreamDefaultReadManyResult<R>> | ReadableStreamDefaultReadManyResult<R>
+  releaseLock: () => void
+var ReadableStreamDefaultReader (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>
+  prototype: ReadableStreamDefaultReader<any>
+interface ReadableStreamDirectController (bun-types/globals.d.ts)
+  close: (error?: Error | undefined) => void
+  end: () => Promise<number> | number
+  flush: (wait?: boolean | undefined) => Promise<number> | number
+  start: () => void
+  write: (data: BufferSource | string) => Promise<number> | number
+interface ReadableStreamGenericReader (bun-types/globals.d.ts)
+  cancel: (reason?: any) => Promise<void>
+  closed [readonly]: Promise<void>
+interface ReadableWritablePair<R = any, W = any> (bun-types/globals.d.ts)
+  readable: ReadableStream<R>
+  writable: WritableStream<W>
+interface RegExpConstructor (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es5.d.ts)
+  call (pattern: RegExp | string): RegExp
+  call (pattern: string, flags?: string | undefined): RegExp
+  call (pattern: RegExp | string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string): RegExp
+  construct new (pattern: string, flags?: string | undefined): RegExp
+  construct new (pattern: RegExp | string, flags?: string | undefined): RegExp
+  $&: string
+  $': string
+  $+: string
+  $1: string
+  $2: string
+  $3: string
+  $4: string
+  $5: string
+  $6: string
+  $7: string
+  $8: string
+  $9: string
+  $_: string
+  $`: string
+  [Symbol.species] [readonly]: RegExpConstructor
+  escape: (string: string) => string
+  input: string
+  lastMatch: string
+  lastParen: string
+  leftContext: string
+  prototype [readonly]: RegExp
+  rightContext: string
+interface Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  cache [readonly]: RequestCache
+  clone: () => Request
+  credentials [readonly]: RequestCredentials
+  destination [readonly]: RequestDestination
+  duplex [readonly]: "half"
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  integrity [readonly]: string
+  json [readonly]: () => Promise<unknown>
+  keepalive [readonly]: boolean
+  method [readonly]: string
+  mode [readonly]: RequestMode
+  redirect [readonly]: RequestRedirect
+  referrer [readonly]: string
+  referrerPolicy [readonly]: ReferrerPolicy
+  signal [readonly]: AbortSignal
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  url [readonly]: string
+var Request (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (requestInfo: string, init?: RequestInit | undefined): Request
+  construct new (requestInfo: RequestInit & { url: string; }): Request
+  construct new (requestInfo: Request, init?: RequestInit | undefined): Request
+  prototype: Request
+interface RequestInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  body [?]: BodyInit | null | undefined
+  cache [?]: RequestCache | undefined
+  credentials [?]: RequestCredentials | undefined
+  dispatcher [?]: Dispatcher | undefined
+  duplex [?]: "half" | undefined
+  headers [?]: HeadersInit | undefined
+  integrity [?]: string | undefined
+  keepalive [?]: boolean | undefined
+  method [?]: string | undefined
+  mode [?]: RequestMode | undefined
+  redirect [?]: RequestRedirect | undefined
+  referrer [?]: string | undefined
+  referrerPolicy [?]: ReferrerPolicy | undefined
+  signal [?]: AbortSignal | null | undefined
+  window [?]: null | undefined
+var ResolveError (bun-types/deprecated.d.ts): typeof ResolveMessage
+class ResolveMessage (bun-types/globals.d.ts)
+  code [readonly]: string
+  importKind [readonly]: "at" | "at_conditional" | "dynamic" | "entry_point" | "import" | "internal" | "require" | "require_resolve" | "stmt" | "url"
+  level [readonly]: "debug" | "error" | "info" | "verbose" | "warning"
+  message [readonly]: string
+  name [readonly]: "ResolveMessage"
+  position [readonly]: Position | null
+  referrer [readonly]: string
+  specifier [readonly]: string
+  toString: () => string
+  [static]
+    construct new (): ResolveMessage
+    prototype: ResolveMessage
+interface Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  arrayBuffer [readonly]: () => Promise<ArrayBuffer>
+  blob [readonly]: () => Promise<Blob>
+  body [readonly]: ReadableStream<any> | null
+  bodyUsed [readonly]: boolean
+  bytes [readonly]: () => Promise<Uint8Array<ArrayBufferLike>>
+  clone: () => Response
+  formData [readonly]: () => Promise<FormData>
+  headers: BunHeadersOverride
+  json [readonly]: () => Promise<unknown>
+  ok [readonly]: boolean
+  redirected [readonly]: boolean
+  status [readonly]: number
+  statusText [readonly]: string
+  text [readonly]: () => Promise<string>
+  textStream: () => ReadableStream<string>
+  type [readonly]: ResponseType
+  url [readonly]: string
+var Response (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response
+  error: () => Response
+  json: (body?: any, init?: ResponseInit | number | undefined) => Response
+  redirect: { (url: string, status?: number | undefined): Response; (url: string, init?: ResponseInit | undefined): Response }
+interface ResponseInit (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  headers [? readonly]: HeadersInit | undefined
+  status [? readonly]: number | undefined
+  statusText [? readonly]: string | undefined
+interface ShadowRealm (bun-types/globals.d.ts)
+  evaluate: (sourceText: string) => any
+  importValue: (specifier: string, bindingName: string) => Promise<any>
+var ShadowRealm (bun-types/globals.d.ts)
+  construct new (): ShadowRealm
+  prototype: ShadowRealm
+interface SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts)
+  [Symbol.toStringTag] [readonly]: "SharedArrayBuffer"
+  byteLength [readonly]: number
+  grow: (size: number) => SharedArrayBuffer
+  slice: (begin?: number | undefined, end?: number | undefined) => SharedArrayBuffer
+var SharedArrayBuffer (bun-types/globals.d.ts, lib.es2017.sharedmemory.d.ts): SharedArrayBufferConstructor
+interface StreamPipeOptions (bun-types/globals.d.ts)
+  preventAbort [?]: boolean | undefined
+  preventCancel [?]: boolean | undefined
+  preventClose [?]: boolean | undefined
+  signal [?]: AbortSignal | undefined
+interface SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  decapsulateBits: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource) => Promise<ArrayBuffer>
+  decapsulateKey: (decapsulationAlgorithm: AlgorithmIdentifier, decapsulationKey: CryptoKey, ciphertext: BufferSource, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<CryptoKey>
+  decrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  deriveBits: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length?: null | number | undefined) => Promise<ArrayBuffer>
+  deriveKey: (algorithm: AlgorithmIdentifier | Argon2Params | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, keyUsages: ReadonlyArray<KeyUsage>) => Promise<CryptoKey>
+  digest: (algorithm: AlgorithmIdentifier | CShakeParams | KangarooTwelveParams | TurboShakeParams, data: BufferSource) => Promise<ArrayBuffer>
+  encapsulateBits: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey) => Promise<EncapsulatedBits>
+  encapsulateKey: (encapsulationAlgorithm: AlgorithmIdentifier, encapsulationKey: CryptoKey, sharedKeyAlgorithm: AesDerivedKeyParams | AlgorithmIdentifier | HmacImportParams | KmacImportParams, extractable: boolean, usages: Array<KeyUsage>) => Promise<EncapsulatedKey>
+  encrypt: (algorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  exportKey: { (format: "jwk", key: CryptoKey): Promise<JsonWebKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", key: CryptoKey): Promise<ArrayBuffer>; (format: KeyFormat, key: CryptoKey): Promise<ArrayBuffer | JsonWebKey> }
+  generateKey: { (algorithm: EcKeyGenParams | RsaHashedKeyGenParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKeyPair>; (algorithm: AesKeyGenParams | HmacKeyGenParams | KmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey | CryptoKeyPair> }
+  getPublicKey: (key: CryptoKey, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
+  importKey: { (format: "jwk", keyData: JsonWebKey, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey>; (format: "pkcs8" | "raw" | "raw-public" | "raw-secret" | "raw-seed" | "spki", keyData: BufferSource, algorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>): Promise<CryptoKey> }
+  sign: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, data: BufferSource) => Promise<ArrayBuffer>
+  unwrapKey: (format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams, unwrappedKeyAlgorithm: AesKeyAlgorithm | AlgorithmIdentifier | EcKeyImportParams | HmacImportParams | KmacImportParams | RsaHashedImportParams, extractable: boolean, keyUsages: Array<KeyUsage>) => Promise<CryptoKey>
+  verify: (algorithm: AlgorithmIdentifier | ContextParams | EcdsaParams | KmacParams | RsaPssParams, key: CryptoKey, signature: BufferSource, data: BufferSource) => Promise<boolean>
+  wrapKey: (format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AeadParams | AesCbcParams | AesCtrParams | AlgorithmIdentifier | RsaOaepParams) => Promise<ArrayBuffer>
+var SubtleCrypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts)
+  construct new (): SubtleCrypto
+  prototype: SubtleCrypto
+interface TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  decode: (input?: AllowSharedBufferSource | undefined, options?: TextDecodeOptions | undefined) => string
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+var TextDecoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextDecoder
+  prototype: TextDecoder
+interface TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  encoding [readonly]: string
+  fatal [readonly]: boolean
+  ignoreBOM [readonly]: boolean
+  readable [readonly]: ReadableStream<string>
+  writable [readonly]: WritableStream<BufferSource>
+var TextDecoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TextDecoderStream
+  prototype: TextDecoderStream
+interface TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  encode: (input?: string | undefined) => NonSharedUint8Array
+  encodeInto: (src?: string | undefined, dest?: BufferSource | undefined) => TextEncoderEncodeIntoResult
+  encoding [readonly]: string
+var TextEncoder (@types/node/web-globals/encoding.d.ts, bun-types/globals.d.ts)
+  construct new (encoding?: Encoding | undefined, options?: undefined | { fatal?: boolean | undefined; ignoreBOM?: boolean | undefined; }): TextEncoder
+  prototype: TextEncoder
+interface TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  encoding [readonly]: string
+  readable [readonly]: ReadableStream<NonSharedUint8Array>
+  writable [readonly]: WritableStream<string>
+var TextEncoderStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TextEncoderStream
+  prototype: TextEncoderStream
+interface Timer (bun-types/globals.d.ts)
+  [Symbol.toPrimitive]: () => number
+  hasRef: () => boolean
+  ref: () => Timer
+  refresh: () => Timer
+  unref: () => Timer
+interface TransformStream<I = any, O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  readable [readonly]: ReadableStream<O>
+  writable [readonly]: WritableStream<I>
+var TransformStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <I = any, O = any>(transformer?: Transformer<I, O> | undefined, writableStrategy?: QueuingStrategy<I> | undefined, readableStrategy?: QueuingStrategy<O> | undefined): TransformStream<I, O>
+  prototype: TransformStream<any, any>
+interface TransformStreamDefaultController<O = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  desiredSize [readonly]: null | number
+  enqueue: (chunk?: O | undefined) => void
+  error: (reason?: any) => void
+  terminate: () => void
+var TransformStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): TransformStreamDefaultController<any>
+  prototype: TransformStreamDefaultController<any>
+interface Transformer<I = any, O = any> (bun-types/globals.d.ts)
+  flush [?]: TransformerFlushCallback<O> | undefined
+  readableType [?]: undefined
+  start [?]: TransformerStartCallback<O> | undefined
+  transform [?]: TransformerTransformCallback<I, O> | undefined
+  writableType [?]: undefined
+interface URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  hash: string
+  host: string
+  hostname: string
+  href: string
+  origin [readonly]: string
+  password: string
+  pathname: string
+  port: string
+  protocol: string
+  search: string
+  searchParams [readonly]: URLSearchParams
+  toJSON: () => string
+  username: string
+var URL (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  construct new (url: URL | string, base?: URL | string | undefined): URL
+  canParse: (url: string, base?: string | undefined) => boolean
+  createObjectURL: (object: Blob) => `blob:${string}`
+  parse: (url: string, base?: string | undefined) => URL | null
+  prototype: URL
+  revokeObjectURL: (url: string) => void
+interface URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  [Symbol.iterator]: () => URLSearchParamsIterator<[string, string]>
+  append: (name: string, value: string) => void
+  delete: (name: string, value?: string | undefined) => void
+  entries: () => URLSearchParamsIterator<[string, string]>
+  forEach: (callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any) => void
+  get: (name: string) => null | string
+  getAll: (name: string) => Array<string>
+  has: (name: string, value?: string | undefined) => boolean
+  keys: () => URLSearchParamsIterator<string>
+  set: (name: string, value: string) => void
+  size [readonly]: number
+  sort: () => void
+  toJSON: () => Record<string, string>
+  values: () => URLSearchParamsIterator<string>
+var URLSearchParams (@types/node/web-globals/url.d.ts, bun-types/globals.d.ts)
+  construct new (init?: Iterable<[string, string]> | ReadonlyArray<[string, string]> | Record<string, string | ReadonlyArray<string>> | URLSearchParams | string | undefined): URLSearchParams
+  prototype: URLSearchParams
+interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es5.d.ts)
+  index [number]: number
+  BYTES_PER_ELEMENT [readonly]: number
+  [Symbol.iterator]: () => ArrayIterator<number>
+  [Symbol.toStringTag] [readonly]: "Uint8Array"
+  buffer [readonly]: TArrayBuffer
+  byteLength [readonly]: number
+  byteOffset [readonly]: number
+  copyWithin: (target: number, start: number, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  entries: () => ArrayIterator<[number, number]>
+  every: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  fill: (value: number, start?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  filter: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => any, thisArg?: any) => Uint8Array<ArrayBuffer>
+  find: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number | undefined
+  findIndex: (predicate: (value: number, index: number, obj: Uint8Array<TArrayBuffer>) => boolean, thisArg?: any) => number
+  forEach: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => void, thisArg?: any) => void
+  includes: (searchElement: number, fromIndex?: number | undefined) => boolean
+  indexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  join: (separator?: string | undefined) => string
+  keys: () => ArrayIterator<number>
+  lastIndexOf: (searchElement: number, fromIndex?: number | undefined) => number
+  length [readonly]: number
+  map: (callbackfn: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => number, thisArg?: any) => Uint8Array<ArrayBuffer>
+  reduce: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reduceRight: { (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number): number; (callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => number, initialValue: number): number; <U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array<TArrayBuffer>) => U, initialValue: U): U }
+  reverse: () => Uint8Array<TArrayBuffer>
+  set: (array: ArrayLike<number>, offset?: number | undefined) => void
+  setFromBase64: (base64: string, offset?: number | undefined) => { read: number; written: number; }
+  setFromHex: (hex: string) => { read: number; written: number; }
+  slice: (start?: number | undefined, end?: number | undefined) => Uint8Array<ArrayBuffer>
+  some: (predicate: (value: number, index: number, array: Uint8Array<TArrayBuffer>) => unknown, thisArg?: any) => boolean
+  sort: (compareFn?: ((a: number, b: number) => number) | undefined) => Uint8Array<TArrayBuffer>
+  subarray: (begin?: number | undefined, end?: number | undefined) => Uint8Array<TArrayBuffer>
+  toBase64: (options?: undefined | { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined; }) => string
+  toHex: () => string
+  toLocaleString: { (): string; (locales: Array<string> | string, options?: NumberFormatOptions | undefined): string }
+  toString: () => string
+  valueOf: () => Uint8Array<TArrayBuffer>
+  values: () => ArrayIterator<number>
+var Uint8Array (bun-types/globals.d.ts, lib.es2015.core.d.ts, lib.es2015.iterable.d.ts, lib.es2015.symbol.wellknown.d.ts, lib.es2016.array.include.d.ts, lib.es5.d.ts): Uint8ArrayConstructor
+interface Uint8ArrayConstructor (bun-types/globals.d.ts, lib.es2015.iterable.d.ts, lib.es2017.typedarrays.d.ts, lib.es5.d.ts)
+  construct new (length: number): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new <TArrayBuffer extends ArrayBufferLike = ArrayBuffer>(buffer: TArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<TArrayBuffer>
+  construct new (buffer: ArrayBuffer, byteOffset?: number | undefined, length?: number | undefined): Uint8Array<ArrayBuffer>
+  construct new (array: ArrayBuffer | ArrayLike<number>): Uint8Array<ArrayBuffer>
+  construct new (elements: Iterable<number>): Uint8Array<ArrayBuffer>
+  construct new (): Uint8Array<ArrayBuffer>
+  BYTES_PER_ELEMENT [readonly]: number
+  from: { (arrayLike: ArrayLike<number>): Uint8Array<ArrayBuffer>; <T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array<ArrayBuffer>; (elements: Iterable<number>): Uint8Array<ArrayBuffer>; <T>(elements: Iterable<T>, mapfn?: ((v: T, k: number) => number) | undefined, thisArg?: any): Uint8Array<ArrayBuffer> }
+  fromBase64: (base64: string, options?: undefined | { alphabet?: "base64" | "base64url" | undefined; lastChunkHandling?: "strict" | "loose" | "stop-before-partial" | undefined; }) => Uint8Array<ArrayBuffer>
+  fromHex: (hex: string) => Uint8Array<ArrayBuffer>
+  of: (...items: Array<number>) => Uint8Array<ArrayBuffer>
+  prototype [readonly]: Uint8Array<ArrayBufferLike>
+namespace WebAssembly (bun-types/wasm.d.ts)
+  interface WebAssembly.CompileError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.CompileError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): CompileError
+    construct new (message?: string | undefined): CompileError
+    prototype: CompileError
+  interface WebAssembly.Global<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    value: ValueTypeMap[T]
+    valueOf: () => ValueTypeMap[T]
+  var WebAssembly.Global (bun-types/wasm.d.ts)
+    construct new <T extends keyof ValueTypeMap = keyof ValueTypeMap>(descriptor: GlobalDescriptor<T>, v?: ValueTypeMap[T] | undefined): Global<T>
+    prototype: Global<keyof ValueTypeMap>
+  interface WebAssembly.GlobalDescriptor<T extends keyof ValueTypeMap = keyof ValueTypeMap> (bun-types/wasm.d.ts)
+    mutable [?]: boolean | undefined
+    value: T
+  interface WebAssembly.Instance (bun-types/wasm.d.ts)
+    exports [readonly]: Exports
+  var WebAssembly.Instance (bun-types/wasm.d.ts)
+    construct new (module: Module, importObject?: Imports | undefined): Instance
+    prototype: Instance
+  interface WebAssembly.LinkError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.LinkError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): LinkError
+    construct new (message?: string | undefined): LinkError
+    prototype: LinkError
+  interface WebAssembly.Memory (bun-types/wasm.d.ts)
+    buffer [readonly]: ArrayBuffer
+    grow: (delta: number) => number
+  var WebAssembly.Memory (bun-types/wasm.d.ts)
+    construct new (descriptor: MemoryDescriptor): Memory
+    prototype: Memory
+  interface WebAssembly.MemoryDescriptor (bun-types/wasm.d.ts)
+    initial: number
+    maximum [?]: number | undefined
+    shared [?]: boolean | undefined
+  interface WebAssembly.Module (bun-types/wasm.d.ts)
+  var WebAssembly.Module (bun-types/wasm.d.ts)
+    construct new (bytes: BufferSource): Module
+    customSections: (moduleObject: Module, sectionName: string) => Array<ArrayBuffer>
+    exports: (moduleObject: Module) => Array<ModuleExportDescriptor>
+    imports: (moduleObject: Module) => Array<ModuleImportDescriptor>
+    prototype: Module
+  interface WebAssembly.ModuleExportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    name: string
+  interface WebAssembly.ModuleImportDescriptor (bun-types/wasm.d.ts)
+    kind: ImportExportKind
+    module: string
+    name: string
+  interface WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    cause [?]: unknown
+    message: string
+    name: string
+    stack [?]: string | undefined
+  var WebAssembly.RuntimeError (bun-types/wasm.d.ts)
+    call (message?: string | undefined): RuntimeError
+    construct new (message?: string | undefined): RuntimeError
+    prototype: RuntimeError
+  interface WebAssembly.Table (bun-types/wasm.d.ts)
+    get: (index: number) => any
+    grow: (delta: number, value?: any) => number
+    length [readonly]: number
+    set: (index: number, value?: any) => void
+  var WebAssembly.Table (bun-types/wasm.d.ts)
+    construct new (descriptor: TableDescriptor, value?: any): Table
+    prototype: Table
+  interface WebAssembly.TableDescriptor (bun-types/wasm.d.ts)
+    element: TableKind
+    initial: number
+    maximum [?]: number | undefined
+  interface WebAssembly.ValueTypeMap (bun-types/wasm.d.ts)
+    anyfunc: Function
+    externref: any
+    f32: number
+    f64: number
+    i32: number
+    i64: bigint
+    v128: never
+  interface WebAssembly.WebAssemblyInstantiatedSource (bun-types/wasm.d.ts)
+    instance: Instance
+    module: Module
+  function WebAssembly.compile (bun-types/wasm.d.ts)
+    call (bytes: BufferSource): Promise<Module>
+  function WebAssembly.compileStreaming (bun-types/wasm.d.ts)
+    call (source: PromiseLike<Response> | Response): Promise<Module>
+  function WebAssembly.instantiate (bun-types/wasm.d.ts)
+    call (bytes: BufferSource, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+    call (moduleObject: Module, importObject?: Imports | undefined): Promise<Instance>
+  function WebAssembly.instantiateStreaming (bun-types/wasm.d.ts)
+    call (source: PromiseLike<Response> | Response, importObject?: Imports | undefined): Promise<WebAssemblyInstantiatedSource>
+  function WebAssembly.validate (bun-types/wasm.d.ts)
+    call (bytes: BufferSource): boolean
+interface WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  URL [readonly]: string
+  addEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  binaryType: "arraybuffer" | "nodebuffer"
+  bufferedAmount [readonly]: number
+  close: (code?: number | undefined, reason?: string | undefined) => void
+  dispatchEvent: (event: Event) => boolean
+  extensions [readonly]: string
+  isPaused [readonly]: boolean
+  onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
+  onerror: ((this: WebSocket, ev: Event) => any) | null
+  onmessage: ((this: WebSocket, ev: BunMessageEvent<any>) => any) | null
+  onopen: ((this: WebSocket, ev: Event) => any) | null
+  pause: () => boolean
+  ping: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  pong: (data?: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string | undefined) => void
+  protocol [readonly]: string
+  readyState [readonly]: 0 | 1 | 2 | 3
+  removeEventListener: { <K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  resume: () => boolean
+  send: (data: ArrayBufferLike | ArrayBufferView<ArrayBufferLike> | string) => void
+  terminate: () => void
+  url [readonly]: string
+var WebSocket (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  construct new (url: URL | string, options?: WebSocketOptions | undefined): WebSocket
+  construct new (url: URL | string, protocols?: Array<string> | string | undefined): WebSocket
+  CLOSED [readonly]: 3
+  CLOSING [readonly]: 2
+  CONNECTING [readonly]: 0
+  OPEN [readonly]: 1
+  prototype: WebSocket
+interface Worker (bun-types/globals.d.ts)
+  addEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void }
+  dispatchEvent: (event: Event) => boolean
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => any) | null
+  onmessage: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  onmessageerror: ((this: Worker, ev: BunMessageEvent<any>) => any) | null
+  postMessage: { (message: any, transfer: Array<Transferable>): void; (message: any, options?: StructuredSerializeOptions | undefined): void }
+  ref: () => void
+  removeEventListener: { <K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void; (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void }
+  terminate: () => void
+  threadId: number
+  unref: () => void
+var Worker (bun-types/globals.d.ts)
+  construct new (scriptURL: URL | string, options?: WorkerOptions | undefined): Worker
+  data: any
+  prototype: Worker
+interface WorkerOptions (bun-types/globals.d.ts)
+  argv [?]: Array<any> | undefined
+  credentials [?]: RequestCredentials | undefined
+  env [?]: Record<string, string> | typeof SHARE_ENV | undefined
+  name [?]: string | undefined
+  preload [?]: Array<string> | string | undefined
+  ref [?]: boolean | undefined
+  smol [?]: boolean | undefined
+  type [?]: WorkerType | undefined
+interface WritableStream<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  getWriter: () => WritableStreamDefaultWriter<W>
+  locked [readonly]: boolean
+var WritableStream (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <W = any>(underlyingSink?: UnderlyingSink<W> | undefined, strategy?: QueuingStrategy<W> | undefined): WritableStream<W>
+  prototype: WritableStream<any>
+interface WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  error: (e?: any) => void
+var WritableStreamDefaultController (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new (): WritableStreamDefaultController
+  prototype: WritableStreamDefaultController
+interface WritableStreamDefaultWriter<W = any> (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  abort: (reason?: any) => Promise<void>
+  close: () => Promise<void>
+  closed [readonly]: Promise<void>
+  desiredSize [readonly]: null | number
+  ready [readonly]: Promise<void>
+  releaseLock: () => void
+  write: (chunk?: W | undefined) => Promise<void>
+var WritableStreamDefaultWriter (@types/node/web-globals/streams.d.ts, bun-types/globals.d.ts)
+  construct new <W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>
+  prototype: WritableStreamDefaultWriter<any>
+function addEventListener (bun-types/globals.d.ts)
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: AddEventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean | undefined): void
+function alert (bun-types/globals.d.ts)
+  call (message?: string | undefined): void
+function clearImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (immediate: Immediate | undefined): void
+function clearInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function clearTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (id?: Timer | number | undefined): void
+  call (timeout: Timeout | number | string | undefined): void
+function confirm (bun-types/globals.d.ts)
+  call (message?: string | undefined): boolean
+var console (@types/node/web-globals/console.d.ts, bun-types/globals.d.ts): Console
+var crypto (@types/node/web-globals/crypto.d.ts, bun-types/globals.d.ts): Crypto
+var exports (@types/node/module.d.ts, bun-types/globals.d.ts): any
+function fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  call (input: Request | URL | string, init?: BunFetchRequestInit | undefined): Promise<Response>
+  call (input: Request | URL | string, init?: RequestInit | undefined): Promise<Response>
+  preconnect: (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }) => void
+namespace fetch (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
+  function fetch.preconnect (bun-types/globals.d.ts)
+    call (url: URL | string, options?: undefined | { dns?: boolean | undefined; tcp?: boolean | undefined; http?: boolean | undefined; https?: boolean | undefined; }): void
+var module (@types/node/module.d.ts, bun-types/globals.d.ts): NodeModule
+var navigator (@types/node/web-globals/navigator.d.ts, bun-types/globals.d.ts): Navigator
+var onmessage (bun-types/index.d.ts): never
+var performance (@types/node/web-globals/performance.d.ts, bun-types/globals.d.ts): Performance
+function postMessage (bun-types/globals.d.ts)
+  call (message: any, transfer?: Array<Transferable> | undefined): void
+function prompt (bun-types/globals.d.ts)
+  call (message?: string | undefined, _default?: string | undefined): null | string
+function queueMicrotask (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (callback: (...args: Array<any>) => void): void
+  call (callback: () => void): void
+function removeEventListener (bun-types/globals.d.ts)
+  call <K extends keyof EventMap>(type: K, listener: (this: object, ev: EventMap[K]) => any, options?: EventListenerOptions | boolean | undefined): void
+  call (type: string, listener: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean | undefined): void
+function reportError (bun-types/globals.d.ts)
+  call (error: any): void
+var require (@types/node/module.d.ts, bun-types/globals.d.ts): Require
+function setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, ...args: MakeVoidParameterOptional<TArgs>): Immediate
+  __promisify__: <T = void>(value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setImmediate (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setImmediate.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function setInterval (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, interval?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+function setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  call (handler: TimerHandler, timeout?: number | undefined, ...arguments: Array<any>): Timer
+  call <TArgs extends Array<any>>(callback: (...args: TArgs) => void, delay?: number | undefined, ...args: MakeVoidParameterOptional<TArgs>): Timeout
+  __promisify__: <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined) => Promise<T>
+namespace setTimeout (@types/node/web-globals/timers.d.ts, bun-types/globals.d.ts)
+  function setTimeout.__promisify__ (@types/node/timers/promises.d.ts)
+    call <T = void>(delay?: number | undefined, value?: T | undefined, options?: TimerOptions | undefined): Promise<T>
+function structuredClone (@types/node/web-globals/messaging.d.ts, bun-types/globals.d.ts)
+  call <T>(value: T, options?: StructuredSerializeOptions | undefined): T
+  call <T = any>(value: T, options?: StructuredSerializeOptions | undefined): T


### PR DESCRIPTION
### Problem
- A change to `packages/bun-types` has no review surface for what users see. The `.d.ts` source merges with `lib.dom.d.ts` and `@types/node`, and `UseLibDomIfAvailable` picks a different shape per `lib` setting. A regression in one configuration is invisible in the others.
- The fixture tests catch a declaration that fails to compile. They do not catch a member that disappears or changes type.

### Fix
- `packages/bun-types/scripts/inventory.ts` packs bun-types into a scratch project and resolves, with the TypeScript checker, every symbol that has a declaration in bun-types: globals, the exports of `bun`, `bun:test`, `*.html` and the other declared modules, and the exports bun-types adds to node modules and namespaces (`node:tls`, `buffer`, `NodeJS`). One file per `lib` preset: `esnext`, `esnext-dom`, `es2022`, `es2022-dom`, `no-lib`.
- The output is stable under refactors. Names are fully qualified (`Bun.XML.Document`, `NodeJS.Dict<string>`), union members are sorted at every level the printer reaches, well-known symbol names are normalized, and `@types/node` and `undici-types` are pinned to the lockfile versions. Moving `interface FormData` elsewhere in the file produces no diff.
- `test/integration/bun-types/inventory.test.ts` runs the script with `--check` against `test/integration/bun-types/inventory/*.txt`. The bun-types workflow runs it, now also when `package.json` or `bun.lock` change. Regenerate with `bun packages/bun-types/scripts/inventory.ts` and commit the diff.
- Verified on Linux and Windows. With the diff of #41536 applied, `--check` reports the three `FormData` members that change in each preset and nothing else.

### Background
- `Bun.__internal.LibDomIsLoaded` (`bun.d.ts:320`) tests `typeof globalThis extends { onabort: any }`. `UseLibDomIfAvailable<"X", T>` yields `typeof globalThis.X` when lib.dom is loaded and `T` otherwise. The inventory resolves these per preset, so the same symbol can read differently in `esnext.txt` and `esnext-dom.txt`.
- `@types/node` uses the same idea with `onmessage` as the probe (`web-globals/*.d.ts`). bun-types declares `var onmessage`, so node's web globals always take the "DOM is loaded" branch and resolve to `{}`. Every member of those globals has to come from bun-types.
- A module augmentation (`declare module "node:tls"` in `overrides.d.ts`) merges into a copy of the target symbol. The script reads `checker.getMergedSymbol` so those declarations count.
- The first baseline surfaced type bugs (missing `Blob.slice()` without lib.dom, stale `Loader` and `EventSource` globals, `Bun.MessageEvent` resolving to the constructor under lib.dom). They are fixed separately in #41809 and #39079. This PR changes no types.

<details><summary>Notes</summary>

Format of an entry, with the declaring files in parentheses:

```
interface FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
  entries: () => IterableIterator<[string, string]>
  values: () => IterableIterator<string>
var FormData (@types/node/web-globals/fetch.d.ts, bun-types/globals.d.ts)
  construct new (): FormData
```

Under `esnext-dom` the same interface also lists `lib.dom.d.ts` and shows the overloads that interface merging produces:

```
  values: { (): FormDataIterator<Bun.FormDataEntryValue>; (): IterableIterator<string> }
```

Module sections:

```
# module "*.html"
export = Bun.HTMLBundle

# module "node:tls"
interface BunConnectionOptions (bun-types/overrides.d.ts)
  ...
function connect (@types/node/tls.d.ts, bun-types/overrides.d.ts)
  call (options: BunConnectionOptions, secureConnectListener?: (() => void) | undefined): TLSSocket
  ...
```

Within a namespace that bun-types only augments (`NodeJS`, `WebAssembly` under lib.dom), only the exports with a bun-types declaration are listed. The members of a listed interface are always printed in full, because members that arrive through an `extends` clause in bun-types (`interface ReadableStream<R> extends LibEmptyOrNodeReadableStream<R> {}`) are exactly what a regression would remove.

`ts7.1/` is not covered: the script uses the compiler API of the repository's `typescript` (6.0.2), which cannot parse `declare module "*" with { type: "text" }`.

On Windows, `os.tmpdir()` can be an 8.3 short path. TypeScript canonicalizes node_modules files with the native realpath, which expands it, so the script does the same for every path it compares.

The script takes about 12 seconds for the five presets after the install. `--keep` leaves the scratch project behind, `--preset <name>` limits the run. The test is `skipIf(isDebug)` like the type-checking cases in `bun-types.test.ts`. BuildKite excludes `test/integration/bun-types`, so the GitHub workflow is where it runs.

</details>
