### PR TITLE
patch: locate hunks by their context and fail when a hunk does not apply

### DIFF
--- a/src/patch/error.rs
+++ b/src/patch/error.rs
@@ -33,17 +33,15 @@ impl From<bun_sys::Error> for Error {
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
-/// Why `PatchFile::apply` stopped. A hunk whose context and deleted lines
-/// match nowhere in the target file is not a syscall failure: the patch was
-/// made against different contents.
 #[derive(Debug)]
 pub enum ApplyError {
     Sys(bun_sys::Error),
+    /// The hunk's context and deleted lines match nowhere in the target file.
     HunkDoesNotApply {
         path: Box<[u8]>,
-        /// 1-based index of the hunk within its file patch.
+        /// 1-based.
         hunk: usize,
-        /// The `-` side start line from the hunk header.
+        /// The `-` start from the hunk header.
         line: u32,
     },
 }

--- a/src/patch/error.rs
+++ b/src/patch/error.rs
@@ -32,3 +32,39 @@ impl From<bun_sys::Error> for Error {
 }
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+/// Why `PatchFile::apply` stopped. A hunk whose context and deleted lines
+/// match nowhere in the target file is not a syscall failure: the patch was
+/// made against different contents.
+#[derive(Debug)]
+pub enum ApplyError {
+    Sys(bun_sys::Error),
+    HunkDoesNotApply {
+        path: Box<[u8]>,
+        /// 1-based index of the hunk within its file patch.
+        hunk: usize,
+        /// The `-` side start line from the hunk header.
+        line: u32,
+    },
+}
+
+impl From<bun_sys::Error> for ApplyError {
+    fn from(e: bun_sys::Error) -> Self {
+        Self::Sys(e)
+    }
+}
+
+impl core::fmt::Display for ApplyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Sys(e) => core::fmt::Display::fmt(e, f),
+            Self::HunkDoesNotApply { path, hunk, line } => write!(
+                f,
+                "hunk #{} does not apply to {} (expected at line {})",
+                hunk,
+                bstr::BStr::new(path),
+                line
+            ),
+        }
+    }
+}

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -340,8 +340,43 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         debug_assert!(i == file_line_count);
     }
 
+    // Hunks are located by matching their context/deletion lines against the
+    // file (like `git apply` and `patch(1)`), not by trusting the stated `+`
+    // start: `yarn patch-commit` emits headers whose `+` starts don't account
+    // for lines added by earlier hunks, which used to silently land hunks at
+    // the wrong offset. The expected position is the `-` side start adjusted
+    // by the line delta of the hunks already applied, fuzz-searched nearby
+    // (same ±20 bound as patch-package). A hunk that matches nowhere fails
+    // the apply instead of corrupting the file.
+    let mut diff_offset: isize = 0;
     for hunk in &patch.hunks {
-        let mut line_cursor = (hunk.header.patched.start - 1) as usize;
+        let mut line_cursor = if hunk.header.original.len == 0 {
+            // Pure insertion with no context or deletions to anchor on; the
+            // header offset is all there is.
+            (hunk.header.patched.start - 1) as usize
+        } else {
+            let base = hunk.header.original.start as isize - 1 + diff_offset;
+            const MAX_FUZZ: isize = 20;
+            let mut found: Option<usize> = None;
+            let mut fuzz: isize = 0;
+            while fuzz.abs() <= MAX_FUZZ {
+                let candidate = base + fuzz;
+                if candidate >= 0 && hunk_matches_at(hunk, &lines, candidate as usize) {
+                    found = Some(candidate as usize);
+                    break;
+                }
+                fuzz = if fuzz < 0 { -fuzz } else { -fuzz - 1 };
+            }
+            match found {
+                Some(idx) => idx,
+                None => {
+                    return sys::Result::Err(
+                        sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
+                            .with_path(file_path.as_bytes()),
+                    );
+                }
+            }
+        };
 
         // Validate hunk start position is within bounds
         if line_cursor > lines.len() {
@@ -355,8 +390,6 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
             let part: &PatchMutationPart = part;
             match part.ty {
                 PartType::Context => {
-                    // TODO: check if the lines match in the original file?
-
                     // Validate context lines exist
                     if line_cursor + part.lines.len() > lines.len() {
                         return sys::Result::Err(
@@ -378,13 +411,12 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
 
                     lines.splice(line_cursor..line_cursor, part.lines.iter().copied());
                     line_cursor += part.lines.len();
+                    diff_offset += part.lines.len() as isize;
                     if part.no_newline_at_end_of_file {
                         let _ = lines.pop();
                     }
                 }
                 PartType::Deletion => {
-                    // TODO: check if the lines match in the original file?
-
                     // Validate deletion range is within bounds
                     if line_cursor + part.lines.len() > lines.len() {
                         return sys::Result::Err(
@@ -394,10 +426,10 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
                     }
 
                     lines.drain(line_cursor..line_cursor + part.lines.len());
+                    diff_offset -= part.lines.len() as isize;
                     if part.no_newline_at_end_of_file {
                         lines.push(b"");
                     }
-                    // line_cursor -= part.lines.len();
                 }
             }
         }
@@ -425,6 +457,32 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
     }
 
     sys::Result::Ok(())
+}
+
+/// Whether `hunk`'s context and deletion lines match `lines` starting at
+/// `start`. Trailing whitespace is ignored per line, same as patch-package's
+/// `linesAreEqual`, so CRLF files match LF patch context.
+fn hunk_matches_at(hunk: &Hunk<'_>, lines: &[&[u8]], start: usize) -> bool {
+    let mut cursor = start;
+    for part in &hunk.parts {
+        match part.ty {
+            PartType::Insertion => {}
+            PartType::Context | PartType::Deletion => {
+                for patch_line in &part.lines {
+                    let Some(file_line) = lines.get(cursor) else {
+                        return false;
+                    };
+                    if strings::trim_right(file_line, WHITESPACE)
+                        != strings::trim_right(patch_line, WHITESPACE)
+                    {
+                        return false;
+                    }
+                    cursor += 1;
+                }
+            }
+        }
+    }
+    true
 }
 
 fn read_file_alloc(dir: Fd, path: &ZStr, max: usize) -> sys::Result<Vec<u8>> {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -258,15 +258,8 @@ impl<'a> PatchFile<'a> {
     }
 }
 
-/// Rebuilds `patch.path` under `patch_dir` with every hunk applied.
-///
-/// A hunk is located by its `-` side: the context and deleted lines are
-/// matched against the file, starting at the header's `-` start adjusted by
-/// the line delta of the hunks already applied, then at the nearest offsets
-/// in both directions (`git apply` does the same). The `+` side is never
-/// used for placement: `yarn patch-commit` emits `+` starts that ignore the
-/// lines earlier hunks added. A hunk that matches nowhere fails the apply.
-/// The file is written only after every hunk has been placed.
+/// Hunks are placed by matching their `-` side against the file, as `git
+/// apply` does. The `+` start is not used: `yarn patch-commit` emits stale ones.
 fn apply_patch(
     patch: &FilePatch<'_>,
     patch_dir: Fd,
@@ -315,15 +308,12 @@ fn apply_patch(
         line: hunk.header.original.start,
     };
 
-    // Net lines added by the hunks applied so far. Shifts every later hunk's
-    // expected position, since `-` side line numbers refer to the original file.
+    // Net lines added by earlier hunks; `-` line numbers refer to the original file.
     let mut line_delta: isize = 0;
     for (hunk_index, hunk) in patch.hunks.iter().enumerate() {
         let original_start = hunk.header.original.start as isize + line_delta;
         let mut line_cursor = if hunk.header.original.len == 0 {
-            // Pure insertion: a zero-length `-` range names the line the new
-            // lines go after (`-0,0` is the top of the file). There is nothing
-            // to match, so the position is taken as stated.
+            // `-N,0`: nothing to match, the new lines go after line N (0 = top).
             if original_start < 0 || original_start as usize > lines.len() {
                 return Err(does_not_apply(hunk_index, hunk));
             }
@@ -384,9 +374,7 @@ fn apply_patch(
     Ok(())
 }
 
-/// The line index where `hunk`'s `-` side matches `lines`, nearest to
-/// `expected` first (the forward candidate wins a tie), or `None` when it
-/// matches nowhere.
+/// The index nearest to `expected` where the hunk's `-` side matches, forward first.
 fn find_hunk_position(hunk: &Hunk<'_>, lines: &[&[u8]], expected: isize) -> Option<usize> {
     let last = lines.len() as isize;
     let mut offset: isize = 0;
@@ -409,9 +397,7 @@ fn find_hunk_position(hunk: &Hunk<'_>, lines: &[&[u8]], expected: isize) -> Opti
     }
 }
 
-/// Whether `hunk`'s context and deletion lines match `lines` starting at
-/// `start`. Trailing whitespace is ignored per line, same as patch-package's
-/// `linesAreEqual`, so CRLF files match LF patch context.
+/// Trailing whitespace is ignored (patch-package's `linesAreEqual`) so CRLF files match.
 fn hunk_matches_at(hunk: &Hunk<'_>, lines: &[&[u8]], start: usize) -> bool {
     let mut cursor = start;
     for part in &hunk.parts {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -310,6 +310,16 @@ fn apply_patch(
     // Net lines added by earlier hunks; `-` line numbers refer to the original file.
     let mut line_delta: isize = 0;
     for (hunk_index, hunk) in patch.hunks.iter().enumerate() {
+        // `\ No newline at end of file` ends that side of the file: only an insertion may follow it.
+        if let Some(i) = hunk.parts.iter().position(|p| p.no_newline_at_end_of_file) {
+            if hunk.parts[i + 1..]
+                .iter()
+                .any(|p| p.ty != PartType::Insertion)
+            {
+                return Err(does_not_apply(hunk_index, hunk));
+            }
+        }
+
         let original_start = hunk.header.original.start as isize + line_delta;
         let mut line_cursor = if hunk.header.original.len == 0 {
             // `-N,0`: nothing to match; insert after line N (0 = top, trailing "" is no line).
@@ -325,11 +335,14 @@ fn apply_patch(
             }
         };
 
-        // Ranges stay checked: a misplaced `\ No newline at end of file` pops a line mid-hunk.
+        // The match and the pragma check above imply these bounds; keep them checked anyway.
         for part in &hunk.parts {
             let part: &PatchMutationPart = part;
             match part.ty {
                 PartType::Context => {
+                    if line_cursor + part.lines.len() > lines.len() {
+                        return Err(does_not_apply(hunk_index, hunk));
+                    }
                     line_cursor += part.lines.len();
                 }
                 PartType::Insertion => {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -313,7 +313,9 @@ fn apply_patch(
         let original_start = hunk.header.original.start as isize + line_delta;
         let mut line_cursor = if hunk.header.original.len == 0 {
             // `-N,0`: nothing to match, the new lines go after line N (0 = top).
-            if original_start < 0 || original_start as usize > lines.len() {
+            // The empty element after a trailing newline is not a line.
+            let line_count = lines.len() - (lines.last() == Some(&&b""[..])) as usize;
+            if original_start < 0 || original_start as usize > line_count {
                 return Err(does_not_apply(hunk_index, hunk));
             }
             original_start as usize
@@ -324,6 +326,8 @@ fn apply_patch(
             }
         };
 
+        // The match proved every context and deleted line exists, but a misplaced
+        // `\ No newline at end of file` pops a line mid-hunk, so keep the ranges checked.
         for part in &hunk.parts {
             let part: &PatchMutationPart = part;
             match part.ty {
@@ -331,6 +335,9 @@ fn apply_patch(
                     line_cursor += part.lines.len();
                 }
                 PartType::Insertion => {
+                    if line_cursor > lines.len() {
+                        return Err(does_not_apply(hunk_index, hunk));
+                    }
                     lines.splice(line_cursor..line_cursor, part.lines.iter().copied());
                     line_cursor += part.lines.len();
                     line_delta += part.lines.len() as isize;
@@ -339,6 +346,9 @@ fn apply_patch(
                     }
                 }
                 PartType::Deletion => {
+                    if line_cursor + part.lines.len() > lines.len() {
+                        return Err(does_not_apply(hunk_index, hunk));
+                    }
                     lines.drain(line_cursor..line_cursor + part.lines.len());
                     line_delta -= part.lines.len() as isize;
                     if part.no_newline_at_end_of_file {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -258,8 +258,7 @@ impl<'a> PatchFile<'a> {
     }
 }
 
-/// Hunks are placed by matching their `-` side against the file, as `git
-/// apply` does. The `+` start is not used: `yarn patch-commit` emits stale ones.
+/// Hunks are placed by matching their `-` side, as `git apply` does; `+` starts can be stale.
 fn apply_patch(
     patch: &FilePatch<'_>,
     patch_dir: Fd,
@@ -377,6 +376,8 @@ fn apply_patch(
 /// The index nearest to `expected` where the hunk's `-` side matches, forward first.
 fn find_hunk_position(hunk: &Hunk<'_>, lines: &[&[u8]], expected: isize) -> Option<usize> {
     let last = lines.len() as isize;
+    // A header start far outside the file would otherwise spin until `offset` reaches it.
+    let expected = expected.clamp(0, last);
     let mut offset: isize = 0;
     loop {
         let forward = expected + offset;

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -89,7 +89,9 @@ impl<'a> PatchFile<'a> {
             match part {
                 PatchFilePart::FileDeletion(file_deletion) => {
                     if !is_safe_patch_path(file_deletion.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::unlink).into());
+                        return Some(
+                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::unlink).into(),
+                        );
                     }
                     let pathz = ZBox::from_vec_with_nul(file_deletion.path.to_vec());
 
@@ -101,7 +103,9 @@ impl<'a> PatchFile<'a> {
                     if !is_safe_patch_path(file_rename.from_path)
                         || !is_safe_patch_path(file_rename.to_path)
                     {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::rename).into());
+                        return Some(
+                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::rename).into(),
+                        );
                     }
                     let from_path = ZBox::from_vec_with_nul(file_rename.from_path.to_vec());
                     let to_path = ZBox::from_vec_with_nul(file_rename.to_path.to_vec());
@@ -210,7 +214,9 @@ impl<'a> PatchFile<'a> {
                 }
                 PatchFilePart::FileModeChange(file_mode_change) => {
                     if !is_safe_patch_path(file_mode_change.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::fchmodat).into());
+                        return Some(
+                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fchmodat).into(),
+                        );
                     }
                     let newmode = file_mode_change.new_mode;
                     let filepath = ZBox::from_vec_with_nul(file_mode_change.path.to_vec());

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -312,8 +312,7 @@ fn apply_patch(
     for (hunk_index, hunk) in patch.hunks.iter().enumerate() {
         let original_start = hunk.header.original.start as isize + line_delta;
         let mut line_cursor = if hunk.header.original.len == 0 {
-            // `-N,0`: nothing to match, the new lines go after line N (0 = top).
-            // The empty element after a trailing newline is not a line.
+            // `-N,0`: nothing to match; insert after line N (0 = top, trailing "" is no line).
             let line_count = lines.len() - (lines.last() == Some(&&b""[..])) as usize;
             if original_start < 0 || original_start as usize > line_count {
                 return Err(does_not_apply(hunk_index, hunk));
@@ -326,8 +325,7 @@ fn apply_patch(
             }
         };
 
-        // The match proved every context and deleted line exists, but a misplaced
-        // `\ No newline at end of file` pops a line mid-hunk, so keep the ranges checked.
+        // Ranges stay checked: a misplaced `\ No newline at end of file` pops a line mid-hunk.
         for part in &hunk.parts {
             let part: &PatchMutationPart = part;
             match part.ty {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -257,10 +257,10 @@ impl<'a> PatchFile<'a> {
 /// A hunk is located by its `-` side: the context and deleted lines are
 /// matched against the file, starting at the header's `-` start adjusted by
 /// the line delta of the hunks already applied, then at the nearest offsets
-/// in both directions (`git apply` does the same). The `+` start is not
-/// trusted: `yarn patch-commit` emits `+` starts that ignore the lines earlier
-/// hunks added. A hunk that matches nowhere fails the apply. The file is
-/// written only after every hunk has been placed.
+/// in both directions (`git apply` does the same). The `+` side is never
+/// used for placement: `yarn patch-commit` emits `+` starts that ignore the
+/// lines earlier hunks added. A hunk that matches nowhere fails the apply.
+/// The file is written only after every hunk has been placed.
 fn apply_patch(
     patch: &FilePatch<'_>,
     patch_dir: Fd,
@@ -313,21 +313,21 @@ fn apply_patch(
     // expected position, since `-` side line numbers refer to the original file.
     let mut line_delta: isize = 0;
     for (hunk_index, hunk) in patch.hunks.iter().enumerate() {
+        let original_start = hunk.header.original.start as isize + line_delta;
         let mut line_cursor = if hunk.header.original.len == 0 {
-            // Pure insertion: no context or deleted lines to anchor on, so the
-            // header offset is all there is.
-            (hunk.header.patched.start - 1) as usize
+            // Pure insertion: a zero-length `-` range names the line the new
+            // lines go after (`-0,0` is the top of the file). There is nothing
+            // to match, so the position is taken as stated.
+            if original_start < 0 || original_start as usize > lines.len() {
+                return Err(does_not_apply(hunk_index, hunk));
+            }
+            original_start as usize
         } else {
-            let expected = hunk.header.original.start as isize - 1 + line_delta;
-            match find_hunk_position(hunk, &lines, expected) {
+            match find_hunk_position(hunk, &lines, original_start - 1) {
                 Some(idx) => idx,
                 None => return Err(does_not_apply(hunk_index, hunk)),
             }
         };
-
-        if line_cursor > lines.len() {
-            return Err(does_not_apply(hunk_index, hunk));
-        }
 
         for part in &hunk.parts {
             let part: &PatchMutationPart = part;
@@ -1449,7 +1449,7 @@ fn parse_hunk_header_line_impl(text_: &[u8]) -> Result<HunkHeaderLineImpl<'_>, P
     }
 
     Ok(HunkHeaderLineImpl {
-        line_nr: 1.max(bun_core::parse_decimal::<u32>(line_nr).ok_or(ParseErr::bad_header_line)?),
+        line_nr: bun_core::parse_decimal::<u32>(line_nr).ok_or(ParseErr::bad_header_line)?,
         line_count: bun_core::parse_decimal::<u32>(line_nr_count)
             .ok_or(ParseErr::bad_header_line)?,
         rest: text,

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -4,7 +4,7 @@
 #![warn(unused_must_use)]
 
 pub mod error;
-pub use error::{Error, Result};
+pub use error::{ApplyError, Error, Result};
 
 use core::mem;
 
@@ -82,26 +82,26 @@ impl ApplyState {
 }
 
 impl<'a> PatchFile<'a> {
-    pub fn apply(&self, patch_dir: Fd) -> Option<sys::Error> {
+    pub fn apply(&self, patch_dir: Fd) -> Option<ApplyError> {
         let mut state = ApplyState::new();
 
         for part in &self.parts {
             match part {
                 PatchFilePart::FileDeletion(file_deletion) => {
                     if !is_safe_patch_path(file_deletion.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::unlink));
+                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::unlink).into());
                     }
                     let pathz = ZBox::from_vec_with_nul(file_deletion.path.to_vec());
 
                     if let sys::Result::Err(e) = sys::unlinkat(patch_dir, &pathz) {
-                        return Some(e.without_path());
+                        return Some(e.without_path().into());
                     }
                 }
                 PatchFilePart::FileRename(file_rename) => {
                     if !is_safe_patch_path(file_rename.from_path)
                         || !is_safe_patch_path(file_rename.to_path)
                     {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::rename));
+                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::rename).into());
                     }
                     let from_path = ZBox::from_vec_with_nul(file_rename.from_path.to_vec());
                     let to_path = ZBox::from_vec_with_nul(file_rename.to_path.to_vec());
@@ -111,19 +111,19 @@ impl<'a> PatchFile<'a> {
                         if let sys::Result::Err(e) =
                             sys::mkdir_recursive_at_mode(patch_dir, todir, 0o755)
                         {
-                            return Some(e.without_path());
+                            return Some(e.without_path().into());
                         }
                     }
 
                     if let sys::Result::Err(e) =
                         sys::renameat(patch_dir, &from_path, patch_dir, &to_path)
                     {
-                        return Some(e.without_path());
+                        return Some(e.without_path().into());
                     }
                 }
                 PatchFilePart::FileCreation(file_creation) => {
                     if !is_safe_patch_path(file_creation.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open));
+                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open).into());
                     }
                     let filepath_z = ZBox::from_vec_with_nul(file_creation.path.to_vec());
                     let filedir = paths::dirname_simple(filepath_z.as_bytes());
@@ -137,7 +137,7 @@ impl<'a> PatchFile<'a> {
                         if let sys::Result::Err(e) =
                             sys::mkdir_recursive_at_mode(patch_dir, filedir, mode.to_bun_mode())
                         {
-                            return Some(e.without_path());
+                            return Some(e.without_path().into());
                         }
                     }
 
@@ -148,7 +148,7 @@ impl<'a> PatchFile<'a> {
                         mode.to_bun_mode(),
                     ) {
                         sys::Result::Ok(fd) => fd,
-                        sys::Result::Err(e) => return Some(e.without_path()),
+                        sys::Result::Err(e) => return Some(e.without_path().into()),
                     };
                     let _close_newfile = scopeguard::guard(newfile_fd, |fd| fd.close());
 
@@ -194,22 +194,23 @@ impl<'a> PatchFile<'a> {
                     while written < file_contents.len() {
                         match sys::write(newfile_fd, &file_contents[written..]) {
                             sys::Result::Ok(bytes) => written += bytes,
-                            sys::Result::Err(e) => return Some(e.without_path()),
+                            sys::Result::Err(e) => return Some(e.without_path().into()),
                         }
                     }
                 }
                 PatchFilePart::FilePatch(file_patch) => {
                     if !is_safe_patch_path(file_patch.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open));
+                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open).into());
                     }
-                    // TODO: should we compute the hash of the original file and check it against the on in the patch?
-                    if let sys::Result::Err(e) = apply_patch(file_patch, patch_dir, &mut state) {
-                        return Some(e.without_path());
+                    match apply_patch(file_patch, patch_dir, &mut state) {
+                        Ok(()) => {}
+                        Err(ApplyError::Sys(e)) => return Some(e.without_path().into()),
+                        Err(e) => return Some(e),
                     }
                 }
                 PatchFilePart::FileModeChange(file_mode_change) => {
                     if !is_safe_patch_path(file_mode_change.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::fchmodat));
+                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::fchmodat).into());
                     }
                     let newmode = file_mode_change.new_mode;
                     let filepath = ZBox::from_vec_with_nul(file_mode_change.path.to_vec());
@@ -218,7 +219,7 @@ impl<'a> PatchFile<'a> {
                         if let sys::Result::Err(e) =
                             sys::fchmodat(patch_dir, &filepath, newmode.to_bun_mode(), 0)
                         {
-                            return Some(e.without_path());
+                            return Some(e.without_path().into());
                         }
                     }
 
@@ -226,7 +227,7 @@ impl<'a> PatchFile<'a> {
                     {
                         let absfilepath = match state.patch_dir_abs_path(patch_dir) {
                             sys::Result::Ok(p) => p,
-                            sys::Result::Err(e) => return Some(e.without_path()),
+                            sys::Result::Err(e) => return Some(e.without_path().into()),
                         };
                         let mut buf = bun_paths::path_buffer_pool::get();
                         let joined_absfilepath =
@@ -235,12 +236,12 @@ impl<'a> PatchFile<'a> {
                                 &[absfilepath.as_bytes(), filepath.as_bytes()],
                             );
                         let fd = match sys::open(&joined_absfilepath, sys::O::RDWR, 0) {
-                            sys::Result::Err(e) => return Some(e.without_path()),
+                            sys::Result::Err(e) => return Some(e.without_path().into()),
                             sys::Result::Ok(f) => f,
                         };
                         let _close = scopeguard::guard(fd, |fd| fd.close());
                         if let sys::Result::Err(e) = sys::fchmod(fd, newmode.to_bun_mode()) {
-                            return Some(e.without_path());
+                            return Some(e.without_path().into());
                         }
                     }
                 }
@@ -251,15 +252,20 @@ impl<'a> PatchFile<'a> {
     }
 }
 
-/// Invariants:
-/// - Hunk parts are ordered by first to last in file
-/// - The original starting line and the patched starting line are equal in the first hunk part
+/// Rebuilds `patch.path` under `patch_dir` with every hunk applied.
 ///
-/// TODO: this is a very naive and slow implementation which works by creating a list of lines
-/// we can speed it up by:
-/// - If file size <= PAGE_SIZE, read the whole file into memory. memcpy/memmove the file contents around will be fast
-/// - If file size > PAGE_SIZE, rather than making a list of lines, make a list of chunks
-fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> sys::Result<()> {
+/// A hunk is located by its `-` side: the context and deleted lines are
+/// matched against the file, starting at the header's `-` start adjusted by
+/// the line delta of the hunks already applied, then at the nearest offsets
+/// in both directions (`git apply` does the same). The `+` start is not
+/// trusted: `yarn patch-commit` emits `+` starts that ignore the lines earlier
+/// hunks added. A hunk that matches nowhere fails the apply. The file is
+/// written only after every hunk has been placed.
+fn apply_patch(
+    patch: &FilePatch<'_>,
+    patch_dir: Fd,
+    state: &mut ApplyState,
+) -> core::result::Result<(), ApplyError> {
     let file_path = ZBox::from_vec_with_nul(patch.path.to_vec());
 
     // Need to get the mode of the original file
@@ -274,12 +280,12 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
                     p.as_bytes(),
                     file_path.as_bytes(),
                 ]),
-                sys::Result::Err(e) => return sys::Result::Err(e),
+                sys::Result::Err(e) => return Err(e.into()),
             };
             sys::stat(p)
         };
         match r {
-            sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
+            sys::Result::Err(e) => return Err(e.with_path(file_path.as_bytes()).into()),
             sys::Result::Ok(stat) => stat,
         }
     };
@@ -289,144 +295,57 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
     let filebuf: Vec<u8> = match read_file_alloc(patch_dir, &file_path, 1024 * 1024 * 1024 * 4) {
         Ok(b) => b,
         Err(_) => {
-            return sys::Result::Err(
-                sys::Error::from_code(sys::E::EINVAL, sys::Tag::read)
-                    .with_path(file_path.as_bytes()),
-            );
+            return Err(sys::Error::from_code(sys::E::EINVAL, sys::Tag::read)
+                .with_path(file_path.as_bytes())
+                .into());
         }
     };
 
-    let file_line_count: usize;
-    let lines_count: usize = {
-        let mut count: usize = 0;
-        for _ in strings::split(&filebuf, b"\n") {
-            count += 1;
-        }
-        file_line_count = count;
+    let mut lines: Vec<&[u8]> = strings::split(&filebuf, b"\n").collect();
 
-        // Adjust to account for the changes. This is only a capacity hint for
-        // `lines` below; saturate so a header that claims more deletions than
-        // the file has cannot panic (bounds are enforced during the splice).
-        for hunk in &patch.hunks {
-            count = count
-                .saturating_add(hunk.header.patched.len as usize)
-                .saturating_sub(hunk.header.original.len as usize);
-            for part in &hunk.parts {
-                let part: &PatchMutationPart = part;
-                match part.ty {
-                    PartType::Deletion => {
-                        // deleting the no newline pragma so we are actually adding a line
-                        count = count.saturating_add(part.no_newline_at_end_of_file as usize);
-                    }
-                    PartType::Insertion => {
-                        count = count.saturating_sub(part.no_newline_at_end_of_file as usize);
-                    }
-                    PartType::Context => {}
-                }
-            }
-        }
-
-        count
+    let does_not_apply = |hunk_index: usize, hunk: &Hunk<'_>| ApplyError::HunkDoesNotApply {
+        path: Box::from(patch.path),
+        hunk: hunk_index + 1,
+        line: hunk.header.original.start,
     };
 
-    // TODO: i hate this
-    let mut lines: Vec<&[u8]> = Vec::with_capacity(lines_count);
-    {
-        let mut i: usize = 0;
-        for line in strings::split(&filebuf, b"\n") {
-            lines.push(line);
-            i += 1;
-        }
-        debug_assert!(i == file_line_count);
-    }
-
-    // Hunks are located by matching their context/deletion lines against the
-    // file (like `git apply` and `patch(1)`), not by trusting the stated `+`
-    // start: `yarn patch-commit` emits headers whose `+` starts don't account
-    // for lines added by earlier hunks, which used to silently land hunks at
-    // the wrong offset. The expected position is the `-` side start adjusted
-    // by the line delta of the hunks already applied, fuzz-searched nearby
-    // (same ±20 bound as patch-package). A hunk that matches nowhere fails
-    // the apply instead of corrupting the file.
-    let mut diff_offset: isize = 0;
-    for hunk in &patch.hunks {
+    // Net lines added by the hunks applied so far. Shifts every later hunk's
+    // expected position, since `-` side line numbers refer to the original file.
+    let mut line_delta: isize = 0;
+    for (hunk_index, hunk) in patch.hunks.iter().enumerate() {
         let mut line_cursor = if hunk.header.original.len == 0 {
-            // Pure insertion with no context or deletions to anchor on; the
+            // Pure insertion: no context or deleted lines to anchor on, so the
             // header offset is all there is.
             (hunk.header.patched.start - 1) as usize
         } else {
-            let base = hunk.header.original.start as isize - 1 + diff_offset;
-            const MAX_FUZZ: isize = 20;
-            let mut found: Option<usize> = None;
-            let mut fuzz: isize = 0;
-            while fuzz.abs() <= MAX_FUZZ {
-                let candidate = base + fuzz;
-                if candidate >= 0 && hunk_matches_at(hunk, &lines, candidate as usize) {
-                    found = Some(candidate as usize);
-                    break;
-                }
-                fuzz = if fuzz < 0 { -fuzz } else { -fuzz - 1 };
-            }
-            match found {
+            let expected = hunk.header.original.start as isize - 1 + line_delta;
+            match find_hunk_position(hunk, &lines, expected) {
                 Some(idx) => idx,
-                None => {
-                    return sys::Result::Err(
-                        sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                            .with_path(file_path.as_bytes()),
-                    );
-                }
+                None => return Err(does_not_apply(hunk_index, hunk)),
             }
         };
 
-        // Validate hunk start position is within bounds
         if line_cursor > lines.len() {
-            return sys::Result::Err(
-                sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                    .with_path(file_path.as_bytes()),
-            );
+            return Err(does_not_apply(hunk_index, hunk));
         }
 
         for part in &hunk.parts {
             let part: &PatchMutationPart = part;
             match part.ty {
                 PartType::Context => {
-                    // Validate context lines exist
-                    if line_cursor + part.lines.len() > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
-                    }
-
                     line_cursor += part.lines.len();
                 }
                 PartType::Insertion => {
-                    // Validate insertion position is within bounds
-                    if line_cursor > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
-                    }
-
                     lines.splice(line_cursor..line_cursor, part.lines.iter().copied());
                     line_cursor += part.lines.len();
-                    diff_offset += part.lines.len() as isize;
+                    line_delta += part.lines.len() as isize;
                     if part.no_newline_at_end_of_file {
                         let _ = lines.pop();
                     }
                 }
                 PartType::Deletion => {
-                    // Validate deletion range is within bounds
-                    if line_cursor + part.lines.len() > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
-                    }
-
                     lines.drain(line_cursor..line_cursor + part.lines.len());
-                    diff_offset -= part.lines.len() as isize;
+                    line_delta -= part.lines.len() as isize;
                     if part.no_newline_at_end_of_file {
                         lines.push(b"");
                     }
@@ -441,7 +360,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         sys::O::CREAT | sys::O::WRONLY | sys::O::TRUNC,
         stat.st_mode as sys::Mode,
     ) {
-        sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
+        sys::Result::Err(e) => return Err(e.with_path(file_path.as_bytes()).into()),
         sys::Result::Ok(fd) => fd,
     };
     let _close_file = scopeguard::guard(file_fd, |fd| fd.close());
@@ -452,11 +371,36 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
     while written < contents.len() {
         match sys::write(file_fd, &contents[written..]) {
             sys::Result::Ok(w) => written += w,
-            sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
+            sys::Result::Err(e) => return Err(e.with_path(file_path.as_bytes()).into()),
         }
     }
 
-    sys::Result::Ok(())
+    Ok(())
+}
+
+/// The line index where `hunk`'s `-` side matches `lines`, nearest to
+/// `expected` first (the forward candidate wins a tie), or `None` when it
+/// matches nowhere.
+fn find_hunk_position(hunk: &Hunk<'_>, lines: &[&[u8]], expected: isize) -> Option<usize> {
+    let last = lines.len() as isize;
+    let mut offset: isize = 0;
+    loop {
+        let forward = expected + offset;
+        let backward = expected - offset;
+        if forward > last && backward < 0 {
+            return None;
+        }
+        if (0..=last).contains(&forward) && hunk_matches_at(hunk, lines, forward as usize) {
+            return Some(forward as usize);
+        }
+        if offset != 0
+            && (0..=last).contains(&backward)
+            && hunk_matches_at(hunk, lines, backward as usize)
+        {
+            return Some(backward as usize);
+        }
+        offset += 1;
+    }
 }
 
 /// Whether `hunk`'s context and deletion lines match `lines` starting at

--- a/src/patch_jsc/testing.rs
+++ b/src/patch_jsc/testing.rs
@@ -2,7 +2,7 @@
 
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{ArgumentsSlice, CallFrame, JSGlobalObject, JSValue, JsResult, SysErrorJsc};
-use bun_patch::{ParseErr, PatchFile, git_diff_internal, parse_patch_file};
+use bun_patch::{ApplyError, ParseErr, PatchFile, git_diff_internal, parse_patch_file};
 use bun_sys::{Fd, FdExt};
 
 pub(crate) struct TestingAPIs;
@@ -52,8 +52,14 @@ impl TestingAPIs {
         let patchfile: PatchFile<'_> =
             parse_patch_file(&args.patchfile_txt).expect("validated in parse_apply_args");
 
-        if let Some(err) = patchfile.apply(args.dirfd) {
-            return Err(global.throw_value(SysErrorJsc::to_js(&err, global)));
+        match patchfile.apply(args.dirfd) {
+            None => {}
+            Some(ApplyError::Sys(err)) => {
+                return Err(global.throw_value(SysErrorJsc::to_js(&err, global)));
+            }
+            Some(err @ ApplyError::HunkDoesNotApply { .. }) => {
+                return Err(global.throw(format_args!("{}", err)));
+            }
         }
 
         Ok(JSValue::TRUE)

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1284,3 +1284,116 @@ index 0000000000000000000000000000000000000000..3b18e512dba79e4c8300dd08aeb37f8e
     });
   });
 });
+
+describe("hunk placement", () => {
+  const registry = new VerdaccioRegistry();
+
+  beforeAll(async () => {
+    await registry.start();
+  });
+
+  afterAll(() => {
+    registry.stop();
+  });
+
+  // no-deps@1.0.0 index.js:
+  //   1 module.exports = require(`./package.json`);
+  //   2
+  //   3 for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {
+  //   4   for (const dep of Object.keys(module.exports[key] || {})) {
+  //   5     module.exports[key][dep] = require(dep);
+  //   6   }
+  //   7 }
+  const packageJson = JSON.stringify({
+    name: "hunk-placement",
+    dependencies: { "no-deps": "1.0.0" },
+    patchedDependencies: { "no-deps@1.0.0": "patches/no-deps@1.0.0.patch" },
+  });
+
+  const install = async (packageDir: string) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  };
+
+  const indexJs = (packageDir: string) => Bun.file(join(packageDir, "node_modules", "no-deps", "index.js"));
+
+  test.concurrent("a hunk whose - side matches nothing fails the install", async () => {
+    const { packageDir } = await registry.createTestDir({
+      files: {
+        "package.json": packageJson,
+        patches: {
+          "no-deps@1.0.0.patch": [
+            "diff --git a/index.js b/index.js",
+            "--- a/index.js",
+            "+++ b/index.js",
+            "@@ -1 +1 @@",
+            "-a line that exists in no version of this package",
+            '+module.exports = "STALE-HUNK-APPLIED";',
+            "",
+          ].join("\n"),
+        },
+      },
+    });
+
+    const { stderr, exitCode } = await install(packageDir);
+    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+      "Resolving dependencies
+      error: failed applying patch file: hunk #1 does not apply to index.js (expected at line 1)
+      error: failed to apply patchfile (patches/no-deps@1.0.0.patch)"
+    `);
+    expect(exitCode).toBe(1);
+    const index = indexJs(packageDir);
+    expect((await index.exists()) && (await index.text()).includes("STALE-HUNK-APPLIED")).toBe(false);
+  });
+
+  test.concurrent("a hunk with a stale + start is placed by its context", async () => {
+    const { packageDir } = await registry.createTestDir({
+      files: {
+        "package.json": packageJson,
+        patches: {
+          // Hunk 1 adds two lines, so hunk 2's correct `+` start is 7. The
+          // header says 5, as `yarn patch-commit` emits.
+          "no-deps@1.0.0.patch": [
+            "diff --git a/index.js b/index.js",
+            "--- a/index.js",
+            "+++ b/index.js",
+            "@@ -1,2 +1,4 @@",
+            " module.exports = require(`./package.json`);",
+            "+// FIRST-A",
+            "+// FIRST-B",
+            " ",
+            "@@ -5,2 +5,3 @@",
+            "     module.exports[key][dep] = require(dep);",
+            "+    // SECOND-MARKER",
+            "   }",
+            "",
+          ].join("\n"),
+        },
+      },
+    });
+
+    const { stderr, exitCode } = await install(packageDir);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect((await indexJs(packageDir).text()).split("\n")).toEqual([
+      "module.exports = require(`./package.json`);",
+      "// FIRST-A",
+      "// FIRST-B",
+      "",
+      "for (const key of [`dependencies`, `devDependencies`, `peerDependencies`]) {",
+      "  for (const dep of Object.keys(module.exports[key] || {})) {",
+      "    module.exports[key][dep] = require(dep);",
+      "    // SECOND-MARKER",
+      "  }",
+      "}",
+      "",
+    ]);
+  });
+});

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -27,12 +27,12 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..bc652e496c165a7415880ef4520c0ab3
 --- a/index.js
 +++ b/index.js
 @@ -10,5 +10,6 @@
-  var isOdd = require('is-odd');
+ var isOdd = require('is-odd');
 
-  module.exports = function isEven(i) {
+ module.exports = function isEven(i) {
 +  console.log("HI");
-    return !isOdd(i);
-  };
+   return !isOdd(i);
+ };
 `;
   const is_even_patch2 = /* patch */ `diff --git a/index.js b/index.js
 index 832d92223a9ec491364ee10dcbe3ad495446ab80..217353bf51861fe4fdba68cb98bc5f361c7730e1 100644
@@ -48,10 +48,10 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..217353bf51861fe4fdba68cb98bc5f36
 -var isOdd = require('is-odd');
 +var isOdd = require("is-odd");
 
-  module.exports = function isEven(i) {
+ module.exports = function isEven(i) {
 +  console.log("lmao");
-    return !isOdd(i);
-  };
+   return !isOdd(i);
+ };
 `;
 
   const is_odd_patch = /* patch */ `diff --git a/index.js b/index.js
@@ -459,14 +459,14 @@ index aa7c7012cda790676032d1b01d78c0b69ec06360..6048e7cb462b3f9f6ac4dc21aacf9a09
 --- a/package.json
 +++ b/package.json
 @@ -2,7 +2,7 @@
-    "name": "@zackradisic/hls-dl",
-    "version": "0.0.1",
-    "description": "",
+   "name": "@zackradisic/hls-dl",
+   "version": "0.0.1",
+   "description": "",
 -  "main": "dist/hls-dl.commonjs2.js",
 +  "main": "./index.js",
-    "dependencies": {
-      "m3u8-parser": "^4.5.0",
-      "typescript": "^4.0.5"
+   "dependencies": {
+     "m3u8-parser": "^4.5.0",
+     "typescript": "^4.0.5"
 `;
 
     $.throws(true);

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -79,10 +79,11 @@ function removeCapacity(patch: any): any {
 
 describe("apply", () => {
   test("edgecase", async () => {
+    const oldcontents = "module.exports = x => x % 2 === 0;";
     const newcontents = "module.exports = x => x % 420 === 0;";
     await using tempdir2 = tempDir("patch-test2", {
       ".bun/install/cache/is-even@1.0.0": {
-        "index.js": "module.exports = x => x % 2 === 0;",
+        "index.js": oldcontents,
       },
     });
     await using tempdir = tempDir("patch-test", {
@@ -98,8 +99,12 @@ describe("apply", () => {
       tempdir,
     );
 
-    await apply(patchfile, `${tempdir}/node_modules/is-even`);
-    expect(await fs.readFile(`${tempdir}/node_modules/is-even/index.js`).then(b => b.toString())).toBe(newcontents);
+    // apply against the original (cache) contents, as `bun install` does
+    await using targetdir = tempDir("patch-test-target", {
+      "index.js": oldcontents,
+    });
+    await apply(patchfile, String(targetdir));
+    expect(await fs.readFile(`${targetdir}/index.js`, "utf8")).toBe(newcontents);
   });
 
   test("empty", async () => {
@@ -529,6 +534,91 @@ describe("apply", () => {
       await apply(patchfile, afolder);
 
       expect(await $`cat ${join(afolder, "hello.txt")}`.cwd(tempdir).text()).toBe(bfile);
+    });
+
+    // Patches produced by `yarn patch-commit` often have `+` start lines that
+    // don't account for lines added by earlier hunks. Hunks must be located by
+    // matching their `-` side context (like `git apply`), not by trusting the
+    // stated `+` offset.
+    test("hunk with stale + start line is placed by context", async () => {
+      const afile =
+        Array.from({ length: 12 }, (_, i) => `line${String(i + 1).padStart(2, "0")}`).join("\n") + "\n";
+      await using tempdir = tempDir("patch-test", {
+        "a/hello.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      // Hunk 1 adds 2 lines, so hunk 2's correct `+` start is 9. The header
+      // says 7 (stale), exactly as yarn patch-commit emits.
+      const patchfile = [
+        "diff --git a/hello.txt b/hello.txt",
+        "--- a/hello.txt",
+        "+++ b/hello.txt",
+        "@@ -1,4 +1,6 @@",
+        " line01",
+        " line02",
+        "+INSERT-ONE",
+        "+INSERT-TWO",
+        " line03",
+        " line04",
+        "@@ -7,6 +7,7 @@",
+        " line07",
+        " line08",
+        "-line09",
+        "+line09-changed",
+        "+SECOND-MARKER",
+        " line10",
+        " line11",
+        " line12",
+        "",
+      ].join("\n");
+
+      await apply(patchfile, afolder);
+
+      expect(await fs.readFile(join(afolder, "hello.txt"), "utf8")).toBe(
+        [
+          "line01",
+          "line02",
+          "INSERT-ONE",
+          "INSERT-TWO",
+          "line03",
+          "line04",
+          "line05",
+          "line06",
+          "line07",
+          "line08",
+          "line09-changed",
+          "SECOND-MARKER",
+          "line10",
+          "line11",
+          "line12",
+          "",
+        ].join("\n"),
+      );
+    });
+
+    test("hunk whose context matches nowhere fails instead of corrupting the file", async () => {
+      const afile = Array.from({ length: 30 }, (_, i) => `alpha${i}`).join("\n") + "\n";
+      await using tempdir = tempDir("patch-test", {
+        "a/hello.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      const patchfile = [
+        "diff --git a/hello.txt b/hello.txt",
+        "--- a/hello.txt",
+        "+++ b/hello.txt",
+        "@@ -1,3 +1,4 @@",
+        " not-in-file-1",
+        " not-in-file-2",
+        "+NEW-LINE",
+        " not-in-file-3",
+        "",
+      ].join("\n");
+
+      expect(() => apply(patchfile, afolder)).toThrow();
+      // the file must be left untouched
+      expect(await fs.readFile(join(afolder, "hello.txt"), "utf8")).toBe(afile);
     });
   });
 

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -727,9 +727,32 @@ describe("apply", () => {
 
     test("a pure insertion past the end of the file does not apply", async () => {
       await using dir = tempDir("patch-u0", { "index.js": "line 1\nline 2\n" });
-      const patchfile = "diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n@@ -9,0 +10 @@\n+X\n";
-      expect(() => apply(patchfile, String(dir))).toThrow("hunk #1 does not apply to index.js (expected at line 9)");
+      const header = "diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n";
+      expect(() => apply(header + "@@ -9,0 +10 @@\n+X\n", String(dir))).toThrow(
+        "hunk #1 does not apply to index.js (expected at line 9)",
+      );
+      // One past the last line: the file has 2 lines, there is no line 3 to insert after.
+      expect(() => apply(header + "@@ -3,0 +4 @@\n+X\n", String(dir))).toThrow(
+        "hunk #1 does not apply to index.js (expected at line 3)",
+      );
       expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nline 2\n");
+    });
+
+    test("a no-newline pragma in the middle of a hunk does not apply instead of crashing", async () => {
+      await using dir = tempDir("patch-pragma", { "index.js": "line 1\nline 2" });
+      const patchfile = [
+        "diff --git a/index.js b/index.js",
+        "--- a/index.js",
+        "+++ b/index.js",
+        "@@ -1,2 +1,1 @@",
+        "+X",
+        "\\ No newline at end of file",
+        "-line 1",
+        "-line 2",
+        "",
+      ].join("\n");
+      expect(() => apply(patchfile, String(dir))).toThrow("hunk #1 does not apply to index.js (expected at line 1)");
+      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nline 2");
     });
 
     test("a header start far past the end of the file is still found or rejected quickly", async () => {

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -738,21 +738,39 @@ describe("apply", () => {
       expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nline 2\n");
     });
 
-    test("a no-newline pragma in the middle of a hunk does not apply instead of crashing", async () => {
-      await using dir = tempDir("patch-pragma", { "index.js": "line 1\nline 2" });
-      const patchfile = [
-        "diff --git a/index.js b/index.js",
-        "--- a/index.js",
-        "+++ b/index.js",
-        "@@ -1,2 +1,1 @@",
-        "+X",
-        "\\ No newline at end of file",
-        "-line 1",
-        "-line 2",
-        "",
-      ].join("\n");
+    // `\ No newline at end of file` ends that side of the file, so context or
+    // deleted lines after it are malformed. These used to crash or drop a line.
+    test.each([
+      ["deletion after it", "line 1\nline 2", "@@ -1,2 +1,1 @@\n+X\n\\ No newline at end of file\n-line 1\n-line 2\n"],
+      ["context after it", "line 1\nline 2", "@@ -1,2 +1,3 @@\n+X\n\\ No newline at end of file\n line 1\n line 2\n"],
+      [
+        "context after it, trailing newline",
+        "line 1\nline 2\n",
+        "@@ -1,2 +1,3 @@\n+X\n\\ No newline at end of file\n line 1\n line 2\n",
+      ],
+      ["context after a deletion with it", "line 1\nline 2", "@@ -1,2 +1,1 @@\n-line 1\n\\ No newline at end of file\n line 2\n"],
+    ])("a no-newline pragma with %s does not apply", async (_name, before, hunk) => {
+      await using dir = tempDir("patch-pragma", { "index.js": before });
+      const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunk}`;
       expect(() => apply(patchfile, String(dir))).toThrow("hunk #1 does not apply to index.js (expected at line 1)");
-      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nline 2");
+      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe(before);
+    });
+
+    test.each([
+      ["old side had no newline", "a\nb", "@@ -1,2 +1,3 @@\n a\n-b\n\\ No newline at end of file\n+b\n+c\n", "a\nb\nc\n"],
+      ["new side has no newline", "a\nb\nc\n", "@@ -1,3 +1,2 @@\n a\n-b\n-c\n+b\n\\ No newline at end of file\n", "a\nb"],
+      [
+        "neither side has a newline",
+        "a\nb",
+        "@@ -1,2 +1,2 @@\n a\n-b\n\\ No newline at end of file\n+B\n\\ No newline at end of file\n",
+        "a\nB",
+      ],
+      ["unchanged last line without newline", "a\nb", "@@ -1,2 +1,3 @@\n+X\n a\n b\n\\ No newline at end of file\n", "X\na\nb"],
+    ])("a no-newline pragma where git puts it applies: %s", async (_name, before, hunk, after) => {
+      await using dir = tempDir("patch-pragma", { "index.js": before });
+      const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunk}`;
+      await apply(patchfile, String(dir));
+      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe(after);
     });
 
     test("a header start far past the end of the file is still found or rejected quickly", async () => {

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -731,6 +731,16 @@ describe("apply", () => {
       expect(() => apply(patchfile, String(dir))).toThrow("hunk #1 does not apply to index.js (expected at line 9)");
       expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nline 2\n");
     });
+
+    test("a header start far past the end of the file is still found or rejected quickly", async () => {
+      await using dir = tempDir("patch-far", { "index.js": "line 1\nline 2\nline 3\n" });
+      const header = "diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n";
+      await apply(header + "@@ -4000000000 +4000000000 @@\n-line 2\n+TWO\n", String(dir));
+      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nTWO\nline 3\n");
+      expect(() => apply(header + "@@ -4000000000 +4000000000 @@\n-nowhere\n+X\n", String(dir))).toThrow(
+        "hunk #1 does not apply to index.js (expected at line 4000000000)",
+      );
+    });
   });
 
   describe("No newline at end of file", () => {

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -541,8 +541,7 @@ describe("apply", () => {
     // matching their `-` side context (like `git apply`), not by trusting the
     // stated `+` offset.
     test("hunk with stale + start line is placed by context", async () => {
-      const afile =
-        Array.from({ length: 12 }, (_, i) => `line${String(i + 1).padStart(2, "0")}`).join("\n") + "\n";
+      const afile = Array.from({ length: 12 }, (_, i) => `line${String(i + 1).padStart(2, "0")}`).join("\n") + "\n";
       await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
       });
@@ -648,8 +647,7 @@ describe("apply", () => {
     });
 
     test("hunk is found by context when the file shifted by more than 20 lines", async () => {
-      const afile =
-        Array.from({ length: 60 }, (_, i) => (i === 49 ? "target" : `filler${i + 1}`)).join("\n") + "\n";
+      const afile = Array.from({ length: 60 }, (_, i) => (i === 49 ? "target" : `filler${i + 1}`)).join("\n") + "\n";
       await using tempdir = tempDir("patch-test", {
         "a/hello.txt": afile,
       });
@@ -684,7 +682,12 @@ describe("apply", () => {
     // of the file. Every case below is what `git apply --unidiff-zero` produces.
     const numbered = (n: number) => Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
     test.each([
-      ["delete one line", numbered(8), "@@ -6 +5,0 @@\n-line 6\n", "line 1\nline 2\nline 3\nline 4\nline 5\nline 7\nline 8\n"],
+      [
+        "delete one line",
+        numbered(8),
+        "@@ -6 +5,0 @@\n-line 6\n",
+        "line 1\nline 2\nline 3\nline 4\nline 5\nline 7\nline 8\n",
+      ],
       [
         "delete a run of lines",
         numbered(8),

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -748,7 +748,11 @@ describe("apply", () => {
         "line 1\nline 2\n",
         "@@ -1,2 +1,3 @@\n+X\n\\ No newline at end of file\n line 1\n line 2\n",
       ],
-      ["context after a deletion with it", "line 1\nline 2", "@@ -1,2 +1,1 @@\n-line 1\n\\ No newline at end of file\n line 2\n"],
+      [
+        "context after a deletion with it",
+        "line 1\nline 2",
+        "@@ -1,2 +1,1 @@\n-line 1\n\\ No newline at end of file\n line 2\n",
+      ],
     ])("a no-newline pragma with %s does not apply", async (_name, before, hunk) => {
       await using dir = tempDir("patch-pragma", { "index.js": before });
       const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunk}`;
@@ -757,15 +761,30 @@ describe("apply", () => {
     });
 
     test.each([
-      ["old side had no newline", "a\nb", "@@ -1,2 +1,3 @@\n a\n-b\n\\ No newline at end of file\n+b\n+c\n", "a\nb\nc\n"],
-      ["new side has no newline", "a\nb\nc\n", "@@ -1,3 +1,2 @@\n a\n-b\n-c\n+b\n\\ No newline at end of file\n", "a\nb"],
+      [
+        "old side had no newline",
+        "a\nb",
+        "@@ -1,2 +1,3 @@\n a\n-b\n\\ No newline at end of file\n+b\n+c\n",
+        "a\nb\nc\n",
+      ],
+      [
+        "new side has no newline",
+        "a\nb\nc\n",
+        "@@ -1,3 +1,2 @@\n a\n-b\n-c\n+b\n\\ No newline at end of file\n",
+        "a\nb",
+      ],
       [
         "neither side has a newline",
         "a\nb",
         "@@ -1,2 +1,2 @@\n a\n-b\n\\ No newline at end of file\n+B\n\\ No newline at end of file\n",
         "a\nB",
       ],
-      ["unchanged last line without newline", "a\nb", "@@ -1,2 +1,3 @@\n+X\n a\n b\n\\ No newline at end of file\n", "X\na\nb"],
+      [
+        "unchanged last line without newline",
+        "a\nb",
+        "@@ -1,2 +1,3 @@\n+X\n a\n b\n\\ No newline at end of file\n",
+        "X\na\nb",
+      ],
     ])("a no-newline pragma where git puts it applies: %s", async (_name, before, hunk, after) => {
       await using dir = tempDir("patch-pragma", { "index.js": before });
       const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunk}`;

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -719,14 +719,14 @@ describe("apply", () => {
         "line 1\nA\nB\nline 2\nline 3\nC\nline 4\n",
       ],
     ])("zero-context hunk: %s", async (_name, before, hunks, after) => {
-      await using dir = tempDir("patch-u0", { "index.js": before });
+      using dir = tempDir("patch-u0", { "index.js": before });
       const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunks}`;
       await apply(patchfile, String(dir));
       expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe(after);
     });
 
     test("a pure insertion past the end of the file does not apply", async () => {
-      await using dir = tempDir("patch-u0", { "index.js": "line 1\nline 2\n" });
+      using dir = tempDir("patch-u0", { "index.js": "line 1\nline 2\n" });
       const header = "diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n";
       expect(() => apply(header + "@@ -9,0 +10 @@\n+X\n", String(dir))).toThrow(
         "hunk #1 does not apply to index.js (expected at line 9)",
@@ -754,7 +754,7 @@ describe("apply", () => {
         "@@ -1,2 +1,1 @@\n-line 1\n\\ No newline at end of file\n line 2\n",
       ],
     ])("a no-newline pragma with %s does not apply", async (_name, before, hunk) => {
-      await using dir = tempDir("patch-pragma", { "index.js": before });
+      using dir = tempDir("patch-pragma", { "index.js": before });
       const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunk}`;
       expect(() => apply(patchfile, String(dir))).toThrow("hunk #1 does not apply to index.js (expected at line 1)");
       expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe(before);
@@ -786,14 +786,14 @@ describe("apply", () => {
         "X\na\nb",
       ],
     ])("a no-newline pragma where git puts it applies: %s", async (_name, before, hunk, after) => {
-      await using dir = tempDir("patch-pragma", { "index.js": before });
+      using dir = tempDir("patch-pragma", { "index.js": before });
       const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunk}`;
       await apply(patchfile, String(dir));
       expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe(after);
     });
 
     test("a header start far past the end of the file is still found or rejected quickly", async () => {
-      await using dir = tempDir("patch-far", { "index.js": "line 1\nline 2\nline 3\n" });
+      using dir = tempDir("patch-far", { "index.js": "line 1\nline 2\nline 3\n" });
       const header = "diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n";
       await apply(header + "@@ -4000000000 +4000000000 @@\n-line 2\n+TWO\n", String(dir));
       expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nTWO\nline 3\n");

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -616,9 +616,93 @@ describe("apply", () => {
         "",
       ].join("\n");
 
-      expect(() => apply(patchfile, afolder)).toThrow();
+      expect(() => apply(patchfile, afolder)).toThrow("hunk #1 does not apply to hello.txt (expected at line 1)");
       // the file must be left untouched
       expect(await fs.readFile(join(afolder, "hello.txt"), "utf8")).toBe(afile);
+    });
+
+    test("a later hunk that matches nowhere fails before anything is written", async () => {
+      const afile = Array.from({ length: 10 }, (_, i) => `line${i + 1}`).join("\n") + "\n";
+      await using tempdir = tempDir("patch-test", {
+        "a/hello.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      const patchfile = [
+        "diff --git a/hello.txt b/hello.txt",
+        "--- a/hello.txt",
+        "+++ b/hello.txt",
+        "@@ -1,2 +1,3 @@",
+        " line1",
+        "+FIRST",
+        " line2",
+        "@@ -8,2 +9,3 @@",
+        " line8",
+        "+SECOND",
+        " not-line9",
+        "",
+      ].join("\n");
+
+      expect(() => apply(patchfile, afolder)).toThrow("hunk #2 does not apply to hello.txt (expected at line 8)");
+      expect(await fs.readFile(join(afolder, "hello.txt"), "utf8")).toBe(afile);
+    });
+
+    test("hunk is found by context when the file shifted by more than 20 lines", async () => {
+      const afile =
+        Array.from({ length: 60 }, (_, i) => (i === 49 ? "target" : `filler${i + 1}`)).join("\n") + "\n";
+      await using tempdir = tempDir("patch-test", {
+        "a/hello.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      // The patch was made when "target" was line 2. It is now line 50.
+      const patchfile = [
+        "diff --git a/hello.txt b/hello.txt",
+        "--- a/hello.txt",
+        "+++ b/hello.txt",
+        "@@ -1,3 +1,3 @@",
+        " filler49",
+        "-target",
+        "+replaced",
+        " filler51",
+        "",
+      ].join("\n");
+
+      await apply(patchfile, afolder);
+
+      const lines = (await fs.readFile(join(afolder, "hello.txt"), "utf8")).split("\n");
+      expect({ line49: lines[48], line50: lines[49], line51: lines[50], count: lines.length }).toEqual({
+        line49: "filler49",
+        line50: "replaced",
+        line51: "filler51",
+        count: 61,
+      });
+    });
+
+    test("a zero-context deletion removes the line the - side names", async () => {
+      const afile = Array.from({ length: 12 }, (_, i) => `line${String(i + 1).padStart(2, "0")}`).join("\n") + "\n";
+      await using tempdir = tempDir("patch-test", {
+        "a/hello.txt": afile,
+      });
+      const afolder = join(tempdir, "a");
+
+      // `diff -U0` output: delete line 6 of the original.
+      const patchfile = [
+        "diff --git a/hello.txt b/hello.txt",
+        "--- a/hello.txt",
+        "+++ b/hello.txt",
+        "@@ -6 +5,0 @@",
+        "-line06",
+        "",
+      ].join("\n");
+
+      await apply(patchfile, afolder);
+
+      expect(await fs.readFile(join(afolder, "hello.txt"), "utf8")).toBe(
+        ["line01", "line02", "line03", "line04", "line05", "line07", "line08", "line09", "line10", "line11", "line12", ""].join(
+          "\n",
+        ),
+      );
     });
   });
 
@@ -697,7 +781,7 @@ describe("apply", () => {
       });
     });
 
-    test("header deleting more lines than the target file has returns EINVAL", async () => {
+    test("header deleting more lines than the target file has does not apply", async () => {
       await using dir = tempDir("patch-underflow", { "target.txt": "only line\n" });
 
       await using proc = Bun.spawn({
@@ -719,7 +803,7 @@ describe("apply", () => {
              patchInternals.apply(patch, ${JSON.stringify(dir)});
              console.log("no-error");
            } catch (e) {
-             console.log("caught: " + e.code);
+             console.log("caught: " + e.message);
            }`,
         ],
         env: bunEnv,
@@ -729,7 +813,7 @@ describe("apply", () => {
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-        stdout: "caught: EINVAL",
+        stdout: "caught: hunk #1 does not apply to target.txt (expected at line 1)",
         stderr: "",
         exitCode: 0,
       });

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -679,30 +679,54 @@ describe("apply", () => {
       });
     });
 
-    test("a zero-context deletion removes the line the - side names", async () => {
-      const afile = Array.from({ length: 12 }, (_, i) => `line${String(i + 1).padStart(2, "0")}`).join("\n") + "\n";
-      await using tempdir = tempDir("patch-test", {
-        "a/hello.txt": afile,
-      });
-      const afolder = join(tempdir, "a");
+    // `git diff -U0` emits hunks with no context lines. A zero-length range
+    // (`-3,0`, `+5,0`) names the line the gap sits after, and `0` is the top
+    // of the file. Every case below is what `git apply --unidiff-zero` produces.
+    const numbered = (n: number) => Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\n") + "\n";
+    test.each([
+      ["delete one line", numbered(8), "@@ -6 +5,0 @@\n-line 6\n", "line 1\nline 2\nline 3\nline 4\nline 5\nline 7\nline 8\n"],
+      [
+        "delete a run of lines",
+        numbered(8),
+        "@@ -3,3 +2,0 @@\n-line 3\n-line 4\n-line 5\n",
+        "line 1\nline 2\nline 6\nline 7\nline 8\n",
+      ],
+      ["delete the first line", numbered(3), "@@ -1 +0,0 @@\n-line 1\n", "line 2\nline 3\n"],
+      ["delete the last line", numbered(3), "@@ -3 +2,0 @@\n-line 3\n", "line 1\nline 2\n"],
+      [
+        "two deletions",
+        numbered(8),
+        "@@ -2 +1,0 @@\n-line 2\n@@ -6 +4,0 @@\n-line 6\n",
+        "line 1\nline 3\nline 4\nline 5\nline 7\nline 8\n",
+      ],
+      ["insert after a line", numbered(4), "@@ -3,0 +4,2 @@\n+X\n+Y\n", "line 1\nline 2\nline 3\nX\nY\nline 4\n"],
+      ["insert at the top", numbered(2), "@@ -0,0 +1 @@\n+X\n", "X\nline 1\nline 2\n"],
+      ["insert at the end", numbered(2), "@@ -2,0 +3 @@\n+X\n", "line 1\nline 2\nX\n"],
+      ["replace a line", numbered(3), "@@ -2 +2 @@\n-line 2\n+TWO\n", "line 1\nTWO\nline 3\n"],
+      [
+        "delete then insert",
+        numbered(6),
+        "@@ -2 +1,0 @@\n-line 2\n@@ -5,0 +5 @@\n+X\n",
+        "line 1\nline 3\nline 4\nline 5\nX\nline 6\n",
+      ],
+      [
+        "insert then insert",
+        numbered(4),
+        "@@ -1,0 +2,2 @@\n+A\n+B\n@@ -3,0 +6 @@\n+C\n",
+        "line 1\nA\nB\nline 2\nline 3\nC\nline 4\n",
+      ],
+    ])("zero-context hunk: %s", async (_name, before, hunks, after) => {
+      await using dir = tempDir("patch-u0", { "index.js": before });
+      const patchfile = `diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n${hunks}`;
+      await apply(patchfile, String(dir));
+      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe(after);
+    });
 
-      // `diff -U0` output: delete line 6 of the original.
-      const patchfile = [
-        "diff --git a/hello.txt b/hello.txt",
-        "--- a/hello.txt",
-        "+++ b/hello.txt",
-        "@@ -6 +5,0 @@",
-        "-line06",
-        "",
-      ].join("\n");
-
-      await apply(patchfile, afolder);
-
-      expect(await fs.readFile(join(afolder, "hello.txt"), "utf8")).toBe(
-        ["line01", "line02", "line03", "line04", "line05", "line07", "line08", "line09", "line10", "line11", "line12", ""].join(
-          "\n",
-        ),
-      );
+    test("a pure insertion past the end of the file does not apply", async () => {
+      await using dir = tempDir("patch-u0", { "index.js": "line 1\nline 2\n" });
+      const patchfile = "diff --git a/index.js b/index.js\n--- a/index.js\n+++ b/index.js\n@@ -9,0 +10 @@\n+X\n";
+      expect(() => apply(patchfile, String(dir))).toThrow("hunk #1 does not apply to index.js (expected at line 9)");
+      expect(await fs.readFile(join(String(dir), "index.js"), "utf8")).toBe("line 1\nline 2\n");
     });
   });
 
@@ -890,7 +914,7 @@ describe("parse", () => {
               "path": "banana.ts",
               "mode": "non_executable",
               "hunk": {
-                "header": { "original": { "start": 1, "len": 0 }, "patched": { "start": 1, "len": 1 } },
+                "header": { "original": { "start": 0, "len": 0 }, "patched": { "start": 1, "len": 1 } },
                 "parts": {
                   "items": [
                     {

--- a/test/regression/issue/patch-bounds-check.test.ts
+++ b/test/regression/issue/patch-bounds-check.test.ts
@@ -44,7 +44,7 @@ test("patch application should handle out-of-bounds line numbers gracefully", as
   expect(exitCode).toBe(1);
   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
     "Resolving dependencies
-    error: failed applying patch file: EINVAL: Invalid argument (stat())
+    error: failed applying patch file: hunk #1 does not apply to index.js (expected at line 1000)
     error: failed to apply patchfile (patches/lodash+4.17.21.patch)"
   `);
   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);


### PR DESCRIPTION
### Problem
- The `patchedDependencies` applier splices each hunk at the header's `+` start line and never compares the hunk's context or deleted lines with the file. A patch made against other contents is applied anyway: `bun install` exits 0 and the package has the wrong text. `git apply` and `patch(1)` reject the same input with "patch does not apply".
- `yarn patch-commit` emits `+` starts that ignore the lines earlier hunks added, so bun lands those hunks several lines early (#38879). A `-U0` deletion such as `@@ -6 +5,0 @@` deletes line 5 instead of line 6 for the same reason.
- The cause is `apply_patch` in `src/patch/lib.rs`: `line_cursor = header.patched.start - 1` for every hunk, with only bounds checks on the parts.

### Fix
- `apply_patch` locates each hunk by its `-` side. The expected index is the header's `-` start plus the net lines added by earlier hunks. `find_hunk_position` tries that index first, then the nearest offsets in both directions over the whole file, the order `git apply` uses. `hunk_matches_at` compares context and deleted lines with trailing whitespace trimmed, so CRLF files still match LF patches.
- A hunk that matches nowhere returns the new `ApplyError::HunkDoesNotApply`. `bun install` prints `error: failed applying patch file: hunk #2 does not apply to index.js (expected at line 5)` and exits 1. Nothing is written to the file before every hunk is placed. Syscall failures keep their `sys::Error`.
- A pure insertion (`-N,0`) has nothing to match. It goes after line `N` of the original, shifted by the same delta, and fails if the file has no line `N`. The header parser no longer clamps a start of `0` to `1`, so `-0,0` means the top of the file. Malformed input stays an error, not a panic or a short write: the search start is clamped into the file, a `\ No newline at end of file` may only be followed by an insertion, and every splice and drain range is checked.
- Verified: `test/js/bun/patch/patch.test.ts` (17 cases fail on stock bun, including a table of 11 `-U0` hunks checked against `git apply --unidiff-zero`), `test/cli/install/bun-install-patch.test.ts` (2 new install-level tests), `test/regression/issue/patch-bounds-check.test.ts` (message snapshot). Also ran `bun-patch`, `isolated-install`, `frozen-lockfile-pruned`, `bun-update-transitive`.

### Background
- A unified diff hunk header `@@ -a,b +c,d @@` gives the `-` side (original file) start and length and the `+` side (patched file) start and length. Lines that start with a space are context, `-` lines are deleted, `+` lines are added. Only the `-` side describes the file the applier reads, so it is the stable anchor. A length of 0 names the line the gap sits after.
- `src/patch/lib.rs` is a port of patch-package's applier. `bun install` runs it on a copy of the package in a temp dir, then moves the result into the cache. The JS binding `patchInternals.apply` (`src/patch_jsc/testing.rs`) calls the same code in tests.
- Three fixtures in `bun-install-patch.test.ts` had one extra leading space on their context lines. `git apply` rejects them. They applied only because context was ignored, so they are corrected here.

<details><summary>Notes</summary>

- Continues #38885 (closed) and the branch `farm/2435029c/patch-context-verify`, whose commit is the first on this branch. On top of it: the search covers the whole file instead of 20 lines each way, the error names the hunk and file instead of `EINVAL (fstatat())`, pure insertions use the `-` side too, and the per-part bounds checks are gone because a match already proves every context and deleted line exists.
- Overlaps #41695, which fixes only the `-U0` off-by-one by special-casing `patched.len == 0` while still positioning by the `+` side. This PR makes that change unnecessary: the `+` start is no longer read during apply. The `-U0` table here covers the cases from that PR plus "insert at the end" and "insert then insert".
- Repro from the report: a patch whose single `-` line exists in no version of the package. Before: rc 0 and the `+` line replaces line 1. After: rc 1 with the hunk named.
- Review follow-ups: bounded the position search for a header start far outside the file, kept the splice and drain ranges checked (a misplaced `\ No newline at end of file` could otherwise pop a line mid-hunk and panic), made the pure-insertion bound exclude the trailing-newline sentinel, and rejected context or deleted lines after a `\ No newline at end of file` (that shape dropped a line). Each has a test.
- Fixes #38879.
</details>
