### PR TITLE
sys: replace the destination atomically in the cross-device move fallback

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7674,34 +7674,7 @@ pub fn move_file_z_with_handle(
             renameat(from_dir, filename, to_dir, destination)
         }
         Err(e) if e.get_errno() == E::EXDEV => {
-            // Cross-device: full `copyFileZSlowWithHandle`.
-            #[cfg(unix)]
-            let st = fstat(from_handle)?;
-            // Unlink dest first — fixes ETXTBUSY on Linux.
-            let _ = unlinkat(to_dir, destination);
-            let dst = openat(
-                to_dir,
-                destination,
-                O::WRONLY | O::CREAT | O::CLOEXEC | O::TRUNC,
-                0o644,
-            )?;
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            {
-                // Preallocation is best-effort.
-                let _ = safe_libc::fallocate(dst.native(), 0, 0, st.st_size);
-            }
-            // Seek input to 0 — caller may have left offset at EOF after writing.
-            let _ = lseek(from_handle, 0, libc::SEEK_SET);
-            let r = copy_file(from_handle, dst);
-            // Only stamp mode/owner on success; on copy error
-            // the partially-written dest keeps its openat() defaults.
-            #[cfg(unix)]
-            if r.is_ok() {
-                let _ = safe_libc::fchmod(dst.native(), st.st_mode);
-                let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
-            }
-            let _ = close(dst);
-            r?;
+            copy_file_z_slow_with_handle(from_handle, to_dir, destination)?;
             let _ = unlinkat(from_dir, filename);
             Ok(())
         }
@@ -8921,7 +8894,11 @@ pub(crate) fn move_file_z_slow(
     let _ = close(in_handle);
     r
 }
-/// `copyFileZSlowWithHandle` (POSIX read/write fallback arm).
+/// The EXDEV arm of the `move_file_z*` family. Copies `in_handle` into a
+/// temp file beside `destination`, then renames it over `destination`, so
+/// `destination` names the previous file or the complete copy at every
+/// moment. A failed copy removes the temp file and leaves `destination` as
+/// it was.
 pub(crate) fn copy_file_z_slow_with_handle(
     in_handle: Fd,
     to_dir: Fd,
@@ -8929,12 +8906,12 @@ pub(crate) fn copy_file_z_slow_with_handle(
 ) -> Maybe<()> {
     #[cfg(unix)]
     let st = fstat(in_handle)?;
-    // Unlink dest first — fixes ETXTBUSY on Linux.
-    let _ = unlinkat(to_dir, destination);
+    let mut tmp_buf = bun_paths::path_buffer_pool::get();
+    let tmp = tmpname_beside(&mut tmp_buf.0, destination.as_bytes())?;
     let dst = openat(
         to_dir,
-        destination,
-        O::WRONLY | O::CREAT | O::CLOEXEC | O::TRUNC,
+        tmp,
+        O::WRONLY | O::CREAT | O::EXCL | O::CLOEXEC,
         0o644,
     )?;
     #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -8943,16 +8920,52 @@ pub(crate) fn copy_file_z_slow_with_handle(
         let _ = safe_libc::fallocate(dst.native(), 0, 0, st.st_size);
     }
     let _ = lseek(in_handle, 0, libc::SEEK_SET);
-    let r = copy_file(in_handle, dst);
-    // Only stamp mode/owner on success; on copy error the
-    // partially-written dest keeps its openat() defaults.
+    let mut r = copy_file(in_handle, dst);
     #[cfg(unix)]
     if r.is_ok() {
         let _ = safe_libc::fchmod(dst.native(), st.st_mode);
         let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
     }
     let _ = close(dst);
+    if r.is_ok() {
+        r = renameat(to_dir, tmp, to_dir, destination);
+    }
+    if r.is_err() {
+        let _ = unlinkat(to_dir, tmp);
+    }
     r
+}
+
+/// Writes `dir/.base.<16 hex digits>.tmp` into `buf` for a `dest` of
+/// `dir/base`. The result is in the same directory as `dest`, so a rename
+/// from it onto `dest` never crosses a filesystem.
+fn tmpname_beside<'a>(buf: &'a mut [u8], dest: &[u8]) -> Maybe<&'a ZStr> {
+    let split = if cfg!(windows) {
+        bun_core::strings::last_index_of_any(dest, b"/\\:")
+    } else {
+        bun_core::strings::last_index_of_char(dest, b'/')
+    }
+    .map_or(0, |i| i + 1);
+    let (dir, base) = dest.split_at(split);
+    // Keep the new component well under NAME_MAX. Cut at a UTF-8 boundary.
+    let mut keep = base.len().min(128);
+    while keep < base.len() && keep > 0 && (base[keep] & 0xC0) == 0x80 {
+        keep -= 1;
+    }
+    let mut rand = [0u8; 16];
+    bun_core::fmt::bytes_to_hex_lower(&bun_core::fast_random().to_ne_bytes(), &mut rand);
+    let parts: [&[u8]; 6] = [dir, b".", &base[..keep], b".", &rand, b".tmp"];
+    let len: usize = parts.iter().map(|p| p.len()).sum();
+    if len >= buf.len() {
+        return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::open).with_path(dest));
+    }
+    let mut at = 0;
+    for part in parts {
+        buf[at..at + part.len()].copy_from_slice(part);
+        at += part.len();
+    }
+    buf[len] = 0;
+    Ok(ZStr::from_buf(buf, len))
 }
 /// `renameatZ` alias (bun_install reaches for it as the NUL-terminated form).
 #[inline]
@@ -9028,9 +9041,11 @@ pub(crate) fn renameat_concurrently_without_fallback(
                     ..Default::default()
                 },
             ) {
-                // if ENOENT don't retry
+                // ENOENT: there is nothing to move. EXDEV: no rename of this
+                // pair can succeed, so the delete-tree below would remove `to`
+                // for nothing. The caller decides whether to copy instead.
                 Err(err) => {
-                    if err.get_errno() == E::ENOENT {
+                    if matches!(err.get_errno(), E::ENOENT | E::EXDEV) {
                         return Err(err);
                     }
                     err

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8894,11 +8894,8 @@ pub(crate) fn move_file_z_slow(
     let _ = close(in_handle);
     r
 }
-/// The EXDEV arm of the `move_file_z*` family. Copies `in_handle` into a
-/// temp file beside `destination`, then renames it over `destination`, so
-/// `destination` names the previous file or the complete copy at every
-/// moment. A failed copy removes the temp file and leaves `destination` as
-/// it was.
+/// EXDEV arm of the `move_file_z*` family: copy into a temp file beside
+/// `destination`, then rename it into place. `destination` is never partial.
 pub(crate) fn copy_file_z_slow_with_handle(
     in_handle: Fd,
     to_dir: Fd,
@@ -8926,7 +8923,7 @@ pub(crate) fn copy_file_z_slow_with_handle(
         let _ = safe_libc::fchmod(dst.native(), st.st_mode);
         let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
     }
-    // Some filesystems (NFS) report a deferred write error only here.
+    // NFS reports a deferred write error only at close().
     let closed = close(dst);
     if r.is_ok() {
         r = closed;
@@ -8940,9 +8937,8 @@ pub(crate) fn copy_file_z_slow_with_handle(
     r
 }
 
-/// Writes `dir/.base.<16 hex digits>.tmp` into `buf` for a `dest` of
-/// `dir/base`. The result is in the same directory as `dest`, so a rename
-/// from it onto `dest` never crosses a filesystem.
+/// `dir/.base.<16 hex digits>.tmp` for a `dest` of `dir/base`. Same
+/// directory, so the rename onto `dest` cannot cross a filesystem.
 fn tmpname_beside<'a>(buf: &'a mut [u8], dest: &[u8]) -> Maybe<&'a ZStr> {
     let split = if cfg!(windows) {
         bun_core::strings::last_index_of_any(dest, b"/\\:")
@@ -9045,9 +9041,8 @@ pub(crate) fn renameat_concurrently_without_fallback(
                     ..Default::default()
                 },
             ) {
-                // ENOENT: there is nothing to move. EXDEV: no rename of this
-                // pair can succeed, so the delete-tree below would remove `to`
-                // for nothing. The caller decides whether to copy instead.
+                // ENOENT: nothing to move. EXDEV: no rename of this pair can
+                // succeed, so do not delete `to` for it below.
                 Err(err) => {
                     if matches!(err.get_errno(), E::ENOENT | E::EXDEV) {
                         return Err(err);
@@ -9084,10 +9079,8 @@ pub(crate) fn renameat_concurrently_without_fallback(
             }
         }
 
-        // Sad path: the flagged renames are unsupported (FreeBSD, NFS,
-        // Windows) or the exchange failed. A plain rename still replaces a
-        // file atomically. Only when that fails too (a directory is in the
-        // way) is `to` deleted first.
+        // Sad path (no NOREPLACE/EXCHANGE support, or the exchange failed).
+        // A plain rename replaces a file; delete `to` only if it is in the way.
         let err = match renameat(from_dir_fd, from, to_dir_fd, to) {
             Ok(()) => break 'attempt,
             Err(err) => err,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8894,8 +8894,7 @@ pub(crate) fn move_file_z_slow(
     let _ = close(in_handle);
     r
 }
-/// EXDEV arm of the `move_file_z*` family: copy into a temp file beside
-/// `destination`, then rename it into place. `destination` is never partial.
+/// EXDEV fallback: copy into a temp file beside `destination`, then rename over it.
 pub(crate) fn copy_file_z_slow_with_handle(
     in_handle: Fd,
     to_dir: Fd,
@@ -8937,8 +8936,7 @@ pub(crate) fn copy_file_z_slow_with_handle(
     r
 }
 
-/// `dir/.base.<16 hex digits>.tmp` for a `dest` of `dir/base`. Same
-/// directory, so the rename onto `dest` cannot cross a filesystem.
+/// `dir/.base.<hex>.tmp` for a `dest` of `dir/base`, so the final rename stays in one directory.
 fn tmpname_beside<'a>(buf: &'a mut [u8], dest: &[u8]) -> Maybe<&'a ZStr> {
     let split = if cfg!(windows) {
         bun_core::strings::last_index_of_any(dest, b"/\\:")
@@ -9041,8 +9039,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
                     ..Default::default()
                 },
             ) {
-                // ENOENT: nothing to move. EXDEV: no rename of this pair can
-                // succeed, so do not delete `to` for it below.
+                // ENOENT: nothing to move. EXDEV: cannot succeed, so do not delete `to` for it.
                 Err(err) => {
                     if matches!(err.get_errno(), E::ENOENT | E::EXDEV) {
                         return Err(err);
@@ -9079,8 +9076,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
             }
         }
 
-        // Sad path (no NOREPLACE/EXCHANGE support, or the exchange failed).
-        // A plain rename replaces a file; delete `to` only if it is in the way.
+        // A plain rename still replaces a file atomically; delete `to` only if it is in the way.
         let err = match renameat(from_dir_fd, from, to_dir_fd, to) {
             Ok(()) => break 'attempt,
             Err(err) => err,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8921,12 +8921,10 @@ pub(crate) fn copy_file_z_slow_with_handle(
     if r.is_ok() {
         let _ = safe_libc::fchmod(dst.native(), st.st_mode);
         let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
+        // Deferred write errors (NFS, delayed allocation) surface here; close() drops them.
+        r = fsync(dst);
     }
-    // NFS reports a deferred write error only at close().
-    let closed = close(dst);
-    if r.is_ok() {
-        r = closed;
-    }
+    let _ = close(dst);
     if r.is_ok() {
         r = renameat(to_dir, tmp, to_dir, destination);
     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8926,7 +8926,11 @@ pub(crate) fn copy_file_z_slow_with_handle(
         let _ = safe_libc::fchmod(dst.native(), st.st_mode);
         let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
     }
-    let _ = close(dst);
+    // Some filesystems (NFS) report a deferred write error only here.
+    let closed = close(dst);
+    if r.is_ok() {
+        r = closed;
+    }
     if r.is_ok() {
         r = renameat(to_dir, tmp, to_dir, destination);
     }
@@ -9080,16 +9084,23 @@ pub(crate) fn renameat_concurrently_without_fallback(
             }
         }
 
-        //  sad path: let's try to delete the folder and then rename it
+        // Sad path: the flagged renames are unsupported (FreeBSD, NFS,
+        // Windows) or the exchange failed. A plain rename still replaces a
+        // file atomically. Only when that fails too (a directory is in the
+        // way) is `to` deleted first.
+        let err = match renameat(from_dir_fd, from, to_dir_fd, to) {
+            Ok(()) => break 'attempt,
+            Err(err) => err,
+        };
+        if matches!(err.get_errno(), E::ENOENT | E::EXDEV) {
+            return Err(err);
+        }
         if to_dir_fd.is_valid() {
             let _ = Dir::borrow(&to_dir_fd).delete_tree(to.as_bytes());
         } else {
             let _ = delete_tree_absolute(to.as_bytes());
         }
-        match renameat(from_dir_fd, from, to_dir_fd, to) {
-            Err(err) => return Err(err),
-            Ok(()) => {}
-        }
+        renameat(from_dir_fd, from, to_dir_fd, to)?;
     }
 
     Ok(())

--- a/test/cli/install/bun-patch-xdev-fixture.ts
+++ b/test/cli/install/bun-patch-xdev-fixture.ts
@@ -1,0 +1,103 @@
+// Driver for the "project and cache on different filesystems" test in
+// bun-patch.test.ts. It runs on its own so that the test can wrap it in
+// `unshare -Urm` and give `proj` a private tmpfs that no other process sees.
+//
+// usage: bun bun-patch-xdev-fixture.ts <proj> <cache>
+//
+// <proj> is an empty directory on a small filesystem that this script may
+// fill. <cache> is a directory on another filesystem. Prints one JSON line.
+import { spawnSync } from "bun";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statfsSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const [proj, cache] = process.argv.slice(2);
+const env = { ...process.env, BUN_INSTALL_CACHE_DIR: cache };
+
+function run(...args: string[]) {
+  const proc = spawnSync({ cmd: [process.execPath, ...args], cwd: proj, env, stdout: "pipe", stderr: "pipe" });
+  return { exitCode: proc.exitCode, stderr: proc.stderr.toString() };
+}
+
+// Fills the filesystem `proj` is on until `leaveFree` bytes are left.
+function fillFilesystem(leaveFree: number) {
+  const limit = statfsSync(proj).blocks * statfsSync(proj).bsize;
+  writeFileSync(join(proj, "reserve"), Buffer.alloc(leaveFree, 1));
+  const chunk = Buffer.alloc(1024 * 1024, 1);
+  let written = 0;
+  let full = false;
+  for (let size = chunk.length; size >= 4096; size = size / 16) {
+    try {
+      while (written <= limit) {
+        writeFileSync(join(proj, "filler"), chunk.subarray(0, size), { flag: "a" });
+        written += size;
+      }
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOSPC") throw e;
+      full = true;
+    }
+  }
+  rmSync(join(proj, "reserve"));
+  if (!full) throw new Error(`wrote ${written} bytes to ${proj} without ENOSPC`);
+}
+
+const result: Record<string, unknown> = {};
+try {
+  result.sameDevice = statSync(proj).dev === statSync(cache).dev;
+
+  // ~400 KB of source, so that a patch that touches every line is far larger
+  // than the space left free below.
+  const lines = Array.from({ length: 8000 }, (_, i) => `exports.v${i} = ${i}; // padding padding padding`);
+  mkdirSync(join(proj, "tarball-src", "package", "lib"), { recursive: true });
+  writeFileSync(
+    join(proj, "tarball-src", "package", "package.json"),
+    JSON.stringify({ name: "big-pkg", version: "1.0.0", main: "lib/big.js" }),
+  );
+  writeFileSync(join(proj, "tarball-src", "package", "lib", "big.js"), lines.join("\n") + "\n");
+  const tar = spawnSync({
+    cmd: ["tar", "-czf", join(proj, "big-pkg-1.0.0.tgz"), "-C", join(proj, "tarball-src"), "package"],
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  if (tar.exitCode !== 0) throw new Error(`tar exited with ${tar.exitCode}`);
+  rmSync(join(proj, "tarball-src"), { recursive: true });
+  writeFileSync(
+    join(proj, "package.json"),
+    JSON.stringify({ name: "proj", dependencies: { "big-pkg": "file:./big-pkg-1.0.0.tgz" } }),
+  );
+
+  // Commit a small patch first. This is the file that has to survive.
+  result.install = run("install");
+  result.patch1 = run("patch", "big-pkg");
+  writeFileSync(join(proj, "node_modules", "big-pkg", "lib", "big.js"), lines.join("\n") + "\n// small change\n");
+  result.commit1 = run("patch", "--commit", "node_modules/big-pkg");
+  const names = readdirSync(join(proj, "patches"));
+  const firstPatch = readFileSync(join(proj, "patches", names[0]), "utf8");
+  result.firstPatch = { names, size: Buffer.byteLength(firstPatch), text: firstPatch };
+
+  // Now prepare a patch that changes every line, and take away the space it
+  // would need.
+  result.patch2 = run("patch", "big-pkg");
+  writeFileSync(
+    join(proj, "node_modules", "big-pkg", "lib", "big.js"),
+    lines.map(line => line.replace("padding", "PATCHED")).join("\n") + "\n",
+  );
+  fillFilesystem(128 * 1024);
+  try {
+    result.commit2 = run("patch", "--commit", "node_modules/big-pkg");
+  } finally {
+    rmSync(join(proj, "filler"), { force: true });
+  }
+  const after = readdirSync(join(proj, "patches"));
+  const afterText = after.includes(names[0]) ? readFileSync(join(proj, "patches", names[0]), "utf8") : null;
+  result.after = { names: after, size: afterText === null ? null : Buffer.byteLength(afterText), text: afterText };
+
+  // And the surviving patch still applies.
+  rmSync(join(proj, "node_modules"), { recursive: true, force: true });
+  result.reinstall = run("install");
+  const bigJsPath = join(proj, "node_modules", "big-pkg", "lib", "big.js");
+  const bigJs = existsSync(bigJsPath) ? readFileSync(bigJsPath, "utf8") : "\n";
+  result.lastLine = bigJs.slice(bigJs.lastIndexOf("\n", bigJs.length - 2) + 1);
+} catch (e) {
+  result.error = String((e as Error)?.stack ?? e);
+}
+console.log(JSON.stringify(result));

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,7 +1,19 @@
 import { $, ShellOutput } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { lstatSync, readFileSync } from "fs";
-import { bunEnv, bunExe, isASAN, tempDir, VerdaccioRegistry } from "harness";
+import {
+  accessSync,
+  constants,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statfsSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { bunEnv, bunExe, isASAN, isLinux, tempDir, VerdaccioRegistry } from "harness";
+import { tmpdir } from "os";
 import { isAbsolute, join, sep } from "path";
 
 const expectNoError = (o: ShellOutput) => expect(o.stderr.toString()).not.toContain("error");
@@ -1230,5 +1242,151 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
     // name-only argument exercises the name-and-version lookup path
     const patchKey = await expectPatchFlowWorks(String(dir), env, "pkg-to-patch");
     expect(patchKey).toBe("pkg-to-patch@./dep.tgz");
+  });
+});
+
+// `bun patch --commit` writes the patch into the install cache's temp dir and
+// renames it into patches/. With the project on another filesystem that rename
+// fails with EXDEV and bun copies instead. The copy goes to a temp file next
+// to the destination that is renamed into place, so a copy that fails part way
+// (here: the disk fills up) leaves the previous patch file as it was.
+describe("bun patch --commit with the project and the cache on different filesystems", () => {
+  // The project goes on a small dedicated tmpfs that the test fills for a
+  // moment: Debian's 5 MB /run/lock, or the 64 MB /dev/shm of a container. It
+  // must not be the filesystem that holds the temp dir, where the cache goes.
+  const smallFsLimit = 128 * 1024 * 1024;
+  function findSmallFilesystem(): string | undefined {
+    if (!isLinux) return undefined;
+    const cacheDev = statSync(tmpdir()).dev;
+    for (const candidate of ["/run/lock", "/dev/shm"]) {
+      try {
+        const dev = statSync(candidate).dev;
+        // a mount of its own, so that filling it fills nothing else
+        if (dev === cacheDev || dev === statSync(join(candidate, "..")).dev) continue;
+        accessSync(candidate, constants.W_OK | constants.X_OK);
+        const fsStat = statfsSync(candidate);
+        if (fsStat.blocks * fsStat.bsize > smallFsLimit) continue;
+        if (fsStat.bavail * fsStat.bsize < 3 * 1024 * 1024) continue;
+        return candidate;
+      } catch {}
+    }
+    return undefined;
+  }
+  const smallFs = findSmallFilesystem();
+
+  async function run(cwd: string, env: Record<string, string | undefined>, ...args: string[]) {
+    await using proc = Bun.spawn({ cmd: [bunExe(), ...args], env, cwd, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Fills the filesystem `dir` is on until `leaveFree` bytes are left.
+  function fillFilesystem(dir: string, leaveFree: number) {
+    writeFileSync(join(dir, "reserve"), Buffer.alloc(leaveFree, 1));
+    const chunk = Buffer.alloc(1024 * 1024, 1);
+    let written = 0;
+    for (let size = chunk.length; size >= 4096; size = size / 16) {
+      try {
+        while (written < smallFsLimit) {
+          writeFileSync(join(dir, "filler"), chunk.subarray(0, size), { flag: "a" });
+          written += size;
+        }
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOSPC") throw e;
+      }
+    }
+    rmSync(join(dir, "reserve"));
+  }
+
+  test.skipIf(!smallFs)("a copy that runs out of space keeps the previous patch", async () => {
+    using cacheDir = tempDir("patch-xdev-cache", {});
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) };
+    const proj = join(smallFs!, `bun-patch-xdev-${process.pid}`);
+    rmSync(proj, { recursive: true, force: true });
+    mkdirSync(proj);
+    try {
+      expect(statSync(proj).dev).not.toBe(statSync(String(cacheDir)).dev);
+
+      // ~400 KB of source, so that a patch that touches every line is far
+      // larger than the space the test leaves free.
+      const lines = Array.from({ length: 8000 }, (_, i) => `exports.v${i} = ${i}; // padding padding padding`);
+      mkdirSync(join(proj, "tarball-src", "package", "lib"), { recursive: true });
+      writeFileSync(
+        join(proj, "tarball-src", "package", "package.json"),
+        JSON.stringify({ name: "big-pkg", version: "1.0.0", main: "lib/big.js" }),
+      );
+      writeFileSync(join(proj, "tarball-src", "package", "lib", "big.js"), lines.join("\n") + "\n");
+      {
+        await using tar = Bun.spawn({
+          cmd: ["tar", "-czf", join(proj, "big-pkg-1.0.0.tgz"), "-C", join(proj, "tarball-src"), "package"],
+          env: bunEnv,
+          stdout: "inherit",
+          stderr: "inherit",
+        });
+        expect(await tar.exited).toBe(0);
+      }
+      rmSync(join(proj, "tarball-src"), { recursive: true });
+      writeFileSync(
+        join(proj, "package.json"),
+        JSON.stringify({ name: "proj", dependencies: { "big-pkg": "file:./big-pkg-1.0.0.tgz" } }),
+      );
+
+      // Commit a small patch first. This is the file that has to survive.
+      {
+        const { stderr, exitCode } = await run(proj, env, "install");
+        expect(exitCode, stderr).toBe(0);
+      }
+      {
+        const { stderr, exitCode } = await run(proj, env, "patch", "big-pkg");
+        expect(exitCode, stderr).toBe(0);
+      }
+      writeFileSync(join(proj, "node_modules", "big-pkg", "lib", "big.js"), lines.join("\n") + "\n// small change\n");
+      {
+        const { stderr, exitCode } = await run(proj, env, "patch", "--commit", "node_modules/big-pkg");
+        expect(exitCode, stderr).toBe(0);
+      }
+      const patchFiles = readdirSync(join(proj, "patches"));
+      expect(patchFiles).toHaveLength(1);
+      const patchFile = join(proj, "patches", patchFiles[0]);
+      const firstPatch = readFileSync(patchFile, "utf8");
+      expect(firstPatch).toContain("+// small change");
+
+      // Now prepare a patch that changes every line, and take away the space
+      // it would need.
+      {
+        const { stderr, exitCode } = await run(proj, env, "patch", "big-pkg");
+        expect(exitCode, stderr).toBe(0);
+      }
+      writeFileSync(
+        join(proj, "node_modules", "big-pkg", "lib", "big.js"),
+        lines.map(line => line.replace("padding", "PATCHED")).join("\n") + "\n",
+      );
+      let result: Awaited<ReturnType<typeof run>>;
+      fillFilesystem(proj, 128 * 1024);
+      try {
+        result = await run(proj, env, "patch", "--commit", "node_modules/big-pkg");
+      } finally {
+        rmSync(join(proj, "filler"), { force: true });
+      }
+      expect(result.stderr).toContain("ENOSPC");
+      expect(result.exitCode).toBe(1);
+      // The previous patch is untouched and nothing else is left in patches/.
+      expect(statSync(patchFile).size).toBe(Buffer.byteLength(firstPatch));
+      expect(readFileSync(patchFile, "utf8")).toBe(firstPatch);
+      expect(readdirSync(join(proj, "patches"))).toEqual(patchFiles);
+
+      // And it still applies.
+      rmSync(join(proj, "node_modules"), { recursive: true, force: true });
+      {
+        const { stderr, exitCode } = await run(proj, env, "install");
+        expect(stderr).not.toContain("failed to apply patchfile");
+        expect(exitCode, stderr).toBe(0);
+      }
+      expect(readFileSync(join(proj, "node_modules", "big-pkg", "lib", "big.js"), "utf8")).toEndWith(
+        "// small change\n",
+      );
+    } finally {
+      rmSync(proj, { recursive: true, force: true });
+    }
   });
 });

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,18 +1,7 @@
 import { $, ShellOutput } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import {
-  accessSync,
-  constants,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  statfsSync,
-  statSync,
-  writeFileSync,
-} from "fs";
-import { bunEnv, bunExe, isASAN, isLinux, tempDir, VerdaccioRegistry } from "harness";
+import { accessSync, constants, lstatSync, mkdirSync, readFileSync, rmSync, statfsSync, statSync } from "fs";
+import { bunEnv, bunExe, isASAN, isLinux, tempDir, tmpdirSync, VerdaccioRegistry } from "harness";
 import { tmpdir } from "os";
 import { isAbsolute, join, sep } from "path";
 
@@ -1250,141 +1239,84 @@ describe.concurrent("bun patch --commit for non-registry dependencies", () => {
 // fails with EXDEV and bun copies instead. The copy goes to a temp file next
 // to the destination that is renamed into place, so a copy that fails part way
 // (here: the disk fills up) leaves the previous patch file as it was.
+//
+// The steps run in bun-patch-xdev-fixture.ts. The project needs a small
+// filesystem of its own that the fixture may fill for a moment:
+// - where unprivileged user namespaces work, a private tmpfs that only the
+//   fixture and its children can see (`unshare -Urm` + `mount -t tmpfs`),
+// - else, inside a container, its /dev/shm (at most 128 MB, a mount of its
+//   own, and not the filesystem of the temp dir where the cache goes),
+// - else the test skips.
 describe("bun patch --commit with the project and the cache on different filesystems", () => {
-  // The project goes on a small dedicated tmpfs that the test fills for a
-  // moment: Debian's 5 MB /run/lock, or the 64 MB /dev/shm of a container. It
-  // must not be the filesystem that holds the temp dir, where the cache goes.
-  const smallFsLimit = 128 * 1024 * 1024;
-  function findSmallFilesystem(): string | undefined {
+  function inPrivateTmpfs(dir: string, ...cmd: string[]) {
+    const script = 'mount -t tmpfs -o size=16m tmpfs "$1" && shift && exec "$@"';
+    return ["unshare", "-Urm", "sh", "-c", script, "sh", dir, ...cmd];
+  }
+  function findProjectFilesystem(): "private" | "shm" | undefined {
     if (!isLinux) return undefined;
-    const cacheDev = statSync(tmpdir()).dev;
-    for (const candidate of ["/run/lock", "/dev/shm"]) {
-      try {
-        const dev = statSync(candidate).dev;
-        // a mount of its own, so that filling it fills nothing else
-        if (dev === cacheDev || dev === statSync(join(candidate, "..")).dev) continue;
-        accessSync(candidate, constants.W_OK | constants.X_OK);
-        const fsStat = statfsSync(candidate);
-        if (fsStat.blocks * fsStat.bsize > smallFsLimit) continue;
-        if (fsStat.bavail * fsStat.bsize < 3 * 1024 * 1024) continue;
-        return candidate;
-      } catch {}
+    const probeDir = tmpdirSync();
+    try {
+      const probe = Bun.spawnSync({
+        cmd: inPrivateTmpfs(probeDir, "true"),
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      if (probe.exitCode === 0) return "private";
+    } catch {
+    } finally {
+      rmSync(probeDir, { recursive: true, force: true });
     }
+    try {
+      const dev = statSync("/dev/shm").dev;
+      if (dev === statSync(tmpdir()).dev || dev === statSync("/dev").dev) return undefined;
+      accessSync("/dev/shm", constants.W_OK | constants.X_OK);
+      const fsStat = statfsSync("/dev/shm");
+      if (fsStat.blocks * fsStat.bsize > 128 * 1024 * 1024) return undefined;
+      if (fsStat.bavail * fsStat.bsize < 3 * 1024 * 1024) return undefined;
+      return "shm";
+    } catch {}
     return undefined;
   }
-  const smallFs = findSmallFilesystem();
+  const projectFs = findProjectFilesystem();
 
-  async function run(cwd: string, env: Record<string, string | undefined>, ...args: string[]) {
-    await using proc = Bun.spawn({ cmd: [bunExe(), ...args], env, cwd, stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
-  }
-
-  // Fills the filesystem `dir` is on until `leaveFree` bytes are left.
-  function fillFilesystem(dir: string, leaveFree: number) {
-    writeFileSync(join(dir, "reserve"), Buffer.alloc(leaveFree, 1));
-    const chunk = Buffer.alloc(1024 * 1024, 1);
-    let written = 0;
-    for (let size = chunk.length; size >= 4096; size = size / 16) {
-      try {
-        while (written < smallFsLimit) {
-          writeFileSync(join(dir, "filler"), chunk.subarray(0, size), { flag: "a" });
-          written += size;
-        }
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException).code !== "ENOSPC") throw e;
-      }
-    }
-    rmSync(join(dir, "reserve"));
-  }
-
-  test.skipIf(!smallFs)("a copy that runs out of space keeps the previous patch", async () => {
-    using cacheDir = tempDir("patch-xdev-cache", {});
-    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: String(cacheDir) };
-    const proj = join(smallFs!, `bun-patch-xdev-${process.pid}`);
+  test.skipIf(!projectFs)("a copy that runs out of space keeps the previous patch", async () => {
+    using dir = tempDir("patch-xdev", { cache: {} });
+    const cache = join(String(dir), "cache");
+    const proj = projectFs === "shm" ? join("/dev/shm", `bun-patch-xdev-${process.pid}`) : join(String(dir), "proj");
     rmSync(proj, { recursive: true, force: true });
     mkdirSync(proj);
     try {
-      expect(statSync(proj).dev).not.toBe(statSync(String(cacheDir)).dev);
+      const fixture = [bunExe(), join(import.meta.dir, "bun-patch-xdev-fixture.ts"), proj, cache];
+      await using proc = Bun.spawn({
+        cmd: projectFs === "private" ? inPrivateTmpfs(proj, ...fixture) : fixture,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout, stderr).toContain("{");
+      const result = JSON.parse(stdout.slice(stdout.lastIndexOf("\n{") + 1));
+      expect(result.error).toBeUndefined();
+      expect(result.sameDevice).toBe(false);
+      for (const step of ["install", "patch1", "commit1", "patch2"]) {
+        expect(result[step].exitCode, `${step}: ${result[step].stderr}`).toBe(0);
+      }
+      expect(result.firstPatch.names).toHaveLength(1);
+      expect(result.firstPatch.text).toContain("+// small change");
 
-      // ~400 KB of source, so that a patch that touches every line is far
-      // larger than the space the test leaves free.
-      const lines = Array.from({ length: 8000 }, (_, i) => `exports.v${i} = ${i}; // padding padding padding`);
-      mkdirSync(join(proj, "tarball-src", "package", "lib"), { recursive: true });
-      writeFileSync(
-        join(proj, "tarball-src", "package", "package.json"),
-        JSON.stringify({ name: "big-pkg", version: "1.0.0", main: "lib/big.js" }),
-      );
-      writeFileSync(join(proj, "tarball-src", "package", "lib", "big.js"), lines.join("\n") + "\n");
-      {
-        await using tar = Bun.spawn({
-          cmd: ["tar", "-czf", join(proj, "big-pkg-1.0.0.tgz"), "-C", join(proj, "tarball-src"), "package"],
-          env: bunEnv,
-          stdout: "inherit",
-          stderr: "inherit",
-        });
-        expect(await tar.exited).toBe(0);
-      }
-      rmSync(join(proj, "tarball-src"), { recursive: true });
-      writeFileSync(
-        join(proj, "package.json"),
-        JSON.stringify({ name: "proj", dependencies: { "big-pkg": "file:./big-pkg-1.0.0.tgz" } }),
-      );
-
-      // Commit a small patch first. This is the file that has to survive.
-      {
-        const { stderr, exitCode } = await run(proj, env, "install");
-        expect(exitCode, stderr).toBe(0);
-      }
-      {
-        const { stderr, exitCode } = await run(proj, env, "patch", "big-pkg");
-        expect(exitCode, stderr).toBe(0);
-      }
-      writeFileSync(join(proj, "node_modules", "big-pkg", "lib", "big.js"), lines.join("\n") + "\n// small change\n");
-      {
-        const { stderr, exitCode } = await run(proj, env, "patch", "--commit", "node_modules/big-pkg");
-        expect(exitCode, stderr).toBe(0);
-      }
-      const patchFiles = readdirSync(join(proj, "patches"));
-      expect(patchFiles).toHaveLength(1);
-      const patchFile = join(proj, "patches", patchFiles[0]);
-      const firstPatch = readFileSync(patchFile, "utf8");
-      expect(firstPatch).toContain("+// small change");
-
-      // Now prepare a patch that changes every line, and take away the space
-      // it would need.
-      {
-        const { stderr, exitCode } = await run(proj, env, "patch", "big-pkg");
-        expect(exitCode, stderr).toBe(0);
-      }
-      writeFileSync(
-        join(proj, "node_modules", "big-pkg", "lib", "big.js"),
-        lines.map(line => line.replace("padding", "PATCHED")).join("\n") + "\n",
-      );
-      let result: Awaited<ReturnType<typeof run>>;
-      fillFilesystem(proj, 128 * 1024);
-      try {
-        result = await run(proj, env, "patch", "--commit", "node_modules/big-pkg");
-      } finally {
-        rmSync(join(proj, "filler"), { force: true });
-      }
-      expect(result.stderr).toContain("ENOSPC");
-      expect(result.exitCode).toBe(1);
+      expect(result.commit2.stderr).toContain("ENOSPC");
+      expect(result.commit2.exitCode).toBe(1);
       // The previous patch is untouched and nothing else is left in patches/.
-      expect(statSync(patchFile).size).toBe(Buffer.byteLength(firstPatch));
-      expect(readFileSync(patchFile, "utf8")).toBe(firstPatch);
-      expect(readdirSync(join(proj, "patches"))).toEqual(patchFiles);
+      expect(result.after.size).toBe(result.firstPatch.size);
+      expect(result.after.text).toBe(result.firstPatch.text);
+      expect(result.after.names).toEqual(result.firstPatch.names);
 
       // And it still applies.
-      rmSync(join(proj, "node_modules"), { recursive: true, force: true });
-      {
-        const { stderr, exitCode } = await run(proj, env, "install");
-        expect(stderr).not.toContain("failed to apply patchfile");
-        expect(exitCode, stderr).toBe(0);
-      }
-      expect(readFileSync(join(proj, "node_modules", "big-pkg", "lib", "big.js"), "utf8")).toEndWith(
-        "// small change\n",
-      );
+      expect(result.reinstall.stderr).not.toContain("failed to apply patchfile");
+      expect(result.reinstall.exitCode, result.reinstall.stderr).toBe(0);
+      expect(result.lastLine).toBe("// small change\n");
+      expect(exitCode, stderr).toBe(0);
     } finally {
       rmSync(proj, { recursive: true, force: true });
     }

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,7 +1,7 @@
 import { $, ShellOutput } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { accessSync, constants, lstatSync, mkdirSync, readFileSync, rmSync, statfsSync, statSync } from "fs";
-import { bunEnv, bunExe, isASAN, isLinux, tempDir, tmpdirSync, VerdaccioRegistry } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, tempDir, VerdaccioRegistry } from "harness";
 import { tmpdir } from "os";
 import { isAbsolute, join, sep } from "path";
 
@@ -1254,19 +1254,16 @@ describe("bun patch --commit with the project and the cache on different filesys
   }
   function findProjectFilesystem(): "private" | "shm" | undefined {
     if (!isLinux) return undefined;
-    const probeDir = tmpdirSync();
     try {
+      using probeDir = tempDir("patch-xdev-probe", {});
       const probe = Bun.spawnSync({
-        cmd: inPrivateTmpfs(probeDir, "true"),
+        cmd: inPrivateTmpfs(String(probeDir), "true"),
         env: bunEnv,
         stdout: "ignore",
         stderr: "ignore",
       });
       if (probe.exitCode === 0) return "private";
-    } catch {
-    } finally {
-      rmSync(probeDir, { recursive: true, force: true });
-    }
+    } catch {}
     try {
       const dev = statSync("/dev/shm").dev;
       if (dev === statSync(tmpdir()).dev || dev === statSync("/dev").dev) return undefined;


### PR DESCRIPTION
### Problem
- `bun patch --commit` with the install cache on another filesystem than the project can lose the previous `patches/<pkg>.patch`. A full disk fails the move with `ENOSPC: No space left on device: failed renaming patch file to patches dir (write)` and leaves a truncated patch under the final name. The next `bun install` fails with `hunk_header_integrity_check_failed`.
- Two places in `src/sys/lib.rs` destroy the destination early. `renameat_concurrently_without_fallback` answers `EXDEV` with `delete_tree(dest)` plus a `renameat` that fails with `EXDEV` again. Then `copy_file_z_slow_with_handle` unlinks the destination, creates it with `O_TRUNC` and copies into it.

### Fix
- `renameat_concurrently_without_fallback` returns `EXDEV` at once, like `ENOENT`. Its last resort now tries a plain `renameat` first and deletes the destination only when that rename fails for another reason (a directory is in the way).
- `copy_file_z_slow_with_handle` copies into `dir/.base.<hex>.tmp` (`O_EXCL`) beside the destination, `fsync`s it, then renames it over the destination. A failed copy unlinks the temp file. `move_file_z_with_handle` calls it instead of an inline duplicate.
- Correct because the final rename stays inside one directory. The destination names the previous file or the complete copy at every moment.
- Verified: `test/cli/install/bun-patch.test.ts` (new test, bun 1.4.3 leaves a 135168 byte torn patch). Also the rest of that file, `bun-install-patch.test.ts`, the lcov tests, `cargo check -p bun_sys` on four targets.

### Background
- `rename(2)` replaces a name atomically, but only inside one filesystem. Across filesystems it fails with `EXDEV` and the caller has to copy.
- `move_file_z`, `move_file_z_with_handle` and `renameat_concurrently` share this `EXDEV` arm. Callers: `bun patch --commit`, `bun upgrade`, `--compile --outfile`, the lcov writer.
- `renameat_concurrently_without_fallback` tries `RENAME_NOREPLACE`, then `RENAME_EXCHANGE`, then delete-tree plus rename. It publishes directories into the install cache.

<details><summary>Notes</summary>

This layout is common: a devcontainer or docker build with the project bind-mounted, a CI cache volume, `BUN_INSTALL_CACHE_DIR` on another disk. A kill during the copy tears the file the same way as `ENOSPC` did.

Repro without root, bun 1.4.3, project on `/dev/shm` (64 MB tmpfs), cache on `/tmp`:

```sh
export BUN_INSTALL_CACHE_DIR=/tmp/cache; cd /dev/shm/proj
# package.json depends on file:./markerbig-1.0.0.tgz (4000 line lib/big.js)
bun install && bun patch markerbig
echo '// small' >> node_modules/markerbig/lib/big.js && bun patch --commit node_modules/markerbig
stat -c %s patches/*.patch                       # 430
bun patch markerbig && sed -i 's/padding padding/PATCHED PATCHED/' node_modules/markerbig/lib/big.js
dd if=/dev/zero of=filler bs=1k count=$(( $(df -k --output=avail . | tail -1) - 100 ))
bun patch --commit node_modules/markerbig        # ENOSPC ... (write), exit 1
stat -c %s patches/*.patch                       # 106496, cut mid-hunk
rm filler; rm -rf node_modules; bun install      # hunk_header_integrity_check_failed
```

With this branch the second `stat` prints 430, `bun install` applies the patch, and nothing is left in `patches/` or in the cache temp dir. A cross-filesystem commit with enough space writes the complete 459971 byte patch with mode 0644.

strace of the unfixed move, for reference:

```
renameat2(cachetmp, ".3e9d…tmp", AT_FDCWD, "patches/markerbig@1.0.0.patch", RENAME_NOREPLACE) = -1 EXDEV
unlinkat(AT_FDCWD, "patches/markerbig@1.0.0.patch", 0) = 0
renameat(cachetmp, ".3e9d…tmp", AT_FDCWD, "patches/markerbig@1.0.0.patch") = -1 EXDEV
openat(AT_FDCWD, "patches/markerbig@1.0.0.patch", O_WRONLY|O_CREAT|O_TRUNC, 0644) = 13
sendfile(13, 12, NULL, …) = -1 ENOSPC
```

The first `unlinkat` is the delete-tree of the sad path, the `openat(O_TRUNC)` is the copy fallback. Both are gone.

Replacing a running executable by rename also avoids the `ETXTBSY` that the old "unlink dest first" worked around, so `bun upgrade` across filesystems keeps working.

The test steps live in `test/cli/install/bun-patch-xdev-fixture.ts`. The project needs a small filesystem of its own that the fixture may fill for about a second. Where unprivileged user namespaces work, the test runs the fixture under `unshare -Urm` with a 16 MB tmpfs mounted on the project directory, so no other process can see or be affected by the fill. Where that is not available it uses `/dev/shm`, but only when `/dev/shm` is a mount of its own, at most 128 MB, and not the filesystem of the temp dir, which in practice means a container whose `/dev/shm` is its own. Elsewhere (macOS, Windows, hosts without user namespaces and with a large `/dev/shm`) it skips. The fixture leaves 128 KB free while the one `bun patch --commit` runs and removes the filler in a `finally`.

The sad path of `renameat_concurrently_without_fallback` used to be "delete-tree, then rename" unconditionally. Where the flagged renames are unsupported (FreeBSD reports `ENOSYS`, NFS `EINVAL`, Windows ignores the flags) every replace went through it. It now tries the plain rename first: a file destination is replaced atomically, an `EXDEV` or `ENOENT` ends the attempt with nothing deleted, and only a destination that is in the way (a directory) is deleted before the second rename.

`move_file_z_slow` still unlinks the source before the copy, as before. Every caller passes a temp file as the source, and unlinking first is what keeps a failed commit from leaving that temp file in the cache.

`cargo check -p bun_sys` passes for `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`, `aarch64-apple-darwin` and `x86_64-unknown-freebsd`.

#36229 and #41682 touch the same function for other reasons and will need a small rebase against this. #39713 fixes the `--compile --outfile` caller on its own by staging in the output directory.

Self-reviewed. Review feedback addressed so far: the temp file is `fsync`ed before the rename (bun's `close()` only reports `EBADF`, so deferred write errors on NFS would otherwise pass unseen), the FreeBSD/`ENOSYS` gap is closed by the sad-path reorder, and the test no longer fills a shared mount where a private one is possible.
</details>
