### PR TITLE
run: pass the arguments after `--` to each script under --parallel and --sequential

### DIFF
--- a/docs/pm/filter.mdx
+++ b/docs/pm/filter.mdx
@@ -159,6 +159,9 @@ bun run --parallel --no-exit-on-error --filter '*' test
 
 # Run multiple scripts across all packages
 bun run --parallel --filter '*' build lint
+
+# Pass the same arguments to every script: each one runs as "<script> --watch"
+bun run --parallel --filter '*' build -- --watch
 ```
 
 Bun prefixes each line of output with the package and script name (`pkg-a:build | ...`). Without `--filter`/`--workspaces`, the prefix is only the script name (`build | ...`). When a package's `package.json` has no `name` field, Bun uses the relative path from the workspace root instead.

--- a/src/clap/comptime.rs
+++ b/src/clap/comptime.rs
@@ -483,6 +483,9 @@ pub struct ComptimeClap<Id> {
     pub(crate) flags: Box<[bool]>,
     pub(crate) pos: Box<[&'static [u8]]>,
     pub(crate) passthrough_positionals: Box<[&'static [u8]]>,
+    /// True when a `--` token directly followed the last positional. That
+    /// token is not part of `passthrough_positionals`.
+    pub(crate) passthrough_follows_separator: bool,
 
     // The converted params are
     // carried as a `&'static` table — either rodata (`comptime_table!`) or
@@ -532,6 +535,7 @@ impl<Id> ComptimeClap<Id> {
 
         let mut pos: Vec<&'static [u8]> = Vec::new();
         let mut passthrough_positionals: Vec<&'static [u8]> = Vec::new();
+        let mut passthrough_follows_separator = false;
 
         let mut single_options: Box<[Option<&'static [u8]>]> =
             vec![None; table.n_single].into_boxed_slice();
@@ -559,6 +563,7 @@ impl<Id> ComptimeClap<Id> {
                     };
                     if !first.is_empty() && first == b"--" {
                         remaining_ = &remaining_[1..];
+                        passthrough_follows_separator = true;
                     }
 
                     passthrough_positionals.reserve_exact(remaining_.len());
@@ -591,6 +596,7 @@ impl<Id> ComptimeClap<Id> {
             flags,
             pos: pos.into_boxed_slice(),
             passthrough_positionals: passthrough_positionals.into_boxed_slice(),
+            passthrough_follows_separator,
             table,
             _id: PhantomData,
         })
@@ -647,5 +653,9 @@ impl<Id> ComptimeClap<Id> {
 
     pub(crate) fn remaining(&self) -> &[&'static [u8]] {
         &self.passthrough_positionals
+    }
+
+    pub(crate) fn remaining_follows_separator(&self) -> bool {
+        self.passthrough_follows_separator
     }
 }

--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -432,6 +432,12 @@ impl<Id: 'static> Args<Id> {
     pub fn remaining(&self) -> &[&'static [u8]] {
         self.clap.remaining()
     }
+
+    /// True when a `--` token came right after the last positional. The
+    /// parser drops that token from `remaining()`.
+    pub fn remaining_follows_separator(&self) -> bool {
+        self.clap.remaining_follows_separator()
+    }
 }
 
 /// Same as `parse_ex` but uses the `args::OsIterator` by default.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -989,6 +989,26 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
 
     ctx.passthrough = slice_to_owned(args.remaining());
 
+    if ctx.parallel || ctx.sequential {
+        // The parser stops at the first script name, so with
+        // `bun run --parallel a b -- --x` the remaining script names and the
+        // `--` separator all land in `remaining()`. Split them here: script
+        // names join `positionals`, and `passthrough` keeps only the
+        // arguments after `--`, the same as a single-script run.
+        let remaining = args.remaining();
+        let (script_names, after_separator): (&[&[u8]], &[&[u8]]) =
+            if args.remaining_follows_separator() {
+                (&[], remaining)
+            } else if let Some(i) = remaining.iter().position(|arg| *arg == b"--") {
+                (&remaining[..i], &remaining[i + 1..])
+            } else {
+                (remaining, &[])
+            };
+        ctx.positionals
+            .extend(script_names.iter().map(|s| Box::<[u8]>::from(*s)));
+        ctx.passthrough = slice_to_owned(after_separator);
+    }
+
     if matches!(
         cmd,
         CommandTag::AutoCommand

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -709,8 +709,23 @@ struct GroupInfo {
     count: usize,
 }
 
+/// Appends the arguments after `--` to a script command, each one quoted as a
+/// single shell word. Same escaping as the single-script run path.
+fn append_passthrough(cmd_buf: &mut Vec<u8>, passthrough: &[Box<[u8]>]) {
+    for part in passthrough {
+        cmd_buf.push(b' ');
+        if crate::shell::needs_escape_utf8_ascii_latin1(part) {
+            crate::shell::escape_8bit::<true, false>(part, cmd_buf).unwrap_or_oom();
+        } else {
+            cmd_buf.extend_from_slice(part);
+        }
+    }
+}
+
 /// Add configs for a single script name (with pre/post handling).
 /// When `label_prefix` is non-null, labels become "{prefix}:{name}" (for workspace runs).
+/// `passthrough` (the arguments after `--`) is appended to the main script and
+/// to a raw command, never to the pre/post scripts.
 ///
 /// Generic over the scripts map value type so both the single-package path
 /// (values borrow the process-lifetime DirInfo-cached package.json) and the
@@ -724,6 +739,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
     cwd: &[u8],
     path: &[u8],
     label_prefix: Option<&[u8]>,
+    passthrough: &[Box<[u8]>],
 ) -> Result<(), Error> {
     let group_start = configs.len();
 
@@ -773,6 +789,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
         {
             let mut cmd_buf: Vec<u8> = Vec::with_capacity(content.len() + 1);
             RunCommand::replace_package_manager_run(&mut cmd_buf, content)?;
+            append_passthrough(&mut cmd_buf, passthrough);
             cmd_buf.push(0);
             configs.push(ScriptConfig {
                 label: label.clone(),
@@ -801,7 +818,7 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
                 || raw_name[0] == b'/'
                 || (cfg!(windows) && raw_name[0] == b'\\')
                 || has_runnable_extension(raw_name));
-        let command_z: Box<[u8]> = if is_file {
+        let mut v: Vec<u8> = if is_file {
             let bun_path: &[u8] = bun::self_exe_path().map(|z| z.as_bytes()).unwrap_or(b"bun");
             // Quote the bun path so that backslashes on Windows are not
             // interpreted as escape characters by `bun exec` (Bun's shell).
@@ -810,15 +827,15 @@ fn add_script_configs<V: core::ops::Deref<Target = [u8]>>(
             v.extend_from_slice(bun_path);
             v.extend_from_slice(b"\" ");
             v.extend_from_slice(raw_name);
-            v.push(0);
-            v.into_boxed_slice()
+            v
         } else {
-            // allocator.dupeZ
             let mut v = Vec::with_capacity(raw_name.len() + 1);
             v.extend_from_slice(raw_name);
-            v.push(0);
-            v.into_boxed_slice()
+            v
         };
+        append_passthrough(&mut v, passthrough);
+        v.push(0);
+        let command_z: Box<[u8]> = v.into_boxed_slice();
         configs.push(ScriptConfig {
             label,
             command: command_z,
@@ -845,7 +862,9 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
         Global::exit(1);
     }
 
-    // Collect script names from positionals + passthrough
+    // Collect script names from positionals. The arguments after `--`
+    // (`ctx.passthrough`) are not script names: they are appended to every
+    // selected script, the same as the single-script run path.
     // For RunCommand: positionals[0] is "run", skip it. For AutoCommand: no "run" prefix.
     // Cloned to owned so the &mut ctx borrow below doesn't conflict.
     let mut script_names: Vec<Box<[u8]>> = Vec::new();
@@ -859,11 +878,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             script_names.push(pos.clone());
         }
     }
-    for pt in &ctx.passthrough {
-        if !pt.is_empty() {
-            script_names.push(pt.clone());
-        }
-    }
+    let passthrough: Vec<Box<[u8]>> = ctx.passthrough.clone();
 
     if script_names.is_empty() {
         bun_core::pretty_errorln!(
@@ -1003,6 +1018,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                             &pkg.dirpath,
                             &pkg.path,
                             Some(&pkg.name),
+                            &passthrough,
                         )?;
                     }
                 } else {
@@ -1015,6 +1031,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                             &pkg.dirpath,
                             &pkg.path,
                             Some(&pkg.name),
+                            &passthrough,
                         )?;
                     } else if ctx.workspaces && !ctx.if_present {
                         bun_core::pretty_errorln!(
@@ -1091,6 +1108,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                             cwd,
                             &path_env,
                             None,
+                            &passthrough,
                         )?;
                     }
                 } else {
@@ -1109,6 +1127,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                     cwd,
                     &path_env,
                     None,
+                    &passthrough,
                 )?;
             }
         }

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1875,6 +1875,119 @@ describe.concurrent("glob pattern matching", () => {
   });
 });
 
+// ─── ARGUMENTS AFTER `--` ───────────────────────────────────────────────────
+
+const ARGS_JS = `console.log(JSON.stringify(process.argv.slice(2)))`;
+
+/** Extract the JSON argv array printed by ARGS_JS for a given label. */
+function argvFor(stdout: string, label: string): string[] {
+  const re = new RegExp(`^${escapeRe(label)}\\s+\\| (\\[.*\\])$`, "m");
+  const m = stdout.match(re);
+  expect(m, `no argv line for ${label} in:\n${stdout}`).not.toBeNull();
+  return JSON.parse(m![1]);
+}
+
+describe.concurrent("arguments after --", () => {
+  const hostile = "$(echo pwned)";
+
+  test("parallel: args are passed literally to every script, not run as commands", async () => {
+    using dir = tempDir("mr-pt-parallel", {
+      "args.js": ARGS_JS,
+      "package.json": JSON.stringify({
+        scripts: { a: `${bunExe()} args.js a`, b: `${bunExe()} args.js b` },
+      }),
+    });
+    const r = await runMulti(["run", "--parallel", "a", "b", "--", "--watch", hostile, "two words"], String(dir));
+    expect(argvFor(r.stdout, "a")).toEqual(["a", "--watch", hostile, "two words"]);
+    expect(argvFor(r.stdout, "b")).toEqual(["b", "--watch", hostile, "two words"]);
+    expect(r.stderr).not.toMatch(/^--watch\s+\|/m);
+    expect(r.stderr).not.toContain("pwned");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("-- right after the only script name: the rest are args, not scripts", async () => {
+    // Script names that are not also `bun` subcommand aliases, so `bun --parallel one two` works too.
+    using dir = tempDir("mr-pt-single", {
+      "args.js": ARGS_JS,
+      "package.json": JSON.stringify({
+        scripts: { one: `${bunExe()} args.js one`, two: `${bunExe()} args.js two` },
+      }),
+    });
+    const r = await runMulti(["run", "--parallel", "one", "--", "two", hostile], String(dir));
+    expect(argvFor(r.stdout, "one")).toEqual(["one", "two", hostile]);
+    expect(r.stdout).not.toMatch(/^two\s+\|/m);
+    expect(r.stderr).not.toMatch(/^two\s+\|/m);
+    expect(r.exitCode).toBe(0);
+
+    const auto = await runMulti(["--parallel", "one", "two", "--", "-v"], String(dir));
+    expect(argvFor(auto.stdout, "one")).toEqual(["one", "-v"]);
+    expect(argvFor(auto.stdout, "two")).toEqual(["two", "-v"]);
+    expect(auto.exitCode).toBe(0);
+  });
+
+  test("sequential: args are passed literally to every script", async () => {
+    using dir = tempDir("mr-pt-sequential", {
+      "args.js": ARGS_JS,
+      "package.json": JSON.stringify({
+        scripts: { a: `${bunExe()} args.js a`, b: `${bunExe()} args.js b` },
+      }),
+    });
+    const r = await runMulti(["run", "--sequential", "a", "b", "--", "--fix", hostile], String(dir));
+    expect(argvFor(r.stdout, "a")).toEqual(["a", "--fix", hostile]);
+    expect(argvFor(r.stdout, "b")).toEqual(["b", "--fix", hostile]);
+    expect(r.stderr).not.toContain("pwned");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("args go to the main script only, not to pre/post", async () => {
+    using dir = tempDir("mr-pt-prepost", {
+      "args.js": ARGS_JS,
+      "package.json": JSON.stringify({
+        scripts: {
+          prebuild: `${bunExe()} args.js pre`,
+          build: `${bunExe()} args.js main`,
+          postbuild: `${bunExe()} args.js post`,
+        },
+      }),
+    });
+    const r = await runMulti(["run", "--sequential", "build", "--", "--flag"], String(dir));
+    const lines = r.stdout
+      .match(/^build\s+\| (\[.*\])$/gm)!
+      .map(l => JSON.parse(l.slice(l.indexOf("[")))) as string[][];
+    expect(lines).toEqual([["pre"], ["main", "--flag"], ["post"]]);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("args are appended to file and raw commands", async () => {
+    using dir = tempDir("mr-pt-raw", {
+      "args.js": ARGS_JS,
+    });
+    const r = await runMulti(["run", "--parallel", "./args.js", "echo raw-cmd", "--", "-x", hostile], String(dir));
+    expect(argvFor(r.stdout, "./args.js")).toEqual(["-x", hostile]);
+    expectPrefixed(r.stdout, "echo raw-cmd", `raw-cmd -x ${hostile}`);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("--parallel --filter: args reach the script in every package", async () => {
+    using dir = tempDir("mr-pt-filter", {
+      "args.js": ARGS_JS,
+      "package.json": JSON.stringify({ name: "monorepo", private: true, workspaces: ["packages/*"] }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        scripts: { build: `${bunExe()} ../../args.js a` },
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        scripts: { build: `${bunExe()} ../../args.js b` },
+      }),
+    });
+    const r = await runMulti(["run", "--parallel", "--filter", "*", "build", "--", "--watch", hostile], String(dir));
+    expect(argvFor(r.stdout, "pkg-a:build")).toEqual(["a", "--watch", hostile]);
+    expect(argvFor(r.stdout, "pkg-b:build")).toEqual(["b", "--watch", hostile]);
+    expect(r.exitCode).toBe(0);
+  });
+});
+
 // ─── WORKSPACE INTEGRATION ──────────────────────────────────────────────────
 
 /** Helper to create a monorepo workspace temp directory. */

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1925,6 +1925,20 @@ describe.concurrent("arguments after --", () => {
     expect(auto.exitCode).toBe(0);
   });
 
+  test("a bare trailing -- adds no args and is not a script", async () => {
+    using dir = tempDir("mr-pt-bare", {
+      "args.js": ARGS_JS,
+      "package.json": JSON.stringify({
+        scripts: { one: `${bunExe()} args.js one`, two: `${bunExe()} args.js two` },
+      }),
+    });
+    const r = await runMulti(["run", "--parallel", "one", "two", "--"], String(dir));
+    expect(argvFor(r.stdout, "one")).toEqual(["one"]);
+    expect(argvFor(r.stdout, "two")).toEqual(["two"]);
+    expect(r.stderr).not.toMatch(/^--\s+\|/m);
+    expect(r.exitCode).toBe(0);
+  });
+
   test("sequential: args are passed literally to every script", async () => {
     using dir = tempDir("mr-pt-sequential", {
       "args.js": ARGS_JS,


### PR DESCRIPTION
### Problem
- `bun run --parallel build -- --watch "$(touch MARKER)"` runs each token after `--` as its own job. A token that is not a package.json script runs as a raw shell command, so `bash -c --watch` fails with `--: invalid option` and `$(touch MARKER)` executes. `--sequential` does the same. With `--filter` or `--workspaces` the tokens are dropped instead. Every other run form passes them to the script.
- The cause is in `src/runtime/cli/multi_run.rs:862`. It appends every token of `ctx.passthrough` to `script_names`. That was a workaround: the argument parser stops at the first script name, so the other script names land in `passthrough` too, together with the `--` separator.

### Fix
- `src/clap/comptime.rs` records when the parser drops a `--` that directly follows the first positional (`passthrough_follows_separator`). It already dropped that token. Now the caller can tell.
- `src/runtime/cli/Arguments.rs`, for `--parallel` and `--sequential` only: split `remaining()` at `--`. Tokens before it join `positionals` (script names). Tokens after it become `passthrough`. Nothing else changes for `bun run <script> -- args`, `bun <file> -- args`, `bunx`, or `bun test`.
- `src/runtime/cli/multi_run.rs` appends `passthrough` to each main script and each raw command, quoted with the same escape as the single-script run path. Pre and post scripts do not get the arguments, the same as a single-script run. That matches npm, pnpm, yarn, and `npm-run-all -p a b -- args`.
- Verified: `test/cli/run/multi-run.test.ts` (7 new tests in `arguments after --`, all fail on bun 1.4.3, all 134 pass with this change). Also `test/cli/run/run-quote.test.ts`, `filter-workspace.test.ts`, `run-eval.test.ts`, `env.test.ts`, and `test/internal/source-lints/`.

### Background
- `bun run --parallel a b` runs several scripts with prefixed output. A name that is not a package.json script runs as a raw shell command (`bun run --parallel 'tsc --watch' vite`). That is a feature for the positionals, not for the tokens after `--`.
- The CLI parser (`src/clap`) has `stop_after_positional_at`. For `bun run` it stops after the script name and puts the rest of argv into `remaining()`, so that script arguments are never parsed as bun flags. A `--` right after the script name is dropped there.
- Not covered: a wrapper script such as `"all": "bun run --parallel a b"` started with `bun run all -- --watch`. The outer run appends `--watch` to the wrapper command, so the inner `bun run --parallel a b --watch` still sees `--watch` as a script name.

<details><summary>Notes</summary>

- Repro on 1.4.2, canary 1.4.3 and 1.3.14: `echo '{"scripts":{"build":"echo $@"}}' > package.json; bun run --parallel build -- --watch "\$(touch M)"; ls M` (the marker exists).
- Self-review: 7 concerns raised, 3 addressed (bare trailing `--` test, docs example in `docs/pm/filter.mdx`, scope of the fix stated above). The review also noted that #36684 removes the `--` drop in the parser. Once that lands, `passthrough_follows_separator` can never be true and can be deleted, and the `position(== "--")` branch alone is enough. I left a note on #36684.
- A `-`-prefixed token between script names (`bun run --parallel a --foo b`) is still a raw command, as before. Out of scope.
- The raw-command test uses `echo raw-cmd` because an absolute path as a raw command is treated as a file to run with bun.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/multi-run.test.ts

<!-- robobun:evidence:end -->