### PR TITLE
spawn: reap a pty child on macOS when kqueue refuses the exit watch

### DIFF
--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -385,11 +385,10 @@ impl Process {
                         if self.reap_on_thread().is_ok() {
                             break 'brk None;
                         }
-                        // No thread could be started: reap with a blocking `wait4`, as before.
-                        break 'brk Status::from(
-                            pid,
-                            &posix_spawn::wait4(pid, 0, Some(&mut rusage_result)),
-                        );
+                        // No thread could start: one more non-blocking reap, else report the error rather than block the loop.
+                        let retry =
+                            posix_spawn::wait4(pid, libc::WNOHANG as u32, Some(&mut rusage_result));
+                        break 'brk Status::from(pid, &retry).or(Some(Status::Err(err_)));
                     }
                     break 'brk Some(Status::Err(err_));
                 }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -370,14 +370,26 @@ impl Process {
     #[cfg(unix)]
     fn on_wait_pid(&mut self, waitpid_result: &bun_sys::Result<WaitPidResult>, rusage: &Rusage) {
         let pid = self.pid;
+        // Mutated only on the macOS ESRCH fallback below.
+        #[cfg(target_os = "macos")]
+        let mut rusage_result = *rusage;
+        #[cfg(not(target_os = "macos"))]
+        let rusage_result = *rusage;
 
         let status: Option<Status> = Status::from(pid, waitpid_result).or_else(|| 'brk: {
             match self.rewatch_posix() {
                 Ok(()) => {}
                 Err(err_) => {
                     #[cfg(target_os = "macos")]
-                    if err_.get_errno() == bun_sys::E::ESRCH && self.reap_on_thread().is_ok() {
-                        break 'brk None;
+                    if err_.get_errno() == bun_sys::E::ESRCH {
+                        if self.reap_on_thread().is_ok() {
+                            break 'brk None;
+                        }
+                        // No thread could be started: reap with a blocking `wait4`, as before.
+                        break 'brk Status::from(
+                            pid,
+                            &posix_spawn::wait4(pid, 0, Some(&mut rusage_result)),
+                        );
                     }
                     break 'brk Some(Status::Err(err_));
                 }
@@ -386,7 +398,7 @@ impl Process {
         });
 
         let Some(status) = status else { return };
-        self.on_exit(status, rusage);
+        self.on_exit(status, &rusage_result);
     }
 
     /// A blocking `wait4` on this thread can deadlock: a pty session leader's exit ends only once this loop drains the master.
@@ -421,15 +433,10 @@ impl Process {
 
         match self.watch() {
             Err(err) => {
-                #[cfg(target_os = "macos")]
+                #[cfg(unix)]
                 if err.get_errno() == bun_sys::E::ESRCH {
-                    // Mid-exit: `WNOHANG` reaps it, or `on_wait_pid` hands it to `reap_on_thread`.
-                    self.wait(false);
-                    return Ok(self.has_exited());
-                }
-                #[cfg(all(unix, not(target_os = "macos")))]
-                if err.get_errno() == bun_sys::E::ESRCH {
-                    self.wait(true);
+                    // macOS: `WNOHANG`, so a child still mid-exit goes to `reap_on_thread` instead of blocking here.
+                    self.wait(cfg!(not(target_os = "macos")));
                     return Ok(self.has_exited());
                 }
                 Err(err)
@@ -524,6 +531,11 @@ impl Process {
             }
             self.ref_();
             WaiterThread::append(self);
+            return Ok(());
+        }
+        // A `reap_on_thread` thread already waits on this pid; its result will arrive.
+        #[cfg(target_os = "macos")]
+        if matches!(self.poller, Poller::WaiterThread(_)) {
             return Ok(());
         }
 
@@ -636,6 +648,7 @@ impl Process {
     pub fn close(&mut self) {
         #[cfg(unix)]
         {
+            let ctx = self.event_loop_ctx();
             let mut stranded_watch_ref = false;
             // Route the `Fd` arm through the centralized `fd_poll_mut()`
             // accessor instead of open-coding `(*poll.as_ptr()).deinit()`.
@@ -643,7 +656,8 @@ impl Process {
                 stranded_watch_ref = poll.is_registered();
                 poll.deinit();
             } else if let Poller::WaiterThread(waiter) = &mut self.poller {
-                waiter.disable();
+                // The loop this process ref'd, which for a mini or spawnSync loop is not `js_vm_ctx()`.
+                waiter.unref(ctx);
             }
             self.poller = Poller::Detached;
             if stranded_watch_ref && !self.has_exited() {
@@ -887,6 +901,7 @@ pub enum PollerPosix {
     /// poll lives in `Store`; freed via `FilePoll::deinit`,
     /// never via Rust `drop`.
     Fd(core::ptr::NonNull<FilePoll>),
+    /// Waited on off-loop: the shared waiter thread (Linux without pidfd) or a one-shot `reap_on_thread` thread (macOS).
     WaiterThread(KeepAlive),
     Detached,
 }
@@ -1317,8 +1332,8 @@ pub mod waiter_thread_posix {
     #[repr(transparent)]
     struct SendPtr(*mut Process);
     // SAFETY: the pointee is refcounted (`ThreadSafeRefCount`) and the thread
-    // reads only `pid`, `event_loop` and `js_poster`, exactly as the shared
-    // waiter thread does with the pointers in its queue.
+    // touches it only through `post_wait_result`, exactly as the shared waiter
+    // thread does with the pointers in its queue.
     #[cfg(target_os = "macos")]
     unsafe impl Send for SendPtr {}
 
@@ -1341,7 +1356,9 @@ pub mod waiter_thread_posix {
         let thread = std::thread::Builder::new()
             .stack_size(STACK_SIZE)
             .spawn(move || {
-                Output::Source::configure_named_thread(bun_core::ZStr::from_static(b"Waitpid\0"));
+                Output::Source::configure_named_thread_no_js(bun_core::ZStr::from_static(
+                    b"Waitpid\0",
+                ));
                 let mut rusage = rusage_zeroed();
                 let result = posix_spawn::wait4(pid, 0, Some(&mut rusage));
                 // SAFETY: the +1 ref taken before the spawn keeps the pointee live.

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -370,34 +370,14 @@ impl Process {
     #[cfg(unix)]
     fn on_wait_pid(&mut self, waitpid_result: &bun_sys::Result<WaitPidResult>, rusage: &Rusage) {
         let pid = self.pid;
-        // Mutated only on the macOS ESRCH retry path below.
-        #[cfg(target_os = "macos")]
-        let mut rusage_result = *rusage;
-        #[cfg(not(target_os = "macos"))]
-        let rusage_result = *rusage;
 
         let status: Option<Status> = Status::from(pid, waitpid_result).or_else(|| 'brk: {
             match self.rewatch_posix() {
                 Ok(()) => {}
                 Err(err_) => {
                     #[cfg(target_os = "macos")]
-                    if err_.get_errno() == bun_sys::E::ESRCH {
-                        break 'brk Status::from(
-                            pid,
-                            &posix_spawn::wait4(
-                                pid,
-                                // Normally we would use WNOHANG to avoid blocking the event loop.
-                                // However, there seems to be a race condition where the operating system
-                                // tells us that the process has already exited (ESRCH) but the waitpid
-                                // call with WNOHANG doesn't return the status yet.
-                                // As a workaround, we use 0 to block the event loop until the status is available.
-                                // This should be fine because the process has already exited, so the data
-                                // should become available basically immediately. Also, testing has shown that this
-                                // occurs extremely rarely and only under high load.
-                                0,
-                                Some(&mut rusage_result),
-                            ),
-                        );
+                    if err_.get_errno() == bun_sys::E::ESRCH && self.reap_on_thread().is_ok() {
+                        break 'brk None;
                     }
                     break 'brk Some(Status::Err(err_));
                 }
@@ -406,7 +386,36 @@ impl Process {
         });
 
         let Some(status) = status else { return };
-        self.on_exit(status, &rusage_result);
+        self.on_exit(status, rusage);
+    }
+
+    /// kqueue refuses `EVFILT_PROC` with ESRCH for a child that has started
+    /// to exit, while `wait4(WNOHANG)` still returns 0 until the exit
+    /// completes. The kernel finishes a pty session leader's exit only once
+    /// its terminal output drains, and the master is read by this event
+    /// loop. A blocking `wait4` here therefore deadlocks. Block on a thread
+    /// of its own instead. The result arrives through
+    /// [`Process::on_wait_pid_from_waiter_thread`].
+    #[cfg(target_os = "macos")]
+    fn reap_on_thread(&mut self) -> Result<(), std::io::Error> {
+        let ctx = self.event_loop_ctx();
+        if let Some(poll) = self.poller.fd_poll_mut() {
+            poll.deinit();
+        }
+        self.poller = Poller::WaiterThread(KeepAlive::default());
+        if let Poller::WaiterThread(w) = &mut self.poller {
+            w.ref_(ctx);
+        }
+        self.ref_();
+        // SAFETY: `self` is live and now carries the ref the delivery releases.
+        if let Err(err) = unsafe { waiter_thread_posix::reap_on_thread(self) } {
+            self.poller.disable_keeping_event_loop_alive(ctx);
+            self.poller = Poller::Detached;
+            // SAFETY: the caller holds its own ref; this drops the one taken above.
+            unsafe { Self::deref(std::ptr::from_mut(self)) };
+            return Err(err);
+        }
+        Ok(())
     }
 
     pub fn watch_or_reap(&mut self) -> bun_sys::Result<bool> {
@@ -418,7 +427,14 @@ impl Process {
 
         match self.watch() {
             Err(err) => {
-                #[cfg(unix)]
+                #[cfg(target_os = "macos")]
+                if err.get_errno() == bun_sys::E::ESRCH {
+                    // The child is mid-exit: reap it now, or from a thread
+                    // when the exit has not completed (see `reap_on_thread`).
+                    self.wait(false);
+                    return Ok(self.has_exited());
+                }
+                #[cfg(all(unix, not(target_os = "macos")))]
                 if err.get_errno() == bun_sys::E::ESRCH {
                     self.wait(true);
                     return Ok(self.has_exited());
@@ -1233,50 +1249,8 @@ pub mod waiter_thread_posix {
                     };
                     if matched {
                         remove = true;
-
-                        match T::event_loop(process_ref) {
-                            EventLoopHandle::Js { .. } => {
-                                let rt = ResultTask::<T>::new(ResultTask {
-                                    result,
-                                    subprocess: process,
-                                    rusage,
-                                });
-                                let ct = ConcurrentTask::create(Task::init(rt));
-                                let poster = T::js_poster(process_ref)
-                                    .expect("JS-owned process has a poster");
-                                if let bun_event_loop::Posted::Refused(ct) = poster.post(ct) {
-                                    // VM torn down: nobody will observe this exit. Free the
-                                    // task and drop the ref its delivery would have released.
-                                    // SAFETY: refused ⇒ we own both boxes; `process` is strong-ref'd.
-                                    unsafe {
-                                        drop(bun_core::heap::take(ct.as_ptr()));
-                                        drop(bun_core::heap::take(rt));
-                                        T::release_ref_from_waiter_thread(process);
-                                    }
-                                }
-                            }
-                            EventLoopHandle::Mini(mut mini) => {
-                                let out = ResultTaskMini::<T>::new(ResultTaskMini {
-                                    result,
-                                    subprocess: process,
-                                    task: AnyTaskWithExtraContext::default(),
-                                });
-                                // SAFETY: `out` just produced by heap::alloc — non-null.
-                                unsafe {
-                                    (*out).task = AnyTaskNew::<ResultTaskMini<T>, ()>::init(
-                                        out,
-                                        ResultTaskMini::<T>::run_from_main_thread_mini,
-                                    );
-                                    mini.get_mut().enqueue_task_concurrent(
-                                        core::ptr::NonNull::new_unchecked(core::ptr::addr_of_mut!(
-                                            (*out).task
-                                        )),
-                                    );
-                                }
-                                // `out` is now owned by the mini queue;
-                                // freed in `run_from_main_thread_mini`.
-                            }
-                        }
+                        // SAFETY: see `process_ref` above.
+                        unsafe { post_wait_result(process, result, rusage) };
                     }
                 }
 
@@ -1292,6 +1266,109 @@ pub mod waiter_thread_posix {
             // SAFETY: sole accessor per the comment at the top of this fn.
             unsafe { *self.active.get() = active };
         }
+    }
+
+    /// Hand a `wait4` result to the loop that owns `process`, which runs
+    /// `T::on_wait_pid_from_waiter_thread` there.
+    ///
+    /// # Safety
+    /// `process` is live and carries a +1 ref that the delivery (or this
+    /// function, when the loop refuses the task) releases.
+    pub(crate) unsafe fn post_wait_result<T: ProcessLike>(
+        process: *mut T,
+        result: bun_sys::Result<WaitPidResult>,
+        rusage: Rusage,
+    ) {
+        // SAFETY: caller contract — the +1 ref keeps the pointee live.
+        let process_ref = unsafe { &*process };
+        match T::event_loop(process_ref) {
+            EventLoopHandle::Js { .. } => {
+                let rt = ResultTask::<T>::new(ResultTask {
+                    result,
+                    subprocess: process,
+                    rusage,
+                });
+                let ct = ConcurrentTask::create(Task::init(rt));
+                let poster = T::js_poster(process_ref).expect("JS-owned process has a poster");
+                if let bun_event_loop::Posted::Refused(ct) = poster.post(ct) {
+                    // VM torn down: nobody will observe this exit. Free the
+                    // task and drop the ref its delivery would have released.
+                    // SAFETY: refused ⇒ we own both boxes; `process` is strong-ref'd.
+                    unsafe {
+                        drop(bun_core::heap::take(ct.as_ptr()));
+                        drop(bun_core::heap::take(rt));
+                        T::release_ref_from_waiter_thread(process);
+                    }
+                }
+            }
+            EventLoopHandle::Mini(mut mini) => {
+                let out = ResultTaskMini::<T>::new(ResultTaskMini {
+                    result,
+                    subprocess: process,
+                    task: AnyTaskWithExtraContext::default(),
+                });
+                // SAFETY: `out` just produced by heap::alloc — non-null.
+                unsafe {
+                    (*out).task = AnyTaskNew::<ResultTaskMini<T>, ()>::init(
+                        out,
+                        ResultTaskMini::<T>::run_from_main_thread_mini,
+                    );
+                    mini.get_mut().enqueue_task_concurrent(core::ptr::NonNull::new_unchecked(
+                        core::ptr::addr_of_mut!((*out).task),
+                    ));
+                }
+                // `out` is now owned by the mini queue;
+                // freed in `run_from_main_thread_mini`.
+            }
+        }
+    }
+
+    /// Send-wrapper for the one `*mut Process` [`reap_on_thread`] hands to its
+    /// thread. The pointee is refcounted (`ThreadSafeRefCount`) and the thread
+    /// reads only `pid`, `event_loop` and `js_poster`, exactly as the shared
+    /// waiter thread does with the pointers in its queue.
+    #[cfg(target_os = "macos")]
+    #[repr(transparent)]
+    struct SendPtr(*mut Process);
+    // SAFETY: see type doc.
+    #[cfg(target_os = "macos")]
+    unsafe impl Send for SendPtr {}
+
+    #[cfg(target_os = "macos")]
+    impl SendPtr {
+        /// Takes `self` by value so the closure below captures the whole
+        /// wrapper (which is `Send`) and not the `*mut Process` field.
+        #[inline]
+        fn get(self) -> *mut Process {
+            self.0
+        }
+    }
+
+    /// Block in `wait4(pid, 0)` on a thread of its own and post the result to
+    /// the owning loop. For one child whose exit kqueue can no longer observe
+    /// (`EVFILT_PROC` returned ESRCH); see [`Process::reap_on_thread`].
+    ///
+    /// The caller took the +1 ref the delivery releases. On error the thread
+    /// did not start and the caller still owns that ref.
+    ///
+    /// # Safety
+    /// `process` must be a live, strong-ref'd `Process`.
+    #[cfg(target_os = "macos")]
+    pub(crate) unsafe fn reap_on_thread(process: *mut Process) -> Result<(), std::io::Error> {
+        // SAFETY: caller contract — `process` is live; raw read of a POD field.
+        let pid = unsafe { (*process).pid };
+        let process = SendPtr(process);
+        let thread = std::thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn(move || {
+                Output::Source::configure_named_thread(bun_core::ZStr::from_static(b"Waitpid\0"));
+                let mut rusage = rusage_zeroed();
+                let result = posix_spawn::wait4(pid, 0, Some(&mut rusage));
+                // SAFETY: the +1 ref taken before the spawn keeps the pointee live.
+                unsafe { post_wait_result(process.get(), result, rusage) };
+            })?;
+        drop(thread); // detached: the thread outlives the handle
+        Ok(())
     }
 
     const STACK_SIZE: usize = 512 * 1024;

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1313,9 +1313,10 @@ pub mod waiter_thread_posix {
                         out,
                         ResultTaskMini::<T>::run_from_main_thread_mini,
                     );
-                    mini.get_mut().enqueue_task_concurrent(core::ptr::NonNull::new_unchecked(
-                        core::ptr::addr_of_mut!((*out).task),
-                    ));
+                    mini.get_mut()
+                        .enqueue_task_concurrent(core::ptr::NonNull::new_unchecked(
+                            core::ptr::addr_of_mut!((*out).task),
+                        ));
                 }
                 // `out` is now owned by the mini queue;
                 // freed in `run_from_main_thread_mini`.

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -389,13 +389,7 @@ impl Process {
         self.on_exit(status, rusage);
     }
 
-    /// kqueue refuses `EVFILT_PROC` with ESRCH for a child that has started
-    /// to exit, while `wait4(WNOHANG)` still returns 0 until the exit
-    /// completes. The kernel finishes a pty session leader's exit only once
-    /// its terminal output drains, and the master is read by this event
-    /// loop. A blocking `wait4` here therefore deadlocks. Block on a thread
-    /// of its own instead. The result arrives through
-    /// [`Process::on_wait_pid_from_waiter_thread`].
+    /// A blocking `wait4` on this thread can deadlock: a pty session leader's exit ends only once this loop drains the master.
     #[cfg(target_os = "macos")]
     fn reap_on_thread(&mut self) -> Result<(), std::io::Error> {
         let ctx = self.event_loop_ctx();
@@ -429,8 +423,7 @@ impl Process {
             Err(err) => {
                 #[cfg(target_os = "macos")]
                 if err.get_errno() == bun_sys::E::ESRCH {
-                    // The child is mid-exit: reap it now, or from a thread
-                    // when the exit has not completed (see `reap_on_thread`).
+                    // Mid-exit: `WNOHANG` reaps it, or `on_wait_pid` hands it to `reap_on_thread`.
                     self.wait(false);
                     return Ok(self.has_exited());
                 }
@@ -1250,7 +1243,7 @@ pub mod waiter_thread_posix {
                     if matched {
                         remove = true;
                         // SAFETY: see `process_ref` above.
-                        unsafe { post_wait_result(process, result, rusage) };
+                        unsafe { post_wait_result(process, result, &rusage) };
                     }
                 }
 
@@ -1268,16 +1261,12 @@ pub mod waiter_thread_posix {
         }
     }
 
-    /// Hand a `wait4` result to the loop that owns `process`, which runs
-    /// `T::on_wait_pid_from_waiter_thread` there.
-    ///
-    /// # Safety
-    /// `process` is live and carries a +1 ref that the delivery (or this
-    /// function, when the loop refuses the task) releases.
+    /// Post a `wait4` result to the loop that owns `process`; it runs `T::on_wait_pid_from_waiter_thread` there.
+    /// SAFETY: `process` is live and carries a +1 ref that the delivery (or this function, if the loop refuses) releases.
     pub(crate) unsafe fn post_wait_result<T: ProcessLike>(
         process: *mut T,
         result: bun_sys::Result<WaitPidResult>,
-        rusage: Rusage,
+        rusage: &Rusage,
     ) {
         // SAFETY: caller contract — the +1 ref keeps the pointee live.
         let process_ref = unsafe { &*process };
@@ -1286,7 +1275,7 @@ pub mod waiter_thread_posix {
                 let rt = ResultTask::<T>::new(ResultTask {
                     result,
                     subprocess: process,
-                    rusage,
+                    rusage: *rusage,
                 });
                 let ct = ConcurrentTask::create(Task::init(rt));
                 let poster = T::js_poster(process_ref).expect("JS-owned process has a poster");
@@ -1318,42 +1307,32 @@ pub mod waiter_thread_posix {
                             core::ptr::addr_of_mut!((*out).task),
                         ));
                 }
-                // `out` is now owned by the mini queue;
-                // freed in `run_from_main_thread_mini`.
+                // `run_from_main_thread_mini` frees `out`.
             }
         }
     }
 
-    /// Send-wrapper for the one `*mut Process` [`reap_on_thread`] hands to its
-    /// thread. The pointee is refcounted (`ThreadSafeRefCount`) and the thread
-    /// reads only `pid`, `event_loop` and `js_poster`, exactly as the shared
-    /// waiter thread does with the pointers in its queue.
+    /// The one `*mut Process` that [`reap_on_thread`] moves to its thread.
     #[cfg(target_os = "macos")]
     #[repr(transparent)]
     struct SendPtr(*mut Process);
-    // SAFETY: see type doc.
+    // SAFETY: the pointee is refcounted (`ThreadSafeRefCount`) and the thread
+    // reads only `pid`, `event_loop` and `js_poster`, exactly as the shared
+    // waiter thread does with the pointers in its queue.
     #[cfg(target_os = "macos")]
     unsafe impl Send for SendPtr {}
 
     #[cfg(target_os = "macos")]
     impl SendPtr {
-        /// Takes `self` by value so the closure below captures the whole
-        /// wrapper (which is `Send`) and not the `*mut Process` field.
+        /// By value, so a closure captures the `Send` wrapper and not its `*mut` field.
         #[inline]
         fn get(self) -> *mut Process {
             self.0
         }
     }
 
-    /// Block in `wait4(pid, 0)` on a thread of its own and post the result to
-    /// the owning loop. For one child whose exit kqueue can no longer observe
-    /// (`EVFILT_PROC` returned ESRCH); see [`Process::reap_on_thread`].
-    ///
-    /// The caller took the +1 ref the delivery releases. On error the thread
-    /// did not start and the caller still owns that ref.
-    ///
-    /// # Safety
-    /// `process` must be a live, strong-ref'd `Process`.
+    /// Block in `wait4(pid, 0)` on a detached thread and post the result to the owning loop.
+    /// SAFETY: `process` is live and carries the +1 ref the delivery releases; on `Err` no thread started and the caller keeps that ref.
     #[cfg(target_os = "macos")]
     pub(crate) unsafe fn reap_on_thread(process: *mut Process) -> Result<(), std::io::Error> {
         // SAFETY: caller contract — `process` is live; raw read of a POD field.
@@ -1366,9 +1345,9 @@ pub mod waiter_thread_posix {
                 let mut rusage = rusage_zeroed();
                 let result = posix_spawn::wait4(pid, 0, Some(&mut rusage));
                 // SAFETY: the +1 ref taken before the spawn keeps the pointee live.
-                unsafe { post_wait_result(process.get(), result, rusage) };
+                unsafe { post_wait_result(process.get(), result, &rusage) };
             })?;
-        drop(thread); // detached: the thread outlives the handle
+        drop(thread);
         Ok(())
     }
 

--- a/test/js/bun/terminal/terminal-spawn.test.ts
+++ b/test/js/bun/terminal/terminal-spawn.test.ts
@@ -1,6 +1,6 @@
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isMusl, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMacOS, isMusl, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 
 // Cross-platform Bun.Terminal + Bun.spawn integration tests that don't rely
@@ -609,6 +609,52 @@ describe("Bun.Terminal subprocess integration", () => {
     if (exitCode === 0 || exitCode === 42) await probeReported.promise;
     expect(output).toContain("PROBE-CLEAN");
     expect(output).not.toContain("PROBE-CORRUPTED");
+    expect(exitCode).toBe(0);
+  });
+
+  // macOS: an inline-terminal child is the session leader of its pty. The
+  // kernel finishes its exit only after the pty output drains, which needs
+  // the parent to read the master. If the child gets that far before the
+  // parent registers the kqueue exit watch (kevent returns ESRCH), the parent
+  // used to block in wait4() on the event-loop thread and the two deadlocked.
+  // A worker that churns the allocator slows the parent enough to hit the
+  // window on every run.
+  test.skipIf(!isMacOS)("a pty child that exits before the parent watches it is still reaped", async () => {
+    using dir = tempDir("pty-early-exit", {
+      "churn.js": `
+        let keep = [];
+        function churn() {
+          for (let i = 0; i < 2000; i++) {
+            keep.push(new Uint8Array(1 + ((i * 7919) % 65536)), { a: i, s: Buffer.alloc(i % 300, "x").toString() }, new Array(i % 100).fill(i));
+            if (keep.length > 4000) keep = [];
+          }
+          setTimeout(churn, 0);
+        }
+        churn();
+      `,
+      "main-fixture.js": `
+        const worker = new Worker(new URL("./churn.js", import.meta.url).href);
+        for (let i = 0; i < 25; i++) {
+          const proc = Bun.spawn({ cmd: ["sh", "-c", "echo hi"], terminal: { data() {} } });
+          const code = await proc.exited;
+          if (code !== 0) throw new Error("exit code " + code + " at iteration " + i);
+        }
+        console.log("done");
+        worker.terminate();
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main-fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done\n");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/terminal/terminal-spawn.test.ts
+++ b/test/js/bun/terminal/terminal-spawn.test.ts
@@ -1,6 +1,6 @@
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS, isMusl, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isMusl, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 
 // Cross-platform Bun.Terminal + Bun.spawn integration tests that don't rely
@@ -609,52 +609,6 @@ describe("Bun.Terminal subprocess integration", () => {
     if (exitCode === 0 || exitCode === 42) await probeReported.promise;
     expect(output).toContain("PROBE-CLEAN");
     expect(output).not.toContain("PROBE-CORRUPTED");
-    expect(exitCode).toBe(0);
-  });
-
-  // macOS: an inline-terminal child is the session leader of its pty. The
-  // kernel finishes its exit only after the pty output drains, which needs
-  // the parent to read the master. If the child gets that far before the
-  // parent registers the kqueue exit watch (kevent returns ESRCH), the parent
-  // used to block in wait4() on the event-loop thread and the two deadlocked.
-  // A worker that churns the allocator slows the parent enough to hit the
-  // window on every run.
-  test.skipIf(!isMacOS)("a pty child that exits before the parent watches it is still reaped", async () => {
-    using dir = tempDir("pty-early-exit", {
-      "churn.js": `
-        let keep = [];
-        function churn() {
-          for (let i = 0; i < 2000; i++) {
-            keep.push(new Uint8Array(1 + ((i * 7919) % 65536)), { a: i, s: Buffer.alloc(i % 300, "x").toString() }, new Array(i % 100).fill(i));
-            if (keep.length > 4000) keep = [];
-          }
-          setTimeout(churn, 0);
-        }
-        churn();
-      `,
-      "main-fixture.js": `
-        const worker = new Worker(new URL("./churn.js", import.meta.url).href);
-        for (let i = 0; i < 15; i++) {
-          const proc = Bun.spawn({ cmd: ["sh", "-c", "echo hi"], terminal: { data() {} } });
-          const code = await proc.exited;
-          if (code !== 0) throw new Error("exit code " + code + " at iteration " + i);
-        }
-        console.log("done");
-        worker.terminate();
-        process.exit(0);
-      `,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main-fixture.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("done\n");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/terminal/terminal-spawn.test.ts
+++ b/test/js/bun/terminal/terminal-spawn.test.ts
@@ -634,7 +634,7 @@ describe("Bun.Terminal subprocess integration", () => {
       `,
       "main-fixture.js": `
         const worker = new Worker(new URL("./churn.js", import.meta.url).href);
-        for (let i = 0; i < 25; i++) {
+        for (let i = 0; i < 15; i++) {
           const proc = Bun.spawn({ cmd: ["sh", "-c", "echo hi"], terminal: { data() {} } });
           const code = await proc.exited;
           if (code !== 0) throw new Error("exit code " + code + " at iteration " + i);

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1541,4 +1541,48 @@ describe.concurrent("Bun.spawn with terminal option", () => {
     await Promise.all(Array.from({ length: N }, one));
     expect(outcomes).toEqual(Array.from({ length: N }, () => "data"));
   });
+
+  // The child is the session leader of its pty, and on macOS its exit completes
+  // only after the parent drains the master. When the child got that far before
+  // the parent's kqueue watch (kevent: ESRCH), the parent blocked in wait4() on
+  // the event-loop thread and both hung. The churning worker slows the parent
+  // into that window; unfixed macOS builds hang by the fifth spawn.
+  test.skipIf(isWindows)("a pty child that exits before the parent watches it is still reaped", async () => {
+    using dir = tempDir("pty-early-exit", {
+      "churn.js": `
+        let keep = [];
+        function churn() {
+          for (let i = 0; i < 2000; i++) {
+            keep.push(new Uint8Array(1 + ((i * 7919) % 65536)), { a: i, s: Buffer.alloc(i % 300, "x").toString() }, new Array(i % 100).fill(i));
+            if (keep.length > 4000) keep = [];
+          }
+          setTimeout(churn, 0);
+        }
+        churn();
+      `,
+      "main-fixture.js": `
+        const worker = new Worker(new URL("./churn.js", import.meta.url).href);
+        for (let i = 0; i < 15; i++) {
+          const proc = Bun.spawn({ cmd: ["sh", "-c", "echo hi"], terminal: { data() {} } });
+          const code = await proc.exited;
+          if (code !== 0) throw new Error("exit code " + code + " at iteration " + i);
+        }
+        console.log("done");
+        worker.terminate();
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main-fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done\n");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- On macOS, a `Bun.spawn({ terminal })` child can exit and never be reaped: `await proc.exited` hangs. CI shows it as `tty-reopen-after-stdin-eof.test.ts - stalled in the parallel batch` on the darwin lanes (builds 111173, 110462, 110377, 110341).
- Cause: the blocking `wait4(pid, 0)` in `Process::on_wait_pid` (`src/spawn/process.rs`), taken on the event-loop thread when kqueue refuses the exit watch with `ESRCH`. The hung CI process sat in exactly that frame.
- XNU finishes a pty session leader's exit only after its terminal output drains, and the event loop is what reads the pty master. So `wait4` waits for the child, and the child waits for the blocked loop.

### Fix
- On that `ESRCH`, block in `wait4` on a detached thread (`reap_on_thread`) and post the result to the owning loop through the existing waiter-thread task. The loop keeps draining the pty. If no thread can start, it tries one more `WNOHANG` reap and otherwise reports the error; it never blocks the loop.
- `watch_or_reap` uses `WNOHANG` on macOS, so a child still mid-exit takes the same path.
- Verified on a macOS CI host: the new test in `test/js/bun/terminal/terminal.test.ts` times out 4/4 with the build 111173 binary and passes 4/4 with this branch's. CI build 111691: both darwin aarch64 lanes green, `tty-reopen-after-stdin-eof.test.ts` passed inside the 4-wide batch.
- Self-reviewed: 9 concerns raised, 7 addressed. Kept: one redundant kevent retry in `watch_or_reap` (simpler than a second path), and the thread name.

### Background
- `EVFILT_PROC` registration calls `proc_find`, which fails with `ESRCH` once a child has entered exit, while `wait4(WNOHANG)` returns 0 until the exit completes.
- An inline `terminal:` child is the session leader of its pty (`setsid` + `TIOCSCTTY`). On exit the kernel waits in `ttywait` for the output queue to empty.
- #36854 moved this test to `Bun.spawn({ terminal })`, which exposed the deadlock on darwin. The blocking `wait4` is older.
- The shared waiter thread is not reused: it cannot be enabled on kqueue platforms, and its macOS wake-up (`sigwait` on an empty set) returns `EINVAL` at once.

<details><summary>Notes</summary>

Measured on `darwin-arm64-sourdough` (macOS 15, M2 Ultra), with a C probe that forks a child, waits `N` us (standing in for the parent work bun does between fork and the watch), then registers `EVFILT_PROC`:

```
plain child,    0 us delay: kevent ESRCH   0/200, of those not yet reapable   0
pty   child,    0 us delay: kevent ESRCH   0/200, of those not yet reapable   0
plain child, 1000 us delay: kevent ESRCH 189/200, of those not yet reapable   0
pty   child, 1000 us delay: kevent ESRCH 178/200, of those not yet reapable 178
plain child,10000 us delay: kevent ESRCH 200/200, of those not yet reapable   0
pty   child,10000 us delay: kevent ESRCH 200/200, of those not yet reapable 200
```

So for a plain child the old blocking `wait4` did return at once, as its comment claimed. For a pty child it cannot: the child is not reapable until the master is drained. A second C probe confirms the direction: `waitpid(pid, 0)` on a pty session leader never returns (killed by a 5 s alarm) when the master is not read, and returns immediately after one `read()` of the master.

The hung CI process, sampled with `sample(1)`: main thread in `__wait4_nocancel` under `Process::on_wait_pid` under the `send_exit_notification` scope guard of `spawn_maybe_sync` (`js_bun_spawn_bindings.rs`), which runs `proc.wait(false)` after `watch()` failed.

Repro with the release binary from build 111173 (the same artifact the red lane ran), 6 trials, each a loop of `Bun.spawn({cmd:["sh","-c","echo hi"], terminal})` with one worker thread churning the allocator: 6/6 hang, at iterations 5, 0, 2, 1, 0, 1. The new test ("a pty child that exits before the parent watches it is still reaped") is that loop, cut to 15 iterations (2x the worst observed). It times out on that binary and the harness reports `killed 1 dangling process`.

Both binaries, the same test, on `darwin-arm64-sourdough`:

```
unfixed (build 111173):  (fail) ... [5002ms]  x4
this branch:             (pass) ... [~380ms]  x4
```

A wider loop with this branch's binary, 300 spawns and four churn workers, which hung 5/5 unfixed: 3/3 pass in 17-20 s. The test costs 0.4 s with a release build on macOS and 1.1 s under a Linux debug ASAN build. CI allows 90 s per test (270 s on an ASAN lane), so no explicit timeout is set (`test/CLAUDE.md`). The test runs on every POSIX platform. Only macOS has the bug, but the scenario (fast pty children under a busy worker are all reaped) is valid everywhere.

The allocator churn matters only because it slows the parent past the ~1 ms mark in the table above. In CI the darwin batch runs 4-wide with `--test-worker --isolate` on a loaded host, which does the same thing.

Review changes after the first push: `post_wait_result` takes `&Rusage` (clippy `large_types_passed_by_value`); `close()` unrefs the `KeepAlive` on the process's own loop instead of `js_vm_ctx()` (the new state is reachable from mini-loop owners that have no VM); `rewatch_posix` returns early when a reap thread already owns the pid; the reap thread uses `configure_named_thread_no_js`; comments trimmed; when `std::thread::Builder::spawn` fails, the fallback is one more `wait4(WNOHANG)` and then `Status::Err(ESRCH)`, never a blocking `wait4` (a review pointed out the blocking fallback would re-open the deadlock for a pty child).

Rejected alternatives:
- Poll `wait4(WNOHANG)` from a loop task. It spins at 100% CPU for as long as the exit takes, and forever if a grandchild holds the slave open.
- Append to the shared waiter thread. It has no wake-up for new entries on kqueue platforms (see Background), and fixing that means a process-wide SIGCHLD handler.
- Drain the pty master before the blocking `wait4`. It would put terminal-specific code in `bun_spawn`, and a grandchild that holds the slave still deadlocks it.
- A one-shot `EVFILT_SIGNAL(SIGCHLD)` poll that retries `wait4(WNOHANG)`. No thread, but it needs a new poll kind through `posix_event_loop.rs` and the dispatch table. A reasonable follow-up if a thread per occurrence ever shows up in a profile.

Occurrence rate: every short-lived pty child whose parent is slow (about 1 ms) between `fork` and the kqueue registration, plus the rare non-pty case the old comment described. Each thread lives only until the loop drains the master, with a 512 KB virtual stack.

The merge gate cannot show fail-before for this change: it builds for linux, and the deadlock and the fix are macOS-only (`#[cfg(target_os = "macos")]`). The darwin evidence above stands in for it.

Open PR #37293 touches the same function for the Linux case: a pidfd whose epoll registration fails with an errno other than `ESRCH`. It excludes `ESRCH`, which is the only errno this change handles, so the two do not overlap.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts, test/regression/issue/tty-reopen-after-stdin-eof.test.ts

<!-- robobun:evidence:end -->