### PR TITLE
prompt, alert, confirm: run JS signal listeners while waiting for input

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -2687,6 +2687,12 @@ impl BufferedStdin {
         self
     }
 
+    /// `true` when the next `read_byte` is served from the buffer and does not touch the fd.
+    #[inline]
+    pub fn has_buffered(&self) -> bool {
+        self.start < self.end
+    }
+
     /// Fill `dest` from the buffer, refilling from
     /// the underlying fd until `dest` is full or EOF. Returns `Ok(0)` on EOF.
     ///

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -5,9 +5,9 @@ use crate::VirtualMachineRef as VirtualMachine;
 use crate::event_loop::EventLoop;
 use crate::{JSGlobalObject, Task};
 use bun_event_loop::{Taskable, task_tag};
-use bun_threading::SignalRing;
 #[cfg(unix)]
 use bun_sys::FdExt as _;
+use bun_threading::SignalRing;
 
 const BUFFER_SIZE: usize = 8192;
 
@@ -46,8 +46,7 @@ impl PosixSignalHandle {
         }
     }
 
-    /// The main thread's handle, and only when `global_object` is the main thread's: workers get
-    /// no POSIX signals, and the ring has a single consumer.
+    /// The main thread's handle; `None` in a worker (no POSIX signals there, and the ring has one consumer).
     #[cfg(unix)]
     fn for_main_thread(global_object: &JSGlobalObject) -> Option<bun_ptr::BackRef<Self>> {
         if !global_object.bun_vm().is_main_thread() {
@@ -58,9 +57,7 @@ impl PosixSignalHandle {
         unsafe { (*(*vm).event_loop()).signal_handler }
     }
 
-    /// A pipe the signal handler writes one byte to per queued signal, for a host function that
-    /// blocks the JS thread outside the event loop (`prompt()`) to poll next to stdin. Returns the
-    /// read end, or `None` off the main thread or when no JS signal listener was ever installed.
+    /// Read end of a pipe the signal handler writes a byte to per queued signal, so `prompt()` can poll it next to stdin. `None` off the main thread or when no JS signal listener exists.
     #[cfg(unix)]
     pub fn blocking_wait_fd(global_object: &JSGlobalObject) -> Option<bun_sys::Fd> {
         Self::for_main_thread(global_object)?;
@@ -87,8 +84,7 @@ impl PosixSignalHandle {
         let Some(handler) = Self::for_main_thread(global_object) else {
             return;
         };
-        // Empty the pipe before the ring: a signal that lands in between leaves a byte behind
-        // (a spurious wakeup), never a queued signal with no byte.
+        // Pipe before ring, so a signal that lands in between leaves a spare byte, never a signal without one.
         let read = BLOCKING_WAIT_PIPE[0].load(Ordering::Acquire);
         if read >= 0 {
             let mut buf = [0u8; 64];
@@ -143,8 +139,7 @@ extern "C" fn Bun__onPosixSignal(number: i32) {
             if handler.enqueue(signal) {
                 let wait_fd = BLOCKING_WAIT_PIPE[1].load(Ordering::Acquire);
                 if wait_fd >= 0 {
-                    // SAFETY: write(2) is async-signal-safe; the fd is O_NONBLOCK, a full pipe is
-                    // already readable so the lost byte does not matter.
+                    // SAFETY: write(2) is async-signal-safe; O_NONBLOCK, and a full pipe is readable anyway.
                     let _ = unsafe { libc::write(wait_fd, (&raw const signal).cast(), 1) };
                 }
                 // SAFETY: same process-lifetime event loop as above; `wakeup`

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -6,6 +6,8 @@ use crate::event_loop::EventLoop;
 use crate::{JSGlobalObject, Task};
 use bun_event_loop::{Taskable, task_tag};
 use bun_threading::SignalRing;
+#[cfg(unix)]
+use bun_sys::FdExt as _;
 
 const BUFFER_SIZE: usize = 8192;
 
@@ -44,31 +46,68 @@ impl PosixSignalHandle {
         }
     }
 
+    /// The main thread's handle, and only when `global_object` is the main thread's: workers get
+    /// no POSIX signals, and the ring has a single consumer.
     #[cfg(unix)]
-    fn main_thread() -> Option<bun_ptr::BackRef<Self>> {
+    fn for_main_thread(global_object: &JSGlobalObject) -> Option<bun_ptr::BackRef<Self>> {
+        if !global_object.bun_vm().is_main_thread() {
+            return None;
+        }
         let vm = VirtualMachine::get_main_thread_vm()?;
-        // SAFETY: `vm` and its event loop are process-lifetime; only the
-        // `signal_handler` slot is read.
+        // SAFETY: `vm` and its event loop are process-lifetime; only the `signal_handler` slot is read.
         unsafe { (*(*vm).event_loop()).signal_handler }
     }
 
-    /// `true` when a signal handler has queued a signal the main thread has not consumed.
+    /// A pipe the signal handler writes one byte to per queued signal, for a host function that
+    /// blocks the JS thread outside the event loop (`prompt()`) to poll next to stdin. Returns the
+    /// read end, or `None` off the main thread or when no JS signal listener was ever installed.
     #[cfg(unix)]
-    pub fn has_queued() -> bool {
-        Self::main_thread().is_some_and(|handler| !handler.ring.is_empty())
+    pub fn blocking_wait_fd(global_object: &JSGlobalObject) -> Option<bun_sys::Fd> {
+        Self::for_main_thread(global_object)?;
+        let existing = BLOCKING_WAIT_PIPE[0].load(Ordering::Acquire);
+        if existing >= 0 {
+            return Some(bun_sys::Fd::from_native(existing));
+        }
+        let [read, write] = bun_sys::pipe().ok()?;
+        for fd in [read, write] {
+            if bun_sys::set_close_on_exec(fd).is_err() || bun_sys::set_nonblocking(fd).is_err() {
+                read.close();
+                write.close();
+                return None;
+            }
+        }
+        BLOCKING_WAIT_PIPE[0].store(read.native(), Ordering::Release);
+        BLOCKING_WAIT_PIPE[1].store(write.native(), Ordering::Release);
+        Some(read)
     }
 
-    /// Runs the JS listeners for every queued signal now (for a host function that blocks the JS thread). Main thread only.
+    /// Runs the JS listeners for every queued signal now. Main thread only (a no-op elsewhere).
     #[cfg(unix)]
     pub fn run_queued_from_js_thread(global_object: &JSGlobalObject) {
-        let Some(handler) = Self::main_thread() else {
+        let Some(handler) = Self::for_main_thread(global_object) else {
             return;
         };
+        // Empty the pipe before the ring: a signal that lands in between leaves a byte behind
+        // (a spurious wakeup), never a queued signal with no byte.
+        let read = BLOCKING_WAIT_PIPE[0].load(Ordering::Acquire);
+        if read >= 0 {
+            let mut buf = [0u8; 64];
+            while matches!(bun_sys::read(bun_sys::Fd::from_native(read), &mut buf), Ok(n) if n == buf.len())
+            {
+            }
+        }
         while let Some(signal) = handler.ring.dequeue() {
             PosixSignalTask::run_from_js_thread(signal, global_object);
         }
     }
 }
+
+/// `[read, write]` ends of the pipe behind [`PosixSignalHandle::blocking_wait_fd`]; -1 until created.
+#[cfg(unix)]
+static BLOCKING_WAIT_PIPE: [core::sync::atomic::AtomicI32; 2] = [
+    core::sync::atomic::AtomicI32::new(-1),
+    core::sync::atomic::AtomicI32::new(-1),
+];
 
 /// This is the signal handler entry point. Calls enqueue on the ring buffer.
 /// Note: Must be minimal logic here. Only do atomics & signal-safe calls.
@@ -102,6 +141,12 @@ extern "C" fn Bun__onPosixSignal(number: i32) {
                 return;
             };
             if handler.enqueue(signal) {
+                let wait_fd = BLOCKING_WAIT_PIPE[1].load(Ordering::Acquire);
+                if wait_fd >= 0 {
+                    // SAFETY: write(2) is async-signal-safe; the fd is O_NONBLOCK, a full pipe is
+                    // already readable so the lost byte does not matter.
+                    let _ = unsafe { libc::write(wait_fd, (&raw const signal).cast(), 1) };
+                }
                 // SAFETY: same process-lifetime event loop as above; `wakeup`
                 // is one async-signal-safe write to the loop's wakeup fd.
                 unsafe { (*(*vm).event_loop()).wakeup() };

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -92,8 +92,15 @@ impl PosixSignalHandle {
             {
             }
         }
+        let mut ran = false;
         while let Some(signal) = handler.ring.dequeue() {
             PosixSignalTask::run_from_js_thread(signal, global_object);
+            ran = true;
+        }
+        // Node runs the microtask checkpoint after a signal callback, so `async` listeners and
+        // `process.nextTick(() => process.exit())` complete here too. `Stopped` is left to the caller's read.
+        if ran {
+            let _ = global_object.drain_microtasks_and_next_ticks();
         }
     }
 }

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -97,8 +97,7 @@ impl PosixSignalHandle {
             PosixSignalTask::run_from_js_thread(signal, global_object);
             ran = true;
         }
-        // Node runs the microtask checkpoint after a signal callback, so `async` listeners and
-        // `process.nextTick(() => process.exit())` complete here too. `Stopped` is left to the caller's read.
+        // Like Node after a signal callback: lets `async` and `nextTick` listeners finish. `Stopped` surfaces at the caller's read.
         if ran {
             let _ = global_object.drain_microtasks_and_next_ticks();
         }

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -58,10 +58,8 @@ impl PosixSignalHandle {
         Self::main_thread().is_some_and(|handler| !handler.ring.is_empty())
     }
 
-    /// Runs the JS listeners for every queued signal now, without the event
-    /// loop. For a host function that blocks the JS thread on stdin (`prompt()`):
-    /// the listener for SIGINT or SIGTERM must run at once, not after the line
-    /// arrives. Main thread only, the ring's single consumer.
+    /// Runs the JS listeners for every queued signal now, for a host function that
+    /// blocks the JS thread (`prompt()`). Main thread only, the ring's single consumer.
     #[cfg(unix)]
     pub fn run_queued_from_js_thread(global_object: &JSGlobalObject) {
         let Some(handler) = Self::main_thread() else {

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -58,8 +58,7 @@ impl PosixSignalHandle {
         Self::main_thread().is_some_and(|handler| !handler.ring.is_empty())
     }
 
-    /// Runs the JS listeners for every queued signal now, for a host function that
-    /// blocks the JS thread (`prompt()`). Main thread only, the ring's single consumer.
+    /// Runs the JS listeners for every queued signal now (for a host function that blocks the JS thread). Main thread only.
     #[cfg(unix)]
     pub fn run_queued_from_js_thread(global_object: &JSGlobalObject) {
         let Some(handler) = Self::main_thread() else {

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -43,6 +43,34 @@ impl PosixSignalHandle {
             event_loop.enqueue_task(task);
         }
     }
+
+    #[cfg(unix)]
+    fn main_thread() -> Option<bun_ptr::BackRef<Self>> {
+        let vm = VirtualMachine::get_main_thread_vm()?;
+        // SAFETY: `vm` and its event loop are process-lifetime; only the
+        // `signal_handler` slot is read.
+        unsafe { (*(*vm).event_loop()).signal_handler }
+    }
+
+    /// `true` when a signal handler has queued a signal the main thread has not consumed.
+    #[cfg(unix)]
+    pub fn has_queued() -> bool {
+        Self::main_thread().is_some_and(|handler| !handler.ring.is_empty())
+    }
+
+    /// Runs the JS listeners for every queued signal now, without the event
+    /// loop. For a host function that blocks the JS thread on stdin (`prompt()`):
+    /// the listener for SIGINT or SIGTERM must run at once, not after the line
+    /// arrives. Main thread only, the ring's single consumer.
+    #[cfg(unix)]
+    pub fn run_queued_from_js_thread(global_object: &JSGlobalObject) {
+        let Some(handler) = Self::main_thread() else {
+            return;
+        };
+        while let Some(signal) = handler.ring.dequeue() {
+            PosixSignalTask::run_from_js_thread(signal, global_object);
+        }
+    }
 }
 
 /// This is the signal handler entry point. Calls enqueue on the ring buffer.

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -6,43 +6,33 @@ use bun_core::EncodedSlice;
 use bun_core::Output;
 use bun_jsc::EncodedSliceJsc as _;
 
-/// Waits for stdin with `pselect(2)` (interruptible, unlike `read(2)` under SA_RESTART handlers) and runs queued JS signal listeners on EINTR.
+/// Waits until stdin is readable and runs the JS listeners of every signal that arrives meanwhile
+/// (a blocking `read(2)` cannot: the handlers are SA_RESTART and only queue the signal).
 #[cfg(unix)]
 fn wait_for_stdin(global: &JSGlobalObject) {
     use bun_jsc::PosixSignalHandle;
+    use bun_sys::posix::{POLL_IN, PollFd, poll};
 
-    let fd = bun_sys::Fd::stdin().native();
+    let Some(signals) = PosixSignalHandle::blocking_wait_fd(global) else {
+        return;
+    };
+    let mut fds = [
+        PollFd {
+            fd: bun_sys::Fd::stdin().native(),
+            events: POLL_IN,
+            revents: 0,
+        },
+        PollFd {
+            fd: signals.native(),
+            events: POLL_IN,
+            revents: 0,
+        },
+    ];
     loop {
         PosixSignalHandle::run_queued_from_js_thread(global);
-
-        // SAFETY: zeroed `sigset_t` and `fd_set` are valid inputs to
-        // `sigfillset` and `FD_SET`, which fill them; `fd` is stdin, below
-        // FD_SETSIZE; `previous` is written by `pthread_sigmask` before
-        // `pselect` reads it.
-        let interrupted = unsafe {
-            let mut all: libc::sigset_t = core::mem::zeroed();
-            let mut previous: libc::sigset_t = core::mem::zeroed();
-            libc::sigfillset(&mut all);
-            libc::pthread_sigmask(libc::SIG_BLOCK, &all, &mut previous);
-
-            let interrupted = PosixSignalHandle::has_queued() || {
-                let mut readable: libc::fd_set = core::mem::zeroed();
-                libc::FD_SET(fd, &mut readable);
-                let rc = libc::pselect(
-                    fd + 1,
-                    &mut readable,
-                    core::ptr::null_mut(),
-                    core::ptr::null_mut(),
-                    core::ptr::null(),
-                    &previous,
-                );
-                rc < 0 && bun_sys::last_errno() == libc::EINTR
-            };
-
-            libc::pthread_sigmask(libc::SIG_SETMASK, &previous, core::ptr::null_mut());
-            interrupted
-        };
-        if !interrupted {
+        fds[0].revents = 0;
+        fds[1].revents = 0;
+        if poll(&mut fds, -1).is_err() || fds[1].revents == 0 {
             return;
         }
     }
@@ -237,17 +227,18 @@ pub mod prompt {
     /// The process-global `BufferedStdin`; calls [`wait_for_stdin`] before each refill.
     pub(crate) struct InterruptibleStdin<'a> {
         global: &'a JSGlobalObject,
-        reader: &'a mut bun_core::output::BufferedStdin,
     }
 
     impl ReadByte for InterruptibleStdin<'_> {
         type Error = bun_core::Error;
         #[inline]
         fn read_byte(&mut self) -> Result<u8, Self::Error> {
-            if !self.reader.has_buffered() {
+            // SAFETY: process-global static, JS thread only. Each `&mut` ends before
+            // `wait_for_stdin`, which can run a JS listener that calls `prompt()` again.
+            if !unsafe { &*Output::buffered_stdin_reader() }.has_buffered() {
                 wait_for_stdin(self.global);
             }
-            self.reader.read_byte()
+            unsafe { &mut *Output::buffered_stdin_reader() }.read_byte()
         }
     }
 
@@ -368,13 +359,7 @@ pub mod prompt {
             });
 
         // 7. Pause while waiting for the user's response.
-        // `bun.Output.buffered_stdin.reader()` — process-global 4 KiB buffered stdin.
-        // SAFETY: process-global static; prompt() runs single-threaded on the JS
-        // main thread, so the exclusive borrow is sound for this scope.
-        let mut reader = InterruptibleStdin {
-            global,
-            reader: unsafe { &mut *Output::buffered_stdin_reader() },
-        };
+        let mut reader = InterruptibleStdin { global };
         let mut second_byte: Option<u8> = None;
         let Ok(first_byte) = reader.read_byte() else {
             // 8. Let result be null if the user aborts, or otherwise the string

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -6,8 +6,7 @@ use bun_core::EncodedSlice;
 use bun_core::Output;
 use bun_jsc::EncodedSliceJsc as _;
 
-/// Waits until stdin is readable and runs the JS listeners of every signal that arrives meanwhile
-/// (a blocking `read(2)` cannot: the handlers are SA_RESTART and only queue the signal).
+/// Waits until stdin is readable, running JS signal listeners as signals arrive (a blocking `read(2)` cannot: handlers are SA_RESTART).
 #[cfg(unix)]
 fn wait_for_stdin(global: &JSGlobalObject) {
     use bun_jsc::PosixSignalHandle;
@@ -233,8 +232,7 @@ pub mod prompt {
         type Error = bun_core::Error;
         #[inline]
         fn read_byte(&mut self) -> Result<u8, Self::Error> {
-            // SAFETY: process-global static, JS thread only. Each `&mut` ends before
-            // `wait_for_stdin`, which can run a JS listener that calls `prompt()` again.
+            // SAFETY: process-global static, JS thread only; no `&mut` is live across `wait_for_stdin` (a listener may re-enter `prompt()`).
             if !unsafe { &*Output::buffered_stdin_reader() }.has_buffered() {
                 wait_for_stdin(self.global);
             }

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -6,6 +6,65 @@ use bun_core::EncodedSlice;
 use bun_core::Output;
 use bun_jsc::EncodedSliceJsc as _;
 
+/// Blocks until stdin has data, and runs queued JS signal listeners in the
+/// meantime. `process.on("SIGINT")` installs its handler with SA_RESTART, so a
+/// plain `read(2)` never returns EINTR and the listener could only run after
+/// the user typed a line. `pselect(2)` is not restarted. Signals are blocked
+/// between the queue check and the wait, so a signal that lands in that gap
+/// is delivered inside `pselect` and still ends the wait with EINTR.
+#[cfg(unix)]
+fn wait_for_stdin(global: &JSGlobalObject) {
+    use bun_jsc::PosixSignalHandle;
+
+    let fd = bun_sys::Fd::stdin().native();
+    loop {
+        PosixSignalHandle::run_queued_from_js_thread(global);
+
+        // SAFETY: zeroed `sigset_t` and `fd_set` are valid inputs to
+        // `sigfillset` and `FD_SET`, which fill them; `fd` is stdin, below
+        // FD_SETSIZE; `previous` is written by `pthread_sigmask` before
+        // `pselect` reads it.
+        let interrupted = unsafe {
+            let mut all: libc::sigset_t = core::mem::zeroed();
+            let mut previous: libc::sigset_t = core::mem::zeroed();
+            libc::sigfillset(&mut all);
+            libc::pthread_sigmask(libc::SIG_BLOCK, &all, &mut previous);
+
+            let interrupted = PosixSignalHandle::has_queued() || {
+                let mut readable: libc::fd_set = core::mem::zeroed();
+                libc::FD_SET(fd, &mut readable);
+                let rc = libc::pselect(
+                    fd + 1,
+                    &mut readable,
+                    core::ptr::null_mut(),
+                    core::ptr::null_mut(),
+                    core::ptr::null(),
+                    &previous,
+                );
+                rc < 0 && bun_sys::last_errno() == libc::EINTR
+            };
+
+            libc::pthread_sigmask(libc::SIG_SETMASK, &previous, core::ptr::null_mut());
+            interrupted
+        };
+        if !interrupted {
+            return;
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn wait_for_stdin(_global: &JSGlobalObject) {}
+
+/// `alert()` and `confirm()` read unbuffered, so every byte waits on the fd.
+fn take_byte(
+    global: &JSGlobalObject,
+    reader: &mut bun_core::output::StdinReader,
+) -> bun_core::CrateResult<u8> {
+    wait_for_stdin(global);
+    reader.take_byte()
+}
+
 /// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-alert
 #[bun_jsc::host_fn(export = "WebCore__alert")]
 fn alert(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
@@ -51,7 +110,9 @@ fn alert(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // 7. Optionally, pause while waiting for the user to acknowledge the message.
     let mut reader = Output::stdin_reader();
     loop {
-        let Ok(byte) = reader.take_byte() else { break };
+        let Ok(byte) = take_byte(global, &mut reader) else {
+            break;
+        };
         if byte == b'\n' {
             break;
         }
@@ -105,7 +166,7 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // 6. Pause until the user responds either positively or negatively.
     let mut reader = Output::stdin_reader();
 
-    let Ok(first_byte) = reader.take_byte() else {
+    let Ok(first_byte) = take_byte(global, &mut reader) else {
         return Ok(JSValue::FALSE);
     };
 
@@ -116,7 +177,7 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     match first_byte {
         b'\n' => return Ok(JSValue::FALSE),
         b'\r' => {
-            let Ok(next_byte) = reader.take_byte() else {
+            let Ok(next_byte) = take_byte(global, &mut reader) else {
                 // They may have said yes, but the stdin is invalid.
                 return Ok(JSValue::FALSE);
             };
@@ -125,7 +186,7 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
             }
         }
         b'y' | b'Y' => {
-            let Ok(next_byte) = reader.take_byte() else {
+            let Ok(next_byte) = take_byte(global, &mut reader) else {
                 // They may have said yes, but the stdin is invalid.
 
                 return Ok(JSValue::FALSE);
@@ -137,7 +198,7 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
                 return Ok(JSValue::TRUE);
             } else if next_byte == b'\r' {
                 // Check Windows style
-                let Ok(second_byte) = reader.take_byte() else {
+                let Ok(second_byte) = take_byte(global, &mut reader) else {
                     return Ok(JSValue::FALSE);
                 };
                 if second_byte == b'\n' {
@@ -148,7 +209,7 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         _ => {}
     }
 
-    while let Ok(b) = reader.take_byte() {
+    while let Ok(b) = take_byte(global, &mut reader) {
         if b == b'\n' || b == b'\r' {
             break;
         }
@@ -172,17 +233,27 @@ pub mod prompt {
     }
 
     /// Small trait exposing `read_byte() -> Result<u8, _>`; the only
-    /// concrete impl is the process-global `BufferedStdin`.
+    /// concrete impl is [`InterruptibleStdin`].
     pub trait ReadByte {
         type Error;
         fn read_byte(&mut self) -> Result<u8, Self::Error>;
     }
 
-    impl ReadByte for bun_core::output::BufferedStdin {
+    /// The process-global `BufferedStdin`, with [`wait_for_stdin`] before
+    /// every refill from the fd.
+    pub(crate) struct InterruptibleStdin<'a> {
+        global: &'a JSGlobalObject,
+        reader: &'a mut bun_core::output::BufferedStdin,
+    }
+
+    impl ReadByte for InterruptibleStdin<'_> {
         type Error = bun_core::Error;
         #[inline]
         fn read_byte(&mut self) -> Result<u8, Self::Error> {
-            bun_core::output::BufferedStdin::read_byte(self)
+            if !self.reader.has_buffered() {
+                wait_for_stdin(self.global);
+            }
+            self.reader.read_byte()
         }
     }
 
@@ -306,8 +377,10 @@ pub mod prompt {
         // `bun.Output.buffered_stdin.reader()` — process-global 4 KiB buffered stdin.
         // SAFETY: process-global static; prompt() runs single-threaded on the JS
         // main thread, so the exclusive borrow is sound for this scope.
-        let reader: &mut bun_core::output::BufferedStdin =
-            unsafe { &mut *Output::buffered_stdin_reader() };
+        let mut reader = InterruptibleStdin {
+            global,
+            reader: unsafe { &mut *Output::buffered_stdin_reader() },
+        };
         let mut second_byte: Option<u8> = None;
         let Ok(first_byte) = reader.read_byte() else {
             // 8. Let result be null if the user aborts, or otherwise the string
@@ -341,7 +414,7 @@ pub mod prompt {
         // size to 4096. If that is too small, then just dynamically allocate
         // the rest.
         if let Err(e) = read_until_delimiter_array_list_append_assume_capacity(
-            &mut *reader,
+            &mut reader,
             &mut input,
             b'\n',
             2048,
@@ -355,7 +428,7 @@ pub mod prompt {
             input.ensure_total_capacity(4096);
 
             if let Err(e2) = read_until_delimiter_array_list_append_assume_capacity(
-                &mut *reader,
+                &mut reader,
                 &mut input,
                 b'\n',
                 4096,
@@ -366,8 +439,7 @@ pub mod prompt {
                     return Ok(JSValue::NULL);
                 }
 
-                if read_until_delimiter_array_list_infinity(&mut *reader, &mut input, b'\n')
-                    .is_err()
+                if read_until_delimiter_array_list_infinity(&mut reader, &mut input, b'\n').is_err()
                 {
                     // 8. Let result be null if the user aborts, or otherwise the string
                     //    that the user responded with.

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -6,12 +6,9 @@ use bun_core::EncodedSlice;
 use bun_core::Output;
 use bun_jsc::EncodedSliceJsc as _;
 
-/// Blocks until stdin has data, and runs queued JS signal listeners in the
-/// meantime. `process.on("SIGINT")` installs its handler with SA_RESTART, so a
-/// plain `read(2)` never returns EINTR and the listener could only run after
-/// the user typed a line. `pselect(2)` is not restarted. Signals are blocked
-/// between the queue check and the wait, so a signal that lands in that gap
-/// is delivered inside `pselect` and still ends the wait with EINTR.
+/// Waits until stdin is readable and runs queued JS signal listeners meanwhile.
+/// Signal handlers are SA_RESTART, so `read(2)` never sees EINTR; `pselect(2)`
+/// does, and the mask closes the gap between the queue check and the wait.
 #[cfg(unix)]
 fn wait_for_stdin(global: &JSGlobalObject) {
     use bun_jsc::PosixSignalHandle;
@@ -239,8 +236,7 @@ pub mod prompt {
         fn read_byte(&mut self) -> Result<u8, Self::Error>;
     }
 
-    /// The process-global `BufferedStdin`, with [`wait_for_stdin`] before
-    /// every refill from the fd.
+    /// The process-global `BufferedStdin`; calls [`wait_for_stdin`] before each refill.
     pub(crate) struct InterruptibleStdin<'a> {
         global: &'a JSGlobalObject,
         reader: &'a mut bun_core::output::BufferedStdin,

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -6,9 +6,7 @@ use bun_core::EncodedSlice;
 use bun_core::Output;
 use bun_jsc::EncodedSliceJsc as _;
 
-/// Waits until stdin is readable and runs queued JS signal listeners meanwhile.
-/// Signal handlers are SA_RESTART, so `read(2)` never sees EINTR; `pselect(2)`
-/// does, and the mask closes the gap between the queue check and the wait.
+/// Waits for stdin with `pselect(2)` (interruptible, unlike `read(2)` under SA_RESTART handlers) and runs queued JS signal listeners on EINTR.
 #[cfg(unix)]
 fn wait_for_stdin(global: &JSGlobalObject) {
     use bun_jsc::PosixSignalHandle;

--- a/src/threading/signal_ring.rs
+++ b/src/threading/signal_ring.rs
@@ -72,12 +72,6 @@ impl<const CAPACITY: usize> SignalRing<CAPACITY> {
         }
     }
 
-    /// `true` when no producer has claimed a slot since the last `dequeue`.
-    pub fn is_empty(&self) -> bool {
-        let (head, tail) = unpack(self.state.load(Ordering::Acquire));
-        head == tail
-    }
-
     /// Consumer side, one thread only. Returns the oldest published signal.
     /// `None` means empty, or that the oldest claimed slot is still 0 because
     /// its producer has not stored yet: come back after that producer's

--- a/src/threading/signal_ring.rs
+++ b/src/threading/signal_ring.rs
@@ -72,6 +72,12 @@ impl<const CAPACITY: usize> SignalRing<CAPACITY> {
         }
     }
 
+    /// `true` when no producer has claimed a slot since the last `dequeue`.
+    pub fn is_empty(&self) -> bool {
+        let (head, tail) = unpack(self.state.load(Ordering::Acquire));
+        head == tail
+    }
+
     /// Consumer side, one thread only. Returns the oldest published signal.
     /// `None` means empty, or that the oldest claimed slot is still 0 because
     /// its producer has not stored yet: come back after that producer's

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -422,9 +422,9 @@ test("confirm (no) windows newline", async () => {
 // prompt(), confirm() and alert() block the JS thread on stdin. A JS signal
 // listener must still run when the signal arrives, not after the next line.
 describe.skipIf(isWindows)("dialogs run JS signal listeners while they wait for input", () => {
-  async function run(dialog, signal, code) {
+  async function run(dialog, signal, code, listener = `() => { console.error("[listener ran]"); process.exit(${code}); }`) {
     const script = `
-      process.on(${JSON.stringify(signal)}, () => { console.error("[listener ran]"); process.exit(${code}); });
+      process.on(${JSON.stringify(signal)}, ${listener});
       const answer = ${dialog};
       console.error("[code after the dialog ran with " + JSON.stringify(answer) + "]");
     `;
@@ -466,6 +466,17 @@ describe.skipIf(isWindows)("dialogs run JS signal listeners while they wait for 
     expect(await run('alert("done?")', "SIGINT", 130)).toEqual({
       shown: "done? [Enter] ",
       stderr: "[listener ran]\n",
+      exitCode: 130,
+    });
+  });
+
+  // Node runs the microtask/nextTick checkpoint after a signal callback, so an
+  // exit that is one tick away must also happen during the wait.
+  test.concurrent("prompt() and a listener that exits on the next tick", async () => {
+    const listener = `() => process.nextTick(() => { console.error("[tick ran]"); process.exit(130); })`;
+    expect(await run('prompt("name?")', "SIGINT", 130, listener)).toEqual({
+      shown: "name? ",
+      stderr: "[tick ran]\n",
       exitCode: 130,
     });
   });

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -438,16 +438,9 @@ describe.skipIf(isWindows)("dialogs run JS signal listeners while they wait for 
       if (done) break;
       shown += Buffer.from(value).toString();
     }
+    // No input follows: the listener alone must end the process. Stdin stays
+    // open, so a dialog that ignores the signal keeps waiting and times out.
     proc.kill(signal);
-    // Then answer the dialog. Without the fix the answer is consumed first and
-    // the code after the dialog runs. With it the child may already be gone,
-    // so a closed pipe (EPIPE) is the expected outcome, not a failure.
-    try {
-      proc.stdin.write("bob\n");
-      await proc.stdin.end();
-    } catch (e) {
-      if (e?.code !== "EPIPE") throw e;
-    }
 
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
     return { shown, stderr, exitCode };

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -422,7 +422,12 @@ test("confirm (no) windows newline", async () => {
 // prompt(), confirm() and alert() block the JS thread on stdin. A JS signal
 // listener must still run when the signal arrives, not after the next line.
 describe.skipIf(isWindows)("dialogs run JS signal listeners while they wait for input", () => {
-  async function run(dialog, signal, code, listener = `() => { console.error("[listener ran]"); process.exit(${code}); }`) {
+  async function run(
+    dialog,
+    signal,
+    code,
+    listener = `() => { console.error("[listener ran]"); process.exit(${code}); }`,
+  ) {
     const script = `
       process.on(${JSON.stringify(signal)}, ${listener});
       const answer = ${dialog};

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -439,8 +439,15 @@ describe.skipIf(isWindows)("dialogs run JS signal listeners while they wait for 
       shown += Buffer.from(value).toString();
     }
     proc.kill(signal);
-    proc.stdin.write("bob\n");
-    await proc.stdin.end();
+    // Then answer the dialog. Without the fix the answer is consumed first and
+    // the code after the dialog runs. With it the child may already be gone,
+    // so a closed pipe (EPIPE) is the expected outcome, not a failure.
+    try {
+      proc.stdin.write("bob\n");
+      await proc.stdin.end();
+    } catch (e) {
+      if (e?.code !== "EPIPE") throw e;
+    }
 
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
     return { shown, stderr, exitCode };

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { expect, it, test } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir, withoutAggressiveGC } from "harness";
 
 test("exists", () => {
@@ -417,6 +417,58 @@ test("confirm (no) windows newline", async () => {
   await proc.exited;
 
   expect(await proc.stderr.text()).toBe("No\n");
+});
+
+// prompt(), confirm() and alert() block the JS thread on stdin. A JS signal
+// listener must still run when the signal arrives, not after the next line.
+describe.skipIf(isWindows)("dialogs run JS signal listeners while they wait for input", () => {
+  async function run(dialog, signal, code) {
+    const script = `
+      process.on(${JSON.stringify(signal)}, () => { console.error("[listener ran]"); process.exit(${code}); });
+      const answer = ${dialog};
+      console.error("[code after the dialog ran with " + JSON.stringify(answer) + "]");
+    `;
+    await using proc = spawn({ cmd: [bunExe(), "-e", script], stdio: ["pipe", "pipe", "pipe"], env: bunEnv });
+
+    // The dialog text is flushed right before the child waits on stdin.
+    const reader = proc.stdout.getReader();
+    let shown = "";
+    while (!shown.includes("? ")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      shown += Buffer.from(value).toString();
+    }
+    proc.kill(signal);
+    proc.stdin.write("bob\n");
+    await proc.stdin.end();
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { shown, stderr, exitCode };
+  }
+
+  test.concurrent("prompt() and SIGINT", async () => {
+    expect(await run('prompt("name?")', "SIGINT", 130)).toEqual({
+      shown: "name? ",
+      stderr: "[listener ran]\n",
+      exitCode: 130,
+    });
+  });
+
+  test.concurrent("confirm() and SIGTERM", async () => {
+    expect(await run('confirm("sure?")', "SIGTERM", 143)).toEqual({
+      shown: "sure? [y/N] ",
+      stderr: "[listener ran]\n",
+      exitCode: 143,
+    });
+  });
+
+  test.concurrent("alert() and SIGINT", async () => {
+    expect(await run('alert("done?")', "SIGINT", 130)).toEqual({
+      shown: "done? [Enter] ",
+      stderr: "[listener ran]\n",
+      exitCode: 130,
+    });
+  });
 });
 
 test("globalThis.self = 123 works", () => {


### PR DESCRIPTION
### Problem
- `prompt()`, `alert()` and `confirm()` block the JS thread on a read from stdin. A `process.on("SIGINT")` or `process.on("SIGTERM")` listener does not run while the read blocks. At an interactive prompt Ctrl+C echoes `^C` and nothing happens. `kill -INT` and `kill -TERM` are absorbed. On a pipe stdin the process survives INT and TERM until SIGKILL. When a line finally arrives, the code after `prompt()` runs first and the listener runs late or not at all.
- The cause is the signal delivery path. Bun installs its handler with `SA_RESTART` (`src/jsc/bindings/BunProcess.cpp:1565`), so the blocking `read(2)` restarts instead of failing with EINTR. The handler only queues the signal on a ring for the event loop. The loop cannot turn while the read blocks, so the JS listener waits for the line. Node runs the listener at once.

### Fix
- The signal handler also writes one byte to a pipe (`PosixSignalHandle::blocking_wait_fd`, created on the first dialog, `O_CLOEXEC` and `O_NONBLOCK`). The dialogs `poll(2)` that pipe next to stdin before each read from the fd. When the pipe is readable they empty it, run the queued JS listeners, and poll again. They read stdin only when it is ready and no signal is pending.
- Correct whichever thread the kernel picks to run the handler, and when input and a signal arrive together: the byte stays in the pipe until the dialog consumes it. The pipe is emptied before the ring, so a signal that lands in between leaves a spare byte (a harmless extra wakeup), never a queued signal with no byte.
- Main thread only. In a worker (no POSIX signals there) the wait is the plain read as before, and the ring keeps its single consumer. `prompt()` reborrows the global stdin buffer per call, so a listener that calls `prompt()` again does not alias a live `&mut`.
- Verified: `test/js/web/web-globals.test.js` (three new tests: `prompt`, `alert`, `confirm`, each sent a signal with stdin left open; the listener alone must end the process). All three time out on the shipped binary and pass 8/8 repeated runs here. The existing `confirm` tests still pass.

### Background
- A Unix signal handler must be async-signal-safe. Bun's handler pushes the signal number onto a lock-free ring and wakes the event loop. `PosixSignalTask` later pops it on the JS thread and emits the listener. `run_queued_from_js_thread` pops the same ring from the blocked host function instead. Listener exceptions are reported inside `fireEventListeners`, so none leak into the dialog.
- The self-pipe trick turns a signal into a readable fd: the handler does one `write(2)`, and any `poll`/`select` that includes the read end wakes up. Unlike `pselect` with a signal mask it does not depend on the signal being delivered to the waiting thread.
- `SA_RESTART` makes the kernel restart a slow syscall that a handler interrupted instead of returning EINTR, which is why the old blocking read never noticed the signal.

<details><summary>Notes</summary>

Repro on the shipped binary (1.4.3 canary), a pty driver that types `^C` then sends SIGTERM:

```
process.on("SIGINT", () => { console.error("[SIGINT]"); process.exit(130); });
process.on("SIGTERM", () => { console.error("[SIGTERM]"); process.exit(143); });
const a = prompt("name?");
```

Before: the process is alive after 8 s and is killed with SIGKILL. After: the listener runs during the wait and the process exits 130 or 143.

History of this PR: the first revision waited with `pselect(2)` under a temporary full signal mask. Review and an aarch64 CI run showed two holes: a process-directed signal can be taken by another thread while the JS thread has it blocked, and `pselect` reports a readable fd in preference to a pending signal, so input that arrives with the signal still won. The self-pipe closes both. The test no longer writes to stdin after the kill for the same reason.

Self-reviewed: 4 concerns raised on the first revision (aliased `&mut` across the JS callout, worker callers draining the main ring, the data-vs-signal race in the test, cross-thread delivery), all 4 addressed by this revision.

Scope: the three dialogs only. Other blocking stdin readers (`bun init`, `bun publish`) are unchanged. Windows is unchanged (signals arrive through libuv there).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/web-globals.test.js

<!-- robobun:evidence:end -->