### PR TITLE
WebKit caa5d805b646: keep the bounds check of a dead string access in the FTL (oven-sh/WebKit#578)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * prebuilt tarball's release tag). Override via `--webkit-version=<hash>` to test a
  * branch. From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "caa5d805b646edc59ca0d12b49a7a574f942dedb";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine, with WTF and bmalloc.

--- a/test/regression/issue/41609.test.ts
+++ b/test/regression/issue/41609.test.ts
@@ -45,15 +45,17 @@ test("optimized code keeps the bounds check of a string access whose result is d
       const latin1 = "Hello, World!";
       const utf16 = "こんにちは世界";
 
-      for (let i = 0; i < 20000; ++i) {
+      // With the JIT thresholds below, the FTL compiles the probes after a few
+      // hundred calls. 1000 leaves margin and stays fast on a debug build.
+      for (let i = 0; i < 1000; ++i) {
         let index = i % latin1.length;
-        shouldBe(codePointAtIsUndefined(latin1, index), false, "codePointAt latin1 " + index);
-        shouldBe(atIsUndefined(latin1, index), false, "at latin1 " + index);
-        shouldBe(charCodeAtIsNaN(latin1, index), false, "charCodeAt latin1 " + index);
+        shouldBe(codePointAtIsUndefined(latin1, index), false, "codePointAt latin1 in bounds");
+        shouldBe(atIsUndefined(latin1, index), false, "at latin1 in bounds");
+        shouldBe(charCodeAtIsNaN(latin1, index), false, "charCodeAt latin1 in bounds");
         index = i % utf16.length;
-        shouldBe(codePointAtIsUndefined(utf16, index), false, "codePointAt utf16 " + index);
-        shouldBe(atIsUndefined(utf16, index), false, "at utf16 " + index);
-        shouldBe(charCodeAtIsNaN(utf16, index), false, "charCodeAt utf16 " + index);
+        shouldBe(codePointAtIsUndefined(utf16, index), false, "codePointAt utf16 in bounds");
+        shouldBe(atIsUndefined(utf16, index), false, "at utf16 in bounds");
+        shouldBe(charCodeAtIsNaN(utf16, index), false, "charCodeAt utf16 in bounds");
         step({ source: latin1, cursor: index % latin1.length, atEnd: false });
       }
 

--- a/test/regression/issue/41609.test.ts
+++ b/test/regression/issue/41609.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/41609
+//
+// The FTL dropped the in-bounds check of `codePointAt` and `String.prototype.at`
+// when their result was only compared against `undefined`. The abstract
+// interpreter folded the compare to `false`, the access node lost its last user,
+// and DCE removed the node together with the speculation inside it. The
+// optimized code then never saw the end of the string.
+//
+// Each probe warms up with in-bounds indices only, so no out-of-bounds exit is
+// profiled before the FTL compiles it. It then reads at `length`.
+test("optimized code keeps the bounds check of a string access whose result is dead", async () => {
+  const source = `
+      function shouldBe(actual, expected, what) {
+        if (actual !== expected) throw new Error(what + ": got " + actual + ", expected " + expected);
+      }
+
+      function codePointAtIsUndefined(string, index) {
+        return string.codePointAt(index) === undefined;
+      }
+      function atIsUndefined(string, index) {
+        return string.at(index) === undefined;
+      }
+      function charCodeAtIsNaN(string, index) {
+        const c = string.charCodeAt(index);
+        return c !== c;
+      }
+
+      // The shape from the issue: @csstools/css-tokenizer's endOfFile() inlined
+      // into a tokenizer step.
+      function endOfFile(reader) {
+        return void 0 === reader.source.codePointAt(reader.cursor);
+      }
+      function step(reader) {
+        if (endOfFile(reader)) {
+          reader.atEnd = true;
+          return null;
+        }
+        reader.cursor++;
+        return 1;
+      }
+
+      const latin1 = "Hello, World!";
+      const utf16 = "こんにちは世界";
+
+      for (let i = 0; i < 20000; ++i) {
+        let index = i % latin1.length;
+        shouldBe(codePointAtIsUndefined(latin1, index), false, "codePointAt latin1 " + index);
+        shouldBe(atIsUndefined(latin1, index), false, "at latin1 " + index);
+        shouldBe(charCodeAtIsNaN(latin1, index), false, "charCodeAt latin1 " + index);
+        index = i % utf16.length;
+        shouldBe(codePointAtIsUndefined(utf16, index), false, "codePointAt utf16 " + index);
+        shouldBe(atIsUndefined(utf16, index), false, "at utf16 " + index);
+        shouldBe(charCodeAtIsNaN(utf16, index), false, "charCodeAt utf16 " + index);
+        step({ source: latin1, cursor: index % latin1.length, atEnd: false });
+      }
+
+      for (let i = 0; i < 10; ++i) {
+        shouldBe(codePointAtIsUndefined(latin1, latin1.length), true, "codePointAt latin1 at length");
+        shouldBe(atIsUndefined(latin1, latin1.length), true, "at latin1 at length");
+        shouldBe(charCodeAtIsNaN(latin1, latin1.length), true, "charCodeAt latin1 at length");
+        shouldBe(codePointAtIsUndefined(utf16, utf16.length), true, "codePointAt utf16 at length");
+        shouldBe(atIsUndefined(utf16, utf16.length), true, "at utf16 at length");
+        shouldBe(charCodeAtIsNaN(utf16, utf16.length), true, "charCodeAt utf16 at length");
+
+        const reader = { source: latin1, cursor: latin1.length, atEnd: false };
+        shouldBe(step(reader), null, "step at end");
+        shouldBe(reader.atEnd, true, "reader.atEnd");
+      }
+      console.log("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: {
+      ...bunEnv,
+      // Tier up fast and deterministically, like the JSTests stress harness.
+      BUN_JSC_thresholdForJITAfterWarmUp: "10",
+      BUN_JSC_thresholdForOptimizeAfterWarmUp: "100",
+      BUN_JSC_thresholdForFTLOptimizeAfterWarmUp: "1000",
+      BUN_JSC_useConcurrentJIT: "false",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- #41609: `@stylexjs/babel-plugin` fails with `Invalid media query syntax` after about 20 compilations in one process. Its tokenizer tests for the end of input with `void 0 === source.codePointAt(cursor)`. Once the FTL compiles that code, `codePointAt(length)` no longer reports the end. `String.prototype.at` has the same defect. `BUN_JSC_useFTLJIT=false` hides it.
- The cause is in JavaScriptCore. `StringCodePointAt` and an in-bounds `StringAt` speculate inside the node that the index is in bounds (`FTLLowerDFGToB3.cpp:12240`). The abstract interpreter relies on that speculation and types the result as Int32, so it folds the compare against `undefined` to `false`. The node has no users left, and the FTL pipeline removes it in DCE (`DFGDCEPhase.cpp:140`) together with its bounds check.

### Fix
- Pin WebKit to `caa5d805b646`, the head of oven-sh/WebKit#578. That commit marks `StringAt`, `StringCharCodeAt` and `StringCodePointAt` as `NodeMustGenerate`, the same convention `ArithAdd` and `GetByVal` follow for a node that carries its own speculation. Fixup clears the flag for an out-of-bounds `StringAt`, which returns `undefined` instead of exiting.
- The pin is the WebKit PR head, not a merge commit. Do not merge before oven-sh/WebKit#578 lands. I move the pin to the merge commit then.
- Verified: `test/regression/issue/41609.test.ts` fails on 1.4.3 (`codePointAt latin1 at length: got false`) and passes on a debug build with this pin. The stylex repro from the issue and the new JSTests stress file pass too. Also ran `test/js/bun/jsc/`, `test/js/node/string_decoder/` and `test/js/web/encoding/`.

### Background
- JSC runs code in four tiers. The DFG and the FTL are the optimizing tiers. They speculate: a check exits back to the baseline tier when it fails, and the exit is recorded so the next compile avoids the speculation.
- The DFG abstract interpreter computes a type for each node. For a node that speculates, the type is only true when the node runs. A node without `NodeMustGenerate` is removed when nothing uses its result. The edge checks survive as a `Check` node, but a check inside the node's own code generation does not.
- A MovHint tells OSR exit where a bytecode local lives. In the DFG tier every call result has one, so the node stays alive by accident. The FTL pipeline removes MovHints before DCE, which is why only the FTL shows the defect.

<details><summary>Notes</summary>

- Delta-debugging with `BUN_JSC_dfgAllowlist` and `BUN_JSC_ftlAllowlist` on the stylex repro: exactly one function needs to reach the FTL, `TokenList.consumeNextToken`, which inlines `endOfFile()` from `@csstools/css-tokenizer`.
- `BUN_JSC_verboseCompilation=true` shows the DFG graph with `StringCodePointAt` present and the compare folded to `JSConstant(False)`. The FTL graph has only `Check(Int32 cursor)` left. `BUN_JSC_useMovHintRemoval=false` also hides the bug.
- `charCodeAt` did not show the symptom because upstream already extracts a `CheckInBounds` node for it in the FTL (298202@main). The DFG tier still relies on the MovHint there, so the flag covers it too.
- Upstream WebKit main has the same code in `DFGNodeType.h`, `DFGAbstractInterpreterInlines.h` and `DFGByteCodeParser.cpp`.
- The WebKit pin is built from source on every CI target since #41330, so no preview tarball is needed.
- The test pins the JIT thresholds and disables the concurrent JIT, the same as the other WebKit upgrade tests, so the FTL compiles the probes at a deterministic point.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/41609.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/41609.test.ts"
bun test v1.4.3 (f42e98025)

test/regression/issue/41609.test.ts:
(pass) optimized code keeps the bounds check of a string access whose result is dead [1253.90ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [4.64s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts        |  2 +-
 test/regression/issue/41609.test.ts | 93 +++++++++++++++++++++++++++++++++++++
 2 files changed, 94 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
scripts/build/deps/webkit.ts             0      0      8
test/regression/issue/41609.test.ts      1      3      8
```

</details>

<!-- robobun:evidence:end -->