### PR TITLE
WebSocket: read http_proxy / https_proxy from the environment like fetch()

### DIFF
--- a/docs/guides/http/proxy.mdx
+++ b/docs/guides/http/proxy.mdx
@@ -48,3 +48,12 @@ To use the same proxy for all requests, set the `$HTTP_PROXY` and `$HTTPS_PROXY`
 ```sh terminal icon="terminal"
 HTTP_PROXY=https://username:password@proxy.example.com:8080 HTTPS_PROXY=https://username:password@proxy.example.com:8080 bun run index.ts
 ```
+
+`new WebSocket()` reads the same variables: `$HTTP_PROXY` for `ws://` URLs and `$HTTPS_PROXY` for `wss://` URLs. Set `$NO_PROXY` to a comma-separated list of hosts that must not go through the proxy.
+
+To ignore the environment variables for one request or connection, pass `proxy: null`.
+
+```ts direct.ts icon="/icons/typescript.svg"
+await fetch("http://localhost:3000", { proxy: null });
+const ws = new WebSocket("ws://localhost:3000", { proxy: null });
+```

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4896,12 +4896,20 @@ declare module "bun" {
      * Can be a string URL, a URL instance, or an object with `url` and
      * optional `headers`.
      *
+     * When omitted, the proxy comes from the `http_proxy` (for `ws://`) or
+     * `https_proxy` (for `wss://`) environment variables, subject to
+     * `NO_PROXY`, like `fetch()`. Pass `null` (or `""`) to connect directly
+     * and ignore the environment variables.
+     *
      * @example
      * ```ts
      * // String format
      * const ws = new WebSocket("wss://example.com", {
      *   proxy: "http://proxy.example.com:8080"
      * });
+     *
+     * // Ignore $HTTP_PROXY / $HTTPS_PROXY for this connection
+     * const direct = new WebSocket("wss://example.com", { proxy: null });
      *
      * // With credentials
      * const ws = new WebSocket("wss://example.com", {
@@ -4922,6 +4930,7 @@ declare module "bun" {
     proxy?:
       | string
       | URL
+      | null
       | {
           /**
            * The proxy URL (http:// or https://), as a string or a `URL`.

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1967,6 +1967,9 @@ interface BunFetchRequestInit extends RequestInit {
    * If a `Proxy-Authorization` header is provided in `proxy.headers`, it takes
    * precedence over credentials parsed from the proxy URL.
    *
+   * Pass `null` (or `""`) to connect directly and ignore the environment
+   * variables.
+   *
    * Not part of the Fetch API specification.
    *
    * @example
@@ -1975,6 +1978,9 @@ interface BunFetchRequestInit extends RequestInit {
    * const response = await fetch("http://example.com", {
    *  proxy: "https://username:password@127.0.0.1:8080"
    * });
+   *
+   * // Ignore $HTTP_PROXY / $HTTPS_PROXY for this request
+   * const direct = await fetch("http://example.com", { proxy: null });
    *
    * // Object format with custom headers sent to the proxy
    * const response = await fetch("http://example.com", {
@@ -1991,6 +1997,7 @@ interface BunFetchRequestInit extends RequestInit {
   proxy?:
     | string
     | URL
+    | null
     | {
         /**
          * The proxy URL, as a string or a `URL`.

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -298,9 +298,7 @@ class BunWebSocket extends EventEmitter {
   #createWebSocket(url, protocols, headers, method, proxy, tls, disableDeflate) {
     // The native WebSocket keeps permessage-deflate enabled by default;
     // forward `perMessageDeflate: false` only when the caller asked to disable.
-    // `proxy: null` keeps ws direct unless a proxy agent is given, like the
-    // npm package, which dials with its own createConnection and never reads
-    // http_proxy / https_proxy.
+    // Like npm ws: direct unless an agent or `proxy` option says otherwise, never http_proxy.
     const wsOptions = { protocols, proxy: proxy || null };
     if (headers) wsOptions.headers = headers;
     if (method) wsOptions.method = method;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -298,17 +298,14 @@ class BunWebSocket extends EventEmitter {
   #createWebSocket(url, protocols, headers, method, proxy, tls, disableDeflate) {
     // The native WebSocket keeps permessage-deflate enabled by default;
     // forward `perMessageDeflate: false` only when the caller asked to disable.
-    let wsOptions;
-    if (headers || proxy || tls || disableDeflate) {
-      wsOptions = { protocols };
-      if (headers) wsOptions.headers = headers;
-      if (method) wsOptions.method = method;
-      if (proxy) wsOptions.proxy = proxy;
-      if (tls) wsOptions.tls = tls;
-      if (disableDeflate) wsOptions.perMessageDeflate = false;
-    } else {
-      wsOptions = protocols;
-    }
+    // `proxy: null` keeps ws direct unless a proxy agent is given, like the
+    // npm package, which dials with its own createConnection and never reads
+    // http_proxy / https_proxy.
+    const wsOptions = { protocols, proxy: proxy || null };
+    if (headers) wsOptions.headers = headers;
+    if (method) wsOptions.method = method;
+    if (tls) wsOptions.tls = tls;
+    if (disableDeflate) wsOptions.perMessageDeflate = false;
     let ws = (this.#ws = new WebSocket(url, wsOptions));
     ws.binaryType = "nodebuffer";
 

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -287,14 +287,20 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
         }
 
         // Parse proxy option - can be string or { url, headers }
+        // proxyUrl stays null when the key is absent or undefined (the env
+        // proxy applies). `null` and "" make it empty but non-null: direct.
         auto proxyValue = Bun::getOwnPropertyIfExists(globalObject, options, PropertyName(Identifier::fromString(vm, "proxy"_s)));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (proxyValue) {
-            if (!proxyValue.isUndefinedOrNull()) {
+            if (proxyValue.isNull()) {
+                proxyUrl = emptyString();
+            } else if (!proxyValue.isUndefined()) {
                 if (proxyValue.isString()) {
                     // proxy: "http://proxy:8080"
                     proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyValue);
                     RETURN_IF_EXCEPTION(throwScope, {});
+                    if (proxyUrl.isNull())
+                        proxyUrl = emptyString();
                 } else if (auto* domUrl = dynamicDowncast<JSDOMURL>(proxyValue)) {
                     // proxy: new URL("http://proxy:8080") — URL has no `.url` own
                     // property, so the object branch below would silently drop it.

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -226,8 +226,9 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
     // ws.WebSocket passes `perMessageDeflate: false` to opt out.
     bool offerPerMessageDeflate = true;
 
-    // Proxy options
+    // Proxy options. Without a `proxy` key the proxy comes from http_proxy / https_proxy.
     String proxyUrl;
+    bool useEnvProxy = true;
     auto proxyHeadersInit = std::optional<Converter<IDLUnion<IDLSequence<IDLSequence<IDLByteString>>, IDLRecord<IDLByteString, IDLByteString>>>::ReturnType>();
 
     if (JSC::JSObject* options = optionsObjectValue.getObject()) {
@@ -286,25 +287,23 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
             offerPerMessageDeflate = false;
         }
 
-        // Parse proxy option - can be string or { url, headers }
-        // proxyUrl stays null when the key is absent or undefined (the env
-        // proxy applies). `null` and "" make it empty but non-null: direct.
+        // Parse proxy option - can be string or { url, headers }. null and "" connect directly.
         auto proxyValue = Bun::getOwnPropertyIfExists(globalObject, options, PropertyName(Identifier::fromString(vm, "proxy"_s)));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (proxyValue) {
             if (proxyValue.isNull()) {
-                proxyUrl = emptyString();
+                useEnvProxy = false;
             } else if (!proxyValue.isUndefined()) {
                 if (proxyValue.isString()) {
                     // proxy: "http://proxy:8080"
                     proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyValue);
                     RETURN_IF_EXCEPTION(throwScope, {});
-                    if (proxyUrl.isNull())
-                        proxyUrl = emptyString();
+                    useEnvProxy = false;
                 } else if (auto* domUrl = dynamicDowncast<JSDOMURL>(proxyValue)) {
                     // proxy: new URL("http://proxy:8080") — URL has no `.url` own
                     // property, so the object branch below would silently drop it.
                     proxyUrl = domUrl->wrapped().href().string();
+                    useEnvProxy = false;
                 } else if (proxyValue.isObject()) {
                     // proxy: { url: "http://proxy:8080", headers: {...} }
                     JSC::JSObject* proxyOptions = proxyValue.getObject();
@@ -313,6 +312,7 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
                     if (proxyUrlValue && !proxyUrlValue.isUndefinedOrNull()) {
                         proxyUrl = convert<IDLUSVString>(*lexicalGlobalObject, proxyUrlValue);
                         RETURN_IF_EXCEPTION(throwScope, {});
+                        useEnvProxy = false;
                     }
 
                     auto proxyHeadersValue = Bun::getOwnPropertyIfExists(globalObject, proxyOptions, builtinnames.headersPublicName());
@@ -340,8 +340,8 @@ static inline JSC::EncodedJSValue constructJSWebSocket3(JSGlobalObject* lexicalG
     }
 
     auto object = (rejectUnauthorized == -1)
-        ? WebSocket::create(*context, WTF::move(url), protocols, WTF::move(headersInit), WTF::move(proxyUrl), WTF::move(proxyHeadersInit), WTF::move(sslConfig), offerPerMessageDeflate)
-        : WebSocket::create(*context, WTF::move(url), protocols, WTF::move(headersInit), rejectUnauthorized ? true : false, WTF::move(proxyUrl), WTF::move(proxyHeadersInit), WTF::move(sslConfig), offerPerMessageDeflate);
+        ? WebSocket::create(*context, WTF::move(url), protocols, WTF::move(headersInit), WTF::move(proxyUrl), WTF::move(proxyHeadersInit), WTF::move(sslConfig), offerPerMessageDeflate, useEnvProxy)
+        : WebSocket::create(*context, WTF::move(url), protocols, WTF::move(headersInit), rejectUnauthorized ? true : false, WTF::move(proxyUrl), WTF::move(proxyHeadersInit), WTF::move(sslConfig), offerPerMessageDeflate, useEnvProxy);
 
     if constexpr (IsExceptionOr<decltype(object)>)
         RETURN_IF_EXCEPTION(throwScope, {});

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -287,6 +287,16 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
 
 ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers)
 {
+    return create(context, url, protocols, WTF::move(headers), true);
+}
+
+ExceptionOr<Ref<WebSocket>> WebSocket::createDirect(ScriptExecutionContext& context, const String& url)
+{
+    return create(context, url, Vector<String> {}, std::nullopt, false);
+}
+
+ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, bool useEnvProxy)
+{
     if (url.isNull())
         return Exception { SyntaxError };
 
@@ -296,8 +306,7 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
     if (socket->m_state == CLOSED)
         return socket;
 
-    auto result = socket->connect(url, protocols, WTF::move(headers));
-    // auto result = socket->connect(url, protocols);
+    auto result = socket->connect(url, protocols, WTF::move(headers), std::nullopt, useEnvProxy);
 
     if (result.hasException())
         return result.releaseException();
@@ -377,11 +386,6 @@ static String hostName(const URL& url, bool secure)
     if (url.port() && ((!secure && url.port().value() != 80) || (secure && url.port().value() != 443)))
         return makeString(asASCIILowercase(url.host()), ':', url.port().value());
     return url.host().convertToASCIILowercase();
-}
-
-ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headersInit)
-{
-    return connect(url, protocols, WTF::move(headersInit), std::nullopt, true);
 }
 
 size_t WebSocket::memoryCost() const
@@ -554,7 +558,7 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
         hasProxy = false;
     }
 
-    if (!is_unix) {
+    if (!is_unix && (hasProxy || useEnvProxy)) {
         auto hostStr = m_url.host().toString();
         auto hostWithPort = hostName(m_url, is_secure);
         auto hostUtf8 = hostStr.utf8();

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -63,6 +63,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocket);
 extern "C" int Bun__getTLSRejectUnauthorizedValue();
 extern "C" bool Bun__isNoProxy(const char* hostname, size_t hostname_len, const char* host, size_t host_len);
+extern "C" BunString Bun__getEnvHttpProxy(bool is_http, const char* hostname, size_t hostname_len, const char* host, size_t host_len);
 
 static ErrorEvent::Init createErrorEventInit(WebSocket& webSocket, const String& reason, JSC::JSGlobalObject* globalObject)
 {
@@ -321,7 +322,9 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
     socket->m_sslConfig = WTF::move(sslConfig); // Set BEFORE connect() so it's available during connection
     socket->setOfferPerMessageDeflate(offerPerMessageDeflate);
 
-    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue());
+    // A null proxyUrl means the constructor got no `proxy` key. An empty
+    // (non-null) one means `proxy: null` / `proxy: ""`: force a direct connection.
+    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue(), proxyUrl.isNull());
     if (result.hasException())
         return result.releaseException();
 
@@ -346,7 +349,9 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
     socket->m_sslConfig = WTF::move(sslConfig); // Set BEFORE connect() so it's available during connection
     socket->setOfferPerMessageDeflate(offerPerMessageDeflate);
 
-    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue());
+    // A null proxyUrl means the constructor got no `proxy` key. An empty
+    // (non-null) one means `proxy: null` / `proxy: ""`: force a direct connection.
+    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue(), proxyUrl.isNull());
     if (result.hasException())
         return result.releaseException();
 
@@ -380,7 +385,7 @@ static String hostName(const URL& url, bool secure)
 
 ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headersInit)
 {
-    return connect(url, protocols, WTF::move(headersInit), std::nullopt);
+    return connect(url, protocols, WTF::move(headersInit), std::nullopt, true);
 }
 
 size_t WebSocket::memoryCost() const
@@ -410,7 +415,7 @@ size_t WebSocket::memoryCost() const
     return cost;
 }
 
-__attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headersInit, std::optional<ProxyConfig>&& proxyConfig)
+__attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headersInit, std::optional<ProxyConfig>&& proxyConfig, bool useEnvProxy)
 {
     // LOG(Network, "WebSocket %p connect() url='%s'", this, url.utf8().data());
     m_url = URL { url };
@@ -553,15 +558,30 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
         hasProxy = false;
     }
 
-    // Check NO_PROXY even for explicitly-provided proxies
-    if (hasProxy) {
+    if (!is_unix) {
         auto hostStr = m_url.host().toString();
         auto hostWithPort = hostName(m_url, is_secure);
         auto hostUtf8 = hostStr.utf8();
         auto hostWithPortUtf8 = hostWithPort.utf8();
-        if (Bun__isNoProxy(hostUtf8.data(), hostUtf8.length(), hostWithPortUtf8.data(), hostWithPortUtf8.length())) {
-            proxyConfig = std::nullopt;
-            hasProxy = false;
+        if (hasProxy) {
+            // Check NO_PROXY even for explicitly-provided proxies
+            if (Bun__isNoProxy(hostUtf8.data(), hostUtf8.length(), hostWithPortUtf8.data(), hostWithPortUtf8.length())) {
+                proxyConfig = std::nullopt;
+                hasProxy = false;
+            }
+        } else if (useEnvProxy) {
+            // No `proxy` option: use the proxy fetch() would pick from
+            // http_proxy / https_proxy (NO_PROXY already applied).
+            String envProxyUrl = Bun__getEnvHttpProxy(!is_secure, hostUtf8.data(), hostUtf8.length(), hostWithPortUtf8.data(), hostWithPortUtf8.length()).transferToWTFString();
+            if (!envProxyUrl.isEmpty()) {
+                auto envProxyConfig = setupProxy(envProxyUrl, std::nullopt);
+                if (envProxyConfig.hasException()) {
+                    m_state = CLOSED;
+                    return envProxyConfig.releaseException();
+                }
+                proxyConfig = envProxyConfig.releaseReturnValue();
+                hasProxy = proxyConfig.has_value();
+            }
         }
     }
 

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -305,7 +305,7 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
     return socket;
 }
 
-ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate)
+ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate, bool useEnvProxy)
 {
     if (url.isNull())
         return Exception { SyntaxError };
@@ -322,16 +322,14 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
     socket->m_sslConfig = WTF::move(sslConfig); // Set BEFORE connect() so it's available during connection
     socket->setOfferPerMessageDeflate(offerPerMessageDeflate);
 
-    // A null proxyUrl means the constructor got no `proxy` key. An empty
-    // (non-null) one means `proxy: null` / `proxy: ""`: force a direct connection.
-    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue(), proxyUrl.isNull());
+    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue(), useEnvProxy);
     if (result.hasException())
         return result.releaseException();
 
     return socket;
 }
 
-ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, bool rejectUnauthorized, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate)
+ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, bool rejectUnauthorized, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate, bool useEnvProxy)
 {
     if (url.isNull())
         return Exception { SyntaxError };
@@ -349,9 +347,7 @@ ExceptionOr<Ref<WebSocket>> WebSocket::create(ScriptExecutionContext& context, c
     socket->m_sslConfig = WTF::move(sslConfig); // Set BEFORE connect() so it's available during connection
     socket->setOfferPerMessageDeflate(offerPerMessageDeflate);
 
-    // A null proxyUrl means the constructor got no `proxy` key. An empty
-    // (non-null) one means `proxy: null` / `proxy: ""`: force a direct connection.
-    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue(), proxyUrl.isNull());
+    auto result = socket->connect(url, protocols, WTF::move(headers), proxyConfigResult.releaseReturnValue(), useEnvProxy);
     if (result.hasException())
         return result.releaseException();
 
@@ -570,14 +566,14 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
                 hasProxy = false;
             }
         } else if (useEnvProxy) {
-            // No `proxy` option: use the proxy fetch() would pick from
-            // http_proxy / https_proxy (NO_PROXY already applied).
+            // NO_PROXY is already applied to the result.
             String envProxyUrl = Bun__getEnvHttpProxy(!is_secure, hostUtf8.data(), hostUtf8.length(), hostWithPortUtf8.data(), hostWithPortUtf8.length()).transferToWTFString();
             if (!envProxyUrl.isEmpty()) {
                 auto envProxyConfig = setupProxy(envProxyUrl, std::nullopt);
                 if (envProxyConfig.hasException()) {
-                    m_state = CLOSED;
-                    return envProxyConfig.releaseException();
+                    // A bad env value is not the caller's bug, so it does not throw.
+                    dispatchConnectFailure(envProxyConfig.releaseException().releaseMessage());
+                    return {};
                 }
                 proxyConfig = envProxyConfig.releaseReturnValue();
                 hasProxy = proxyConfig.has_value();
@@ -667,15 +663,7 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
     headerNames.clear();
 
     if (this->m_upgradeClient == nullptr) {
-        m_state = CLOSED;
-        if (scriptExecutionContext()) {
-            queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [](WebSocket& ws) {
-                auto eventInit = createErrorEventInit(ws, "Failed to connect"_s, ws.scriptExecutionContext()->jsGlobalObject());
-                auto message = eventInit.message;
-                ws.dispatchEvent(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
-                ws.dispatchEvent(CloseEvent::create(false, 1006, WTF::move(message)));
-            });
-        }
+        dispatchConnectFailure("Failed to connect"_s);
         // create() still holds a Ref, so releasing connect()'s claim here cannot destroy `this`.
         m_pendingActivity = nullptr;
         return {};
@@ -683,6 +671,19 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
 
     m_state = CONNECTING;
     return {};
+}
+
+void WebSocket::dispatchConnectFailure(String&& reason)
+{
+    m_state = CLOSED;
+    if (!scriptExecutionContext())
+        return;
+    queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [reason = WTF::move(reason)](WebSocket& ws) {
+        auto eventInit = createErrorEventInit(ws, reason, ws.scriptExecutionContext()->jsGlobalObject());
+        auto message = eventInit.message;
+        ws.dispatchEvent(ErrorEvent::create(eventNames().errorEvent, WTF::move(eventInit), EventIsTrusted::Yes));
+        ws.dispatchEvent(CloseEvent::create(false, 1006, WTF::move(message)));
+    });
 }
 
 ExceptionOr<void> WebSocket::send(const String& message)

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -122,6 +122,9 @@ public:
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const String& protocol);
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols);
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&);
+    static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, bool useEnvProxy);
+    // For Bun's own connections (the WebView DevTools socket): never through http_proxy / https_proxy.
+    static ExceptionOr<Ref<WebSocket>> createDirect(ScriptExecutionContext&, const String& url);
     // With proxy support
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate, bool useEnvProxy);
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, bool rejectUnauthorized, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate, bool useEnvProxy);
@@ -162,11 +165,10 @@ public:
         ProxyTLS // ws:// or wss:// through HTTPS proxy (TLS socket to proxy)
     };
 
-    ExceptionOr<void> connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&);
-    // Report a connect() failure found before a socket exists like a refused connection: error event, then close 1006.
-    void dispatchConnectFailure(String&& reason);
     // useEnvProxy: with no proxy config, take the proxy from http_proxy / https_proxy like fetch().
     ExceptionOr<void> connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, std::optional<struct ProxyConfig>&&, bool useEnvProxy);
+    // Report a connect() failure found before a socket exists like a refused connection: error event, then close 1006.
+    void dispatchConnectFailure(String&& reason);
 
     ExceptionOr<void> send(const String& message);
     ExceptionOr<void> send(JSC::ArrayBuffer&);

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -123,8 +123,8 @@ public:
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols);
     static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&);
     // With proxy support
-    static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate);
-    static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, bool rejectUnauthorized, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate);
+    static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext&, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate, bool useEnvProxy);
+    static ExceptionOr<Ref<WebSocket>> create(ScriptExecutionContext& context, const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&& headers, bool rejectUnauthorized, const String& proxyUrl, std::optional<FetchHeaders::Init>&& proxyHeaders, WebSocketSSLConfigPtr&& sslConfig, bool offerPerMessageDeflate, bool useEnvProxy);
     ~WebSocket();
 
     enum State {
@@ -163,9 +163,9 @@ public:
     };
 
     ExceptionOr<void> connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&);
-    // Internal connect with proxy config (used by create() with proxy support).
-    // With no proxy config and `useEnvProxy`, the proxy comes from
-    // http_proxy / https_proxy like fetch(). `proxy: null` / `""` pass false.
+    // Report a connect() failure found before a socket exists like a refused connection: error event, then close 1006.
+    void dispatchConnectFailure(String&& reason);
+    // useEnvProxy: with no proxy config, take the proxy from http_proxy / https_proxy like fetch().
     ExceptionOr<void> connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, std::optional<struct ProxyConfig>&&, bool useEnvProxy);
 
     ExceptionOr<void> send(const String& message);

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -163,8 +163,10 @@ public:
     };
 
     ExceptionOr<void> connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&);
-    // Internal connect with proxy config (used by create() with proxy support)
-    ExceptionOr<void> connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, std::optional<struct ProxyConfig>&&);
+    // Internal connect with proxy config (used by create() with proxy support).
+    // With no proxy config and `useEnvProxy`, the proxy comes from
+    // http_proxy / https_proxy like fetch(). `proxy: null` / `""` pass false.
+    ExceptionOr<void> connect(const String& url, const Vector<String>& protocols, std::optional<FetchHeaders::Init>&&, std::optional<struct ProxyConfig>&&, bool useEnvProxy);
 
     ExceptionOr<void> send(const String& message);
     ExceptionOr<void> send(JSC::ArrayBuffer&);

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -240,31 +240,13 @@ pub unsafe fn is_no_proxy(
 
 // HOST_EXPORT(Bun__getEnvHttpProxy, c)
 /// The `http_proxy` (`is_http`) or `https_proxy` href `fetch()` would use for this host, or empty for direct.
-///
-/// # Safety
-/// Same contract as [`is_no_proxy`].
-pub unsafe fn get_env_http_proxy(
-    is_http: bool,
-    hostname_ptr: *const u8,
-    hostname_len: usize,
-    host_ptr: *const u8,
-    host_len: usize,
-) -> BunString {
-    // SAFETY: VM singleton is process-lifetime.
-    let vm = VirtualMachine::get();
-    let hostname: Option<&[u8]> = if hostname_len > 0 {
-        // SAFETY: caller guarantees `hostname_ptr[..hostname_len]` is valid for reads.
-        Some(unsafe { bun_core::ffi::slice(hostname_ptr, hostname_len) })
-    } else {
-        None
-    };
-    let host: Option<&[u8]> = if host_len > 0 {
-        // SAFETY: caller guarantees `host_ptr[..host_len]` is valid for reads.
-        Some(unsafe { bun_core::ffi::slice(host_ptr, host_len) })
-    } else {
-        None
-    };
-    match vm.env_loader().get_http_proxy(is_http, hostname, host) {
+pub fn get_env_http_proxy(is_http: bool, hostname: &[u8], host: &[u8]) -> BunString {
+    let hostname = (!hostname.is_empty()).then_some(hostname);
+    let host = (!host.is_empty()).then_some(host);
+    match VirtualMachine::get()
+        .env_loader()
+        .get_http_proxy(is_http, hostname, host)
+    {
         // `HTTPThread::dial` treats a schemeless value (`proxy:3128`) as http (#11343).
         Some(url) if url.protocol.is_empty() => {
             BunString::clone_utf8(&[b"http://".as_slice(), url.href].concat())

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -239,13 +239,10 @@ pub unsafe fn is_no_proxy(
 }
 
 // HOST_EXPORT(Bun__getEnvHttpProxy, c)
-/// The proxy `fetch()` would pick for a target from `http_proxy` /
-/// `https_proxy` (NO_PROXY applied), or an empty string for a direct
-/// connection. `is_http` selects `http_proxy`, otherwise `https_proxy`.
+/// The `http_proxy` (`is_http`) or `https_proxy` href `fetch()` would use for this host, or empty for direct.
 ///
 /// # Safety
-/// `hostname_ptr[..hostname_len]` and `host_ptr[..host_len]` must each be valid
-/// for reads for the duration of the call (or the corresponding len must be 0).
+/// Same contract as [`is_no_proxy`].
 pub unsafe fn get_env_http_proxy(
     is_http: bool,
     hostname_ptr: *const u8,
@@ -268,6 +265,10 @@ pub unsafe fn get_env_http_proxy(
         None
     };
     match vm.env_loader().get_http_proxy(is_http, hostname, host) {
+        // `HTTPThread::dial` treats a schemeless value (`proxy:3128`) as http (#11343).
+        Some(url) if url.protocol.is_empty() => {
+            BunString::clone_utf8(&[b"http://".as_slice(), url.href].concat())
+        }
         Some(url) => BunString::clone_utf8(url.href),
         None => BunString::EMPTY,
     }

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -238,6 +238,41 @@ pub unsafe fn is_no_proxy(
     vm.env_loader().is_no_proxy(hostname, host)
 }
 
+// HOST_EXPORT(Bun__getEnvHttpProxy, c)
+/// The proxy `fetch()` would pick for a target from `http_proxy` /
+/// `https_proxy` (NO_PROXY applied), or an empty string for a direct
+/// connection. `is_http` selects `http_proxy`, otherwise `https_proxy`.
+///
+/// # Safety
+/// `hostname_ptr[..hostname_len]` and `host_ptr[..host_len]` must each be valid
+/// for reads for the duration of the call (or the corresponding len must be 0).
+pub unsafe fn get_env_http_proxy(
+    is_http: bool,
+    hostname_ptr: *const u8,
+    hostname_len: usize,
+    host_ptr: *const u8,
+    host_len: usize,
+) -> BunString {
+    // SAFETY: VM singleton is process-lifetime.
+    let vm = VirtualMachine::get();
+    let hostname: Option<&[u8]> = if hostname_len > 0 {
+        // SAFETY: caller guarantees `hostname_ptr[..hostname_len]` is valid for reads.
+        Some(unsafe { bun_core::ffi::slice(hostname_ptr, hostname_len) })
+    } else {
+        None
+    };
+    let host: Option<&[u8]> = if host_len > 0 {
+        // SAFETY: caller guarantees `host_ptr[..host_len]` is valid for reads.
+        Some(unsafe { bun_core::ffi::slice(host_ptr, host_len) })
+    } else {
+        None
+    };
+    match vm.env_loader().get_http_proxy(is_http, hostname, host) {
+        Some(url) => BunString::clone_utf8(url.href),
+        None => BunString::EMPTY,
+    }
+}
+
 // HOST_EXPORT(Bun__setVerboseFetchValue, c)
 pub fn set_verbose_fetch_value(value: i32) {
     use bun_http::HTTPVerboseLevel;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -412,6 +412,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     }
 
     let mut proxy: Option<ZigURL> = None;
+    // false for `proxy: null` / `proxy: ""`: connect directly, ignore http_proxy / https_proxy.
+    let mut use_env_proxy = true;
     let mut redirect_type: FetchRedirect = FetchRedirect::Follow;
     let signal: Option<AbortSignalRef>;
     let mut range: Option<bun_core::ZBox> = None;
@@ -864,13 +866,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     // branch below would silently ignore it. Treat it as its href here.
                     let is_url_instance =
                         bun_jsc::DOMURL::cast_(proxy_arg, global_this.vm()).is_some();
-                    // proxy: null or proxy: "" opts out of the http_proxy /
-                    // https_proxy env lookup. `FetchTasklet` turns the empty
-                    // href into a direct connection.
                     if proxy_arg.is_null()
                         || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? == 0)
                     {
-                        proxy = Some(ZigURL::parse(b""));
+                        use_env_proxy = false;
                         break 'extract_proxy url_proxy_buffer;
                     }
                     // Handle string format: proxy: "http://proxy.example.com:8080"
@@ -1217,7 +1216,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         break 'extract_headers result;
     };
 
-    if proxy.as_ref().is_some_and(|p| !p.is_empty()) && !unix_socket_path.is_empty() {
+    if proxy.is_some() && !unix_socket_path.is_empty() {
         let err = ctx.to_type_error(
             jsc::ErrorCode::INVALID_ARG_VALUE,
             format_args!("fetch() cannot use a proxy with a unix socket."),
@@ -1519,10 +1518,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // An explicit `compress` request always wins over the sendfile
             // heuristic — otherwise the same `Bun.file()` body would compress
             // over https/proxy/<32 KiB/Windows but silently not over plain http.
-            if !proxy.as_ref().is_some_and(|p| !p.is_empty())
-                && compress.is_none()
-                && http::SendFile::is_eligible(&url)
-            {
+            if proxy.is_none() && compress.is_none() && http::SendFile::is_eligible(&url) {
                 'use_sendfile: {
                     let stat: bun_sys::Stat = match bun_sys::fstat(opened_fd) {
                         Ok(result) => result,
@@ -1721,7 +1717,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             let s3_path = url_static.s3_path();
 
             // Proxy href (if any) lives in the same buffer, immediately after `url`.
-            let proxy_url: Option<&[u8]> = if proxy.as_ref().is_some_and(|p| !p.is_empty()) {
+            let proxy_url: Option<&[u8]> = if proxy.is_some() {
                 // SAFETY: see `url_static` SAFETY note above.
                 Some(unsafe { bun_ptr::detach_lifetime(&owned_buffer[url_len..]) })
             } else {
@@ -1878,6 +1874,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         redirect_type,
         verbose,
         proxy: proxy_static,
+        use_env_proxy,
         proxy_headers: proxy_headers.take(),
         url_proxy_buffer: url_proxy_boxed,
         signal,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -864,9 +864,17 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     // branch below would silently ignore it. Treat it as its href here.
                     let is_url_instance =
                         bun_jsc::DOMURL::cast_(proxy_arg, global_this.vm()).is_some();
-                    // Handle string format: proxy: "http://proxy.example.com:8080"
-                    if is_url_instance || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? > 0)
+                    // proxy: null or proxy: "" opts out of the http_proxy /
+                    // https_proxy env lookup. `FetchTasklet` turns the empty
+                    // href into a direct connection.
+                    if proxy_arg.is_null()
+                        || (proxy_arg.is_string() && proxy_arg.get_length(ctx)? == 0)
                     {
+                        proxy = Some(ZigURL::parse(b""));
+                        break 'extract_proxy url_proxy_buffer;
+                    }
+                    // Handle string format: proxy: "http://proxy.example.com:8080"
+                    if is_url_instance || proxy_arg.is_string() {
                         let href = jsc::URL::href_from_js(proxy_arg, global_this)?;
                         if href.tag() == BunStringTag::Dead {
                             let err = ctx.to_type_error(
@@ -1209,7 +1217,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         break 'extract_headers result;
     };
 
-    if proxy.is_some() && !unix_socket_path.is_empty() {
+    if proxy.as_ref().is_some_and(|p| !p.is_empty()) && !unix_socket_path.is_empty() {
         let err = ctx.to_type_error(
             jsc::ErrorCode::INVALID_ARG_VALUE,
             format_args!("fetch() cannot use a proxy with a unix socket."),
@@ -1511,7 +1519,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // An explicit `compress` request always wins over the sendfile
             // heuristic — otherwise the same `Bun.file()` body would compress
             // over https/proxy/<32 KiB/Windows but silently not over plain http.
-            if proxy.is_none() && compress.is_none() && http::SendFile::is_eligible(&url) {
+            if !proxy.as_ref().is_some_and(|p| !p.is_empty())
+                && compress.is_none()
+                && http::SendFile::is_eligible(&url)
+            {
                 'use_sendfile: {
                     let stat: bun_sys::Stat = match bun_sys::fstat(opened_fd) {
                         Ok(result) => result,
@@ -1710,7 +1721,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             let s3_path = url_static.s3_path();
 
             // Proxy href (if any) lives in the same buffer, immediately after `url`.
-            let proxy_url: Option<&[u8]> = if proxy.is_some() {
+            let proxy_url: Option<&[u8]> = if proxy.as_ref().is_some_and(|p| !p.is_empty()) {
                 // SAFETY: see `url_static` SAFETY note above.
                 Some(unsafe { bun_ptr::detach_lifetime(&owned_buffer[url_len..]) })
             } else {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1904,14 +1904,11 @@ impl FetchTasklet {
         // ...` on the JS thread cannot invalidate them mid-request.
         let proxy_settings: Option<Box<http::ProxySettings>> =
             if let Some(proxy_opt) = &fetch_options.proxy {
-                if !proxy_opt.is_empty() {
-                    http::ProxySettings::from_explicit(proxy_opt.href, env)
-                } else {
-                    // proxy: "" means explicitly no proxy (direct connection)
-                    None
-                }
-            } else {
+                http::ProxySettings::from_explicit(proxy_opt.href, env)
+            } else if fetch_options.use_env_proxy {
                 http::ProxySettings::from_env(env)
+            } else {
+                None
             };
         // Hop-0 proxy borrows the boxed `ProxySettings` heap storage, which is
         // moved into `AsyncHTTP::init` below and lives on `client` for the
@@ -2589,6 +2586,8 @@ pub struct FetchOptions {
     pub(crate) verbose: http::HTTPVerboseLevel,
     pub(crate) redirect_type: FetchRedirect,
     pub(crate) proxy: Option<ZigURL<'static>>,
+    /// With no `proxy`, resolve one from http_proxy / https_proxy. False for `proxy: null` / `""`.
+    pub(crate) use_env_proxy: bool,
     pub(crate) proxy_headers: Option<Headers>,
     pub(crate) url_proxy_buffer: Box<[u8]>,
     pub(crate) signal: Option<AbortSignalRef>,

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -475,7 +475,7 @@ bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl
     }
 
     auto* ctx = zig->scriptExecutionContext();
-    auto result = WebCore::WebSocket::create(*ctx, wsUrl);
+    auto result = WebCore::WebSocket::createDirect(*ctx, wsUrl);
     if (result.hasException()) {
         m_dead = true;
         m_mode = TransportMode::None;

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -247,7 +247,10 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: ["CMD-SHELL", "pgrep squid > /dev/null"]
+      # The squid process exists seconds before it listens on 3128. Until it
+      # listens, docker-proxy accepts connections on the published port and
+      # drops them, which a client sees as "Connection ended".
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/3128"]
       interval: 5s
       timeout: 5s
       retries: 30

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir, tls as tlsCert } from "harness";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { once } from "node:events";
 import net from "node:net";
@@ -1986,6 +1986,29 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: `${expected}\n`, stderr: "", exitCode: 0 });
+  });
+
+  // A Bun.file() body of this size goes out with sendfile over plain http,
+  // a path that only runs without a proxy.
+  test("proxy: null sends a Bun.file body directly", async () => {
+    const noProxyEnv = { ...bunEnv };
+    for (const k of PROXY_ENV_KEYS) delete noProxyEnv[k];
+    using dir = tempDir("fetch-proxy-null-sendfile", { "body.txt": Buffer.alloc(64 * 1024, "a").toString() });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const resp = await fetch("http://127.0.0.1:${httpServer.port}", { method: "POST", body: Bun.file("body.txt"), proxy: null });
+        console.log(resp.status, (await resp.text()).length);`,
+      ],
+      env: { ...noProxyEnv, HTTP_PROXY: `http://127.0.0.1:${deadProxyPort}` },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "200 65536\n", stderr: "", exitCode: 0 });
   });
 
   test("S3 ops use runtime process.env.HTTP_PROXY and survive overwrite while in flight", async () => {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1959,6 +1959,35 @@ describe.concurrent("NO_PROXY with explicit proxy option", () => {
     expect(exitCode).toBe(0);
   });
 
+  // HTTP_PROXY points at the dead proxy, so a fetch that consults the env
+  // fails. `null` and "" opt out of the env; `undefined` is the same as absent.
+  test.each([
+    ["proxy: null ignores HTTP_PROXY", "null", "200"],
+    ['proxy: "" ignores HTTP_PROXY', '""', "200"],
+    ["proxy: undefined uses HTTP_PROXY", "undefined", "error: ECONNRESET"],
+  ])("%s", async (_, proxy, expected) => {
+    const noProxyEnv = { ...bunEnv };
+    for (const k of PROXY_ENV_KEYS) delete noProxyEnv[k];
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `try {
+          const resp = await fetch("http://127.0.0.1:${httpServer.port}", { proxy: ${proxy} });
+          console.log(resp.status);
+        } catch (error) {
+          console.log("error:", error.code);
+        }`,
+      ],
+      env: { ...noProxyEnv, HTTP_PROXY: `http://127.0.0.1:${deadProxyPort}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: `${expected}\n`, stderr: "", exitCode: 0 });
+  });
+
   test("S3 ops use runtime process.env.HTTP_PROXY and survive overwrite while in flight", async () => {
     // Covers two things this PR introduced:
     //  1) S3's getHttpProxy() observes a runtime process.env.HTTP_PROXY write.

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -101,10 +101,10 @@ const mockCDP = /* js */ `
 
 // Runs a scenario after the mock definitions in a fresh bun process and
 // returns the JSON it printed.
-async function runScenario(body: string): Promise<unknown> {
+async function runScenario(body: string, env: Record<string, string | undefined> = {}): Promise<unknown> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", mockCDP + body],
-    env: bunEnv,
+    env: { ...bunEnv, ...env },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -115,6 +115,38 @@ async function runScenario(body: string): Promise<unknown> {
 }
 
 const wsClosed = expect.stringMatching(/^rejected: Chrome WebSocket closed \(code \d+\)$/);
+
+// The DevTools socket is Bun's own connection, not the app's traffic: it must
+// not follow http_proxy like `new WebSocket()` does. The proxy here refuses
+// every connection, so a navigate() that completes proves the dial was direct.
+test.concurrent("the DevTools WebSocket ignores HTTP_PROXY", async () => {
+  using deadProxy = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.end();
+      },
+      data() {},
+    },
+  });
+  const result = await runScenario(
+    `
+    const mock = startMockCDP();
+    const view = mock.newView();
+    const navigate = await view.navigate("http://mock/1").then(() => "resolved", e => "rejected: " + e.message);
+    console.log(JSON.stringify({ navigate, url: view.url }));
+    mock.stop();
+  `,
+    {
+      HTTP_PROXY: `http://127.0.0.1:${deadProxy.port}`,
+      http_proxy: undefined,
+      NO_PROXY: undefined,
+      no_proxy: undefined,
+    },
+  );
+  expect(result).toEqual({ navigate: "resolved", url: "http://mock/1" });
+});
 
 test.concurrent.each([
   ["navigate", `view.navigate("http://mock/2")`],

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -821,12 +821,14 @@ describe.concurrent("WebSocket proxy from the environment", () => {
     ["https_proxy proxies wss://", () => `wss://127.0.0.1:${wssPort}`, "https_proxy", "proxied"],
     ["HTTPS_PROXY does not apply to ws://", () => `ws://127.0.0.1:${wsPort}`, "HTTPS_PROXY", "direct"],
     ["HTTP_PROXY does not apply to wss://", () => `wss://127.0.0.1:${wssPort}`, "HTTP_PROXY", "direct"],
-  ] as const)("%s", async (_, url, variable, outcome) => {
+    // fetch() dials a schemeless value as an http:// proxy, so WebSocket does too.
+    ["HTTP_PROXY without a scheme proxies ws://", () => `ws://127.0.0.1:${wsPort}`, "HTTP_PROXY", "proxied", ""],
+  ] as const)("%s", async (_, url, variable, outcome, scheme = "http://") => {
     using recorded = await startRecordingProxy();
     const target = url();
     const targetPort = Number(new URL(target).port);
     const result = await run(target, `{ tls: { rejectUnauthorized: false } }`, {
-      [variable]: `http://127.0.0.1:${recorded.port}`,
+      [variable]: `${scheme}127.0.0.1:${recorded.port}`,
     });
     expect({ ...result, requests: recorded.requests }).toEqual({
       stdout: connected,
@@ -878,10 +880,11 @@ describe.concurrent("WebSocket proxy from the environment", () => {
     });
   });
 
-  test("an unsupported env proxy scheme throws like the proxy option does", async () => {
+  test("an unsupported env proxy scheme fails the connection with an error event", async () => {
     const result = await run(`ws://127.0.0.1:${wsPort}`, "{}", { HTTP_PROXY: "socks5://127.0.0.1:1" });
+    const message = `WebSocket connection to 'ws://127.0.0.1:${wsPort}/' failed: Unsupported proxy protocol "socks5" (expected "http" or "https")`;
     expect(result).toEqual({
-      stdout: `throw: Unsupported proxy protocol "socks5" (expected "http" or "https")\n`,
+      stdout: `error: ${message}\nclose: 1006 ${JSON.stringify(message)}\n`,
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/web/websocket/websocket-proxy.test.ts
+++ b/test/js/web/websocket/websocket-proxy.test.ts
@@ -776,3 +776,166 @@ describe.concurrent("WebSocket NO_PROXY bypass", () => {
     );
   });
 });
+
+describe.concurrent("WebSocket proxy from the environment", () => {
+  // Each child connects to an echo server with no `proxy` option. The env
+  // decides whether the connection tunnels through the recording proxy
+  // (which forwards CONNECT to the echo server) or dials the server directly.
+  const noProxyEnv = {
+    HTTP_PROXY: undefined,
+    http_proxy: undefined,
+    HTTPS_PROXY: undefined,
+    https_proxy: undefined,
+    NO_PROXY: undefined,
+    no_proxy: undefined,
+  };
+  const childScript = (url: string, options: string) => `
+    let ws;
+    try {
+      ws = new WebSocket(${JSON.stringify(url)}, ${options});
+    } catch (error) {
+      console.log("throw:", error.message);
+      process.exit(0);
+    }
+    ws.onmessage = event => { console.log("message:", event.data); ws.close(1000); };
+    ws.onerror = event => console.log("error:", event.message);
+    ws.onclose = event => console.log("close:", event.code, JSON.stringify(event.reason));
+  `;
+  const connected = `message: connected\nclose: 1000 ""\n`;
+
+  async function run(url: string, options: string, env: Record<string, string | undefined>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", childScript(url, options)],
+      env: { ...bunEnv, ...noProxyEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.each([
+    ["HTTP_PROXY proxies ws://", () => `ws://127.0.0.1:${wsPort}`, "HTTP_PROXY", "proxied"],
+    ["http_proxy proxies ws://", () => `ws://127.0.0.1:${wsPort}`, "http_proxy", "proxied"],
+    ["HTTPS_PROXY proxies wss://", () => `wss://127.0.0.1:${wssPort}`, "HTTPS_PROXY", "proxied"],
+    ["https_proxy proxies wss://", () => `wss://127.0.0.1:${wssPort}`, "https_proxy", "proxied"],
+    ["HTTPS_PROXY does not apply to ws://", () => `ws://127.0.0.1:${wsPort}`, "HTTPS_PROXY", "direct"],
+    ["HTTP_PROXY does not apply to wss://", () => `wss://127.0.0.1:${wssPort}`, "HTTP_PROXY", "direct"],
+  ] as const)("%s", async (_, url, variable, outcome) => {
+    using recorded = await startRecordingProxy();
+    const target = url();
+    const targetPort = Number(new URL(target).port);
+    const result = await run(target, `{ tls: { rejectUnauthorized: false } }`, {
+      [variable]: `http://127.0.0.1:${recorded.port}`,
+    });
+    expect({ ...result, requests: recorded.requests }).toEqual({
+      stdout: connected,
+      stderr: "",
+      exitCode: 0,
+      requests: outcome === "proxied" ? [connectRequest(targetPort)] : [],
+    });
+  });
+
+  test("NO_PROXY bypasses the env proxy", async () => {
+    using recorded = await startRecordingProxy();
+    const result = await run(`ws://127.0.0.1:${wsPort}`, "{}", {
+      HTTP_PROXY: `http://127.0.0.1:${recorded.port}`,
+      NO_PROXY: "127.0.0.1",
+    });
+    expect({ ...result, connections: recorded.connections }).toEqual({
+      stdout: connected,
+      stderr: "",
+      exitCode: 0,
+      connections: 0,
+    });
+  });
+
+  test("credentials in the env proxy URL become Proxy-Authorization on the CONNECT", async () => {
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const result = await run(`ws://127.0.0.1:${wsPort}`, "{}", {
+      HTTP_PROXY: `http://proxy_user:proxy_pass@127.0.0.1:${recorded.port}`,
+    });
+    expect({ ...result, requests: recorded.requests }).toEqual({
+      stdout: connected,
+      stderr: "",
+      exitCode: 0,
+      requests: [connectRequest(wsPort, { "proxy-authorization": `Basic ${btoa("proxy_user:proxy_pass")}` })],
+    });
+  });
+
+  test("an explicit proxy option wins over the env", async () => {
+    using envProxy = await startRecordingProxy();
+    using optionProxy = await startRecordingProxy();
+    const result = await run(`ws://127.0.0.1:${wsPort}`, `{ proxy: "http://127.0.0.1:${optionProxy.port}" }`, {
+      HTTP_PROXY: `http://127.0.0.1:${envProxy.port}`,
+    });
+    expect({ ...result, env: envProxy.connections, option: optionProxy.requests }).toEqual({
+      stdout: connected,
+      stderr: "",
+      exitCode: 0,
+      env: 0,
+      option: [connectRequest(wsPort)],
+    });
+  });
+
+  test("an unsupported env proxy scheme throws like the proxy option does", async () => {
+    const result = await run(`ws://127.0.0.1:${wsPort}`, "{}", { HTTP_PROXY: "socks5://127.0.0.1:1" });
+    expect(result).toEqual({
+      stdout: `throw: Unsupported proxy protocol "socks5" (expected "http" or "https")\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The proxy answers every CONNECT with 407, so a connection that reaches it
+  // fails. `undefined` is the same as an absent key: the env proxy applies.
+  test.each([
+    ["proxy: null connects directly", "{ proxy: null }", "direct"],
+    ['proxy: "" connects directly', '{ proxy: "" }', "direct"],
+    ["proxy: undefined uses the env proxy", "{ proxy: undefined }", "proxied"],
+  ])("%s", async (_, options, outcome) => {
+    using recorded = await startRecordingProxy({ requireAuth: true });
+    const result = await run(`ws://127.0.0.1:${wsPort}`, options, {
+      HTTP_PROXY: `http://127.0.0.1:${recorded.port}`,
+    });
+    expect({ ...result, connections: recorded.connections }).toEqual(
+      outcome === "direct"
+        ? { stdout: connected, stderr: "", exitCode: 0, connections: 0 }
+        : {
+            stdout:
+              `error: WebSocket connection to 'ws://127.0.0.1:${wsPort}/' failed: Proxy connection failed\n` +
+              `close: 1006 "Proxy connection failed"\n`,
+            stderr: "",
+            exitCode: 0,
+            connections: 1,
+          },
+    );
+  });
+
+  test("require('ws') connects directly unless it is given a proxy agent", async () => {
+    using recorded = await startRecordingProxy();
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const WebSocket = require("ws");
+        const ws = new WebSocket("ws://127.0.0.1:${wsPort}");
+        ws.on("message", data => { console.log("message:", String(data)); ws.close(1000); });
+        ws.on("error", error => console.log("error:", error.message));
+        ws.on("close", code => console.log("close:", code));
+        `,
+      ],
+      env: { ...bunEnv, ...noProxyEnv, HTTP_PROXY: `http://127.0.0.1:${recorded.port}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, connections: recorded.connections }).toEqual({
+      stdout: "message: connected\nclose: 1000\n",
+      stderr: "",
+      exitCode: 0,
+      connections: 0,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `new WebSocket("ws://...")` and `new WebSocket("wss://...")` dial the origin directly. `fetch()` in the same process goes through the proxy from `HTTP_PROXY` / `HTTPS_PROXY`. On an egress-controlled network the HTTP traffic is proxied and the WebSocket silently is not. Node v26 under `NODE_USE_ENV_PROXY=1` tunnels the global `WebSocket` with `CONNECT`.
- The cause: `WebSocket::connect` (`src/jsc/bindings/webcore/WebSocket.cpp`) only builds a `ProxyConfig` from the `proxy` constructor option. Nothing reads the env. The CONNECT tunnel code for `{proxy}` already handles ws and wss, `NO_PROXY`, and `Proxy-Authorization`.
- There was no opt-out from the env: `fetch(url, {proxy: ""})` fell through to the env lookup (`fetch.rs:868`), so the "direct" branch in `FetchTasklet.rs` was unreachable.

### Fix
- With no `proxy` key, `WebSocket::connect` calls a new export, `Bun__getEnvHttpProxy`. It wraps `Loader::get_http_proxy`, the resolver `fetch()` uses: `http_proxy` for `ws://`, `https_proxy` for `wss://`, lowercase first, `NO_PROXY` applied, a schemeless value read as `http://`. The href goes through the existing `setupProxy` CONNECT path. A bad env value (`socks5://`) fails the connection with an error event and close 1006.
- `proxy: null` and `proxy: ""` mean "connect directly" in both `WebSocket` and `fetch()`, carried as an explicit `useEnvProxy` / `use_env_proxy` flag. `undefined` is the same as an absent key. Types and docs updated.
- `require("ws")` passes `proxy: null` unless it has a proxy agent, like the npm package, which never reads the env. The WebView DevTools socket uses a new `WebSocket::createDirect`, so Bun's own loopback connection ignores `HTTP_PROXY`.
- Verified: `websocket-proxy.test.ts` (new block, 15 cases, 9 fail on stock bun), `http/proxy.test.ts` (4 new), `webview-chrome-disconnect.test.ts` (1 new). Also the other websocket proxy suites, `first_party/ws/`, `proxy-stress-protocol.test.ts`, and the types test. Self-reviewed: 1 concern raised (several open PRs each align one client with fetch's env proxy rules, which points at one shared resolver), 0 code changes: this PR calls fetch's resolver instead of adding another copy, a step toward that shape.

### Background
- The WebSocket client is C++ (`WebSocket.cpp`) over a Rust upgrade client (`src/http_jsc/websocket_client`). Option parsing is in `JSWebSocket.cpp`. The C++ side picks the socket type (plain or TLS, to the origin or to the proxy) before it calls into Rust.
- `HOST_EXPORT` markers in `src/jsc/*.rs` generate the `extern "C"` thunk. `Bun__isNoProxy`, which the WebSocket already used, is the sibling of the new export.
- The env lookup is default-on to match `fetch()`. Bun gates only `node:http` behind `NODE_USE_ENV_PROXY` (`_http_agent.ts`). The Web globals follow `fetch()`.

<details><summary>Notes</summary>

Loopback repro before the change (recorder proxy P answers 502, Bun.serve echo origin O, `HTTP_PROXY=HTTPS_PROXY=http://127.0.0.1:P NO_PROXY=`):

```
fetch          -> 502 | proxy saw: [ "GET http://127.0.0.1:O/ HTTP/1.1" ]
node:http.get  -> 502 | proxy saw: [ "GET http://127.0.0.1:O/ HTTP/1.1" ]
new WebSocket  -> "echo:hi" (DIRECT) | proxy saw: []
```

Review changes after the first push:
- The first version encoded the tri-state in a null vs empty `WTF::String` and an empty `ZigURL` sentinel in fetch. Both are now explicit booleans (`useEnvProxy` through `WebSocket::create`/`connect`, `use_env_proxy` on `FetchOptions`). This also keeps `fetch(url, { proxy: null, body: Bun.file(big) })` on the sendfile path without tripping the `debug_assert!(proxy.is_none())` in `FetchTasklet.rs` (new test).
- A schemeless env value (`HTTP_PROXY=127.0.0.1:3128`) is accepted by `HTTPThread::dial` for fetch (#11343). `Bun__getEnvHttpProxy` prefixes `http://` so WebKit's URL parser in `setupProxy` accepts it too (new test).
- An unsupported env scheme no longer throws from the constructor. A bad env value is not the caller's bug, so it surfaces as `error` + `close` 1006 through the new `dispatchConnectFailure`, which the "no upgrade client" path now shares.
- `ChromeBackend.cpp` used the short `WebSocket::create(ctx, url)` overload for the CDP socket (`ws://127.0.0.1:<port>/devtools/...`). With `HTTP_PROXY` set and no loopback entry in `NO_PROXY` that connection would have been tunneled through the proxy. It now uses `createDirect`. The new WebView test fails on the intermediate commit and passes on HEAD.
- Object shapes the parser already ignored (`proxy: {}`, `proxy: { url: null }`, #25413) keep meaning "no option given", so the env applies, the same as fetch.

Unix-socket WebSockets (`ws+unix:`) skip the env lookup, as they skip the option.

`test/docker/docker-compose.yml`: the squid healthcheck was `pgrep squid`, which passes before squid listens on 3128. A modified `websocket-proxy.test.ts` runs first in its shard, right after the coordinator starts squid, so docker-proxy accepted the CONNECT and dropped it ("Connection ended" in the two squid tests, also seen on #37439 and #37638). The healthcheck now opens a TCP connection to 3128.

Suites run locally with the debug build: `websocket-proxy.test.ts`, `test-ws-bidir-proxy.test.ts`, `websocket-proxy-close-reentrancy.test.ts`, `websocket-unix.test.ts`, `websocket-client.test.ts`, `websocket-pause.test.ts`, `websocket-buffered-amount.test.ts`, `websocket-custom-headers.test.ts`, `websocket-permessage-deflate-simple.test.ts`, `test/js/first_party/ws/`, `test/js/bun/http/proxy.test.ts`, `proxy-stress-protocol.test.ts`, `fetch-proxy-connect-tunnel-split-envelope.test.ts`, `webview-chrome-disconnect.test.ts`, `webview-chrome-ws.test.ts`, `test/integration/bun-types/bun-types.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-disconnect.test.ts

<!-- robobun:evidence:end -->