### PR TITLE
install: name the tarball cache folder by a truncated sha256 of the URL

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -732,12 +732,8 @@ pub fn cached_npm_package_folder_print_basename<'a>(
     w.finish_z()
 }
 
-/// `@T@<32 hex>@@@<cache version>`: the first 16 bytes of `sha256(url)`.
-///
-/// A 64-bit wyhash of the URL has cheap multicollisions, so two distinct
-/// tarball URLs could share one extraction folder and the second extraction
-/// overwrote the first. No colliding pair is feasible to construct for 128
-/// bits of SHA-256.
+/// `@T@<first 16 bytes of sha256(url) as hex>@@@<cache version>`. The name is
+/// the entry's only identity in the shared cache, so the hash must not collide.
 pub fn cached_tarball_folder_name_print<'a>(
     buf: &'a mut [u8],
     url: &[u8],

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -488,6 +488,12 @@ impl<'a> ByteCursor<'a> {
         self.put(bun_fmt::u64_hex_var_lower(&mut tmp, n));
     }
 
+    /// Two lower-hex digits per byte.
+    #[inline(always)]
+    fn put_hex_lower(&mut self, bytes: &[u8]) {
+        self.at += bun_fmt::bytes_to_hex_lower(bytes, &mut self.buf[self.at..]);
+    }
+
     /// `@@@{d}` when set.
     #[inline(always)]
     fn put_cache_version(&mut self, v: Option<usize>) {
@@ -728,9 +734,10 @@ pub fn cached_npm_package_folder_print_basename<'a>(
 
 /// `@T@<32 hex>@@@<cache version>`: the first 16 bytes of `sha256(url)`.
 ///
-/// A 64-bit wyhash has cheap multicollisions, so two distinct tarball URLs
-/// could share one extraction folder and the second extraction overwrote the
-/// first. A truncated SHA-256 has no such pairs.
+/// A 64-bit wyhash of the URL has cheap multicollisions, so two distinct
+/// tarball URLs could share one extraction folder and the second extraction
+/// overwrote the first. No colliding pair is feasible to construct for 128
+/// bits of SHA-256.
 pub fn cached_tarball_folder_name_print<'a>(
     buf: &'a mut [u8],
     url: &[u8],
@@ -739,11 +746,9 @@ pub fn cached_tarball_folder_name_print<'a>(
     use bun_sha_hmac::sha::hashers::SHA256;
     let mut digest = [0u8; SHA256::DIGEST];
     SHA256::hash(url, &mut digest);
-    let (hi, lo) = digest[..16].split_at(8);
     let mut w = ByteCursor::new(buf);
     w.put(b"@T@");
-    w.put_u64_hex16::<true>(u64::from_be_bytes(hi.try_into().expect("8 bytes")));
-    w.put_u64_hex16::<true>(u64::from_be_bytes(lo.try_into().expect("8 bytes")));
+    w.put_hex_lower(&digest[..16]);
     w.put_cache_version(Some(CacheVersion::CURRENT));
     w.put_patch_hash(patch_hash);
     w.finish_z()

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -732,8 +732,7 @@ pub fn cached_npm_package_folder_print_basename<'a>(
     w.finish_z()
 }
 
-/// `@T@<first 16 bytes of sha256(url) as hex>@@@<cache version>`. The name is
-/// the entry's only identity in the shared cache, so the hash must not collide.
+/// `@T@<first 16 bytes of sha256(url), hex>@@@<cache version>`; collision-resistant on purpose.
 pub fn cached_tarball_folder_name_print<'a>(
     buf: &'a mut [u8],
     url: &[u8],

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -726,14 +726,24 @@ pub fn cached_npm_package_folder_print_basename<'a>(
     w.finish_z()
 }
 
+/// `@T@<32 hex>@@@<cache version>`: the first 16 bytes of `sha256(url)`.
+///
+/// A 64-bit wyhash has cheap multicollisions, so two distinct tarball URLs
+/// could share one extraction folder and the second extraction overwrote the
+/// first. A truncated SHA-256 has no such pairs.
 pub fn cached_tarball_folder_name_print<'a>(
     buf: &'a mut [u8],
     url: &[u8],
     patch_hash: Option<u64>,
 ) -> &'a ZStr {
+    use bun_sha_hmac::sha::hashers::SHA256;
+    let mut digest = [0u8; SHA256::DIGEST];
+    SHA256::hash(url, &mut digest);
+    let (hi, lo) = digest[..16].split_at(8);
     let mut w = ByteCursor::new(buf);
     w.put(b"@T@");
-    w.put_u64_hex16::<true>(Semver::semver_string::Builder::string_hash(url));
+    w.put_u64_hex16::<true>(u64::from_be_bytes(hi.try_into().expect("8 bytes")));
+    w.put_u64_hex16::<true>(u64::from_be_bytes(lo.try_into().expect("8 bytes")));
     w.put_cache_version(Some(CacheVersion::CURRENT));
     w.put_patch_hash(patch_hash);
     w.finish_z()

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -28,6 +28,7 @@ import {
   type TestContext,
 } from "./dummy.registry.js";
 import { constructStdCollision } from "./wyhash-std-collision.js";
+import { wyhash11 } from "./wyhash11.js";
 
 expect.extend({
   toBeWorkspaceLink,
@@ -11217,6 +11218,52 @@ it.skipIf(isWindows)("file: deps with colliding abs-path hashes resolve to disti
   const alpha = await file(join(victimDir, "node_modules", "alphadep", "package.json")).json();
   const beta = await file(join(victimDir, "node_modules", "betadep", "package.json")).json();
   expect({ alpha: alpha.name, beta: beta.name }).toEqual({ alpha: "pkg-alpha", beta: "pkg-beta" });
+});
+
+// Two local tarball paths that collide under Wyhash11(0), the hash that used
+// to name the `@T@<hash>` extraction folder in the shared install cache. Each
+// project depends on one of them. The second install must not overwrite the
+// first project's cache entry, and a reinstall of the first project must get
+// its own tarball's bytes back.
+it("local tarballs with colliding path hashes get separate cache folders", async () => {
+  const pathA = "./t/m3daaaaaaaaaaaaaaaaaaaaaaaaa.7aQs_ePaaaaaaaaw9Aaaaaaaaaaaaaa.tgz";
+  const pathB = "./t/m3daaaaaaaaaaaaaaaaaaaaaaaaa.7aQs_ePbaaaaaaaw9Aaaaaaaaaaaaaa.tgz";
+  expect(pathA).not.toBe(pathB);
+  const enc = new TextEncoder();
+  expect(wyhash11(0, enc.encode(pathA))).toBe(wyhash11(0, enc.encode(pathB)));
+
+  using root = tempDir("tarball-cache-collision", {
+    "p1/package.json": JSON.stringify({ name: "p1", dependencies: { bar: `file:${pathA}` } }),
+    [`p1/${pathA.slice(2)}`]: readFileSync(join(import.meta.dir, "bar-0.0.2.tgz")),
+    "p2/package.json": JSON.stringify({ name: "p2", dependencies: { baz: `file:${pathB}` } }),
+    [`p2/${pathB.slice(2)}`]: readFileSync(join(import.meta.dir, "baz-0.0.3.tgz")),
+  });
+  const cacheDir = join(String(root), "cache");
+  const testEnv = { ...env, BUN_INSTALL_CACHE_DIR: cacheDir };
+
+  async function install(project: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(String(root), project),
+      env: testEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 package installed");
+    expect(exitCode).toBe(0);
+  }
+
+  await install("p1");
+  await install("p2");
+  await rm(join(String(root), "p1", "node_modules"), { recursive: true, force: true });
+  await install("p1");
+
+  const bar = await file(join(String(root), "p1", "node_modules", "bar", "package.json")).json();
+  const baz = await file(join(String(root), "p2", "node_modules", "baz", "package.json")).json();
+  expect({ bar: bar.name, baz: baz.name }).toEqual({ bar: "bar", baz: "baz" });
+  expect((await readdirSorted(cacheDir)).filter(name => name.startsWith("@T@"))).toHaveLength(2);
 });
 
 it("reports an invalid URL for a manifest tarball URL containing a newline", async () => {

--- a/test/cli/install/wyhash11.ts
+++ b/test/cli/install/wyhash11.ts
@@ -1,0 +1,85 @@
+// Pure-JS port of `Wyhash11` (the legacy 32-byte-round, 5-prime wyhash variant
+// in src/wyhash/lib.rs). `Wyhash11::hash(0, bytes)` keys the lockfile string
+// interning pool (`semver::string::Buf`), so two different strings whose bytes
+// collide under this function share one pool slot. Use this to confirm a
+// collision holds before a test relies on it. This is a different algorithm
+// from `Bun.hash.wyhash` (the final4 variant); do not substitute one for the
+// other.
+
+const MASK = (1n << 64n) - 1n;
+const M128 = (1n << 128n) - 1n;
+const P = [
+  0xa0761d6478bd642fn,
+  0xe7037ed1a0b428dbn,
+  0x8ebc6af09c88c6e3n,
+  0x589965cc75374cc3n,
+  0x1d8e4e27c47d124fn,
+];
+
+function rd(n: number, d: Uint8Array, o: number): bigint {
+  let r = 0n;
+  for (let i = 0; i < n; i++) r |= BigInt(d[o + i]) << BigInt(8 * i);
+  return r;
+}
+// read_8bytes_swapped: the two 32-bit halves are swapped relative to a plain LE u64.
+const rd8sw = (d: Uint8Array, o: number) => ((rd(4, d, o) << 32n) | rd(4, d, o + 4)) & MASK;
+
+function mum(a: bigint, b: bigint): bigint {
+  const r = ((a & MASK) * (b & MASK)) & M128;
+  return ((r >> 64n) ^ r) & MASK;
+}
+const mix0 = (a: bigint, b: bigint, s: bigint) => mum((a ^ s ^ P[0]) & MASK, (b ^ s ^ P[1]) & MASK);
+const mix1 = (a: bigint, b: bigint, s: bigint) => mum((a ^ s ^ P[2]) & MASK, (b ^ s ^ P[3]) & MASK);
+
+function byteWord(k: Uint8Array, o: number, len: number): bigint {
+  // Reproduces the `read4<<N | read2<<M | read1` tail assembly for 1..=7 bytes.
+  switch (len) {
+    case 1:
+      return rd(1, k, o);
+    case 2:
+      return rd(2, k, o);
+    case 3:
+      return (rd(2, k, o) << 8n) | rd(1, k, o + 2);
+    case 4:
+      return rd(4, k, o);
+    case 5:
+      return (rd(4, k, o) << 8n) | rd(1, k, o + 4);
+    case 6:
+      return (rd(4, k, o) << 16n) | rd(2, k, o + 4);
+    case 7:
+      return (rd(4, k, o) << 24n) | (rd(2, k, o + 4) << 8n) | rd(1, k, o + 6);
+    default:
+      throw new Error("byteWord: len must be 1..=7, got " + len);
+  }
+}
+
+function finalSeed(seed: bigint, k: Uint8Array, o: number, len: number): bigint {
+  if (len === 0) return seed;
+  if (len <= 7) return mix0(byteWord(k, o, len), P[4], seed);
+  if (len === 8) return mix0(rd8sw(k, o), P[4], seed);
+  if (len <= 15) return mix0(rd8sw(k, o), byteWord(k, o + 8, len - 8), seed);
+  if (len === 16) return mix0(rd8sw(k, o), rd8sw(k, o + 8), seed);
+  // 17..=31: head over the first 16 bytes, tail over the remainder.
+  const head = mix0(rd8sw(k, o), rd8sw(k, o + 8), seed);
+  const remLen = len - 16;
+  const tail = remLen <= 7 ? mix1(byteWord(k, o + 16, remLen), P[4], seed) : mix1(rd8sw(k, o + 16), remLen === 8 ? P[4] : byteWord(k, o + 24, remLen - 8), seed);
+  return (head ^ tail) & MASK;
+}
+
+export function wyhash11(seed: bigint | number, bytes: Uint8Array): bigint {
+  let s = BigInt(seed) & MASK;
+  const len = bytes.length;
+  const aligned = len - (len % 32);
+  let off = 0;
+  while (off < aligned) {
+    s =
+      (mix0(rd(8, bytes, off), rd(8, bytes, off + 8), s) ^
+        mix1(rd(8, bytes, off + 16), rd(8, bytes, off + 24), s)) &
+      MASK;
+    off += 32;
+  }
+  const finalLen = len - aligned;
+  const s2 = finalSeed(s, bytes, aligned, finalLen);
+  const msgLen = BigInt(aligned + finalLen);
+  return mum((s2 ^ msgLen) & MASK, P[4]);
+}

--- a/test/cli/install/wyhash11.ts
+++ b/test/cli/install/wyhash11.ts
@@ -8,13 +8,7 @@
 
 const MASK = (1n << 64n) - 1n;
 const M128 = (1n << 128n) - 1n;
-const P = [
-  0xa0761d6478bd642fn,
-  0xe7037ed1a0b428dbn,
-  0x8ebc6af09c88c6e3n,
-  0x589965cc75374cc3n,
-  0x1d8e4e27c47d124fn,
-];
+const P = [0xa0761d6478bd642fn, 0xe7037ed1a0b428dbn, 0x8ebc6af09c88c6e3n, 0x589965cc75374cc3n, 0x1d8e4e27c47d124fn];
 
 function rd(n: number, d: Uint8Array, o: number): bigint {
   let r = 0n;
@@ -62,7 +56,10 @@ function finalSeed(seed: bigint, k: Uint8Array, o: number, len: number): bigint 
   // 17..=31: head over the first 16 bytes, tail over the remainder.
   const head = mix0(rd8sw(k, o), rd8sw(k, o + 8), seed);
   const remLen = len - 16;
-  const tail = remLen <= 7 ? mix1(byteWord(k, o + 16, remLen), P[4], seed) : mix1(rd8sw(k, o + 16), remLen === 8 ? P[4] : byteWord(k, o + 24, remLen - 8), seed);
+  const tail =
+    remLen <= 7
+      ? mix1(byteWord(k, o + 16, remLen), P[4], seed)
+      : mix1(rd8sw(k, o + 16), remLen === 8 ? P[4] : byteWord(k, o + 24, remLen - 8), seed);
   return (head ^ tail) & MASK;
 }
 
@@ -73,8 +70,7 @@ export function wyhash11(seed: bigint | number, bytes: Uint8Array): bigint {
   let off = 0;
   while (off < aligned) {
     s =
-      (mix0(rd(8, bytes, off), rd(8, bytes, off + 8), s) ^
-        mix1(rd(8, bytes, off + 16), rd(8, bytes, off + 24), s)) &
+      (mix0(rd(8, bytes, off), rd(8, bytes, off + 8), s) ^ mix1(rd(8, bytes, off + 16), rd(8, bytes, off + 24), s)) &
       MASK;
     off += 32;
   }


### PR DESCRIPTION
### Problem
- `bun install` extracts a local or remote tarball dependency into the shared cache folder `@T@<hex16>@@@1`. The hex is `Wyhash11(0, url)` (`cached_tarball_folder_name_print` in `src/install/PackageManager/PackageManagerDirectories.rs`). A 64-bit wyhash has cheap multicollisions, so two distinct tarball URLs or paths can name one folder.
- Then the second extraction overwrites the first, and a later install of the first project links the second project's package. Reproduced with bun 1.4.3 and two `file:` paths that differ in one byte.

### Fix
- Name the folder by the first 16 bytes of `sha256(url)`: `@T@<hex32>@@@1`, written by a new panic-free `ByteCursor::put_hex_lower`.
- Correct because every caller (extraction, both installers, lifecycle scripts, `bun patch`) gets the name from this one function, and nothing parses it back. No colliding pair is feasible to construct for 128 bits of SHA-256.
- Old `@T@` entries no longer match and are extracted once more. `CacheVersion` is unchanged, so npm and git entries stay.
- Verified: `test/cli/install/bun-install.test.ts` (`local tarballs with colliding path hashes get separate cache folders`, fails on stock bun). Also `bun-install-tarball-integrity`, `bun-add`, `bun-install-patch`, `isolated-install`. Self-reviewed: 5 concerns, 2 addressed, 3 out of scope (see Notes).

### Background
- The install cache (`~/.bun/install/cache` or `BUN_INSTALL_CACHE_DIR`) is shared by every project on a machine. A cache hit is a directory probe, so the folder name is the only identity.
- `Wyhash11` (`src/wyhash/lib.rs`) is a fast map hash, not an identity. #41642 fixes the same collision in the lockfile string pool.
- #39016 keys local tarballs by their lockfile integrity. It has a different goal (same path, different bytes) and leaves URL tarballs on the 64-bit hash.

<details><summary>Notes</summary>

Repro outside the test runner: two projects `p1` and `p2` share one `BUN_INSTALL_CACHE_DIR`. `p1` depends on `file:./t/m3daaaaaaaaaaaaaaaaaaaaaaaaa.7aQs_ePaaaaaaaaw9Aaaaaaaaaaaaaa.tgz` (package `pa`), `p2` on the same path with `ePb` (package `pb`). Both paths hash to `57f49f457e3a9e60`. After installing both and reinstalling `p1`, `p1/node_modules/pa/package.json` says `pb`. With this change the cache holds `@T@0811c19e5117043c8a9d3c2b7ead2559@@@1` and `@T@8c6f8c9cbefa737ce98f29a2cfe2671f@@@1` (equal to `printf %s <path> | sha256sum | cut -c1-32`), and each project gets its own package.

`test/cli/install/wyhash11.ts` is a JS port of `Wyhash11` so the test can assert the collision holds before it relies on it. It is the same helper as in #41642. Whichever lands second drops the duplicate.

The 13 failures in a full local run of `bun-install.test.ts` are the bitbucket/gitlab/gitpkg network tests, which fail the same way on main in this sandbox.

Self-review concerns. Addressed: the first revision used `.try_into().expect(..)` in a module whose header promises no reachable panic-format code (now `put_hex_lower` over `bun_fmt::bytes_to_hex_lower`), and the doc comment overclaimed. Left out of scope: (1) two other persisted names still use a 64-bit wyhash of a URL, the bare git clone dir `<hex16>.git` (`Task::Id::for_git_clone`) and the `@@host__<hex16>` scoped-registry suffix used when a registry hostname is longer than 32 bytes. They have the same weakness but a different blast radius and can follow the same pattern in a separate change. (2) For `file:` tarballs the key is the path as written, so two projects with the same relative path and different bytes still share an entry even with a perfect hash. That is what #39016 addresses. (3) Old `@T@<hex16>@@@1` folders are orphaned, not deleted. There is no cache GC today and `bun pm cache rm` clears them.

`SHA256::hash` is the BoringSSL one-shot. It needs no prior `boringssl::load()` (CPU dispatch is a lazy `CRYPTO_once`), same as the EVP one-shots `integrity.rs` already runs on offline installs, and it is safe on the thread-pool workers that run extraction.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->