### PR TITLE
js_parser: read both halves of an accessor pair for decorator metadata

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -568,6 +568,13 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// We must be careful to avoid revisiting nodes that have scopes.
     pub(crate) is_revisit_for_substitution: bool,
 
+    /// Set while the type annotations of an undecorated class accessor are
+    /// parsed for decorator metadata. The metadata is only emitted when the
+    /// other half of the accessor pair is decorated, so the identifiers it
+    /// names must not count as used yet (that would keep a type-only import
+    /// alive). `serialize_metadata` records the use when it emits them.
+    pub(crate) ts_metadata_defer_usage: bool,
+
     pub(crate) method_call_must_be_replaced_with_undefined: bool,
 
     // Inside a TypeScript namespace, an "export declare" statement can be used
@@ -7315,7 +7322,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let mut static_members = BumpVec::<Stmt>::new_in(self.arena);
                 let mut class_properties = BumpVec::<G::Property>::new_in(self.arena);
 
-                for prop in s_class.class.properties.slice_mut().iter_mut() {
+                let accessor_siblings = if self.options.features.emit_decorator_metadata {
+                    self.collect_decorated_accessor_siblings(s_class.class.properties.slice())
+                } else {
+                    BumpVec::new_in(self.arena)
+                };
+
+                for (prop_index, prop) in
+                    s_class.class.properties.slice_mut().iter_mut().enumerate()
+                {
                     // merge parameter decorators with method decorators
                     if prop.flags.contains(Flags::Property::IsMethod) {
                         if let Some(prop_value) = prop.value {
@@ -7397,7 +7412,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let mut array = BumpVec::<Expr>::new_in(self.arena);
 
                         if self.options.features.emit_decorator_metadata {
-                            self.emit_decorator_metadata_for_prop(prop, &mut array, loc);
+                            let sibling = accessor_siblings
+                                .iter()
+                                .find(|(i, _)| *i == prop_index)
+                                .map(|(_, value)| *value);
+                            self.emit_decorator_metadata_for_prop(prop, sibling, &mut array, loc);
                         }
 
                         let mut full = BumpVec::<Expr>::with_capacity_in(
@@ -7706,16 +7725,103 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// For every decorated getter or setter, the value (an `E::Function`) of
+    /// the other half of its accessor pair: same key, same `static`, opposite
+    /// kind. Legacy decorator metadata for a pair reads both halves, like tsc's
+    /// `getAllAccessorDeclarations`.
+    #[cold]
+    #[inline(never)]
+    fn collect_decorated_accessor_siblings(
+        &self,
+        properties: &[G::Property],
+    ) -> BumpVec<'a, (usize, Expr)> {
+        use js_ast::g::PropertyKind;
+
+        fn keys_match(a: Expr, b: Expr) -> bool {
+            match (&a.data, &b.data) {
+                (js_ast::ExprData::EString(x), js_ast::ExprData::EString(y)) => x.eql_string(y),
+                (js_ast::ExprData::ENumber(x), js_ast::ExprData::ENumber(y)) => {
+                    x.value() == y.value()
+                }
+                (
+                    js_ast::ExprData::EPrivateIdentifier(x),
+                    js_ast::ExprData::EPrivateIdentifier(y),
+                ) => x.ref_.eql(y.ref_),
+                _ => false,
+            }
+        }
+
+        let mut out = BumpVec::new_in(self.arena);
+        for (index, prop) in properties.iter().enumerate() {
+            let sibling_kind = match prop.kind {
+                PropertyKind::Get => PropertyKind::Set,
+                PropertyKind::Set => PropertyKind::Get,
+                _ => continue,
+            };
+            if prop.ts_decorators.len_u32() == 0 || !prop.flags.contains(Flags::Property::IsMethod)
+            {
+                continue;
+            }
+            let Some(key) = prop.key else { continue };
+            let is_static = prop.flags.contains(Flags::Property::IsStatic);
+            let sibling_value = properties
+                .iter()
+                .find(|other| {
+                    other.kind == sibling_kind
+                        && other.flags.contains(Flags::Property::IsMethod)
+                        && other.flags.contains(Flags::Property::IsStatic) == is_static
+                        && matches!(other.key, Some(other_key) if keys_match(key, other_key))
+                })
+                .and_then(|other| other.value);
+            if let Some(value) = sibling_value {
+                out.push((index, value));
+            }
+        }
+        out
+    }
+
+    /// `design:paramtypes` for `args`: one serialized type per parameter.
+    fn serialize_param_types_metadata(&mut self, args: &[G::Arg]) -> Expr {
+        let args_array = self.arena.alloc_slice_fill_default::<Expr>(args.len());
+        for (entry, arg) in args_array.iter_mut().zip(args) {
+            *entry = self
+                .serialize_metadata(arg.ts_metadata.clone())
+                .expect("unreachable");
+        }
+        let items = ExprNodeList::from_arena_slice(args_array);
+        self.new_expr(
+            E::Array {
+                items,
+                ..Default::default()
+            },
+            bun_ast::Loc::EMPTY,
+        )
+    }
+
+    /// The getter's return type as the `design:type` of an accessor pair.
+    /// The parser stores `MUndefined` for a missing return annotation (the
+    /// `design:returntype` of a method is `undefined` then), but tsc serializes
+    /// a missing accessor type as `Object`.
+    fn accessor_return_type_metadata(getter: &G::Fn) -> bun_ast::ts::Metadata {
+        match getter.return_ts_metadata {
+            bun_ast::ts::Metadata::MUndefined => bun_ast::ts::Metadata::MNone,
+            ref metadata => metadata.clone(),
+        }
+    }
+
     // Helper extracted from lower_class to keep that fn readable; condenses
-    // the per-kind metadata switch.
+    // the per-kind metadata switch. `accessor_sibling` is the other half of a
+    // decorated getter/setter pair, from `collect_decorated_accessor_siblings`.
     #[cold]
     #[inline(never)]
     fn emit_decorator_metadata_for_prop(
         &mut self,
         prop: &G::Property,
+        accessor_sibling: Option<Expr>,
         array: &mut BumpVec<'a, Expr>,
         loc: bun_ast::Loc,
     ) {
+        use bun_ast::ts::Metadata as M;
         use js_ast::g::PropertyKind;
 
         // Local helper: bump-alloc an arg pair and call __legacyMetadataTS.
@@ -7749,22 +7855,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // arena-owned `StoreSlice<Arg>` valid for parser 'a.
                         let method_args: &[G::Arg] = func.func.args.slice();
                         {
-                            let args_array = self
-                                .arena
-                                .alloc_slice_fill_default::<Expr>(method_args.len());
-                            for (entry, method_arg) in args_array.iter_mut().zip(method_args) {
-                                *entry = self
-                                    .serialize_metadata(method_arg.ts_metadata.clone())
-                                    .expect("unreachable");
-                            }
-                            let items = ExprNodeList::from_arena_slice(args_array);
-                            let arr = self.new_expr(
-                                E::Array {
-                                    items,
-                                    ..Default::default()
-                                },
-                                bun_ast::Loc::EMPTY,
-                            );
+                            let arr = self.serialize_param_types_metadata(method_args);
                             push_metadata!(b"design:paramtypes", arr);
                         }
                         {
@@ -7778,26 +7869,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             PropertyKind::Get => {
                 if prop.flags.contains(Flags::Property::IsMethod) {
-                    // typescript sets design:type to the return value & design:paramtypes to [].
+                    // typescript sets design:type to the setter's parameter type when the pair
+                    // has an annotated setter, else to the getter's return type. design:paramtypes
+                    // is the setter's parameter list, or [] without a setter.
                     if let Some(prop_value) = prop.value {
                         let func = prop_value
                             .data
                             .e_function()
                             .expect("infallible: variant checked");
+                        let setter_args: &[G::Arg] = accessor_sibling
+                            .and_then(|value| value.data.e_function())
+                            .map(|setter| setter.func.args.slice())
+                            .unwrap_or(&[]);
                         {
-                            let v = self
-                                .serialize_metadata(func.func.return_ts_metadata.clone())
-                                .expect("unreachable");
+                            let metadata = match setter_args.first() {
+                                Some(arg) if !matches!(arg.ts_metadata, M::MNone) => {
+                                    arg.ts_metadata.clone()
+                                }
+                                _ => Self::accessor_return_type_metadata(&func.func),
+                            };
+                            let v = self.serialize_metadata(metadata).expect("unreachable");
                             push_metadata!(b"design:type", v);
                         }
                         {
-                            let arr = self.new_expr(
-                                E::Array {
-                                    items: bun_alloc::AstAlloc::vec(),
-                                    ..Default::default()
-                                },
-                                bun_ast::Loc::EMPTY,
-                            );
+                            let arr = self.serialize_param_types_metadata(setter_args);
                             push_metadata!(b"design:paramtypes", arr);
                         }
                     }
@@ -7805,7 +7900,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             PropertyKind::Set => {
                 if prop.flags.contains(Flags::Property::IsMethod) {
-                    // typescript sets design:type to the return value & design:paramtypes to [arg].
+                    // typescript sets design:type to the parameter type (or the getter's return
+                    // type when the parameter has no annotation) & design:paramtypes to [arg].
                     // note that typescript does not allow you to put a decorator on both the getter and the setter.
                     // if you do anyway, bun will set design:type and design:paramtypes twice, so it's fine.
                     if let Some(prop_value) = prop.value {
@@ -7816,28 +7912,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // arena-owned `StoreSlice<Arg>` valid for parser 'a.
                         let method_args: &[G::Arg] = func.func.args.slice();
                         {
-                            let args_array = self
-                                .arena
-                                .alloc_slice_fill_default::<Expr>(method_args.len());
-                            for (entry, method_arg) in args_array.iter_mut().zip(method_args) {
-                                *entry = self
-                                    .serialize_metadata(method_arg.ts_metadata.clone())
-                                    .expect("unreachable");
-                            }
-                            let items = ExprNodeList::from_arena_slice(args_array);
-                            let arr = self.new_expr(
-                                E::Array {
-                                    items,
-                                    ..Default::default()
-                                },
-                                bun_ast::Loc::EMPTY,
-                            );
+                            let arr = self.serialize_param_types_metadata(method_args);
                             push_metadata!(b"design:paramtypes", arr);
                         }
-                        if !method_args.is_empty() {
-                            let v = self
-                                .serialize_metadata(method_args[0].ts_metadata.clone())
-                                .expect("unreachable");
+                        if let Some(arg) = method_args.first() {
+                            let metadata = if matches!(arg.ts_metadata, M::MNone) {
+                                accessor_sibling
+                                    .and_then(|value| value.data.e_function())
+                                    .map(|getter| Self::accessor_return_type_metadata(&getter.func))
+                                    .unwrap_or(M::MNone)
+                            } else {
+                                arg.ts_metadata.clone()
+                            };
+                            let v = self.serialize_metadata(metadata).expect("unreachable");
                             push_metadata!(b"design:type", v);
                         }
                     }
@@ -7899,6 +7986,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             M::MDot(refs) => {
                 debug_assert!(refs.len() >= 2);
+                self.record_usage(refs[0]);
                 // (refs.deinit(p.arena) — arena-backed; nothing to free in Rust)
 
                 macro_rules! ref_name {
@@ -9809,6 +9897,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             span_uses: Vec::new(),
             is_inside_single_stmt_body: false,
             is_revisit_for_substitution: false,
+            ts_metadata_defer_usage: false,
             method_call_must_be_replaced_with_undefined: false,
             has_non_local_export_declare_inside_namespace: false,
             await_target: None,

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -286,13 +286,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if p.lexer.token == T::TColon {
                     p.lexer.next()?;
                     if !rest_arg {
+                        let is_decorated = opts.has_argument_decorators
+                            || opts.has_decorators
+                            || arg_has_decorators;
                         if p.options.features.emit_decorator_metadata
                             && opts.allow_ts_decorators
-                            && (opts.has_argument_decorators
-                                || opts.has_decorators
-                                || arg_has_decorators)
+                            && (is_decorated || opts.is_class_accessor)
                         {
-                            ts_metadata = p.skip_type_script_type_with_metadata(Level::Lowest)?;
+                            p.ts_metadata_defer_usage = !is_decorated;
+                            let result = p.skip_type_script_type_with_metadata(Level::Lowest);
+                            p.ts_metadata_defer_usage = false;
+                            ts_metadata = result?;
                         } else {
                             p.skip_type_script_type(Level::Lowest)?;
                         }
@@ -372,17 +376,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if p.lexer.token == T::TColon {
                 p.lexer.next()?;
 
+                let is_decorated = opts.has_argument_decorators || opts.has_decorators;
                 if p.options.features.emit_decorator_metadata
                     && opts.allow_ts_decorators
-                    && (opts.has_argument_decorators || opts.has_decorators)
+                    && (is_decorated || opts.is_class_accessor)
                 {
-                    func.return_ts_metadata = p.skip_typescript_return_type_with_metadata()?;
+                    p.ts_metadata_defer_usage = !is_decorated;
+                    let result = p.skip_typescript_return_type_with_metadata();
+                    p.ts_metadata_defer_usage = false;
+                    func.return_ts_metadata = result?;
                 } else {
                     p.skip_typescript_return_type()?;
                 }
             } else if p.options.features.emit_decorator_metadata
                 && opts.allow_ts_decorators
-                && (opts.has_argument_decorators || opts.has_decorators)
+                && (opts.has_argument_decorators || opts.has_decorators || opts.is_class_accessor)
             {
                 if func.flags.contains(Flags::Function::IsAsync) {
                     func.return_ts_metadata = bun_ast::ts::Metadata::MPromise;

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -107,6 +107,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 is_constructor,
                 has_decorators: opts.ts_decorators.len() > 0
                     || (opts.has_class_decorators && is_constructor),
+                is_class_accessor: opts.is_class
+                    && matches!(kind, PropertyKind::Get | PropertyKind::Set),
 
                 // Only allow omitting the body if we're parsing TypeScript class
                 allow_missing_body_for_type_script: Self::IS_TYPESCRIPT_ENABLED && opts.is_class,

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -57,6 +57,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(result)
     }
 
+    /// The symbol a type annotation names, for decorator metadata. See
+    /// `ts_metadata_defer_usage`.
+    fn find_symbol_for_metadata(
+        &mut self,
+        ident: &'a [u8],
+    ) -> Result<crate::parser::FindSymbolResult, Error> {
+        if self.ts_metadata_defer_usage {
+            self.find_symbol_without_usage(bun_ast::Loc::EMPTY, ident)
+        } else {
+            self.find_symbol(bun_ast::Loc::EMPTY, ident)
+        }
+    }
+
     pub(crate) fn skip_type_script_binding(&mut self) -> Result<(), Error> {
         self.mark_type_script_only();
         // Nested destructuring patterns in skipped type positions recurse through
@@ -634,7 +647,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         TsIdentKind::Normal => {
                             if GET_METADATA {
                                 let ident = self.lexer.identifier;
-                                let find_result = self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
+                                let find_result = self.find_symbol_for_metadata(ident)?;
                                 **result
                                     .as_mut()
                                     .expect("infallible: GET_METADATA implies Some") =
@@ -909,14 +922,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 let id_ref = *id_ref;
                                 let mut dot: Vec<Ref> = Vec::with_capacity(2);
                                 dot.push(id_ref);
-                                let find_result = self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
+                                let find_result = self.find_symbol_for_metadata(ident)?;
                                 dot.push(find_result.r#ref);
                                 *r = Metadata::MDot(dot);
                             }
                             Metadata::MDot(dot) => {
                                 if self.lexer.is_identifier_or_keyword() {
-                                    let find_result =
-                                        self.find_symbol(bun_ast::Loc::EMPTY, ident)?;
+                                    let find_result = self.find_symbol_for_metadata(ident)?;
                                     dot.push(find_result.r#ref);
                                 }
                             }

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1231,6 +1231,10 @@ pub struct FnOrArrowDataParse {
 
     pub(crate) has_argument_decorators: bool,
     pub(crate) has_decorators: bool,
+    /// A getter or setter in a class body. Its type annotations become
+    /// decorator metadata when the other half of the accessor pair is
+    /// decorated, so they are collected even without decorators of its own.
+    pub(crate) is_class_accessor: bool,
 
     pub(crate) is_return_disallowed: bool,
     pub(crate) is_this_disallowed: bool,
@@ -1258,6 +1262,7 @@ impl Default for FnOrArrowDataParse {
             is_typescript_declare: false,
             has_argument_decorators: false,
             has_decorators: false,
+            is_class_accessor: false,
             is_return_disallowed: false,
             is_this_disallowed: false,
             arrow_arg_errors: DeferredArrowArgErrors::default(),

--- a/src/js_parser/scan/scan_symbols.rs
+++ b/src/js_parser/scan/scan_symbols.rs
@@ -10,10 +10,30 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         name: &'a [u8],
     ) -> Result<FindSymbolResult, crate::Error> {
-        self.find_symbol_with_record_usage::<true>(loc, name)
+        self.find_symbol_impl::<true, true>(loc, name)
     }
 
+    /// With `RECORD_USAGE == false` the use counts stay untouched and a name
+    /// with no symbol gives `Ref::NONE`.
     pub(crate) fn find_symbol_with_record_usage<const RECORD_USAGE: bool>(
+        &mut self,
+        loc: bun_ast::Loc,
+        name: &'a [u8],
+    ) -> Result<FindSymbolResult, crate::Error> {
+        self.find_symbol_impl::<RECORD_USAGE, RECORD_USAGE>(loc, name)
+    }
+
+    /// Like `find_symbol`, but the use counts stay untouched. A name with no
+    /// symbol still gets an unbound symbol.
+    pub(crate) fn find_symbol_without_usage(
+        &mut self,
+        loc: bun_ast::Loc,
+        name: &'a [u8],
+    ) -> Result<FindSymbolResult, crate::Error> {
+        self.find_symbol_impl::<false, true>(loc, name)
+    }
+
+    fn find_symbol_impl<const RECORD_USAGE: bool, const DECLARE_UNBOUND: bool>(
         &mut self,
         loc: bun_ast::Loc,
         name: &'a [u8],
@@ -104,7 +124,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             // Allocate an "unbound" symbol
             self.check_for_non_bmp_code_point(loc, name);
-            if !RECORD_USAGE {
+            if !DECLARE_UNBOUND {
                 return Ok(FindSymbolResult {
                     r#ref: Ref::NONE,
                     declare_loc: Some(loc),

--- a/test/bundler/bundler_decorator_metadata.test.ts
+++ b/test/bundler/bundler_decorator_metadata.test.ts
@@ -1261,4 +1261,82 @@ describe("bundler", () => {
       stdout: "true\n",
     },
   });
+
+  // The decorated getter's metadata names the setter's parameter type, so
+  // that import is kept.
+  itBundled("decorator_metadata/AccessorPairKeepsSetterImport", {
+    files: {
+      "/entry.ts": /* ts */ `
+            ${reflectMetadata}
+
+            import { Foo } from "./foo.js";
+            import * as ns from "./foo.js";
+
+            function d1() {}
+
+            class Bar {
+                @d1
+                get foo(): number { return 1; }
+                set foo(v: Foo) {}
+
+                @d1
+                get dotted(): number { return 1; }
+                set dotted(v: ns.Foo) {}
+            }
+
+            console.log(Reflect.getMetadata("design:type", Bar.prototype, "foo") === Foo);
+            console.log(Reflect.getMetadata("design:paramtypes", Bar.prototype, "foo")[0] === Foo);
+            console.log(Reflect.getMetadata("design:type", Bar.prototype, "dotted") === Foo);
+        `,
+      "/foo.js": /* js */ `
+            const f = () => "Foo";
+            module.exports[f()] = class Foo {};
+        `,
+      "/tsconfig.json": /* json */ `
+            {
+                "compilerOptions": {
+                    "experimentalDecorators": true,
+                    "emitDecoratorMetadata": true,
+                }
+            }
+        `,
+    },
+    run: {
+      stdout: "true\ntrue\ntrue\n",
+    },
+  });
+
+  // An accessor pair with no decorator emits no metadata, so a type-only
+  // import it names is still removed.
+  itBundled("decorator_metadata/UndecoratedAccessorElidesTypeImport", {
+    files: {
+      "/entry.ts": /* ts */ `
+            import { Foo } from "./foo";
+            import * as ns from "./foo";
+
+            class Bar {
+                get foo(): Foo { return null as any; }
+                set foo(v: Foo) {}
+                set dotted(v: ns.Foo) {}
+            }
+
+            console.log(typeof Bar);
+        `,
+      "/foo.ts": /* ts */ `
+            console.log("foo evaluated");
+            export interface Foo {}
+        `,
+      "/tsconfig.json": /* json */ `
+            {
+                "compilerOptions": {
+                    "experimentalDecorators": true,
+                    "emitDecoratorMetadata": true,
+                }
+            }
+        `,
+    },
+    run: {
+      stdout: "function\n",
+    },
+  });
 });

--- a/test/bundler/transpiler/decorator-metadata.test.ts
+++ b/test/bundler/transpiler/decorator-metadata.test.ts
@@ -427,6 +427,134 @@ describe("decorator metadata", () => {
     expect(Reflect.getMetadata("design:returntype", A.prototype, "prop3")).toBeUndefined();
   });
 
+  // tsc reads an accessor pair as one member: design:type is the setter's
+  // parameter type (else the getter's return type) and design:paramtypes is
+  // the setter's parameter list, whichever half carries the decorator.
+  test("accessor pairs", () => {
+    function d1(target: any, key: string) {}
+    class Foo {}
+
+    class A {
+      @d1
+      get getterFirst(): number {
+        return 1;
+      }
+      set getterFirst(v: number) {}
+
+      @d1
+      get getterOnly(): number {
+        return 1;
+      }
+
+      @d1
+      get typeFromSetter() {
+        return "";
+      }
+      set typeFromSetter(v: string) {}
+
+      @d1
+      set setterFirst(v: string) {}
+      get setterFirst() {
+        return "";
+      }
+
+      @d1
+      // @ts-ignore
+      set untypedSetter(v) {}
+      get untypedSetter(): Foo {
+        return new Foo();
+      }
+
+      get setterDecorated(): string {
+        return "";
+      }
+      @d1
+      set setterDecorated(v: string) {}
+
+      @d1
+      static get staticPair(): boolean {
+        return true;
+      }
+      static set staticPair(v: boolean) {}
+
+      get mixedStatic(): number {
+        return 1;
+      }
+      @d1
+      // @ts-ignore
+      set mixedStatic(v) {}
+      static set mixedStatic(v: string) {}
+
+      @d1
+      get ["computed"](): number {
+        return 1;
+      }
+      set ["computed"](v: Foo) {}
+
+      @d1
+      get 7(): number {
+        return 1;
+      }
+      set 7(v: string) {}
+
+      @d1
+      // @ts-ignore
+      set setterOnly(v) {}
+
+      @d1
+      get untypedGetter() {
+        return 1;
+      }
+
+      @d1
+      // @ts-ignore
+      set bothUntyped(v) {}
+      get bothUntyped() {
+        return 1;
+      }
+
+      @d1
+      get voidGetter(): void {}
+    }
+
+    const metadata = (target: any, key: string) => ({
+      type: Reflect.getMetadata("design:type", target, key),
+      paramtypes: Reflect.getMetadata("design:paramtypes", target, key),
+    });
+
+    expect({
+      getterFirst: metadata(A.prototype, "getterFirst"),
+      getterOnly: metadata(A.prototype, "getterOnly"),
+      typeFromSetter: metadata(A.prototype, "typeFromSetter"),
+      setterFirst: metadata(A.prototype, "setterFirst"),
+      untypedSetter: metadata(A.prototype, "untypedSetter"),
+      setterDecorated: metadata(A.prototype, "setterDecorated"),
+      staticPair: metadata(A, "staticPair"),
+      mixedStatic: metadata(A.prototype, "mixedStatic"),
+      computed: metadata(A.prototype, "computed"),
+      7: metadata(A.prototype, "7"),
+      setterOnly: metadata(A.prototype, "setterOnly"),
+      untypedGetter: metadata(A.prototype, "untypedGetter"),
+      bothUntyped: metadata(A.prototype, "bothUntyped"),
+      voidGetter: metadata(A.prototype, "voidGetter"),
+    }).toEqual({
+      getterFirst: { type: Number, paramtypes: [Number] },
+      getterOnly: { type: Number, paramtypes: [] },
+      typeFromSetter: { type: String, paramtypes: [String] },
+      setterFirst: { type: String, paramtypes: [String] },
+      untypedSetter: { type: Foo, paramtypes: [Object] },
+      setterDecorated: { type: String, paramtypes: [String] },
+      staticPair: { type: Boolean, paramtypes: [Boolean] },
+      mixedStatic: { type: Number, paramtypes: [Object] },
+      computed: { type: Foo, paramtypes: [Foo] },
+      7: { type: String, paramtypes: [String] },
+      setterOnly: { type: Object, paramtypes: [Object] },
+      untypedGetter: { type: Object, paramtypes: [] },
+      bothUntyped: { type: Object, paramtypes: [Object] },
+      voidGetter: { type: undefined, paramtypes: [] },
+    });
+  });
+
   test("class with only constructor argument decorators", () => {
     function d1() {}
     class A {


### PR DESCRIPTION
### Problem
- With `emitDecoratorMetadata`, a decorated getter that has a setter sibling gets `design:paramtypes` `[]`. tsc records the setter's parameter type, for example `[Number]` for `@d get acc(): number` plus `set acc(v: number)`. A decorated getter with no return annotation gets `design:type` `undefined` where tsc uses the setter's parameter type.
- The cause is `emit_decorator_metadata_for_prop` (`src/js_parser/p.rs`). It reads only the decorated half of the pair. tsc's `getAllAccessorDeclarations` reads both halves: `design:type` is the setter's parameter type, else the getter's return type, and `design:paramtypes` is the setter's parameter list.
- The parser also only parses type annotations into metadata for decorated members, so an undecorated setter had nothing for its decorated getter to read.

### Fix
- `lower_class` pairs every decorated accessor with its sibling (same key, same `static`, opposite kind) before the property loop. The Get and Set arms then read the sibling's parameter or return metadata the way tsc does.
- The parser now collects type metadata for every getter and setter in a class body (`is_class_accessor`). For an undecorated accessor it looks the names up with `find_symbol_without_usage`, so the identifiers do not count as used. `serialize_metadata` records the use when it emits them. A type-only import named only by an undecorated accessor stays elided, and one named by a decorated pair is kept.
- A missing getter return annotation now serializes as `Object` for an accessor's `design:type`, as in tsc. The parser stores `MUndefined` for it because a method's `design:returntype` is `undefined` in that case.
- Verified: `test/bundler/transpiler/decorator-metadata.test.ts` (new `accessor pairs` test, 14 shapes checked against tsc 6.0.2) and `test/bundler/bundler_decorator_metadata.test.ts` (import kept for a decorated pair, import elided for an undecorated pair). Also `decorators.test.ts`, `es-decorators.test.ts`, `transpiler.test.js`, `test/integration/nest`, `test/integration/typegraphql`.

### Background
- Legacy decorator metadata (`experimentalDecorators` + `emitDecoratorMetadata`) makes the transpiler emit `Reflect.metadata("design:type", T)` calls next to each decorator. DI containers and ORMs read them at runtime.
- `bun_ast::ts::Metadata` is the parser's summary of one type annotation (`MString`, `MIdentifier(ref)`, `MNone` for no annotation). `serialize_metadata` turns it into the runtime expression.
- TypeScript removes an import that is only used in type positions. Bun does that with `ts_use_counts`, which `find_symbol` bumps. A name that reaches metadata is a value use, so it must bump the count only when the metadata is emitted.

<details><summary>Notes</summary>

The 14 accessor shapes in the new test were run through tsc 6.0.2 (`--experimentalDecorators --emitDecoratorMetadata --strict --target ES2022`) and the expected values are tsc's output. Bun 1.4.3 fails 8 of them.

One shape still differs from tsc: `@d get x(): undefined` gives `Object` here and `undefined` in tsc. Bun stores `MUndefined` both for an explicit `undefined` annotation and for a missing one, and a missing one is by far the common case (`@Expose() get fullName() {}`).

The `strictNullChecks` divergence reported next to this one (`string | null` serialized as `String` where tsc `--strict` gives `Object`) is a separate decision and is not part of this change.

`find_symbol_with_record_usage::<false>` keeps its old contract (`Ref::NONE` for an unknown name). The new `find_symbol_without_usage` creates the unbound symbol, which the metadata needs for the `typeof X === "undefined" ? Object : X` guard.

`serialize_metadata` now records a use for the root of an `MDot` chain (`ns.Foo`). For a decorated member that use was already recorded at parse time, so the count is bumped twice. Only `!= 0` is checked for import elision.
</details>
