### PR TITLE
install: trim .npmrc keys and values with the JS whitespace set, like npm

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2244,6 +2244,13 @@ pub const fn is_unicode_space_separator(cp: u32) -> bool {
     )
 }
 
+/// The set `String.prototype.trim` removes: ECMAScript `WhiteSpace`
+/// (TAB VT FF SP ZWNBSP + Zs) plus `LineTerminator` (LF CR LS PS).
+#[inline]
+pub const fn is_js_whitespace(cp: u32) -> bool {
+    matches!(cp, 0x0009..=0x000D | 0x2028 | 0x2029 | 0xFEFF) || is_unicode_space_separator(cp)
+}
+
 /// SIMD-accelerated iterator that yields slices of text between ANSI escape sequences.
 /// The C++ side uses ANSI::findEscapeCharacter (SIMD) and ANSI::consumeANSI.
 #[repr(C)]

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -8,25 +8,30 @@ use bun_ast::Loc;
 // they are unit-testable without the Expr-carrying struct.
 // ──────────────────────────────────────────────────────────────────────────
 
-#[inline]
-pub(crate) fn should_skip_line(line: &[u8]) -> bool {
-    if line.is_empty()
-        // comments
-        || line[0] == b';'
-        || line[0] == b'#'
-    {
-        return true;
-    }
-
-    // check the rest is whitespace
-    for &c in line {
-        match c {
-            b' ' | b'\t' | b'\n' | b'\r' => {}
-            b'#' | b';' => return true,
-            _ => return false,
+/// npm's `ini` trims keys, values and section names with
+/// `String.prototype.trim`, so the set is wider than ASCII whitespace.
+pub(crate) fn trim_js_whitespace(mut s: &[u8]) -> &[u8] {
+    use bun_core::strings::is_js_whitespace;
+    loop {
+        match bstr::decode_utf8(s) {
+            (Some(c), n) if is_js_whitespace(c as u32) => s = &s[n..],
+            _ => break,
         }
     }
-    true
+    loop {
+        match bstr::decode_last_utf8(s) {
+            (Some(c), n) if is_js_whitespace(c as u32) => s = &s[..s.len() - n],
+            _ => break,
+        }
+    }
+    s
+}
+
+#[inline]
+pub(crate) fn should_skip_line(line: &[u8]) -> bool {
+    let line = trim_js_whitespace(line);
+    // empty or a comment
+    line.is_empty() || line[0] == b';' || line[0] == b'#'
 }
 
 #[inline]
@@ -143,7 +148,7 @@ mod draft {
 
     use super::{
         ConfigItem, ConfigOpt, IniOption, NODE_LINKER_MAP, NodeLinker, is_quoted, next_dot,
-        should_skip_line,
+        should_skip_line, trim_js_whitespace,
     };
 
     type OOM<T> = Result<T, AllocError>;
@@ -245,13 +250,9 @@ mod draft {
                             break 'treat_as_key;
                         };
                         // Make sure the rest is just whitespace
-                        if close_bracket_idx + 1 < line.len() {
-                            for &c in &line[close_bracket_idx + 1..] {
-                                if !matches!(c, b' ' | b'\t') {
-                                    treat_as_key = true;
-                                    break 'treat_as_key;
-                                }
-                            }
+                        if !trim_js_whitespace(&line[close_bracket_idx + 1..]).is_empty() {
+                            treat_as_key = true;
+                            break 'treat_as_key;
                         }
                         let offset = i32::try_from(line.as_ptr() as usize - src.as_ptr() as usize)
                             .unwrap()
@@ -426,7 +427,7 @@ mod draft {
             offset_: i32,
         ) -> OOM<PrepareResult<'a>> {
             let mut offset = offset_;
-            let mut val = bun_core::trim(val_, b" \n\r\t");
+            let mut val = trim_js_whitespace(val_);
 
             if is_quoted(val) {
                 'out: {

--- a/src/runtime/node/node_assert.rs
+++ b/src/runtime/node/node_assert.rs
@@ -203,24 +203,6 @@ fn append_ascii<C: CodeUnit>(out: &mut Vec<C>, bytes: &[u8]) {
     out.extend(bytes.iter().map(|&b| C::from(b)));
 }
 
-/// `String.prototype.trimEnd` whitespace set (WhiteSpace + LineTerminator).
-fn is_js_whitespace(c: u32) -> bool {
-    matches!(
-        c,
-        0x09..=0x0D
-            | 0x20
-            | 0xA0
-            | 0x1680
-            | 0x2000..=0x200A
-            | 0x2028
-            | 0x2029
-            | 0x202F
-            | 0x205F
-            | 0x3000
-            | 0xFEFF
-    )
-}
-
 fn emit<C, T>(
     global: &JSGlobalObject,
     diff_list: &MyersDiff::DiffList<T>,
@@ -341,7 +323,7 @@ fn render_lines<C: CodeUnit, T: DiffText<C>>(diff: &[Diff<T>], colors: &Colors) 
     }
 
     // `message.trimEnd()` (the leading "\n" is prepended after trimming in JS, so keep it).
-    while out.len() > 1 && is_js_whitespace(out[out.len() - 1].as_u32()) {
+    while out.len() > 1 && bun_core::strings::is_js_whitespace(out[out.len() - 1].as_u32()) {
         out.pop();
     }
     (out, skipped)

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -282,6 +282,31 @@ registry=http://localhost:\${PORT}/
     expect(result.default_registry_url).toEqual(`http://localhost:${registry.port}/`);
   });
 
+  // npm's `ini` trims keys and values with `String.prototype.trim`, so Unicode
+  // whitespace (NBSP from a copy-paste, FF/VT, a BOM in the middle of the file)
+  // around a key or a value is not part of it.
+  describe("trims Unicode whitespace like npm", () => {
+    const url = "http://127.0.0.1:4873/";
+    const expected = {
+      default_registry_url: url,
+      default_registry_token: "SECRET",
+      default_registry_username: "",
+      default_registry_password: "",
+      default_registry_email: "",
+    };
+
+    it.each([
+      ["NBSP after the registry key", `registry\u00a0= ${url}\n//127.0.0.1:4873/:_authToken=SECRET\n`],
+      ["NBSP after the registry value", `registry=${url}\u00a0\n//127.0.0.1:4873/:_authToken=SECRET\n`],
+      ["NBSP around the token", `registry=${url}\n//127.0.0.1:4873/:_authToken\u00a0=\u00a0SECRET\u00a0\n`],
+      ["FF and VT around the token", `registry=${url}\n//127.0.0.1:4873/:_authToken\u000c=\u000bSECRET\u000c\n`],
+      ["BOM before a key", `registry=${url}\n\ufeff//127.0.0.1:4873/:_authToken=SECRET\n`],
+      ["other Zs spaces", `registry\u3000=\u2003${url}\u202f\n//127.0.0.1:4873/:_authToken=SECRET\n`],
+    ])("%s", (_, ini) => {
+      expect(loadNpmrc(ini)).toEqual(expected);
+    });
+  });
+
   async function makeTest(
     options: [option: string, value: string][],
     check: (result: {


### PR DESCRIPTION
### Problem
- The `.npmrc` parser trims keys and values with only space, tab, CR and LF (`src/ini/lib.rs`, `prepare_str`). npm's `ini` trims with `String.prototype.trim`, which also removes NBSP, VT, FF, U+FEFF, the other `Zs` spaces, and U+2028/U+2029.
- So `registry<NBSP>= http://private/` is an unknown key in bun and bun resolves from registry.npmjs.org with no warning. The same file uses the private registry under npm. A NBSP after a `registry=` value breaks the `//host/:_authToken` match, so requests carry no Authorization header. NBSP, FF or VT around a token go into the header as raw bytes.
- Found by diffing the parser against npm's bundled `ini` 6.0.0. There is no user report.

### Fix
- Add `bun_core::strings::is_js_whitespace` (the `String.prototype.trim` set) and `trim_js_whitespace` in the ini crate. It decodes UTF-8 at both ends of the slice with `bstr`.
- Use it for keys, values, blank-line and comment detection, and the text after a `[section]` header. ASCII behaviour does not change.
- `node:assert` had a private copy of the same predicate. It now uses the shared one.
- Verified: `test/cli/install/npmrc.test.ts` (6 new cases, all fail on the released bun). Also all of `test/cli/install/npmrc.test.ts`, `test/js/bun/ini/` and `test/js/node/assert/`.

### Background
- bun reads `.npmrc` with its own port of npm's `ini` parser in `src/ini/lib.rs`. `load_npmrc` then maps `registry` and `//host/:_authToken` keys onto the install config.
- A leading file BOM is already stripped at load (`convert_bom: true`). This change only affects a BOM or other Unicode whitespace inside the file.
- `bun:internal-for-testing` exposes `loadNpmrc(text)`, which runs the same parser and returns the resolved default registry and credentials. The tests use it, so they stay offline.

<details><summary>Notes</summary>

Reference check with node and npm's bundled `ini`:

```
node -e 'const ini=require("/usr/local/lib/node_modules/npm/node_modules/ini");
console.log(Object.keys(ini.parse("registry\u00a0= http://x/\n\ufeffcache\u3000=\u000bfoo\u000c\n")))'
# [ "registry", "cache" ]
```

`ini` also strips an inline `; comment` from an unquoted value. bun keeps it. That is a separate bug and is tracked on its own.

ZWSP (U+200B) and WORD JOINER (U+2060) are not in the JS trim set. npm treats them as part of the key too, so they stay unknown keys in bun as well.

Self-reviewed: 4 concerns raised, 4 addressed (commit message wording, a test that passed without the fix, the shared predicate, the doc comment).
</details>
