### PR TITLE
resolver: expand ${configDir} in an extended tsconfig with the root config's directory

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3972,10 +3972,14 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// `config_dir` is the directory that `${configDir}` expands to. It is
+    /// `None` for the root config of an `extends` chain (its own directory)
+    /// and the root config's directory for every config the chain reaches.
     pub(crate) fn parse_tsconfig(
         &mut self,
         file: &[u8],
         dirname_fd: FD,
+        config_dir: Option<&[u8]>,
     ) -> crate::CrateResult<Option<Box<TSConfigJSON>>> {
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
@@ -4020,12 +4024,15 @@ impl<'a> Resolver<'a> {
 
         // SAFETY: BACKREF — `self.log` (see `log()` NOTE); disjoint from `self.caches`,
         // narrow `&mut` for this call only.
-        let mut result =
-            match TSConfigJSON::parse(unsafe { &mut *self.log() }, &source, &mut self.caches.json)?
-            {
-                Some(r) => r,
-                None => return Ok(None),
-            };
+        let mut result = match TSConfigJSON::parse(
+            unsafe { &mut *self.log() },
+            &source,
+            &mut self.caches.json,
+            config_dir.unwrap_or(file_dir),
+        )? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
 
         if result.has_base_url() {
             // this might leak
@@ -6442,6 +6449,7 @@ impl<'a> Resolver<'a> {
                     } else {
                         FD::ZERO
                     },
+                    None,
                 ) {
                     Ok(v) => v.map(bun_core::heap::into_raw),
                     Err(err) => {
@@ -6490,6 +6498,13 @@ impl<'a> Resolver<'a> {
                     let mut current = bun_ptr::BackRef::from(
                         core::ptr::NonNull::new(tsconfig_json).expect("heap alloc"),
                     );
+                    // `${configDir}` in every config of the chain expands to the
+                    // directory of the config that started it (tsc semantics).
+                    // SAFETY: `tsconfig_json` is a live heap allocation. Nothing
+                    // writes through it until the merge loop below, after the
+                    // last use of this borrow.
+                    let root_config_dir: &[u8] =
+                        Dirname::dirname(unsafe { &(*tsconfig_json).abs_path });
                     while !current.extends.is_empty() {
                         let ts_dir_name = Dirname::dirname(&current.abs_path);
                         let abs_path = ResolvePath::join_abs_string_buf(
@@ -6498,22 +6513,23 @@ impl<'a> Resolver<'a> {
                             &[ts_dir_name, &current.extends],
                             bun_paths::Platform::AUTO,
                         );
-                        let parent_config_maybe: Option<*mut TSConfigJSON> =
-                            match self.parse_tsconfig(abs_path, FD::INVALID) {
-                                Ok(v) => v.map(bun_core::heap::into_raw),
-                                Err(err) => {
-                                    let _ = self.log_mut().add_debug_fmt(
-                                        None,
-                                        bun_ast::Loc::EMPTY,
-                                        format_args!(
-                                            "{} loading tsconfig.json extends {}",
-                                            bstr::BStr::new(err.name()),
-                                            bun_core::fmt::quote(abs_path)
-                                        ),
-                                    );
-                                    break;
-                                }
-                            };
+                        let parent_config_maybe: Option<*mut TSConfigJSON> = match self
+                            .parse_tsconfig(abs_path, FD::INVALID, Some(root_config_dir))
+                        {
+                            Ok(v) => v.map(bun_core::heap::into_raw),
+                            Err(err) => {
+                                let _ = self.log_mut().add_debug_fmt(
+                                    None,
+                                    bun_ast::Loc::EMPTY,
+                                    format_args!(
+                                        "{} loading tsconfig.json extends {}",
+                                        bstr::BStr::new(err.name()),
+                                        bun_core::fmt::quote(abs_path)
+                                    ),
+                                );
+                                break;
+                            }
+                        };
                         if let Some(parent_config) = parent_config_maybe {
                             parent_configs.append(parent_config)?;
                             current = bun_ptr::BackRef::from(

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -264,9 +264,14 @@ impl TSConfigJSON {
     // "${configDir}" with "./" and then convert it to an absolute path sometimes.
     // We convert it to an absolute path during module resolution, so we shouldn't need to do that here.
     // https://github.com/microsoft/TypeScript/blob/ef802b1e4ddaf8d6e61d6005614dd796520448f8/src/compiler/commandLineParser.ts#L3243-L3245
+    //
+    // `config_dir` is the directory of the config that started the `extends`
+    // chain, not the directory of the file being parsed. tsc defines
+    // `${configDir}` that way so a shared base can point into the project
+    // that extends it.
     fn str_replacing_templates(
         input: Box<[u8]>,
-        source: &bun_ast::Source,
+        config_dir: &[u8],
     ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
         const TEMPLATE: &[u8] = b"${configDir}";
         let mut remaining: &[u8] = &input;
@@ -275,7 +280,6 @@ impl TSConfigJSON {
             cap: 0,
             ptr: None,
         };
-        let config_dir = source.path.source_dir();
 
         // There's only one template variable we support, so we can keep this simple for now.
         while let Some(index) = strings::index_of(remaining, TEMPLATE) {
@@ -307,10 +311,15 @@ impl TSConfigJSON {
         Ok(Box::from(&written[..len]))
     }
 
+    /// `config_dir` replaces `${configDir}` in `baseUrl` and `paths`. It is
+    /// the directory (with a trailing separator) of the root config of the
+    /// `extends` chain. For a config with no `extends` chain it is the
+    /// directory of `source`.
     pub fn parse(
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
         json_cache: &mut JsonCache,
+        config_dir: &[u8],
     ) -> Result<Option<Box<TSConfigJSON>>, crate::Error> {
         // Unfortunately "tsconfig.json" isn't actually JSON. It's some other
         // format that appears to be defined by the implementation details of the
@@ -424,7 +433,7 @@ impl TSConfigJSON {
             if let Some(base_url_prop) = base_url_v {
                 if let Some(base_url) = base_url_prop.as_str() {
                     result.base_url =
-                        match Self::str_replacing_templates(Box::from(base_url), source) {
+                        match Self::str_replacing_templates(Box::from(base_url), config_dir) {
                             Ok(v) => v,
                             Err(_) => return Ok(None),
                         };
@@ -621,7 +630,7 @@ impl TSConfigJSON {
                                             let item_loc = this_item_loc;
                                             let str = match Self::str_replacing_templates(
                                                 Box::from(str_),
-                                                source,
+                                                config_dir,
                                             ) {
                                                 Ok(v) => v,
                                                 Err(_) => return Ok(None),

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -309,10 +309,13 @@ impl Config {
                 // TODO: JSC -> Ast conversion
                 // SAFETY: VirtualMachine::get() returns the live singleton on the JS thread.
                 let vm = VirtualMachine::get().as_mut();
+                let tsconfig_source =
+                    bun_ast::Source::init_path_string(b"tsconfig.json", &self.tsconfig_buf[..]);
                 if let Ok(Some(parsed_tsconfig)) = TSConfigJSON::parse(
                     &mut self.log,
-                    &bun_ast::Source::init_path_string(b"tsconfig.json", &self.tsconfig_buf[..]),
+                    &tsconfig_source,
                     &mut vm.transpiler.resolver.caches.json,
+                    tsconfig_source.path.source_dir(),
                 ) {
                     self.tsconfig = Some(parsed_tsconfig);
                 }

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2729,6 +2729,91 @@ describe("bundler", () => {
     },
   });
 
+  // ${configDir} inside an extended base expands to the directory of the
+  // config that started the extends chain (the leaf), not the base's own
+  // directory. This is what tsc and esbuild do.
+  itBundled("edgecase/TSConfigPathsConfigDirViaExtends", {
+    files: {
+      "/packages/app/src/entry.ts": /* ts */ `
+        import { where } from "~/lib/util";
+        console.log(where);
+      `,
+      "/packages/app/src/lib/util.ts": `export const where = "app";`,
+      "/packages/tsconfig-base/src/lib/util.ts": `export const where = "base";`,
+      "/packages/tsconfig-base/tsconfig.json": /* json */ `{
+        "compilerOptions": {
+          "paths": { "~/*": ["\${configDir}/src/*"] }
+        }
+      }`,
+      "/packages/app/tsconfig.json": /* json */ `{ "extends": "../tsconfig-base/tsconfig.json" }`,
+    },
+    run: {
+      stdout: "app",
+    },
+  });
+
+  itBundled("edgecase/TSConfigPathsConfigDirViaExtendsTargetOnlyInLeaf", {
+    files: {
+      "/packages/app/src/entry.ts": /* ts */ `
+        import { where } from "~/lib/util";
+        console.log(where);
+      `,
+      "/packages/app/src/lib/util.ts": `export const where = "app";`,
+      "/configs/tsconfig.base.json": /* json */ `{
+        "compilerOptions": {
+          "paths": { "~/*": ["\${configDir}/src/*"] }
+        }
+      }`,
+      "/packages/app/tsconfig.json": /* json */ `{ "extends": "../../configs/tsconfig.base.json" }`,
+    },
+    run: {
+      stdout: "app",
+    },
+  });
+
+  itBundled("edgecase/TSConfigBaseUrlConfigDirViaExtends", {
+    files: {
+      "/packages/app/src/entry.ts": /* ts */ `
+        import { where } from "lib/util";
+        console.log(where);
+      `,
+      "/packages/app/src/lib/util.ts": `export const where = "app";`,
+      "/packages/tsconfig-base/src/lib/util.ts": `export const where = "base";`,
+      "/packages/tsconfig-base/tsconfig.json": /* json */ `{
+        "compilerOptions": {
+          "baseUrl": "\${configDir}/src"
+        }
+      }`,
+      "/packages/app/tsconfig.json": /* json */ `{ "extends": "../tsconfig-base/tsconfig.json" }`,
+    },
+    run: {
+      stdout: "app",
+    },
+  });
+
+  itBundled("edgecase/TSConfigPathsConfigDirViaExtendsChain", {
+    // Two levels of extends. ${configDir} still anchors at the leaf.
+    files: {
+      "/packages/app/src/entry.ts": /* ts */ `
+        import { where } from "~/lib/util";
+        console.log(where);
+      `,
+      "/packages/app/src/lib/util.ts": `export const where = "app";`,
+      "/packages/mid/src/lib/util.ts": `export const where = "mid";`,
+      "/packages/root/src/lib/util.ts": `export const where = "root";`,
+      "/packages/root/tsconfig.json": /* json */ `{
+        "compilerOptions": {
+          "paths": { "~/*": ["\${configDir}/src/*"] }
+        }
+      }`,
+      "/packages/mid/tsconfig.json": /* json */ `{ "extends": "../root/tsconfig.json" }`,
+      "/packages/app/tsconfig.json": /* json */ `{ "extends": "../mid/tsconfig.json" }`,
+    },
+    run: {
+      stdout: "app",
+    },
+  });
+
   itBundled("edgecase/TSPublicFieldMinification", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/js/bun/resolve/tsconfig-extends-leak.test.ts
+++ b/test/js/bun/resolve/tsconfig-extends-leak.test.ts
@@ -122,3 +122,39 @@ test("tsconfig 'extends' merge still works after freeing intermediates", async (
   expect(stdout.trim()).toBe("leaf");
   expect(exitCode).toBe(0);
 });
+
+// ${configDir} in an extended base expands to the directory of the config
+// that started the chain (the leaf), the same as tsc. The base's own
+// directory also holds a matching file so a wrong anchor is visible.
+test("tsconfig 'extends' expands ${configDir} in the base with the leaf's directory", async () => {
+  using dir = tempDir("tsconfig-extends-configdir", {
+    "packages/tsconfig-base/tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        paths: { "~/*": ["${configDir}/src/*"] },
+      },
+    }),
+    "packages/tsconfig-base/src/lib/util.ts": `export const where = "base";`,
+    "packages/app/tsconfig.json": JSON.stringify({
+      extends: "../tsconfig-base/tsconfig.json",
+    }),
+    "packages/app/src/lib/util.ts": `export const where = "app";`,
+    "packages/app/src/main.ts": `
+      import { where } from "~/lib/util";
+      console.log(where);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "src/main.ts"],
+    env: bunEnv,
+    cwd: path.join(String(dir), "packages", "app"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("app");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- A shared tsconfig base that uses `${configDir}` in `paths` or `baseUrl` resolves into the base's own directory when another project extends it. With the base at `packages/tsconfig-base` and the leaf at `packages/app`, `~/lib/util` imports `packages/tsconfig-base/src/lib/util.ts`. If that file does not exist, `bun run` prints `error: Cannot find module '~/lib/util'` and `bun build` prints `Could not resolve: "~/lib/util"`. tsc 6.0.3 and esbuild 0.28.1 resolve into `packages/app`.
- `TSConfigJSON::str_replacing_templates` (`src/resolver/tsconfig_json.rs:278`) expanded the template with `source.path.source_dir()`, the directory of the file being parsed. The extends walk in `dir_info_uncached` (`src/resolver/resolver.rs:6493`) parses each base through that path, so a base saw its own directory.

### Fix
- `TSConfigJSON::parse` and `Resolver::parse_tsconfig` take the directory that `${configDir}` expands to. The extends walk passes the root config's directory to every base it reaches. The root config and the `Bun.Transpiler` tsconfig path keep their own directory, so nothing else changes.
- This matches the tsc definition: `${configDir}` is the directory of the tsconfig that started the chain. A base that does not use the template is not affected. Relative `paths` and `baseUrl` in a base still resolve against the base's directory, as before.
- Verified: `test/bundler/bundler_edgecase.test.ts` (four `TSConfig*ConfigDirViaExtends*` cases) and `test/js/bun/resolve/tsconfig-extends-leak.test.ts` (one new `bun run` case). All five fail on bun 1.4.2. Also `test/bundler/esbuild/tsconfig.test.ts`, `test/cli/run/tsconfig-override.test.ts`, `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts` and the rest of `test/js/bun/resolve/`.

### Background
- `${configDir}` (TypeScript 5.5) lets a shared base point into whichever project extends it. tsc substitutes it once, after the extends chain is merged, with the directory of the root config.
- `dir_info_uncached` parses the `tsconfig.json` of a directory, then follows `extends` one file at a time with `parse_tsconfig`, and merges the chain from the deepest base up. `${configDir}` is substituted during parsing, so the parser needs to know the root directory up front.
- #40823 also changes this as part of a larger rewrite of extends resolution (package specifiers, arrays, exports). This PR is the minimal change for the `${configDir}` anchor alone.

<details><summary>Notes</summary>

Repro used:

```
mkdir -p packages/tsconfig-base/src/lib packages/app/src/lib && cd packages
echo '{ "compilerOptions": { "paths": { "~/*": ["${configDir}/src/*"] } } }' > tsconfig-base/tsconfig.json
echo '{ "extends": "../tsconfig-base/tsconfig.json" }' > app/tsconfig.json
echo "export const where = 'app';"  > app/src/lib/util.ts
echo "export const where = 'base';" > tsconfig-base/src/lib/util.ts
echo "import { where } from '~/lib/util'; console.log(where);" > app/src/main.ts
cd app && bun src/main.ts   # base (before), app (after)
```

`Dirname::dirname` and `Path::source_dir` both return the directory with a trailing separator, so the root directory passed through the chain has the same shape as the value the parser used before.

The `tsconfig-extends-leak.test.ts` and `bundler_edgecase.test.ts` `TSConfig*` cases pass under the debug build. Three `toml.test.js` tests in `test/js/bun/resolve/` time out at 5 s under the debug build on main without this change as well.
</details>
