### PR TITLE
Do not pass GIT_DIR to the git that bun install and bun create spawn

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1507,6 +1507,34 @@ impl Map {
             map: self.map.clone()?,
         })
     }
+
+    /// Removes the variables that select which repository git operates on
+    /// (git(1), "Environment Variables: The Git Repository"). git exports
+    /// `GIT_DIR` and `GIT_INDEX_FILE` to hooks. A git child that names its own
+    /// repository (`-C`, cwd, or the clone target) must not inherit them, or it
+    /// resolves and checks out in the caller's repository instead.
+    pub fn remove_git_repository_vars(&mut self) {
+        const VARS: &[&[u8]] = &[
+            b"GIT_DIR",
+            b"GIT_WORK_TREE",
+            b"GIT_INDEX_FILE",
+            b"GIT_NAMESPACE",
+            b"GIT_OBJECT_DIRECTORY",
+            b"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            b"GIT_COMMON_DIR",
+            b"GIT_PREFIX",
+        ];
+        for key in VARS {
+            self.remove(key);
+        }
+    }
+
+    /// The envp for a git child that operates on a repository bun names itself.
+    pub fn create_git_child_env(&self) -> Result<NullDelimitedEnvMap, AllocError> {
+        let mut map = self.clone_with_allocator()?;
+        map.remove_git_repository_vars();
+        map.create_null_delimited_env_map()
+    }
 }
 
 /// Owns the `K=V\0` strings backing a NULL-terminated envp array.
@@ -1524,6 +1552,10 @@ pub struct NullDelimitedEnvMap {
     _storage: Vec<Box<[u8]>>,
     envp: Box<[*const c_char]>,
 }
+
+// SAFETY: every pointer in `envp` points into `_storage`, which the struct
+// owns and never shares. Moving both together to another thread is sound.
+unsafe impl Send for NullDelimitedEnvMap {}
 
 impl NullDelimitedEnvMap {
     /// `[:null]?[*:0]const u8` — last element is `ptr::null()`.

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -160,9 +160,11 @@ impl GitEnv {
     }
 
     fn init(loader: &mut bun_dotenv::Loader) -> GitEnv {
-        // No prompts by default: the install's own output would hide them.
         let mut map = bun_core::handle_oom(loader.map.clone_with_allocator());
+        // Every git the install spawns names its repository (`-C` or the clone target).
+        map.remove_git_repository_vars();
 
+        // No prompts by default: the install's own output would hide them.
         if map.get(b"GIT_ASKPASS").is_none() {
             let config = SloppyGlobalGitConfig::get();
             if !config.has_askpass {

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1077,15 +1077,16 @@ impl CreateCommand {
         create_options.skip_install = create_options.skip_install || !has_dependencies;
 
         if !create_options.skip_git {
+            let git_env = env_loader.map.create_git_child_env()?;
             if !create_options.skip_install {
-                GitHandler::spawn(destination, path_env, create_options.verbose);
+                GitHandler::spawn(destination, path_env, git_env, create_options.verbose);
             } else {
                 if create_options.verbose {
                     create_options.skip_git =
-                        GitHandler::run::<true>(destination, path_env).unwrap_or(false);
+                        GitHandler::run::<true>(destination, path_env, &git_env).unwrap_or(false);
                 } else {
                     create_options.skip_git =
-                        GitHandler::run::<false>(destination, path_env).unwrap_or(false);
+                        GitHandler::run::<false>(destination, path_env, &git_env).unwrap_or(false);
                 }
             }
         }
@@ -2362,7 +2363,7 @@ static THREAD: bun_core::RacyCell<Option<std::thread::JoinHandle<()>>> =
     bun_core::RacyCell::new(None);
 
 impl GitHandler {
-    fn spawn(destination: &[u8], path: &[u8], verbose: bool) {
+    fn spawn(destination: &[u8], path: &[u8], env: DotEnv::NullDelimitedEnvMap, verbose: bool) {
         SUCCESS.store(0, Ordering::Relaxed);
 
         // Own copies so the spawned closure is `'static` without any lifetime
@@ -2370,7 +2371,7 @@ impl GitHandler {
         let destination: Box<[u8]> = Box::from(destination);
         let path: Box<[u8]> = Box::from(path);
         let thread = match std::thread::Builder::new()
-            .spawn(move || Self::spawn_thread(&destination, &path, verbose))
+            .spawn(move || Self::spawn_thread(&destination, &path, &env, verbose))
         {
             Ok(t) => t,
             Err(err) => {
@@ -2382,12 +2383,17 @@ impl GitHandler {
         unsafe { *THREAD.get() = Some(thread) };
     }
 
-    fn spawn_thread(destination: &[u8], path: &[u8], verbose: bool) {
+    fn spawn_thread(
+        destination: &[u8],
+        path: &[u8],
+        env: &DotEnv::NullDelimitedEnvMap,
+        verbose: bool,
+    ) {
         Output::Source::configure_named_thread(bun_core::zstr!("git"));
         let outcome = if verbose {
-            Self::run::<true>(destination, path).unwrap_or(false)
+            Self::run::<true>(destination, path, env).unwrap_or(false)
         } else {
-            Self::run::<false>(destination, path).unwrap_or(false)
+            Self::run::<false>(destination, path, env).unwrap_or(false)
         };
 
         SUCCESS.store(if outcome { 1 } else { 2 }, Ordering::Release);
@@ -2406,7 +2412,11 @@ impl GitHandler {
         outcome
     }
 
-    fn run<const VERBOSE: bool>(destination: &[u8], path: &[u8]) -> crate::Result<bool> {
+    fn run<const VERBOSE: bool>(
+        destination: &[u8],
+        path: &[u8],
+        env: &DotEnv::NullDelimitedEnvMap,
+    ) -> crate::Result<bool> {
         let git_start = bun_core::time::nano_timestamp();
 
         // Not sure why...
@@ -2462,6 +2472,7 @@ impl GitHandler {
                 let _ = spawn_sync::spawn(&spawn_sync::Options {
                     argv: command.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
                     cwd: Box::from(destination),
+                    envp: Some(env.as_ptr()),
                     stdin: spawn_sync::SyncStdio::Inherit,
                     stdout: spawn_sync::SyncStdio::Inherit,
                     stderr: spawn_sync::SyncStdio::Inherit,

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -342,6 +342,61 @@ it("should create template from local folder", async () => {
   expect(await Bun.file(join(x_dir, testTemplate, "foo", "bar.js")).text()).toBe("hi");
 });
 
+// git exports GIT_DIR and GIT_INDEX_FILE to commit hooks. With them inherited,
+// the `git init` / `git add` / `git commit` that bun create runs in the new
+// project operated on that other repository instead: its tracked files were
+// committed away and the new project got no `.git`.
+it("initializes the new project's own repository when GIT_DIR points at another repository", async () => {
+  using dir = tempDir("create-gitdir", {
+    "bun-create/tmpl/index.js": "// hi\n",
+    "bun-create/tmpl/package.json": JSON.stringify({ name: "tmpl", version: "1.0.0" }),
+    "other/keep.txt": "keep\n",
+  });
+  const root = String(dir);
+  const other = join(root, "other");
+  const gitEnv = {
+    ...env,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+  const git = (cwd: string, ...args: string[]) => {
+    const proc = spawnSync({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+    if (proc.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed:\n${proc.stderr}`);
+    return proc.stdout.toString();
+  };
+  git(other, "init", "-q", "-b", "main");
+  git(other, "add", "-A");
+  git(other, "-c", "commit.gpgsign=false", "commit", "-qm", "other-initial");
+  const otherLog = () => git(other, "log", "--format=%s", "--name-status");
+  const before = otherLog();
+  expect(before).toBe("other-initial\n\nA\tkeep.txt\n");
+
+  const proc = spawnSync({
+    cmd: [bunExe(), "create", "tmpl", join(root, "dest"), "--no-install"],
+    cwd: root,
+    env: {
+      ...gitEnv,
+      BUN_CREATE_DIR: join(root, "bun-create"),
+      GIT_DIR: join(other, ".git"),
+      GIT_INDEX_FILE: join(other, ".git", "index"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stderr = proc.stderr.toString();
+  expect(stderr).not.toContain("error:");
+  expect(proc.exitCode).toBe(0);
+
+  expect(otherLog()).toBe(before);
+  expect(await exists(join(root, "dest", ".git"))).toBe(true);
+  expect(git(join(root, "dest"), "log", "--format=%s", "--name-status")).toBe(
+    "Initial commit (via bun create)\n\nA\tindex.js\nA\tpackage.json\n",
+  );
+});
+
 // `bun create <github-url>` hits https://api.github.com/repos/{owner}/{repo}/tarball.
 // CI exhausts the unauthenticated 60 req/hr limit (403) and the endpoint serves 5xx
 // during outages; skip rather than fail since these tests exercise `bun create`, not GitHub.

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -587,6 +587,59 @@ test.concurrent("installs a git+file:// dependency", async () => {
   expect(exitCode).toBe(0);
 });
 
+// With GIT_DIR in the environment (git exports it to commit hooks), git ignores
+// the repository that `-C` names and operates on $GIT_DIR instead. The install
+// then resolves and checks out the branch in the user's repository and installs
+// its tree as the dependency. The git children must not inherit it.
+test.concurrent("installs a git dependency when GIT_DIR points at another repository", async () => {
+  using dir = tempDir("git-dep-gitdir", {});
+  const root = String(dir);
+  // an unrelated non-bare repo, on `main`, that also has a `pkg-b` branch
+  const other = join(root, "other");
+  mkdirSync(other);
+  await git(other, "init", "-q", "-b", "main");
+  writeFileSync(join(other, "keep.txt"), "keep\n");
+  await git(other, "add", "-A");
+  await git(other, "-c", "commit.gpgsign=false", "commit", "-qm", "main");
+  await git(other, "checkout", "-qb", "pkg-b");
+  writeFileSync(join(other, "other-file.txt"), "x\n");
+  await git(other, "add", "-A");
+  await git(other, "-c", "commit.gpgsign=false", "commit", "-qm", "pkg-b");
+  await git(other, "checkout", "-q", "main");
+  // the branch line plus one line per changed file
+  const otherState = async () => {
+    await using proc = Bun.spawn({
+      cmd: ["git", "-C", other, "status", "--porcelain=v2", "--branch"],
+      env: gitEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(`git status failed:\n${stderr}`);
+    return stdout.split("\n").filter(line => line.startsWith("# branch.head") || !line.startsWith("#"));
+  };
+  expect(await otherState()).toEqual(["# branch.head main", ""]);
+
+  const repoUrl = `git+${pathToFileURL(sharedBare)}`;
+  const project = writeProject(root, { [nameOf("b")]: `${repoUrl}#pkg-b` });
+  const { resolutions, locked } = expectedGitPackages(repoUrl, sharedCommits, ["b"]);
+
+  const { stdout, stderr, exitCode } = await runInstall(project, join(root, "cache"), {
+    GIT_DIR: join(other, ".git"),
+    GIT_INDEX_FILE: join(other, ".git", "index"),
+  });
+  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+    "Resolving dependencies
+    Resolved, downloaded and extracted [2]
+    Saved lockfile"
+  `);
+  expectInstalled(stdout, resolutions);
+  expect(await installedVersions(project, [nameOf("b")])).toEqual(markers(["b"]));
+  expect(await lockedPackages(project)).toEqual(locked);
+  expect(exitCode).toBe(0);
+  expect(await otherState()).toEqual(["# branch.head main", ""]);
+});
+
 // issue #40803: `bun install <git url>` (no alias) sorted the workspace dep
 // under its version literal. The real name is only known once the repo is
 // fetched; it is rewritten in place after resolution, so the written key


### PR DESCRIPTION
### Problem
- `bun install` of a git dependency and `bun create` spawn `git` with the full process environment. With `GIT_DIR` set (git exports `GIT_DIR` and `GIT_INDEX_FILE` to pre-commit and post-commit hooks), git ignores the repository that `-C` or cwd names and operates on `$GIT_DIR`.
- For install (`src/install/repository.rs`, `GitEnv::init`), `git log` resolves the ref in the user's repository, `git checkout` leaves it on a detached HEAD with a rewritten index, and the dependency is that repository's tree. The lockfile records a commit that does not exist in the dependency's repository. Exit code 0.
- For create (`src/runtime/cli/create_command.rs`, `GitHandler::run`), `git add` and `git commit` land in the user's repository. Its tracked files are committed away. The new project gets no `.git`.

### Fix
- Add `Map::remove_git_repository_vars` and `Map::create_git_child_env` to `bun_dotenv`. They drop the variables from git(1) "The Git Repository": `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_NAMESPACE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_COMMON_DIR`, `GIT_PREFIX`.
- `GitEnv::init` (install) removes them from its copy of the env. `GitHandler` (create) builds its env with `create_git_child_env` on the main thread and hands it to the git thread. `NullDelimitedEnvMap` gets a `Send` impl for that: it owns every buffer its pointers reference.
- Correct because every git these commands run names its own repository. githooks(5) says the same: a hook that runs git in a foreign repository must clear these variables. User-facing knobs (`GIT_SSH_COMMAND`, `GIT_ASKPASS`, `GIT_CONFIG_*`, proxies) still pass through.
- Verified: `test/cli/install/bun-install-git-deps.test.ts` and `test/cli/install/bun-create.test.ts` (one new test each, both fail on 1.4.3-canary). Both files pass in full.

### Background
- `GitEnv` is the one env every `git` of an install runs with. It is built once from the install's `bun_dotenv::Loader` and adds `GIT_ASKPASS=echo` and a default `GIT_SSH_COMMAND`.
- `bun create` runs `git init`, `git add`, `git commit` in the new project on its own thread while the install runs. The thread had no env loader, so it inherited the process env.
- `bun test --changed` and `bun pm version` also run git. They act on the user's own repository at cwd, where `GIT_DIR` expresses the user's intent. This PR leaves them unchanged.

<details><summary>Notes</summary>

Repro for install (offline):

```
git init -q -b main dep; echo '{"name":"r1","version":"2.0.0"}' > dep/package.json; git -C dep add -A; git -C dep commit -qm main
git -C dep checkout -qb dev; echo '{"name":"r1","version":"2.1.0-dev"}' > dep/package.json; git -C dep commit -qam dev; git clone -q --bare dep r1.git
git init -q -b main other; echo keep > other/keep.txt; git -C other add -A; git -C other commit -qm o1
git -C other checkout -qb dev; echo x > other/devfile.txt; git -C other add -A; git -C other commit -qm o2; git -C other checkout -q main
mkdir app; cd app; echo '{"dependencies":{"r1":"git+file://'$W'/r1.git#dev"}}' > package.json
GIT_DIR=$W/other/.git bun install
git -C ../other status -sb     # HEAD (no branch), D devfile.txt
ls node_modules/r1             # .bun-tag devfile.txt
```

`GIT_OBJECT_DIRECTORY` has a second effect: `git clone --bare` writes its pack into that directory and the cache mirror ends up with no objects, which breaks later installs from the same cache. Removing the variable prevents that. This PR does not validate or re-clone an existing objectless mirror.

`bun patch --commit` runs `git diff --no-index` with a minimal env of its own and is not affected.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-git-deps.test.ts

<!-- robobun:evidence:end -->