### PR TITLE
fetch: redact credential headers in the verbose curl line and response trace

### DIFF
--- a/docs/runtime/debugger.mdx
+++ b/docs/runtime/debugger.mdx
@@ -169,7 +169,7 @@ await fetch("https://example.com", {
 
 The lines with `[fetch] >` are the request from your local code, and the lines with `[fetch] <` are the response from the remote server.
 
-Credentials are not logged. The values of the `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie` and `x-amz-security-token` headers print as `[redacted]` (an auth scheme such as `Bearer` is kept), and a password in the URL is masked with `*`. This applies to the `curl` command as well, so add the credentials back before you run it. The request body is printed in full.
+Credentials are not logged. The values of the `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie` and `x-amz-security-token` headers print as `[redacted]` (an auth scheme such as `Bearer` is kept). In the URL, a password is masked with `*`, and a UUID or an npm token (`npm_...`) anywhere in it prints as `***`. This applies to the `curl` command as well, so add these values back before you run it. The request body is printed in full.
 
 To print without the `curl` command, set `BUN_CONFIG_VERBOSE_FETCH` to `true`.
 

--- a/docs/runtime/debugger.mdx
+++ b/docs/runtime/debugger.mdx
@@ -169,6 +169,8 @@ await fetch("https://example.com", {
 
 The lines with `[fetch] >` are the request from your local code, and the lines with `[fetch] <` are the response from the remote server.
 
+Credentials are not logged. The values of the `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie` and `x-amz-security-token` headers print as `[redacted]` (an auth scheme such as `Bearer` is kept), and a password in the URL is masked with `*`. This applies to the `curl` command as well, so add the credentials back before you run it. The request body is printed in full.
+
 To print without the `curl` command, set `BUN_CONFIG_VERBOSE_FETCH` to `true`.
 
 ```ts index.ts icon="/icons/typescript.svg"

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1400,20 +1400,7 @@ pub(crate) fn print_request(
         bun_core::fmt::redacted_npm_url(url),
     );
     for header in request.headers {
-        let name = header.name();
-        if strings::eql_case_insensitive_ascii(name, b"authorization", true)
-            || strings::eql_case_insensitive_ascii(name, b"proxy-authorization", true)
-        {
-            let value = header.value();
-            let scheme_len = strings::index_of_char_usize(value, b' ').map_or(0, |i| i + 1);
-            bun_core::pretty_errorln!(
-                "> <r><cyan>{}<r><d>: <r>{}<d>[redacted]<r>",
-                BStr::new(name),
-                BStr::new(&value[..scheme_len]),
-            );
-        } else {
-            bun_core::pretty_errorln!("> {}", header);
-        }
+        bun_core::pretty_errorln!("> {}", header);
     }
     Output::flush();
 }

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -178,7 +178,10 @@ impl fmt::Display for LoggedHeaderValue<'_> {
         if strings::eql_any_case_insensitive_ascii(name, &Self::SCHEME_HEADERS) {
             let scheme_len = strings::index_of_char_usize(value, b' ').map_or(0, |i| i + 1);
             write!(f, "{}[redacted]", BStr::new(&value[..scheme_len]))
-        } else if strings::eql_any_case_insensitive_ascii(name, &Self::SECRET_HEADERS) {
+        } else if self.header.is_multiline()
+            || strings::eql_any_case_insensitive_ascii(name, &Self::SECRET_HEADERS)
+        {
+            // A folded continuation line has no name: the header it continues is unknown here.
             f.write_str("[redacted]")
         } else {
             write!(f, "{}", BStr::new(value))
@@ -192,7 +195,7 @@ impl fmt::Display for Header {
         // codes).
         if enable_ansi_colors_stderr() {
             if self.is_multiline() {
-                write!(f, pretty_fmt!("<r><cyan>{}", true), BStr::new(self.value()))
+                write!(f, pretty_fmt!("<r><cyan>{}", true), self.logged_value())
             } else {
                 write!(
                     f,
@@ -203,11 +206,7 @@ impl fmt::Display for Header {
             }
         } else {
             if self.is_multiline() {
-                write!(
-                    f,
-                    pretty_fmt!("<r><cyan>{}", false),
-                    BStr::new(self.value())
-                )
+                write!(f, pretty_fmt!("<r><cyan>{}", false), self.logged_value())
             } else {
                 write!(
                     f,

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -154,16 +154,12 @@ impl Header {
         HeaderCurlFormatter { header: self }
     }
 
-    /// The value as verbose logging prints it. A credential header keeps only
-    /// its auth scheme: `Bearer [redacted]`, `[redacted]`.
+    /// The value for the `BUN_CONFIG_VERBOSE_FETCH` trace: credentials print as `[redacted]`.
     pub fn logged_value(&self) -> LoggedHeaderValue<'_> {
         LoggedHeaderValue { header: self }
     }
 }
 
-/// The value of a credential header is never logged. The `Display` impls
-/// below (the `> name: value` lines and the `curl` line of
-/// `BUN_CONFIG_VERBOSE_FETCH`) all go through `logged_value`.
 pub struct LoggedHeaderValue<'a> {
     header: &'a Header,
 }

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -173,21 +173,16 @@ impl LoggedHeaderValue<'_> {
     const SCHEME_HEADERS: [&[u8]; 2] = [b"authorization", b"proxy-authorization"];
     /// The whole value is a secret.
     const SECRET_HEADERS: [&[u8]; 3] = [b"cookie", b"set-cookie", b"x-amz-security-token"];
-
-    fn matches(name: &[u8], list: &[&[u8]]) -> bool {
-        list.iter()
-            .any(|n| strings::eql_case_insensitive_ascii(name, n, true))
-    }
 }
 
 impl fmt::Display for LoggedHeaderValue<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = self.header.name();
         let value = self.header.value();
-        if Self::matches(name, &Self::SCHEME_HEADERS) {
+        if strings::eql_any_case_insensitive_ascii(name, &Self::SCHEME_HEADERS) {
             let scheme_len = strings::index_of_char_usize(value, b' ').map_or(0, |i| i + 1);
             write!(f, "{}[redacted]", BStr::new(&value[..scheme_len]))
-        } else if Self::matches(name, &Self::SECRET_HEADERS) {
+        } else if strings::eql_any_case_insensitive_ascii(name, &Self::SECRET_HEADERS) {
             f.write_str("[redacted]")
         } else {
             write!(f, "{}", BStr::new(value))

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -153,6 +153,46 @@ impl Header {
     pub(crate) fn curl(&self) -> HeaderCurlFormatter<'_> {
         HeaderCurlFormatter { header: self }
     }
+
+    /// The value as verbose logging prints it. A credential header keeps only
+    /// its auth scheme: `Bearer [redacted]`, `[redacted]`.
+    pub fn logged_value(&self) -> LoggedHeaderValue<'_> {
+        LoggedHeaderValue { header: self }
+    }
+}
+
+/// The value of a credential header is never logged. The `Display` impls
+/// below (the `> name: value` lines and the `curl` line of
+/// `BUN_CONFIG_VERBOSE_FETCH`) all go through `logged_value`.
+pub struct LoggedHeaderValue<'a> {
+    header: &'a Header,
+}
+
+impl LoggedHeaderValue<'_> {
+    /// `Authorization: <scheme> <credentials>`: the scheme is kept.
+    const SCHEME_HEADERS: [&[u8]; 2] = [b"authorization", b"proxy-authorization"];
+    /// The whole value is a secret.
+    const SECRET_HEADERS: [&[u8]; 3] = [b"cookie", b"set-cookie", b"x-amz-security-token"];
+
+    fn matches(name: &[u8], list: &[&[u8]]) -> bool {
+        list.iter()
+            .any(|n| strings::eql_case_insensitive_ascii(name, n, true))
+    }
+}
+
+impl fmt::Display for LoggedHeaderValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = self.header.name();
+        let value = self.header.value();
+        if Self::matches(name, &Self::SCHEME_HEADERS) {
+            let scheme_len = strings::index_of_char_usize(value, b' ').map_or(0, |i| i + 1);
+            write!(f, "{}[redacted]", BStr::new(&value[..scheme_len]))
+        } else if Self::matches(name, &Self::SECRET_HEADERS) {
+            f.write_str("[redacted]")
+        } else {
+            write!(f, "{}", BStr::new(value))
+        }
+    }
 }
 
 impl fmt::Display for Header {
@@ -167,7 +207,7 @@ impl fmt::Display for Header {
                     f,
                     pretty_fmt!("<r><cyan>{}<r><d>: <r>{}", true),
                     BStr::new(self.name()),
-                    BStr::new(self.value()),
+                    self.logged_value(),
                 )
             }
         } else {
@@ -182,7 +222,7 @@ impl fmt::Display for Header {
                     f,
                     pretty_fmt!("<r><cyan>{}<r><d>: <r>{}", false),
                     BStr::new(self.name()),
-                    BStr::new(self.value()),
+                    self.logged_value(),
                 )
             }
         }
@@ -204,7 +244,7 @@ impl fmt::Display for HeaderCurlFormatter<'_> {
                 f,
                 "-H \"{}: {}\"",
                 BStr::new(header.name()),
-                BStr::new(header.value())
+                header.logged_value()
             )
         } else {
             write!(f, "-H \"{}\"", BStr::new(header.name()))
@@ -348,10 +388,14 @@ impl fmt::Display for RequestCurlFormatter<'_> {
             write!(
                 f,
                 pretty_fmt!("<b><cyan>curl<r> <d>--http1.1<r> <b>\"{}\"<r>", true),
-                BStr::new(request.path),
+                bun_core::fmt::redacted_npm_url(request.path),
             )?;
         } else {
-            write!(f, "curl --http1.1 \"{}\"", BStr::new(request.path))?;
+            write!(
+                f,
+                "curl --http1.1 \"{}\"",
+                bun_core::fmt::redacted_npm_url(request.path)
+            )?;
         }
 
         if request.method != b"GET" {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3690,13 +3690,28 @@ describe.concurrent("verbose fetch logging redacts credentials", () => {
       for (const secret of Object.values(secrets)) {
         expect(stderr).not.toContain(secret);
       }
-      expect(stderr).toContain("Authorization: Bearer [redacted]");
-      expect(stderr).toContain("Proxy-Authorization: Basic [redacted]");
-      expect(stderr).toContain("Cookie: [redacted]");
-      expect(stderr).toContain("x-amz-security-token: [redacted]");
-      expect(stderr).toContain("X-Plain: plain-value");
+
+      // One `> name: value` (request) or `< name: value` (response) trace line per
+      // header. Match on the full header name so `Cookie` and `Set-Cookie` are
+      // checked independently.
+      const traceLines = stderr.split(/\r?\n/).map(line => line.replace(/^(?:\[fetch\])?\s*[<>]?\s*/, ""));
+      const headerLines = (name: string) =>
+        traceLines.filter(line => line.toLowerCase().startsWith(name.toLowerCase() + ":"));
+      expect(headerLines("Authorization")).toEqual(["Authorization: Bearer [redacted]"]);
+      expect(headerLines("Proxy-Authorization")).toEqual(["Proxy-Authorization: Basic [redacted]"]);
+      expect(headerLines("Cookie")).toEqual(["Cookie: [redacted]"]);
+      expect(headerLines("x-amz-security-token")).toEqual(["x-amz-security-token: [redacted]"]);
+      expect(headerLines("X-Plain")).toEqual(["X-Plain: plain-value"]);
+      expect(headerLines("Set-Cookie").map(line => line.toLowerCase())).toEqual(["set-cookie: [redacted]"]);
+
       if (mode === "curl") {
-        expect(stderr).toContain(`curl --http1.1 "http://user:***`);
+        const curlLine = stderr.split(/\r?\n/).find(line => line.includes("curl --http1.1")) ?? "";
+        expect(curlLine).toContain(`curl --http1.1 "http://user:***`);
+        expect(curlLine).toContain(`-H "Authorization: Bearer [redacted]"`);
+        expect(curlLine).toContain(`-H "Proxy-Authorization: Basic [redacted]"`);
+        expect(curlLine).toContain(`-H "Cookie: [redacted]"`);
+        expect(curlLine).toContain(`-H "x-amz-security-token: [redacted]"`);
+        expect(curlLine).toContain(`-H "X-Plain: plain-value"`);
       }
       expect(exitCode).toBe(0);
     });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3650,25 +3650,24 @@ describe.concurrent("verbose fetch logging redacts credentials", () => {
     setCookie: "set-cookie-sekret",
   };
 
-  for (const mode of ["1", "curl"]) {
-    it(`BUN_CONFIG_VERBOSE_FETCH=${mode}`, async () => {
-      using server = Bun.serve({
-        port: 0,
-        fetch(req) {
-          return new Response(req.headers.get("authorization") ?? "", {
-            headers: { "Set-Cookie": `sid=${secrets.setCookie}` },
-          });
-        },
-      });
-      const url = new URL(server.url);
-      url.username = "user";
-      url.password = secrets.password;
+  it.each(["1", "curl"])("BUN_CONFIG_VERBOSE_FETCH=%s", async mode => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response(req.headers.get("authorization") ?? "", {
+          headers: { "Set-Cookie": `sid=${secrets.setCookie}` },
+        });
+      },
+    });
+    const url = new URL(server.url);
+    url.username = "user";
+    url.password = secrets.password;
 
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `const res = await fetch(process.env.SERVER_URL, {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const res = await fetch(process.env.SERVER_URL, {
              headers: {
                Authorization: "Bearer ${secrets.authorization}",
                "Proxy-Authorization": "Basic ${secrets.proxyAuthorization}",
@@ -3678,42 +3677,41 @@ describe.concurrent("verbose fetch logging redacts credentials", () => {
              },
            });
            console.log(await res.text());`,
-        ],
-        env: { ...bunEnv, BUN_CONFIG_VERBOSE_FETCH: mode, SERVER_URL: url.href },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stdout).toBe(`Bearer ${secrets.authorization}\n`);
-      for (const secret of Object.values(secrets)) {
-        expect(stderr).not.toContain(secret);
-      }
-
-      // One `> name: value` (request) or `< name: value` (response) trace line per
-      // header. Match on the full header name so `Cookie` and `Set-Cookie` are
-      // checked independently.
-      const traceLines = stderr.split(/\r?\n/).map(line => line.replace(/^(?:\[fetch\])?\s*[<>]?\s*/, ""));
-      const headerLines = (name: string) =>
-        traceLines.filter(line => line.toLowerCase().startsWith(name.toLowerCase() + ":"));
-      expect(headerLines("Authorization")).toEqual(["Authorization: Bearer [redacted]"]);
-      expect(headerLines("Proxy-Authorization")).toEqual(["Proxy-Authorization: Basic [redacted]"]);
-      expect(headerLines("Cookie")).toEqual(["Cookie: [redacted]"]);
-      expect(headerLines("x-amz-security-token")).toEqual(["x-amz-security-token: [redacted]"]);
-      expect(headerLines("X-Plain")).toEqual(["X-Plain: plain-value"]);
-      expect(headerLines("Set-Cookie").map(line => line.toLowerCase())).toEqual(["set-cookie: [redacted]"]);
-
-      if (mode === "curl") {
-        const curlLine = stderr.split(/\r?\n/).find(line => line.includes("curl --http1.1")) ?? "";
-        expect(curlLine).toContain(`curl --http1.1 "http://user:***`);
-        expect(curlLine).toContain(`-H "Authorization: Bearer [redacted]"`);
-        expect(curlLine).toContain(`-H "Proxy-Authorization: Basic [redacted]"`);
-        expect(curlLine).toContain(`-H "Cookie: [redacted]"`);
-        expect(curlLine).toContain(`-H "x-amz-security-token: [redacted]"`);
-        expect(curlLine).toContain(`-H "X-Plain: plain-value"`);
-      }
-      expect(exitCode).toBe(0);
+      ],
+      env: { ...bunEnv, BUN_CONFIG_VERBOSE_FETCH: mode, SERVER_URL: url.href },
+      stdout: "pipe",
+      stderr: "pipe",
     });
-  }
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe(`Bearer ${secrets.authorization}\n`);
+    for (const secret of Object.values(secrets)) {
+      expect(stderr).not.toContain(secret);
+    }
+
+    // One `> name: value` (request) or `< name: value` (response) trace line per
+    // header. Match on the full header name so `Cookie` and `Set-Cookie` are
+    // checked independently.
+    const traceLines = stderr.split(/\r?\n/).map(line => line.replace(/^(?:\[fetch\])?\s*[<>]?\s*/, ""));
+    const headerLines = (name: string) =>
+      traceLines.filter(line => line.toLowerCase().startsWith(name.toLowerCase() + ":"));
+    expect(headerLines("Authorization")).toEqual(["Authorization: Bearer [redacted]"]);
+    expect(headerLines("Proxy-Authorization")).toEqual(["Proxy-Authorization: Basic [redacted]"]);
+    expect(headerLines("Cookie")).toEqual(["Cookie: [redacted]"]);
+    expect(headerLines("x-amz-security-token")).toEqual(["x-amz-security-token: [redacted]"]);
+    expect(headerLines("X-Plain")).toEqual(["X-Plain: plain-value"]);
+    expect(headerLines("Set-Cookie").map(line => line.toLowerCase())).toEqual(["set-cookie: [redacted]"]);
+
+    if (mode === "curl") {
+      const curlLine = stderr.split(/\r?\n/).find(line => line.includes("curl --http1.1")) ?? "";
+      expect(curlLine).toContain(`curl --http1.1 "http://user:***`);
+      expect(curlLine).toContain(`-H "Authorization: Bearer [redacted]"`);
+      expect(curlLine).toContain(`-H "Proxy-Authorization: Basic [redacted]"`);
+      expect(curlLine).toContain(`-H "Cookie: [redacted]"`);
+      expect(curlLine).toContain(`-H "x-amz-security-token: [redacted]"`);
+      expect(curlLine).toContain(`-H "X-Plain: plain-value"`);
+    }
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3639,3 +3639,66 @@ it("verbose fetch logging prints [redacted] in place of Authorization credential
   expect(stderr).not.toContain("sekret-token");
   expect(exitCode).toBe(0);
 });
+
+describe.concurrent("verbose fetch logging redacts credentials", () => {
+  const secrets = {
+    password: "url-pw-sekret",
+    authorization: "auth-sekret",
+    proxyAuthorization: "proxy-sekret",
+    cookie: "cookie-sekret",
+    sessionToken: "session-sekret",
+    setCookie: "set-cookie-sekret",
+  };
+
+  for (const mode of ["1", "curl"]) {
+    it(`BUN_CONFIG_VERBOSE_FETCH=${mode}`, async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response(req.headers.get("authorization") ?? "", {
+            headers: { "Set-Cookie": `sid=${secrets.setCookie}` },
+          });
+        },
+      });
+      const url = new URL(server.url);
+      url.username = "user";
+      url.password = secrets.password;
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const res = await fetch(process.env.SERVER_URL, {
+             headers: {
+               Authorization: "Bearer ${secrets.authorization}",
+               "Proxy-Authorization": "Basic ${secrets.proxyAuthorization}",
+               Cookie: "sid=${secrets.cookie}",
+               "x-amz-security-token": "${secrets.sessionToken}",
+               "X-Plain": "plain-value",
+             },
+           });
+           console.log(await res.text());`,
+        ],
+        env: { ...bunEnv, BUN_CONFIG_VERBOSE_FETCH: mode, SERVER_URL: url.href },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toBe(`Bearer ${secrets.authorization}\n`);
+      for (const secret of Object.values(secrets)) {
+        expect(stderr).not.toContain(secret);
+      }
+      expect(stderr).toContain("Authorization: Bearer [redacted]");
+      expect(stderr).toContain("Proxy-Authorization: Basic [redacted]");
+      expect(stderr).toContain("Cookie: [redacted]");
+      expect(stderr).toContain("x-amz-security-token: [redacted]");
+      expect(stderr).toContain("X-Plain: plain-value");
+      if (mode === "curl") {
+        expect(stderr).toContain(`curl --http1.1 "http://user:***`);
+      }
+      expect(exitCode).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
### Problem
- `BUN_CONFIG_VERBOSE_FETCH=curl` prints the `curl` line with `-H "Authorization: Bearer <token>"`, `-H "Proxy-Authorization: ..."` and the URL password in clear text, one line above the `>` block that already prints `Authorization: Bearer [redacted]`. `docs/runtime/debugger.mdx` recommends `=curl` for CI logs.
- In both modes `Cookie`, `x-amz-security-token` (the STS session credential that `Bun.S3Client` sends, and that `Bun.inspect(s3client)` already prints as `[REDACTED]`) and the response `Set-Cookie` print raw.
- The cause: the redaction from #37669 lives in `print_request` (`src/http/lib.rs:1402`) and covers only the `>` lines. The curl line (`RequestCurlFormatter` / `HeaderCurlFormatter`) and the `<` lines (`Response` `Display`) in `src/picohttp/lib.rs` format `header.value()` directly.

### Fix
- Add `Header::logged_value()` in `src/picohttp/lib.rs`. It keeps the auth scheme for `Authorization` / `Proxy-Authorization` (`Bearer [redacted]`, `AWS4-HMAC-SHA256 [redacted]`) and prints `[redacted]` for `Cookie`, `Set-Cookie` and `x-amz-security-token`. `Header`'s `Display` and the curl `-H` formatter use it, so the `>`, `<` and curl printers share one list. `print_request` drops its own copy.
- The curl line prints the URL through `redacted_npm_url`, the same as the `>` request line.
- Correct because `Header`'s `Display` is used only by the verbose trace (`Request`/`Response` `Display`, `print_request`, `print_response`, the HTTP/2 and HTTP/3 callers of `print_request`). The wire serializer is the separate `Headers` formatter and is unchanged.
- Verified: `test/js/web/fetch/fetch.test.ts` `-t redact` (2 new cases, modes `1` and `curl`, fail on 1.4.3, pass here, plus the existing Authorization case). Also `test/regression/issue/12042.test.ts` and `test/cli/install/redacted-config-logs.test.ts`.

### Background
- `BUN_CONFIG_VERBOSE_FETCH=1` prints each request as `> name: value` lines and each response as `< name: value` lines. `=curl` adds a copy-paste `curl` command before them. `bun install --verbose` uses the same printer.
- `picohttp::Header` is the `{name, value}` pair the HTTP client builds requests from and parses responses into. Its `Display` impl exists for this trace.
- `redacted_npm_url` (`src/bun_core/fmt.rs`) masks the password of a URL and npm tokens / UUIDs in it. #37669 applied it to the `>` request line.

<details><summary>Notes</summary>

- The request body (`--data-raw` for json / form / text bodies) is left as is. It is documented in `debugger.mdx`, and the docs now say that credentials are redacted and the body is not.
- Generic key headers (`X-Api-Key`, `X-Auth-Token`, `Private-Token`) and query-string tokens are not in the list. The list is one constant (`LoggedHeaderValue::SECRET_HEADERS`) if that is wanted.
- An obsolete folded continuation line (picohttpparser reports it with an empty name) prints as before, since the header it belongs to is not known at that point.
- #38673 (escape control characters in the trace) and #38691 (restore the `> ` prefixes) touch the same two functions. Neither redacts the curl line or these headers. Whichever lands second needs a small rebase.
- Full `fetch.test.ts` on the debug build: the failures are the ones that fail on main in this container (public HTTPS hosts, IPv6, root file permissions, 5 s timeouts under ASAN). None involve the verbose trace.
- Self-reviewed: checked every `Display` user of `picohttp::Header`, the HTTP/2 and HTTP/3 trace callers, and the open PRs on the same printers.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->