### PR TITLE
test(child_process): warm JSC's lazy descriptors before the fd 0 handle test closes stdin

### DIFF
--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -632,25 +632,43 @@ server.listen(0, '127.0.0.1', () => {
     },
   );
 
+  // The runtime opens some descriptors on first use and keeps them open: JSC opens /proc/self/statm
+  // when a GC cycle ends (WTF::LinuxMemory in AvailableMemory.cpp), WTF and bmalloc open /dev/urandom.
+  // If one of those opens runs between closeSync(0) and the SCM_RIGHTS receive, it takes fd 0 and the
+  // handle lands elsewhere. So the child first receives one handle (which runs every code path the real
+  // receive runs) and forces a full GC, then closes fd 0 and asks for the handle under test.
   test.concurrent("a received handle that lands on fd 0 is adopted", async () => {
     using dir = tempDir("ipc-handle-fd0", {
       "parent.js": `
 const { fork } = require('node:child_process');
 const net = require('node:net');
 const child = fork('child.js');
-const server = net.createServer(sock => {
-  child.send('sock', sock);
-  child.once('message', m => { console.log(JSON.stringify(m)); sock.destroy(); server.close(); child.disconnect(); });
-});
-server.listen(0, '127.0.0.1', () => {
+const server = net.createServer(sock => child.send('sock', sock));
+function connect() {
   const client = net.connect(server.address().port, '127.0.0.1');
   client.on('data', d => { client.end(); });
   client.on('error', () => {});
+}
+child.on('message', m => {
+  if (m === 'fd 0 is free') return connect();
+  console.log(JSON.stringify(m));
+  server.close();
+  child.disconnect();
 });
+server.listen(0, '127.0.0.1', connect);
 `,
       "child.js": `
-require('node:fs').closeSync(0); // the next descriptor this process receives is fd 0
+const fs = require('node:fs');
+let warmedUp = false;
 process.on('message', (m, sock) => {
+  if (!warmedUp) {
+    warmedUp = true;
+    sock.end('hi');
+    Bun.gc(true);
+    fs.closeSync(0); // the next descriptor this process receives is fd 0
+    process.send('fd 0 is free');
+    return;
+  }
   const fd = sock && sock._handle && sock._handle.fd;
   sock.end('hi', () => process.send({ message: m, receivedFd: fd, writable: true }));
 });


### PR DESCRIPTION
### Problem
- `test/js/node/child_process/child_process_ipc_handle.test.ts` > "a received handle that lands on fd 0 is adopted" fails on the x64-asan lane with `receivedFd: 9` instead of `0` (builds [110482](https://buildkite.com/bun/bun/builds/110482), [111370](https://buildkite.com/bun/bun/builds/111370)). The test came in with #31829.
- The child calls `fs.closeSync(0)` at script start and expects the next `SCM_RIGHTS` descriptor to be 0. JSC opens `/proc/self/statm` on first use and keeps it open (`WTF::LinuxMemory::singleton()` in `Source/WTF/wtf/AvailableMemory.cpp:111`, reached from `JSC::Heap::overCriticalMemoryThreshold`, `heap/Heap.cpp:713`). That open runs at the end of a GC cycle, or on the 100th heap threshold check. When it runs after `closeSync(0)` and before the receive, it takes fd 0. The handle then lands on the next free descriptor, which is 9 in that process (1,2 stdio pipes, 3 ipc, 4 urandom, 5 epoll, 6 eventfd, 7 urandom, 8 statm).

### Fix
- The child first receives one warm-up handle and calls `Bun.gc(true)`. Then it closes fd 0 and tells the parent to send the handle under test. The warm-up runs every code path the real receive runs, and the full GC reaches `Heap::updateAllocationLimits`, which opens the `statm` descriptor.
- The test still checks the same thing: a descriptor received over IPC that the kernel places at fd 0 is adopted as a working `net.Socket` (`receivedFd: 0`, `writable: true`). No `src/` change: the lazy opens are correct behavior, the test's assumption about descriptor numbering was the bug.
- Verified: `bun bd test test/js/node/child_process/child_process_ipc_handle.test.ts` (14 pass, 3 runs), and the same file under a local `release-asan` build with the CI lane's env (`BUN_GARBAGE_COLLECTOR_LEVEL=1`, `BUN_FEATURE_FLAG_NO_ORPHANS=1`), 5 runs of the fd 0 test.

### Background
- `process.send(msg, handle)` passes the handle's descriptor over the IPC unix socket with `SCM_RIGHTS`. The kernel installs it in the receiver at the lowest free descriptor number, like `open(2)` does.
- The receive side in `src/runtime/ipc.rs` must treat descriptor 0 as a valid handle (0 is falsy in JS, and Bun's internal close helpers skip stdio numbers). That is what this test guards.
- The IPC channel itself opens lazily, on the first `process.on('message')`, so module-level code in the child runs before any receive.

<details><summary>Notes</summary>

- Other lazily opened, cached descriptors in the process: `/dev/urandom` from `WTF::RandomDevice` (`RandomDevice.cpp:91`) and from `bmalloc::ARC4RandomNumberGenerator::stir` (`bmalloc/CryptoRandom.cpp:127`). Both open during startup in practice, before user code runs. The warm-up round trip covers them too if that ever changes.
- Found with an `LD_PRELOAD` hook that logs every descriptor-creating libc call in the child, plus a gdb breakpoint on the `statm` open: the backtrace is `Heap::collectIfNecessaryOrDefer` -> `overCriticalMemoryThreshold(Cached)` -> `WTF::percentAvailableMemoryInUse` -> `LinuxMemory::singleton`.
- I could not make the original test fail locally (debug ASAN build, release-asan build, with and without the CI env). Whether the 100th threshold check or a GC end phase falls inside the window depends on allocation volume during startup, which differs per machine. The fix removes the dependency instead of tuning it.
- No recent main build shows this test in its annotations (checked the last 12). The two sightings are on PR branches with unrelated diffs.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/child_process/child_process_ipc_handle.test.ts

<!-- robobun:evidence:end -->