### PR TITLE
Do not keep the main thread alive for a global 'message' listener

### DIFF
--- a/src/jsc/bindings/GlobalEventScope.cpp
+++ b/src/jsc/bindings/GlobalEventScope.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include "GlobalEventScope.h"
+#include "BunClientData.h"
 #include "MessagePort.h"
 #include "ScriptExecutionContext.h"
 #include "ZigGlobalObject.h"
@@ -10,32 +11,33 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GlobalEventScope);
 
+// A 'message' listener on the global scope holds the event loop open only in a worker, where the
+// parent can still post to it. The main thread has no parent, so the listener can never fire.
 void GlobalEventScope::onDidChangeListenerImpl(EventTarget& self, const AtomString& eventType, OnDidChangeListenerKind kind)
 {
-    if (eventType == eventNames().messageEvent) {
-        auto& global = static_cast<GlobalEventScope&>(self);
-        switch (kind) {
-        case Add:
-            if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->refEventLoop();
-            }
-            global.m_messageEventCount++;
-            break;
-        case Remove:
-            global.m_messageEventCount--;
-            if (global.m_messageEventCount == 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
-            }
-            break;
-        // I dont think clear in this context is ever called. If it is (search OnDidChangeListenerKind::Clear for the impl),
-        // it may actually call once per event, in a way the Remove code above would suffice.
-        case Clear:
-            if (global.m_messageEventCount > 0) {
-                global.scriptExecutionContext()->unrefEventLoop();
-            }
-            global.m_messageEventCount = 0;
-            break;
-        }
+    if (eventType != eventNames().messageEvent)
+        return;
+    auto& global = static_cast<GlobalEventScope&>(self);
+    auto* context = global.scriptExecutionContext();
+    if (!context || !WebCore::clientData(context->vm())->isWorkerVM())
+        return;
+
+    switch (kind) {
+    case Add:
+        if (global.m_messageEventCount == 0)
+            context->refEventLoop();
+        global.m_messageEventCount++;
+        break;
+    case Remove:
+        global.m_messageEventCount--;
+        if (global.m_messageEventCount == 0)
+            context->unrefEventLoop();
+        break;
+    case Clear:
+        if (global.m_messageEventCount > 0)
+            context->unrefEventLoop();
+        global.m_messageEventCount = 0;
+        break;
     }
 };
 

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -119,6 +119,60 @@ test.concurrent("onmessage/onerror assignment through a Proxy of globalThis", as
   expect(exitCode).toBe(0);
 });
 
+// Only a worker has a parent that can post to its global scope. On the main thread a
+// global "message" listener can never fire, so it must not keep the process alive.
+test.concurrent("main thread: global 'message' listener does not keep the process alive", async () => {
+  const script = `
+    self.onmessage = e => console.log("onmessage", e.data);
+    addEventListener("message", e => console.log("listener", e.data));
+    process.on("beforeExit", () => console.log("beforeExit"));
+    console.log("installed");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("installed\nbeforeExit\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("worker: global 'message' listener keeps the worker alive until it is removed", async () => {
+  using dir = tempDir("worker-global-message-keepalive", {
+    "worker.js": `
+      const onMessage = e => {
+        postMessage("echo:" + e.data);
+        if (e.data === "two") removeEventListener("message", onMessage);
+      };
+      addEventListener("message", onMessage);
+      postMessage("ready");
+    `,
+    "main.js": `
+      const worker = new Worker(new URL("./worker.js", import.meta.url).href);
+      worker.onmessage = e => {
+        console.log(e.data);
+        if (e.data === "ready") {
+          worker.postMessage("one");
+          worker.postMessage("two");
+        }
+      };
+      worker.addEventListener("close", e => console.log("close", e.code));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ready\necho:one\necho:two\nclose 0\n");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("worker: onmessage assignment through a Proxy of self", async () => {
   using dir = tempDir("worker-proxy-onmessage", {
     "worker.js": `


### PR DESCRIPTION
### Problem
- On the main thread, `self.onmessage = fn` or `addEventListener("message", fn)` keeps the process alive forever. Nothing can dispatch to that listener (main-thread `postMessage()` has no target), so the process hangs. Node exits with code 0. Fixes #24256.
- The cause is `GlobalEventScope::onDidChangeListenerImpl` (`src/jsc/bindings/GlobalEventScope.cpp:16`). It refs the event loop while the global scope has a `message` listener. #4114 added that rule for workers, and the main-thread global shares the same class.

### Fix
- Take the ref only when `clientData(vm)->isWorkerVM()` is true. A worker keeps the existing behavior: a global `message` listener holds it open until the listener is removed.
- Correct because only a worker has a parent (`WorkerMessagingProxy`) that dispatches `message` events onto the global scope. The flag is per VM, so it also covers a `ShadowRealm` or other extra global created on the main thread, which `ScriptExecutionContext::isMainThread()` (identifier `== 1`) does not.
- Verified: `test/js/web/web-globals.test.js` (two new tests, the main-thread one times out on stock bun). Also ran `test/js/web/workers/worker.test.ts`, `worker-terminate-lifetime.test.ts`, and `worker-late-completion.test.ts`.

### Background
- `GlobalEventScope` is the `EventTarget` behind `globalThis.addEventListener` / `self.onmessage`. Every `Zig::GlobalObject` owns one, on the main thread and in workers.
- `EventTarget::onDidChangeListener` is a hook that fires on each listener add, remove, or clear. `MessagePort` and `GlobalEventScope` use it to ref or unref the event loop so that a pending `message` listener keeps the thread alive.
- `JSVMClientData::isWorkerVM()` is set once in `JSVMClientData::create` from whether a `WorkerMessagingProxy` created the VM.

<details><summary>Notes</summary>

- #32482 (@0xfandom, June) is the earlier attempt at the same fix with `isMainThread()`. It still targets `BunWorkerGlobalScope.cpp`, which #37075 renamed to `GlobalEventScope.cpp`, so it has conflicted since then. This PR carries the same idea onto the renamed file and credits the author in the commit.
- Main-thread `postMessage(x)` stays a no-op that returns `undefined`. Whether it should throw or self-dispatch (browser `window.postMessage` semantics) is a separate decision.
- The two worker suites above show two local-only failures that also fail without this diff in this container: `terminate() while fs.readFile completions keep arriving` (5 s timeout under debug ASAN) and the `dns.lookup()` LSAN case (the `node:fs` `Binding` box, covered by the `Bun::generateInternalModule` suppression when the stack is deep enough). Neither touches a main-thread global listener. Latest main CI (build 111080) does not list them.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/web-globals.test.js

<!-- robobun:evidence:end -->