### PR TITLE
FileSink: keep the event loop alive until end() has drained a pipe

### DIFF
--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -857,9 +857,7 @@ impl FileSink {
                 (*this).auto_flusher.with_mut(|a| a.registered.set(false));
                 return false;
             }
-            // `end()` took a short flush and left the tail in the buffer. The
-            // writable poll drains it, and its ref on the loop must stay until
-            // then, or the process exits with the tail unwritten.
+            // After `end()` the writable poll drains the tail and drops the ref.
             if (*this).done.get() {
                 (*this).auto_flusher.with_mut(|a| a.registered.set(false));
                 return false;

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -852,8 +852,15 @@ impl FileSink {
     pub(crate) unsafe fn on_auto_flush(this: *mut FileSink) -> bool {
         // SAFETY: caller contract — `this` is live with write+dealloc provenance.
         unsafe {
-            if (*this).done.get() || !(*this).writer.get().has_pending_data() {
+            if !(*this).writer.get().has_pending_data() {
                 (*this).update_ref(false);
+                (*this).auto_flusher.with_mut(|a| a.registered.set(false));
+                return false;
+            }
+            // `end()` took a short flush and left the tail in the buffer. The
+            // writable poll drains it, and its ref on the loop must stay until
+            // then, or the process exits with the tail unwritten.
+            if (*this).done.get() {
                 (*this).auto_flusher.with_mut(|a| a.registered.set(false));
                 return false;
             }

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -983,12 +983,14 @@ describe("FileSink on a pipe stays alive until end() has drained the buffer", ()
     return { stdoutLength: stdout.length, stderr, exitCode };
   }
 
+  // On Windows uv_write takes the whole chunk at once and end() can return a
+  // plain number, hence Promise.resolve().
   it.concurrent("end() without await", async () => {
     expect(
       await run(`
         const w = Bun.stdout.writer();
         w.write(Buffer.alloc(${size}, 46));
-        w.end().then(() => { settled = "resolved"; }, e => { settled = "rejected: " + e.code; });
+        Promise.resolve(w.end()).then(() => { settled = "resolved"; }, e => { settled = "rejected: " + e.code; });
         console.error("ended");
       `),
     ).toEqual({
@@ -1024,24 +1026,36 @@ describe("FileSink on a pipe stays alive until end() has drained the buffer", ()
   // count arrives on the parent's stdout after it has read everything.
   it.concurrent("Bun.spawn stdin pipe with an unref'd child", async () => {
     const flag = join(tmpdirSync(), "ended");
+    // Polls for the flag with a deadline so that it cannot outlive a parent
+    // that died before writing it.
+    const reader = `
+      const fs = require("fs");
+      const deadline = Date.now() + 60_000;
+      while (!fs.existsSync(process.argv[1])) {
+        if (Date.now() > deadline) {
+          console.error("gave up waiting for " + process.argv[1]);
+          process.exit(3);
+        }
+        Bun.sleepSync(1);
+      }
+      console.log((await Bun.stdin.bytes()).length);
+    `;
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
           const child = Bun.spawn(
-            [
-              process.execPath,
-              "-e",
-              'while (!require("fs").existsSync(process.argv[1])) Bun.sleepSync(1); console.log((await Bun.stdin.bytes()).length);',
-              ${JSON.stringify(flag)},
-            ],
+            [process.execPath, "-e", ${JSON.stringify(reader)}, ${JSON.stringify(flag)}],
             { stdin: "pipe", stdout: "inherit", stderr: "inherit" },
           );
-          child.stdin.write(Buffer.alloc(${size}, 65));
-          child.stdin.end();
-          child.unref();
-          require("fs").writeFileSync(${JSON.stringify(flag)}, "");
+          try {
+            child.stdin.write(Buffer.alloc(${size}, 65));
+            child.stdin.end();
+            child.unref();
+          } finally {
+            require("fs").writeFileSync(${JSON.stringify(flag)}, "");
+          }
         `,
       ],
       env: bunEnv,

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -938,6 +938,121 @@ describe("FileSink flush() from a 'beforeExit' listener", () => {
   });
 });
 
+// A chunk larger than the pipe buffer leaves its tail in the sink's buffer
+// and write() returns a promise. end() after that takes a short flush and
+// hands back the same promise. The writable poll drains the tail over the
+// next loop ticks, so the process must stay alive until it is empty, with or
+// without an await on that promise. It used to exit on the next deferred
+// tick with the tail unwritten.
+describe("FileSink on a pipe stays alive until end() has drained the buffer", () => {
+  const size = 4 * 1024 * 1024;
+
+  // The parent reads stdout only after the child reports on stderr that
+  // end() returned, so the child's first write has already filled the pipe.
+  async function run(body: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          let settled = "pending";
+          process.on("exit", code => console.error(JSON.stringify({ settled, code })));
+          ${body}
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const decoder = new TextDecoder();
+    const reader = proc.stderr.getReader();
+    let stderr = "";
+    while (!stderr.startsWith("ended\n")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      stderr += decoder.decode(value, { stream: true });
+    }
+    const rest = (async () => {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) return;
+        stderr += decoder.decode(value, { stream: true });
+      }
+    })();
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.bytes(), rest, proc.exited]);
+    return { stdoutLength: stdout.length, stderr, exitCode };
+  }
+
+  it.concurrent("end() without await", async () => {
+    expect(
+      await run(`
+        const w = Bun.stdout.writer();
+        w.write(Buffer.alloc(${size}, 46));
+        w.end().then(() => { settled = "resolved"; }, e => { settled = "rejected: " + e.code; });
+        console.error("ended");
+      `),
+    ).toEqual({
+      stdoutLength: size,
+      stderr: "ended\n" + JSON.stringify({ settled: "resolved", code: 0 }) + "\n",
+      exitCode: 0,
+    });
+  });
+
+  it.concurrent("await end() inside an async function", async () => {
+    expect(
+      await run(`
+        async function main() {
+          const w = Bun.stdout.writer();
+          w.write(Buffer.alloc(${size}, 46));
+          const p = w.end();
+          console.error("ended");
+          await p;
+          settled = "resolved";
+        }
+        main();
+      `),
+    ).toEqual({
+      stdoutLength: size,
+      stderr: "ended\n" + JSON.stringify({ settled: "resolved", code: 0 }) + "\n",
+      exitCode: 0,
+    });
+  });
+
+  // The unref'd child does not hold the loop. The bytes still owed to its
+  // stdin must. The child starts to read only once end() has been called, so
+  // the first write has filled the pipe by then. It inherits stdout, so its
+  // count arrives on the parent's stdout after it has read everything.
+  it.concurrent("Bun.spawn stdin pipe with an unref'd child", async () => {
+    const flag = join(tmpdirSync(), "ended");
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const child = Bun.spawn(
+            [
+              process.execPath,
+              "-e",
+              'while (!require("fs").existsSync(process.argv[1])) Bun.sleepSync(1); console.log((await Bun.stdin.bytes()).length);',
+              ${JSON.stringify(flag)},
+            ],
+            { stdin: "pipe", stdout: "inherit", stderr: "inherit" },
+          );
+          child.stdin.write(Buffer.alloc(${size}, 65));
+          child.stdin.end();
+          child.unref();
+          require("fs").writeFileSync(${JSON.stringify(flag)}, "");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: `${size}\n`, stderr: "", exitCode: 0 });
+  });
+});
+
 it("fs.promises.writeFile with iterables under GC pressure does not crash", async () => {
   const dir = tmpdirSync();
   await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- A pipe-backed `FileSink` (`Bun.stdout.writer()`, `Bun.file(fifo).writer()`, `Bun.spawn` `stdin`) loses data when `write()` goes async and the script does not await `end()`. `bun a.mjs | (sleep 1; wc -c)` with a 4 MiB chunk delivers 65536 bytes. The process exits with code 0 a few ms later. An `await end()` inside an async function (not top level) loses the data the same way.
- The cause is `on_auto_flush` (`src/runtime/webcore/FileSink.rs:855`). `write()` enabled the writable poll's ref on the loop for the buffered tail. `end()` took a short flush, set `done`, and returned the pending promise. The deferred auto-flush task then saw `done` and called `update_ref(false)`. Nothing held the loop, so it exited before the poll could drain the tail.

### Fix
- `on_auto_flush` releases the poll's ref only when the buffer is empty. When `done` is set with bytes still buffered, it unregisters itself and leaves the ref in place. The writable poll drains the tail. `on_write` releases the ref once the buffer is empty, then `end_writer` closes the sink and settles the promise.
- Correct because an accepted byte that has not reached the fd is active work. `write()` without `end()` already kept the loop alive for the same bytes. Node keeps the process alive for a pending `stdout.write` too.
- Verified: `test/js/bun/util/filesink.test.ts` (three new tests, all fail on 1.4.3: 694336 and 438528 of 4194304 bytes, and an empty count from the unref'd child). Also the rest of that file, `bun-write.test.js`, the spawn stdin suites, `spawn.test.ts`, `child_process.test.ts`, `process-stdio.test.ts`.

### Background
- `FileSink` is the native writer behind `Blob.writer()` and a subprocess `stdin` pipe. It owns a `StreamingWriter` with a byte buffer and, on a pipe or socket, a `FilePoll` registered for writability.
- `FilePoll::enable_keeping_process_alive` bumps the uws loop's `active` count. The loop exits when that count and the task queues are all zero. `update_ref(bool)` on the sink turns this on or off.
- `on_write` runs after each drain. It sets the ref from `has_pending_data()`. The `AutoFlusher` runs `on_auto_flush` as a deferred task after the current tick, to flush small buffered writes without a poll wake.

<details><summary>Notes</summary>

- `write()` alone, with no `end()`, delivers all 4 MiB on 1.4.3. Only the `end()` path lost data, which pointed at the `done` check.
- The FIFO case (`Bun.file(fifo).writer()`) delivered 3489792 of 4194304 on 1.4.3 and 4194304 with the fix.
- `Bun.spawn` stdin with `unref()`: on 1.4.3 the count depends on how fast the child reads. A `wc -c` that reads from the start often gets all 4 MiB because the first synchronous write loop keeps up. The test makes the child wait until `end()` was called before it reads, so the pipe is full and the result is stable.
- Windows shares `on_auto_flush`. There `has_pending_data()` also covers a `uv_write` in flight, so the ref now stays until the write callback runs.
- Pre-existing failures on main in this container, unrelated to this change: `bun-write.test.js` "copyFileRange is not available > on large files" (5 s timeout in debug), `process-stdio.test.ts` the three `process.stdin` tests, `child_process.test.ts` "spawn in the default shell" and "extra stdio pipes are not double-closed on GC".
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->