### PR TITLE
sql: close a TLS socket at once instead of waiting for the peer's close_notify

### DIFF
--- a/src/sql_jsc/lib.rs
+++ b/src/sql_jsc/lib.rs
@@ -40,6 +40,8 @@ pub mod shared {
     #[path = "SQLDataCell.rs"]
     pub mod sql_data_cell;
 
+    pub mod socket_teardown;
+
     pub use cached_structure::CachedStructure;
     pub(crate) use query_binding_iterator::QueryBindingIterator;
 }

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -41,6 +41,7 @@ use crate::mysql::js_mysql_connection::JSMySQLConnection;
 use crate::mysql::js_mysql_query::JSMySQLQuery;
 use crate::mysql::my_sql_request_queue::MySQLRequestQueue;
 use crate::mysql::my_sql_statement::{self as mysql_statement, MySQLStatement, Param};
+use crate::shared::socket_teardown;
 use bun_ptr::RefPtr;
 
 pub use bun_sql::mysql::protocol::error_packet::ErrorPacket;
@@ -282,8 +283,10 @@ impl MySQLConnection {
     }
 
     pub(crate) fn close(&mut self) {
-        self.socket.close(uws::CloseKind::Normal);
         self.write_buffer = OffsetByteList::default();
+        // A copy: the close dispatches `on_close`, which detaches `self.socket`.
+        let socket = self.socket;
+        socket_teardown::close_now(&socket);
     }
 
     pub(crate) fn clean_queue_and_close(

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -33,6 +33,7 @@ use crate::postgres::postgres_sql_statement::{Error as StatementError, Status as
 use crate::postgres::sasl::SASLStatus;
 use crate::shared::CachedStructure as PostgresCachedStructure;
 use crate::shared::connection_ctor_args::ConnectionCtorArgs;
+use crate::shared::socket_teardown;
 use bun_sql::postgres::AnyPostgresError;
 use bun_sql::postgres::PostgresErrorOptions;
 use bun_sql::postgres::PostgresProtocol as protocol;
@@ -1485,11 +1486,13 @@ impl PostgresSQLConnection {
     fn ref_and_close(&self, js_reason: Option<JSValue>) {
         // refAndClose is always called when we wanna to disconnect or when we are closed
 
-        if !self.socket.get().is_closed() {
+        // A copy: the close dispatches `on_close`, which detaches `self.socket`.
+        let socket = *self.socket.get();
+        if !socket.is_closed() {
             // event loop need to be alive to close the socket
             self.poll_ref.with_mut(|r| r.ref_(self.vm_ctx()));
             // will unref on socket close
-            self.socket.get().close(uws::CloseKind::Normal);
+            socket_teardown::close_now(&socket);
         }
 
         // cleanup requests

--- a/src/sql_jsc/shared/socket_teardown.rs
+++ b/src/sql_jsc/shared/socket_teardown.rs
@@ -1,22 +1,16 @@
-//! Teardown of a database socket the client has given up on: `close()`,
-//! an idle or lifetime eviction, a connection timeout, a rejected
-//! certificate, a protocol error.
+//! Teardown of a database socket the client has given up on.
 
 use bun_uws::{AnySocket, CloseCode};
 
 /// Closes `socket` before this returns, whatever the peer does.
-///
-/// `CloseCode::Normal` on a TLS socket keeps the fd until the peer answers
-/// close_notify. This sends close_notify and closes the fd at once, like
-/// libpq and the MySQL client library. `shutdown()` before the handshake
-/// finished makes usockets report the handshake as failed, so it is
-/// skipped. usockets defers `FastShutdown` while ciphertext is stuck behind
-/// a full kernel buffer (a peer that stopped reading); that socket is reset.
+/// `CloseCode::Normal` on a TLS socket would wait for the peer's close_notify.
 pub(crate) fn close_now(socket: &AnySocket) {
+    // shutdown() before the handshake finished makes usockets report the handshake as failed
     if matches!(socket, AnySocket::SocketTls(_)) && socket.is_ssl_handshake_finished() {
         socket.shutdown();
     }
     socket.close(CloseCode::FastShutdown);
+    // usockets defers a fast shutdown while ciphertext is stuck behind a full kernel buffer
     if !socket.is_closed() {
         socket.close(CloseCode::Failure);
     }

--- a/src/sql_jsc/shared/socket_teardown.rs
+++ b/src/sql_jsc/shared/socket_teardown.rs
@@ -1,25 +1,17 @@
 //! Teardown of a database socket the client has given up on: `close()`,
 //! an idle or lifetime eviction, a connection timeout, a rejected
 //! certificate, a protocol error.
-//!
-//! `CloseCode::Normal` on a TLS socket sends close_notify and then keeps the
-//! fd, and with it the close callback, until the peer answers. A peer that
-//! holds its side open (a proxy or load balancer, a partition at shutdown,
-//! the server whose certificate was just rejected) then decides when the
-//! pool's `close()` settles and when the process can exit. libpq and the
-//! MySQL client library send close_notify and close the fd at once.
 
 use bun_uws::{AnySocket, CloseCode};
 
 /// Closes `socket` before this returns, whatever the peer does.
 ///
-/// A TLS socket whose handshake completed sends its close_notify through
-/// `shutdown()` first. Before the handshake there is no session to notify,
-/// and a shut-down socket makes usockets report the unfinished handshake as
-/// failed with no reason. The fd then closes with `FastShutdown`, a FIN. On
-/// plain TCP that equals `Normal`. usockets still defers a fast shutdown
-/// while ciphertext is stuck behind a full kernel buffer, which only a peer
-/// that stopped reading produces. That socket is reset instead.
+/// `CloseCode::Normal` on a TLS socket keeps the fd until the peer answers
+/// close_notify. This sends close_notify and closes the fd at once, like
+/// libpq and the MySQL client library. `shutdown()` before the handshake
+/// finished makes usockets report the handshake as failed, so it is
+/// skipped. usockets defers `FastShutdown` while ciphertext is stuck behind
+/// a full kernel buffer (a peer that stopped reading); that socket is reset.
 pub(crate) fn close_now(socket: &AnySocket) {
     if matches!(socket, AnySocket::SocketTls(_)) && socket.is_ssl_handshake_finished() {
         socket.shutdown();

--- a/src/sql_jsc/shared/socket_teardown.rs
+++ b/src/sql_jsc/shared/socket_teardown.rs
@@ -1,0 +1,31 @@
+//! Teardown of a database socket the client has given up on: `close()`,
+//! an idle or lifetime eviction, a connection timeout, a rejected
+//! certificate, a protocol error.
+//!
+//! `CloseCode::Normal` on a TLS socket sends close_notify and then keeps the
+//! fd, and with it the close callback, until the peer answers. A peer that
+//! holds its side open (a proxy or load balancer, a partition at shutdown,
+//! the server whose certificate was just rejected) then decides when the
+//! pool's `close()` settles and when the process can exit. libpq and the
+//! MySQL client library send close_notify and close the fd at once.
+
+use bun_uws::{AnySocket, CloseCode};
+
+/// Closes `socket` before this returns, whatever the peer does.
+///
+/// A TLS socket whose handshake completed sends its close_notify through
+/// `shutdown()` first. Before the handshake there is no session to notify,
+/// and a shut-down socket makes usockets report the unfinished handshake as
+/// failed with no reason. The fd then closes with `FastShutdown`, a FIN. On
+/// plain TCP that equals `Normal`. usockets still defers a fast shutdown
+/// while ciphertext is stuck behind a full kernel buffer, which only a peer
+/// that stopped reading produces. That socket is reset instead.
+pub(crate) fn close_now(socket: &AnySocket) {
+    if matches!(socket, AnySocket::SocketTls(_)) && socket.is_ssl_handshake_finished() {
+        socket.shutdown();
+    }
+    socket.close(CloseCode::FastShutdown);
+    if !socket.is_closed() {
+        socket.close(CloseCode::Failure);
+    }
+}

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -296,8 +296,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         )
     }
 
-    /// Whether the TLS handshake has completed. Always true for a plain TCP
-    /// socket; false while connecting or once detached.
+    /// Always true for a plain TCP socket. False while connecting or once detached.
     pub fn is_ssl_handshake_finished(&self) -> bool {
         on_socket!(self.socket;
             connected s => s.is_ssl_handshake_finished(),

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -296,6 +296,17 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         )
     }
 
+    /// Whether the TLS handshake has completed. Always true for a plain TCP
+    /// socket; false while connecting or once detached.
+    pub fn is_ssl_handshake_finished(&self) -> bool {
+        on_socket!(self.socket;
+            connected s => s.is_ssl_handshake_finished(),
+            duplex d => d.is_established(),
+            pipe p => p.is_established(),
+            else => false,
+        )
+    }
+
     #[inline]
     pub fn is_closed_or_has_error(&self) -> bool {
         self.is_closed() || self.is_shutdown() || self.get_error() != 0
@@ -954,6 +965,7 @@ impl AnySocket {
         fn is_closed(&self) -> bool;
         fn is_shutdown(&self) -> bool;
         fn is_established(&self) -> bool;
+        fn is_ssl_handshake_finished(&self) -> bool;
         fn close(&self, code: CloseCode);
         fn write(&self, data: &[u8]) -> i32;
         fn set_timeout(&self, seconds: c_uint);

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -464,6 +464,11 @@ impl us_socket_t {
     pub(crate) fn is_established(&self) -> bool {
         c::us_socket_is_established(self) > 0
     }
+
+    /// Always true for a plain TCP socket.
+    pub(crate) fn is_ssl_handshake_finished(&self) -> bool {
+        c::us_socket_is_ssl_handshake_finished(self) > 0
+    }
 }
 
 /// Raw externs. Private — every operation has a typed method on `us_socket_t`.
@@ -576,6 +581,7 @@ mod c {
         pub(super) safe fn us_socket_verify_error(s: &us_socket_t) -> us_bun_verify_error_t;
         pub(super) safe fn us_socket_get_error(s: &us_socket_t) -> c_int;
         pub(super) safe fn us_socket_is_established(s: &us_socket_t) -> i32;
+        pub(super) safe fn us_socket_is_ssl_handshake_finished(s: &us_socket_t) -> i32;
 
         /// ssl_ctx is required (the whole point); sni may be null.
         pub(super) fn us_socket_adopt_tls(

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -380,7 +380,7 @@ test.concurrent("postgres: a rejected certificate over a holding TLS peer does n
       bunExe(),
       "-e",
       `
-      const { SQL } = require("bun");
+      import { SQL } from "bun";
       const sql = new SQL("postgres://u:p@127.0.0.1:${server.port}/db?sslmode=verify-full", { max: 1 });
       const code = await sql.connect().then(() => "connected", e => e.code);
       console.log(code);

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -26,6 +26,7 @@ import {
   mysqlAckSessionSetup,
   mysqlHandshakeV10,
   mysqlOkPacket,
+  mysqlRawPacket,
   mysqlReadPackets,
   neverAnsweringServer,
   pgAuthenticationOk,
@@ -260,7 +261,10 @@ function holdingTlsPeer(
   };
 }
 
-function holdingPostgresPeer(): HoldingPeer {
+// `startupReply` answers the StartupMessage
+function holdingPostgresPeer(
+  startupReply: Buffer = Buffer.concat([pgAuthenticationOk(), pgReadyForQuery("I")]),
+): HoldingPeer {
   let started = false;
   return holdingTlsPeer(
     null,
@@ -272,13 +276,13 @@ function holdingPostgresPeer(): HoldingPeer {
     (socket, _chunk) => {
       if (started) return;
       started = true;
-      // the StartupMessage
-      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery("I")]));
+      socket.write(startupReply);
     },
   );
 }
 
-function holdingMysqlPeer(): HoldingPeer {
+// `authReply` answers the HandshakeResponse that carries sequence id `seq`
+function holdingMysqlPeer(authReply: (seq: number) => Buffer = seq => mysqlOkPacket(seq + 1)): HoldingPeer {
   let buffered = Buffer.alloc(0);
   let authed = false;
   return holdingTlsPeer(
@@ -288,7 +292,7 @@ function holdingMysqlPeer(): HoldingPeer {
       buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
         if (!authed) {
           authed = true;
-          socket.write(mysqlOkPacket(seq + 1));
+          socket.write(authReply(seq));
           return;
         }
         mysqlAckSessionSetup(socket, payload);
@@ -297,9 +301,12 @@ function holdingMysqlPeer(): HoldingPeer {
   );
 }
 
+const postgresTlsUrl = (port: number) => `postgres://u:p@127.0.0.1:${port}/db?sslmode=require`;
+const mysqlTlsUrl = (port: number) => `mysql://root:pw@127.0.0.1:${port}/db`;
+
 const holdingPeers = [
-  ["postgres", holdingPostgresPeer, (port: number) => `postgres://u:p@127.0.0.1:${port}/db?sslmode=require`],
-  ["mysql", holdingMysqlPeer, (port: number) => `mysql://root:pw@127.0.0.1:${port}/db`],
+  ["postgres", holdingPostgresPeer, postgresTlsUrl],
+  ["mysql", holdingMysqlPeer, mysqlTlsUrl],
 ] as const;
 
 for (const [name, peer, url] of holdingPeers) {
@@ -326,6 +333,39 @@ for (const [name, peer, url] of holdingPeers) {
       });
       await sql.connect();
       await closed.promise;
+      await server.ended;
+      await server.closed;
+      await sql.close();
+    },
+  );
+}
+
+// The peer answers the startup with a message the client rejects: a
+// ReadyForQuery before any Authentication message, resp. an auth reply whose
+// header byte no auth packet uses. The client fails the connection from
+// inside the TLS data dispatch, the same path an ErrorResponse during
+// authentication takes.
+const protocolViolations = [
+  ["postgres", () => holdingPostgresPeer(pgReadyForQuery("I")), postgresTlsUrl, "ERR_POSTGRES_UNEXPECTED_MESSAGE"],
+  [
+    "mysql",
+    () => holdingMysqlPeer(seq => mysqlRawPacket(seq + 1, Buffer.from([0x42]))),
+    mysqlTlsUrl,
+    "ERR_MYSQL_UNEXPECTED_PACKET",
+  ],
+] as const;
+
+for (const [name, peer, url, code] of protocolViolations) {
+  test.concurrent(
+    `${name}: a protocol violation closes the socket against a TLS peer that never answers close_notify`,
+    async () => {
+      using server = peer();
+      const sql = new SQL({ url: url(server.port), max: 1, tls: { rejectUnauthorized: false } });
+      const settled = await sql.connect().then(
+        () => "connected",
+        e => e.code,
+      );
+      expect(settled).toBe(code);
       await server.ended;
       await server.closed;
       await sql.close();

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -312,22 +312,25 @@ for (const [name, peer, url] of holdingPeers) {
     await server.closed;
   });
 
-  test.concurrent(`${name}: idleTimeout eviction settles against a TLS peer that never answers close_notify`, async () => {
-    using server = peer();
-    const closed = Promise.withResolvers<void>();
-    const sql = new SQL({
-      url: url(server.port),
-      max: 1,
-      idleTimeout: 1,
-      tls: { rejectUnauthorized: false },
-      onclose: () => closed.resolve(),
-    });
-    await sql.connect();
-    await closed.promise;
-    await server.ended;
-    await server.closed;
-    await sql.close();
-  });
+  test.concurrent(
+    `${name}: idleTimeout eviction settles against a TLS peer that never answers close_notify`,
+    async () => {
+      using server = peer();
+      const closed = Promise.withResolvers<void>();
+      const sql = new SQL({
+        url: url(server.port),
+        max: 1,
+        idleTimeout: 1,
+        tls: { rejectUnauthorized: false },
+        onclose: () => closed.resolve(),
+      });
+      await sql.connect();
+      await closed.promise;
+      await server.ended;
+      await server.closed;
+      await sql.close();
+    },
+  );
 }
 
 test.concurrent("postgres: a rejected certificate over a holding TLS peer does not pin the process", async () => {
@@ -353,4 +356,3 @@ test.concurrent("postgres: a rejected certificate over a holding TLS peer does n
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
-

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -16,9 +16,22 @@
 // connectionTimeout: 0 disables the connect timer, so close() is the only
 // thing that can tear the connection down — without the fix these tests hang.
 
-import { SQL } from "bun";
+import { SQL, type Socket } from "bun";
 import { expect, mock, test } from "bun:test";
-import { listeningServer, neverAnsweringServer, pgAuthenticationOk, pgReadyForQuery } from "./wire-frames";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
+import {
+  listeningServer,
+  MYSQL_CLIENT_SSL,
+  MYSQL_DEFAULT_CAPABILITIES,
+  mysqlAckSessionSetup,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  neverAnsweringServer,
+  pgAuthenticationOk,
+  pgReadyForQuery,
+  pgSSLResponse,
+} from "./wire-frames";
 
 const drivers = [
   ["postgres", "postgres://postgres@", "ERR_POSTGRES_CONNECTION_CLOSED"],
@@ -179,3 +192,165 @@ test("pool scans tolerate unassigned connection slots during pool start", async 
     server.close();
   }
 });
+
+// A TLS peer that stays silent after the client's close_notify: it answers
+// the handshake, reports itself ready, and then holds its side of the
+// connection open (a half-open proxy, a partition at shutdown). The client
+// used to send close_notify and keep the fd until the peer replied, so the
+// pool's close() never settled and the process never exited. Teardown of a
+// connection the client has given up on must not depend on the peer.
+//
+// Bun.listen peers instead of node:tls: a TLSSocket wrapped over a net.Socket
+// always ends its own side when the client's close_notify arrives, which is
+// exactly the reply a holding peer never sends.
+type HoldingPeer = { port: number; ended: Promise<void>; closed: Promise<void>; [Symbol.dispose](): void };
+
+function holdingTlsPeer(
+  greeting: Buffer | null,
+  // answers the client's plaintext SSL request; returns the bytes after it
+  onSslRequest: (raw: Socket, chunk: Buffer) => Buffer,
+  onSecureData: (socket: Socket, chunk: Buffer) => void,
+): HoldingPeer {
+  const ended = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<void>();
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    allowHalfOpen: true,
+    socket: {
+      open(raw) {
+        if (greeting) raw.write(greeting);
+      },
+      data(raw, chunk) {
+        // the raw socket keeps observing bytes after the upgrade
+        if (raw.data) return;
+        raw.data = true;
+        raw.upgradeTLS({
+          isServer: true,
+          initialData: onSslRequest(raw, chunk),
+          tls: { key: tlsCert.key, cert: tlsCert.cert },
+          socket: {
+            handshake() {},
+            data: onSecureData,
+            // the client's close_notify; hold the connection open. The probe
+            // write only fails, and so only closes this side, once the
+            // client's fd is gone: the kernel answers it with a reset.
+            end(socket) {
+              ended.resolve();
+              socket.write("probe");
+            },
+            close() {
+              closed.resolve();
+            },
+            error() {},
+          },
+        });
+      },
+      close() {},
+      error() {},
+    },
+  });
+  return {
+    port: listener.port,
+    ended: ended.promise,
+    closed: closed.promise,
+    [Symbol.dispose]() {
+      listener.stop(true);
+    },
+  };
+}
+
+function holdingPostgresPeer(): HoldingPeer {
+  let started = false;
+  return holdingTlsPeer(
+    null,
+    (raw, chunk) => {
+      // the 8-byte SSLRequest; the client sends nothing else until it sees 'S'
+      raw.write(pgSSLResponse("S"));
+      return chunk.subarray(8);
+    },
+    (socket, _chunk) => {
+      if (started) return;
+      started = true;
+      // the StartupMessage
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery("I")]));
+    },
+  );
+}
+
+function holdingMysqlPeer(): HoldingPeer {
+  let buffered = Buffer.alloc(0);
+  let authed = false;
+  return holdingTlsPeer(
+    mysqlHandshakeV10({ capabilities: MYSQL_DEFAULT_CAPABILITIES | MYSQL_CLIENT_SSL }),
+    (_raw, chunk) => chunk.subarray(4 + (chunk[0] | (chunk[1] << 8) | (chunk[2] << 16))),
+    (socket, chunk) => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        mysqlAckSessionSetup(socket, payload);
+      });
+    },
+  );
+}
+
+const holdingPeers = [
+  ["postgres", holdingPostgresPeer, (port: number) => `postgres://u:p@127.0.0.1:${port}/db?sslmode=require`],
+  ["mysql", holdingMysqlPeer, (port: number) => `mysql://root:pw@127.0.0.1:${port}/db`],
+] as const;
+
+for (const [name, peer, url] of holdingPeers) {
+  test.concurrent(`${name}: close() settles against a TLS peer that never answers close_notify`, async () => {
+    using server = peer();
+    const sql = new SQL({ url: url(server.port), max: 1, tls: { rejectUnauthorized: false } });
+    await sql.connect();
+    await sql.close({ timeout: 0 });
+    await server.ended;
+    await server.closed;
+  });
+
+  test.concurrent(`${name}: idleTimeout eviction settles against a TLS peer that never answers close_notify`, async () => {
+    using server = peer();
+    const closed = Promise.withResolvers<void>();
+    const sql = new SQL({
+      url: url(server.port),
+      max: 1,
+      idleTimeout: 1,
+      tls: { rejectUnauthorized: false },
+      onclose: () => closed.resolve(),
+    });
+    await sql.connect();
+    await closed.promise;
+    await server.ended;
+    await server.closed;
+    await sql.close();
+  });
+}
+
+test.concurrent("postgres: a rejected certificate over a holding TLS peer does not pin the process", async () => {
+  using server = holdingPostgresPeer();
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { SQL } = require("bun");
+      const sql = new SQL("postgres://u:p@127.0.0.1:${server.port}/db?sslmode=verify-full", { max: 1 });
+      const code = await sql.connect().then(() => "connected", e => e.code);
+      console.log(code);
+      // the socket the client gave up on must not keep the event loop alive
+      setTimeout(() => process.exit(7), 2000).unref();
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("DEPTH_ZERO_SELF_SIGNED_CERT\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+


### PR DESCRIPTION
### Problem
- `Bun.SQL` over TLS (postgres and mysql) never finishes a teardown that the peer does not answer. `sql.close()`, `close({ timeout: 0 })`, an `idleTimeout` or `maxLifetime` eviction, a connection timeout after the handshake, and the close after bun itself rejected the server certificate (`DEPTH_ZERO_SELF_SIGNED_CERT`) all send a TLS close_notify and then keep the socket until the server closes its side. Against a peer that holds its half open (a proxy, a partition at shutdown, the MITM that just failed verification) the `close()` promise never settles and the process never exits. Plaintext closes in 1 ms.
- Cause: both adapters close with `CloseCode::Normal` (`src/sql_jsc/postgres/PostgresSQLConnection.rs:1492`, `src/sql_jsc/mysql/MySQLConnection.rs:285`). On a TLS socket `us_internal_ssl_close` (`packages/bun-usockets/src/crypto/openssl.c:2186`) treats code 0 as a graceful close: it sends close_notify and defers the fd close, and with it `on_close`, until the peer's close_notify or FIN arrives. Nothing bounds that wait.

### Fix
- New `socket_teardown::close_now` (`src/sql_jsc/shared/socket_teardown.rs`): a TLS socket whose handshake completed sends close_notify through `shutdown()`, then the fd closes with `FastShutdown` (a FIN). If usockets defers that fast shutdown behind ciphertext the peer stopped reading, the socket is reset with `Failure`. Both adapters use it on every teardown path, so `on_close` now runs inside the close call, as it already did on plain TCP.
- This is what libpq does in `PQfinish` (`SSL_shutdown`, then `close`). The peer still gets a clean TLS shutdown. It no longer decides when the client is done.
- Adds `is_ssl_handshake_finished` to `bun_uws_sys` (binds the existing `us_socket_is_ssl_handshake_finished`). Before the handshake there is no session to notify, and a `shutdown()` there made usockets report the unfinished handshake as failed with an empty reason.
- Verified: `test/js/sql/sql-close-pending-connection.test.ts` (7 new tests: `close()`, idle eviction, a protocol violation during startup, rejected certificate, postgres and mysql, against a TLS peer that never answers close_notify; all seven hang or exit 7 on stock bun). Also the other fault-injection files in `test/js/sql` and `wire-frames.test.ts`.

### Background
- usockets close codes: `Normal` (0) is a graceful close. On TLS it sends close_notify and waits for the peer's reply before closing the fd. `FastShutdown` (2) closes the fd now with a FIN and no alert, but is still held back while a ciphertext spill is pending. `Failure` (1) closes now with `SO_LINGER{1,0}`, an RST, and is never deferred.
- `shutdown()` on a TLS socket is node's `end()`: it sends close_notify and `shutdown(SHUT_WR)`, and keeps reading. Calling it first and then `FastShutdown` gives close_notify plus an immediate fd close.
- The adapters' `on_close` detaches the stored socket handle and rejects pending queries. The callers copy the `AnySocket` before the close because that dispatch now happens inside the call.
- Supersedes #39015 (closed), which switched only the `fail()` path to `Failure` (an RST) and left the user `close()` path waiting on the peer. This change covers both paths with a clean TLS shutdown. Its protocol-violation scenario is folded into the test file here.

<details><summary>Notes</summary>

- The test peers are `Bun.listen({ allowHalfOpen: true })` servers that `upgradeTLS({ isServer: true })` after the plaintext SSL request. A `node:tls` `TLSSocket` wrapped over a `net.Socket` forces `allowHalfOpen: false` and always answers the client's close_notify, which is exactly the reply a holding peer never sends.
- The peer proves the client fd is gone with a probe write after the client's close_notify: the write only fails (and closes the peer's side) once the kernel answers it with a reset.
- The rejected-certificate case runs in a child process: after `sql.connect()` rejects, an unref'd 2 s timer exits with code 7. Without the fix the held poll ref keeps the loop alive and the timer fires; with the fix the child exits 0 at once.
- `shutdown()` before the handshake is finished: `us_internal_ssl_shutdown` does a raw `SHUT_WR`, then `ssl_update_handshake` sees a shut-down socket and reports the pending handshake as failed with no reason, which trips `!message.isEmpty()` in `JSC::createError` (seen in `sql-mysql-tls-plaintext-injection.test.ts`). Hence the handshake check.
- The `Failure` fallback only fires when `FastShutdown` left the socket open. usockets defers it only for a ciphertext spill (`ssl_close_after_spill`), or when the close runs from inside a BoringSSL callback (`ssl_in_use`), which these adapters never do.
- Suites run: `sql-close-pending-connection`, `sql-mysql-tls-plaintext-injection`, `wire-frames`, `postgres-tls-ctx-leak`, `sql-onconnect-onclose-throw`, `sql-mysql-clean-reentry`, `sql-mariadb-json`, `postgres-failed-connection-resurrection`, `sql-reserve-abort`, `sql-connect-error-reporting`, `postgres-pgsslmode-env`, `sql-mysql-duplicate-auth-switch`, `postgres-duplicate-auth-request`, and the service-backed parts of `sql.test.ts` and `sql-mysql.test.ts`. `cargo check -p bun_sql_jsc --target x86_64-pc-windows-msvc` passes.
</details>

