### PR TITLE
install: reject an empty or scope-only package name before it reaches the registry

### DIFF
--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -953,13 +953,10 @@ impl TagExt for Tag {
             // newspeak/repo
             // npm:package@1.2.3
             b'n' => {
-                if dependency.starts_with(b"npm:") && dependency.len() > b"npm:".len() {
-                    let remain =
-                        &dependency[b"npm:".len() + (dependency[b"npm:".len()] == b'@') as usize..];
-                    for (i, &c) in remain.iter().enumerate() {
-                        if c == b'@' {
-                            return Tag::infer(&remain[i + 1..]);
-                        }
+                if let Some(remain) = dependency.strip_prefix(b"npm:") {
+                    let remain = &remain[remain.starts_with(b"@") as usize..];
+                    if let Some(at) = strings::index_of_char(remain, b'@') {
+                        return Tag::infer(&remain[at as usize + 1..]);
                     }
 
                     return Tag::Npm;
@@ -1162,9 +1159,9 @@ pub(crate) fn parse_with_tag(
 
             let mut is_alias = false;
             let name = 'brk: {
-                if input.starts_with(b"npm:") {
+                if let Some(target) = input.strip_prefix(b"npm:") {
                     is_alias = true;
-                    let (name, rest) = split_npm_alias(&input[b"npm:".len()..]);
+                    let (name, rest) = split_npm_alias(target);
                     if is_scoped_package_name(name).is_err() {
                         return invalid_package_name(log_, name, dependency);
                     }
@@ -1174,10 +1171,6 @@ pub(crate) fn parse_with_tag(
 
                 alias
             };
-
-            if name.is_empty() {
-                return invalid_package_name(log_, b"", dependency);
-            }
 
             is_alias = is_alias && alias_hash.is_some();
 
@@ -1219,9 +1212,9 @@ pub(crate) fn parse_with_tag(
         Tag::DistTag => {
             let mut tag_to_use = sliced.value();
 
-            let actual = if dependency.starts_with(b"npm:") && dependency.len() > b"npm:".len() {
+            let actual = if let Some(target) = dependency.strip_prefix(b"npm:") {
                 // npm:@foo/bar@latest
-                let (name, rest) = split_npm_alias(&dependency[b"npm:".len()..]);
+                let (name, rest) = split_npm_alias(target);
                 if is_scoped_package_name(name).is_err() {
                     return invalid_package_name(log_, name, dependency);
                 }
@@ -1230,10 +1223,6 @@ pub(crate) fn parse_with_tag(
             } else {
                 alias
             };
-
-            if actual.is_empty() {
-                return invalid_package_name(log_, b"", dependency);
-            }
 
             Some(Version {
                 literal: sliced.value(),

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -1116,8 +1116,7 @@ pub(crate) fn parse_with_optional_tag<'a, 'b>(
     )
 }
 
-/// Splits `npm:<name>@<version>` (the part after `npm:`) into the package name
-/// and the rest after the separating `@`. A leading `@` belongs to the scope.
+/// `@scope/name@version` after `npm:` -> (`@scope/name`, `version`).
 fn split_npm_alias(str: &[u8]) -> (&[u8], &[u8]) {
     let mut i: usize = (!str.is_empty() && str[0] == b'@') as usize;
     while i < str.len() {
@@ -1129,9 +1128,6 @@ fn split_npm_alias(str: &[u8]) -> (&[u8], &[u8]) {
     (str, &str[i..])
 }
 
-/// Rejects a name that the registry cannot serve: empty, or `@` with a
-/// missing scope or package part. Such a name turns into a request for the
-/// registry root (`GET /`) or for `/@scope%2f`.
 fn invalid_package_name(
     log_: Option<&mut bun_ast::Log>,
     name: &[u8],

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -1116,6 +1116,41 @@ pub(crate) fn parse_with_optional_tag<'a, 'b>(
     )
 }
 
+/// Splits `npm:<name>@<version>` (the part after `npm:`) into the package name
+/// and the rest after the separating `@`. A leading `@` belongs to the scope.
+fn split_npm_alias(str: &[u8]) -> (&[u8], &[u8]) {
+    let mut i: usize = (!str.is_empty() && str[0] == b'@') as usize;
+    while i < str.len() {
+        if str[i] == b'@' {
+            return (&str[0..i], &str[i + 1..]);
+        }
+        i += 1;
+    }
+    (str, &str[i..])
+}
+
+/// Rejects a name that the registry cannot serve: empty, or `@` with a
+/// missing scope or package part. Such a name turns into a request for the
+/// registry root (`GET /`) or for `/@scope%2f`.
+fn invalid_package_name(
+    log_: Option<&mut bun_ast::Log>,
+    name: &[u8],
+    dependency: &[u8],
+) -> Option<Version> {
+    if let Some(log) = log_ {
+        log.add_error_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "invalid package name \"{}\" in dependency \"{}\"",
+                bstr::BStr::new(name),
+                bstr::BStr::new(dependency)
+            ),
+        );
+    }
+    None
+}
+
 pub(crate) fn parse_with_tag(
     alias: String,
     alias_hash: Option<PackageNameHash>,
@@ -1133,24 +1168,20 @@ pub(crate) fn parse_with_tag(
             let name = 'brk: {
                 if input.starts_with(b"npm:") {
                     is_alias = true;
-                    let str = &input[b"npm:".len()..];
-                    let mut i: usize = (!str.is_empty() && str[0] == b'@') as usize;
-
-                    while i < str.len() {
-                        if str[i] == b'@' {
-                            input = &str[i + 1..];
-                            break 'brk sliced.sub(&str[0..i]).value();
-                        }
-                        i += 1;
+                    let (name, rest) = split_npm_alias(&input[b"npm:".len()..]);
+                    if is_scoped_package_name(name).is_err() {
+                        return invalid_package_name(log_, name, dependency);
                     }
-
-                    input = &str[i..];
-
-                    break 'brk sliced.sub(&str[0..i]).value();
+                    input = rest;
+                    break 'brk sliced.sub(name).value();
                 }
 
                 alias
             };
+
+            if name.is_empty() {
+                return invalid_package_name(log_, b"", dependency);
+            }
 
             is_alias = is_alias && alias_hash.is_some();
 
@@ -1194,33 +1225,19 @@ pub(crate) fn parse_with_tag(
 
             let actual = if dependency.starts_with(b"npm:") && dependency.len() > b"npm:".len() {
                 // npm:@foo/bar@latest
-                sliced
-                    .sub('brk: {
-                        let mut i = b"npm:".len();
-
-                        // npm:@foo/bar@latest
-                        //     ^
-                        i += (dependency[i] == b'@') as usize;
-
-                        while i < dependency.len() {
-                            // npm:@foo/bar@latest
-                            //             ^
-                            if dependency[i] == b'@' {
-                                break;
-                            }
-                            i += 1;
-                        }
-
-                        tag_to_use = sliced.sub(&dependency[i + 1..]).value();
-                        break 'brk &dependency[b"npm:".len()..i];
-                    })
-                    .value()
+                let (name, rest) = split_npm_alias(&dependency[b"npm:".len()..]);
+                if is_scoped_package_name(name).is_err() {
+                    return invalid_package_name(log_, name, dependency);
+                }
+                tag_to_use = sliced.sub(rest).value();
+                sliced.sub(name).value()
             } else {
                 alias
             };
 
-            // name should never be empty
-            debug_assert!(!actual.is_empty());
+            if actual.is_empty() {
+                return invalid_package_name(log_, b"", dependency);
+            }
 
             Some(Version {
                 literal: sliced.value(),

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1817,11 +1817,7 @@ impl Package<u64> {
             Some(&mut *log),
             Some(&mut *pm),
         )
-        .unwrap_or_else(|| dependency::Version {
-            tag: dependency::version::Tag::Uninitialized,
-            literal: sliced.value(),
-            value: dependency::Value::default(),
-        });
+        .unwrap_or_default();
         let mut workspace_range: Option<semver::query::Group> = None;
         #[allow(non_snake_case)]
         let FEATURES = features;

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1761,6 +1761,18 @@ impl Package<u64> {
         version: &[u8],
         key_loc: bun_ast::Loc,
     ) -> crate::Result<Option<Dependency>> {
+        if external_alias.value.is_empty() {
+            log.add_error_fmt(
+                source,
+                key_loc,
+                format_args!(
+                    "Dependency name cannot be empty (in \"{}\")",
+                    bstr::BStr::new(group.prop)
+                ),
+            );
+            return Err(crate::Error::InstallFailed);
+        }
+
         #[cfg(windows)]
         let external_version = 'brk: {
             match tag.unwrap_or_else(|| dependency::version::Tag::infer(version)) {
@@ -1805,7 +1817,11 @@ impl Package<u64> {
             Some(&mut *log),
             Some(&mut *pm),
         )
-        .unwrap_or_default();
+        .unwrap_or_else(|| dependency::Version {
+            tag: dependency::version::Tag::Uninitialized,
+            literal: sliced.value(),
+            value: dependency::Value::default(),
+        });
         let mut workspace_range: Option<semver::query::Group> = None;
         #[allow(non_snake_case)]
         let FEATURES = features;

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -299,9 +299,17 @@ describe.concurrent("bun-install", () => {
     ["an empty name with a dist-tag", { "": "latest" }, 'Dependency name cannot be empty (in "dependencies")'],
     ["an empty name with a range", { "": "^1" }, 'Dependency name cannot be empty (in "dependencies")'],
     ["an npm alias with no name", { "x": "npm:@1.0.0" }, 'invalid package name "@1.0.0" in dependency "npm:@1.0.0"'],
-    ["an npm alias with no name and a dist-tag", { "x": "npm:@latest" }, 'invalid package name "@latest" in dependency "npm:@latest"'],
+    [
+      "an npm alias with no name and a dist-tag",
+      { "x": "npm:@latest" },
+      'invalid package name "@latest" in dependency "npm:@latest"',
+    ],
     ["an npm alias with an empty version", { "x": "npm:@" }, 'invalid package name "@" in dependency "npm:@"'],
-    ["an npm alias scope with no name", { "x": "npm:@scope/@1" }, 'invalid package name "@scope/" in dependency "npm:@scope/@1"'],
+    [
+      "an npm alias scope with no name",
+      { "x": "npm:@scope/@1" },
+      'invalid package name "@scope/" in dependency "npm:@scope/@1"',
+    ],
   ])("rejects %s without a registry request", async (_, dependencies, message) => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -305,10 +305,16 @@ describe.concurrent("bun-install", () => {
       'invalid package name "@latest" in dependency "npm:@latest"',
     ],
     ["an npm alias with an empty version", { "x": "npm:@" }, 'invalid package name "@" in dependency "npm:@"'],
+    ["a bare npm alias", { "x": "npm:" }, 'invalid package name "" in dependency "npm:"'],
     [
       "an npm alias scope with no name",
       { "x": "npm:@scope/@1" },
       'invalid package name "@scope/" in dependency "npm:@scope/@1"',
+    ],
+    [
+      "an npm alias scope with no name and a dist-tag",
+      { "x": "npm:@scope@latest" },
+      'invalid package name "@scope" in dependency "npm:@scope@latest"',
     ],
   ])("rejects %s without a registry request", async (_, dependencies, message) => {
     await withContext(defaultOpts, async ctx => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -294,6 +294,39 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it.each([
+    ["an empty name", { "": "" }, 'Dependency name cannot be empty (in "dependencies")'],
+    ["an empty name with a dist-tag", { "": "latest" }, 'Dependency name cannot be empty (in "dependencies")'],
+    ["an empty name with a range", { "": "^1" }, 'Dependency name cannot be empty (in "dependencies")'],
+    ["an npm alias with no name", { "x": "npm:@1.0.0" }, 'invalid package name "@1.0.0" in dependency "npm:@1.0.0"'],
+    ["an npm alias with no name and a dist-tag", { "x": "npm:@latest" }, 'invalid package name "@latest" in dependency "npm:@latest"'],
+    ["an npm alias with an empty version", { "x": "npm:@" }, 'invalid package name "@" in dependency "npm:@"'],
+    ["an npm alias scope with no name", { "x": "npm:@scope/@1" }, 'invalid package name "@scope/" in dependency "npm:@scope/@1"'],
+  ])("rejects %s without a registry request", async (_, dependencies, message) => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+      expect(err).toContain(message);
+      expect(out).toEqual(expect.stringContaining("bun install v1."));
+      expect(exitCode).toBe(1);
+      expect(urls).toEqual([]);
+      expect(ctx.requested).toBe(0);
+    });
+  });
+
   describe("chooses", () => {
     async function runTest(ctx: TestContext, latest: string, range: string, chosen = "0.0.5") {
       const exeName: string = {


### PR DESCRIPTION
### Problem
- `bun install` with an empty dependency key (`"dependencies": {"": "^1"}`) sends `GET <registry>/`. With `""` or `"latest"` as the value, an assert build panics first: `assertion failed: !actual.is_empty()` at `src/install/dependency.rs:1223`.
- A nameless `npm:` alias does the same: `npm:@1.0.0` requests `/@1.0.0`, `npm:@scope/@1` requests `/@scope%2f`, and a bare `npm:` is taken for a git host and runs `git clone`.
- Cause: `Package::parse_dependency` accepts an empty key, and `parse_with_tag` takes whatever precedes the version separator of an `npm:` target as the registry name. The only guard was a `debug_assert!`.

### Fix
- `parse_dependency` rejects an empty key in the root and workspace `package.json` with a located error, as it does for an unsafe folder path. npm 11 refuses the same manifest.
- The `Npm` and `DistTag` branches of `parse_with_tag` share one `npm:` splitter and check the target with the existing `is_scoped_package_name` (rejects `""`, `@`, `@x`, `@x/`). A bad target logs `invalid package name "<name>" in dependency "<spec>"` and returns `None`, like the other unsupported specs there. A bare `npm:` now infers as an alias and reaches that check.
- The `debug_assert!` goes away. An empty key inside a registry manifest stays tolerated, which #31655 relies on.
- Verified: `test/cli/install/bun-install.test.ts`, `rejects %s without a registry request` (9 cases: stock bun fails all, the fix makes zero requests), plus `bun-add.test.ts` and `regression/issue/31652.test.ts`.

### Background
- `Tag::infer` classifies a value before parsing: `^1` is `Tag::Npm`, an empty string or `latest` is `Tag::DistTag`. `npm:<name>@<spec>` is an alias: the key names the `node_modules` folder, `<name>` is what the registry serves, as `<registry>/<name>`. An empty name fetches the registry root.
- `parse_with_tag` reports errors through `bun_ast::Log`. `bun install` prints the log and exits 1 when it has errors.

<details><summary>Notes</summary>

- Variants checked against a local registry that records paths, before the fix: `{"":""}` and `{"":"latest"}` assert on debug builds and `GET /` on release. `{"":"^1"}` and `{"":"*"}` do not assert but still `GET /`. `devDependencies` behaves the same. `{"":"file:./sub"}` was already refused at install time (`refusing to install dependency with unsafe name`) and is now refused at parse time with the new message, which points at the key in `package.json`.
- npm 11.16 on the same manifests: `{"": "1.0.0"}` in `dependencies` or `optionalDependencies` fails with `could not detect node name from path or package`, `npm:@1.0.0` fails with `EINVALIDTAGNAME`, and `npm:` fails with `aliases must have a name`. All exit 1.
- `npm:@1.0.0` parses as scope `@1.0.0` with no package part, so the error names `@1.0.0` rather than an empty string. That is the string bun previously sent to the registry.
- `bun add npm:@1.0.0`, `bun add npm:` and `bun add x@npm:@scope/@1` now stop at `unrecognised dependency format` instead of requesting `/@1.0.0`, running git, or requesting `/@scope%2f`.
- Valid aliases are unchanged: `npm:foo`, `npm:foo@^1`, `npm:foo@latest`, `npm:foo@` (the tag defaults to `latest`), `npm:@scope/pkg`, `npm:@scope/pkg@^1`.
- The parser itself does not reject an empty non-alias name. Registry manifests and lockfiles can carry an empty key on an optional dependency (`test/regression/issue/31652.test.ts`), and the parser does not know whether a dependency is optional. The root manifest check covers the reported case. `@openai/codex@0.135.0`, the package from #31652, installs with this branch.
- The check is structural on purpose. A target such as `@scope/pkg/extra` still becomes one encoded path segment (`/@scope%2fpkg%2fextra`) and fails like any unknown name. Full name validation is a separate change (#34737).
- The old dist-tag branch indexed `dependency[i + 1..]` after its scan loop. That is out of bounds for an `npm:` value with no `@`, if the branch were ever reached with one. The shared helper returns an empty remainder instead.

</details>
