### PR TITLE
Fix use-after-free and panic from re-entrant user JS in socket and sink methods

### DIFF
--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3311,7 +3311,11 @@ impl<const SSL: bool> NewSocket<SSL> {
             .get(global, "socket")?
             .ok_or_else(|| global.throw(format_args!("Expected \"socket\" option")))?;
 
-        let handlers = this.get_handlers();
+        // The "socket" getter above runs user JS that can close this socket
+        // and drop its handlers. Re-check before reading them.
+        let Some(handlers) = this.handlers_opt() else {
+            return Ok(JSValue::UNDEFINED);
+        };
         // Parse and validate first: the option getters run user JS that can
         // close this socket and repoint its `Handlers`.
         let reloaded = Handlers::prepare_reload(global, socket_obj)?;
@@ -3380,11 +3384,11 @@ impl<const SSL: bool> NewSocket<SSL> {
         // adopt; the old `isDetached()/isNamedPipe()` guard let those
         // through and the `.connected` payload read below would then be
         // illegal-union-access on a `.connecting` socket.
-        let uws::InternalSocket::Connected(raw_socket) = this.socket.get().socket else {
+        if !matches!(this.socket.get().socket, uws::InternalSocket::Connected(_)) {
             return Err(global.throw_invalid_arguments(format_args!(
                 "upgradeTLS requires an established socket"
             )));
-        };
+        }
         if opts.is_empty_or_undefined_or_null() || opts.is_boolean() || !opts.is_object() {
             return Err(global.throw(format_args!("Expected options object")));
         }
@@ -3517,6 +3521,16 @@ impl<const SSL: bool> NewSocket<SSL> {
             default_data = v;
             default_data.ensure_still_alive();
         }
+
+        // The option getters above run user JS. It can close this socket or
+        // re-enter upgradeTLS on it, which adopts the fd and detaches
+        // `this.socket`, freeing the original `us_socket_t`. Re-read the live
+        // pointer and bail instead of adopting a freed socket.
+        let uws::InternalSocket::Connected(raw_socket) = this.socket.get().socket else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "upgradeTLS requires an established socket"
+            )));
+        };
 
         let vm = handlers.vm;
 

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -477,7 +477,11 @@ impl<T: JsSinkType> JSSink<T> {
                 .to_js(global));
         }
 
-        if !arg.is_string() {
+        // `is_string` is string-like: it admits a `String` object, whose
+        // `to_js_string_view` below runs user JS (`Symbol.toPrimitive`). That
+        // JS can `close()` this sink, which frees it, and the write then reads
+        // freed memory. Accept a primitive string only, which never runs JS.
+        if !arg.is_string_literal() {
             return Err(global.throw_value(global.to_type_error(
                 bun_jsc::ErrorCode::INVALID_ARG_TYPE,
                 format_args!("write() expects a string, ArrayBufferView, or ArrayBuffer"),

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2036,6 +2036,107 @@ it("reload() backs out cleanly when a handler getter closes the socket mid-reloa
   void stderr;
 });
 
+it.each(["end", "terminate"])(
+  "reload() backs out when the top-level socket getter %ss the socket mid-reload",
+  async verb => {
+    // reload() reads opts.socket before it reads the current handlers. A
+    // getter on that property can run JS that closes the socket and drops
+    // its handlers, so reading them with an unchecked accessor panicked with
+    // "No handlers set on Socket". reload() must back out instead.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const h = { data() {}, open() {}, close() {}, error() {} };
+          const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { ...h } });
+          const sock = await Bun.connect({ hostname: "127.0.0.1", port: listener.port, socket: { ...h } });
+          // Let the event loop idle once so the socket is fully settled. On a
+          // settled socket end()/terminate() closes it and drops its handlers
+          // synchronously, which is what triggers the bug from inside reload().
+          await Bun.sleep(20);
+          sock.reload({
+            get socket() {
+              sock.${verb}();
+              return h;
+            },
+          });
+          console.log("reload-ok");
+          sock.end();
+          listener.stop(true);
+          process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("reload-ok");
+    expect(exitCode).toBe(0);
+    void stderr;
+  },
+);
+
+it("upgradeTLS() backs out when an option getter re-enters upgradeTLS on the same socket", async () => {
+  // upgradeTLS() captured the raw us_socket_t, then ran user JS through the
+  // option getters. A getter that re-entered upgradeTLS on the same socket
+  // adopted the fd and freed that socket, so the outer call then adopted a
+  // freed socket and a later write used it after free. The outer call must
+  // re-check the socket after parsing the options and back out.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const h = { data() {}, open() {}, close() {}, error() {}, handshake() {}, drain() {} };
+        const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { ...h } });
+        const sock = await Bun.connect({ hostname: "127.0.0.1", port: listener.port, socket: { ...h } });
+        // Settle the socket first: upgradeTLS only adopts an established fd.
+        await Bun.sleep(20);
+        let inner = null;
+        let reentered = false;
+        const opts = {
+          data: {},
+          socket: { ...h },
+          get tls() {
+            if (!reentered) {
+              reentered = true;
+              try {
+                inner = sock.upgradeTLS({ data: {}, socket: { ...h }, tls: true });
+              } catch {}
+            }
+            return true;
+          },
+        };
+        let outerThrew = false;
+        try {
+          const r = sock.upgradeTLS(opts);
+          if (r && r[0]) r[0].write("a");
+          if (r && r[1]) r[1].write("b");
+        } catch {
+          outerThrew = true;
+        }
+        if (inner && inner[0]) inner[0].write("c");
+        if (inner && inner[1]) inner[1].write("d");
+        try { sock.write("z"); } catch {}
+        console.log("upgrade-ok:" + outerThrew);
+        listener.stop(true);
+        process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe("upgrade-ok:true");
+  expect(exitCode).toBe(0);
+  void stderr;
+});
+
 it("node:net connect() reusing a server-accepted handle keeps the listener's handlers working", async () => {
   // A Bun.listen()-accepted socket wrapper does not own its handlers — they
   // live inside the listener. Reusing such a wrapper as the handle for an

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -183,4 +183,35 @@ describe("ArrayBufferSink", () => {
     if (exitCode !== 0) expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
+
+  it("write() rejects a String object instead of coercing it mid-write", async () => {
+    // write() accepted any string-like value, including a String object. Its
+    // string coercion runs user JS (Symbol.toPrimitive), which can close the
+    // sink and free it, so the write then read freed memory. write() now
+    // accepts a primitive string only, which never runs JS.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const s = new Bun.ArrayBufferSink();
+        s.start({ highWaterMark: 64 });
+        s.write("seed");
+        const h = Object.assign(new String("x"), {
+          [Symbol.toPrimitive]() { s.close(); return "payload"; },
+        });
+        let code = "";
+        try { s.write(h); } catch (e) { code = e.code; }
+        console.log(code);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("ERR_INVALID_ARG_TYPE");
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- Three native methods borrow `this` or a raw native handle, then run user JS through an argument or option conversion, then use the stale capture.
- `ArrayBufferSink` and `FileSink` `write()` accept a `String` object. The string coercion (`to_js_string_view`, `src/runtime/webcore/Sink.rs`) runs `Symbol.toPrimitive`, which can `close()` and free the sink. The write then reads freed memory (ASAN heap-use-after-free in `ArrayBufferSink::write_latin1`).
- `TCPSocket.reload()` reads its handlers with `get_handlers()`, which panics `No handlers set on Socket`, after the `socket` option getter can close the socket and drop them. `TCPSocket.upgradeTLS()` captures the `us_socket_t` before the option getters run. A getter that re-enters `upgradeTLS` on the same socket adopts the fd and frees it, so the outer call adopts a freed socket and a later write uses it after free.

### Fix
- `write()` accepts a primitive string only (`is_string_literal`). A primitive string needs no coercion, so no user JS runs between the type check and the write. A `String` object now throws `ERR_INVALID_ARG_TYPE`.
- `reload()` reads the handlers with `handlers_opt()` after the `socket` getter and backs out when they are gone.
- `upgradeTLS()` keeps the early guard that rejects a non-established socket, then re-reads `this.socket` after the last option getter and before `adopt_tls`, and backs out when the socket is no longer the established fd. No user JS runs between that re-check and `adopt_tls`.
- Verified: `test/js/bun/net/socket.test.ts` (reload end/terminate, upgradeTLS re-entry) and `test/js/bun/util/arraybuffersink.test.ts` (write String object). Each fails on the base build (panic, or ASAN use-after-free) and passes with the fix. Also ran the full two files (pre-existing failures are two tests that reach `www.example.com`, which the sandbox blocks).

### Background
- A sink (`ArrayBufferSink`, `FileSink`) is a native object behind a JS wrapper. `close()` runs `doClose`, which frees the native sink. A host fn that still holds a reference to it then dereferences freed memory.
- `JSValue::is_string()` is string-like: it is true for a `String` object, not only a primitive string. `is_string_literal()` is the primitive-string-only test.
- `upgradeTLS` adopts the socket fd into a TLS context with `adopt_tls`, which consumes the original `us_socket_t` and returns a new one. Adopting an already-adopted (freed) socket is the use-after-free.

<details><summary>Notes</summary>

Reported via a fuzz ledger. The shared shape across all three: resolve a `this`-derived native value first, then convert an argument or option through a path that runs user JS, then use the stale value. The fix follows that shape: validate or re-check liveness after the last conversion that can run JS.

Repro sketches (each crashes on the base build):
- sink: `const s = new Bun.ArrayBufferSink(); s.start({highWaterMark:64}); s.write("seed"); s.write(Object.assign(new String("x"), {[Symbol.toPrimitive](){ s.close(); return "p"; }}))`
- reload: `sock.reload({ get socket(){ sock.end(); return h; } })` on a settled socket
- upgradeTLS: an `opts.tls` getter that re-enters `sock.upgradeTLS(...)`, then a write to the returned sockets

Self-reviewed the diff. The main design question is whether `write()` should reject `String` objects or preserve them by re-acquiring `this` after the coercion. Rejecting is the simpler, allocation-free path, matches the intent of the type check, and no test or documented API depends on passing a `String` object to a byte sink.
</details>
