### PR TITLE
node errors: make code an own enumerable property on ERR_* errors and warnings

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2261,16 +2261,16 @@ __attribute__((minsize)) JSValue Process::emitWarning(JSC::JSGlobalObject* lexic
         auto s = warning.getString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
+        // Node's createWarningObject assigns name, code and detail with plain assignment, and
+        // only on the Error it creates for a string warning. An Error passed in is left as is.
         errorInstance->putDirect(vm, vm.propertyNames->name, type, 0);
+        if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, 0);
+        if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, 0);
     } else if (warning.isCell() && warning.asCell()->type() == ErrorInstanceType) {
         errorInstance = warning.getObject();
     } else {
         return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "warning"_s, "string or Error"_s, warning));
     }
-
-    // Node's createWarningObject assigns name, code and detail as plain enumerable properties.
-    if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, 0);
-    if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, 0);
 
     RELEASE_AND_RETURN(scope, emitWarningErrorInstance(lexicalGlobalObject, errorInstance));
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2261,8 +2261,7 @@ __attribute__((minsize)) JSValue Process::emitWarning(JSC::JSGlobalObject* lexic
         auto s = warning.getString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
-        // Node's createWarningObject assigns name, code and detail with plain assignment, and
-        // only on the Error it creates for a string warning. An Error passed in is left as is.
+        // Like Node's createWarningObject: plain assignment, and only on the Error made for a string.
         errorInstance->putDirect(vm, vm.propertyNames->name, type, 0);
         if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, 0);
         if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, 0);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2261,15 +2261,16 @@ __attribute__((minsize)) JSValue Process::emitWarning(JSC::JSGlobalObject* lexic
         auto s = warning.getString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
-        errorInstance->putDirect(vm, vm.propertyNames->name, type, JSC::PropertyAttribute::DontEnum | 0);
+        errorInstance->putDirect(vm, vm.propertyNames->name, type, 0);
     } else if (warning.isCell() && warning.asCell()->type() == ErrorInstanceType) {
         errorInstance = warning.getObject();
     } else {
         return JSValue::decode(Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "warning"_s, "string or Error"_s, warning));
     }
 
-    if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, JSC::PropertyAttribute::DontEnum | 0);
-    if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, JSC::PropertyAttribute::DontEnum | 0);
+    // Node's createWarningObject assigns name, code and detail as plain enumerable properties.
+    if (!code.isUndefined()) errorInstance->putDirect(vm, builtinNames(vm).codePublicName(), code, 0);
+    if (!detail.isUndefined()) errorInstance->putDirect(vm, vm.propertyNames->detail, detail, 0);
 
     RELEASE_AND_RETURN(scope, emitWarningErrorInstance(lexicalGlobalObject, errorInstance));
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -101,7 +101,7 @@ namespace Bun {
 using namespace JSC;
 using namespace WTF;
 
-static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name, WTF::ASCIILiteral code)
+static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name)
 {
     JSC::JSObject* prototype;
 
@@ -135,11 +135,9 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
         break;
     }
 
-    // Node's NodeError has no enumerable prototype properties, so `for (k in err)` yields only
-    // the instance's own `code` (and whatever a site adds). `code` lives here so every
-    // instance can share one string, see `putOwnCode`.
+    // Non-enumerable, like the members of Node's NodeError class prototype, so `for (k in err)`
+    // yields only the instance's own properties. `code` is one of those, see `putOwnCode`.
     prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), JSC::PropertyAttribute::DontEnum | 0);
-    prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), JSC::PropertyAttribute::DontEnum | 0);
     prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), JSC::PropertyAttribute::DontEnum | 0);
 
     return prototype;
@@ -147,11 +145,9 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
 
 // Node assigns `code` as a plain own property (`error.code = key` in lib/internal/errors.js),
 // so `Object.keys`, `JSON.stringify` and `{ ...err }` all carry it.
-static JSC::ErrorInstance* putOwnCode(JSC::VM& vm, JSC::Structure* structure, JSC::ErrorInstance* error)
+static JSC::ErrorInstance* putOwnCode(JSC::VM& vm, JSC::ErrorInstance* error, WTF::ASCIILiteral code)
 {
-    auto& codeName = WebCore::builtinNames(vm).codePublicName();
-    JSValue code = asObject(structure->storedPrototype())->getDirect(vm, codeName);
-    error->putDirect(vm, codeName, code, 0);
+    error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);
     return error;
 }
 
@@ -202,9 +198,9 @@ static ErrorCodeCache* errorCache(Zig::GlobalObject* globalObject)
 }
 
 // clang-format on
-static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name, WTF::ASCIILiteral code)
+static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name)
 {
-    auto* prototype = createErrorPrototype(vm, globalObject, type, name, code);
+    auto* prototype = createErrorPrototype(vm, globalObject, type, name);
     return ErrorInstance::createStructure(vm, globalObject, prototype);
 }
 
@@ -214,7 +210,7 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* cache = errorCache(globalObject);
     const auto& data = errors[static_cast<size_t>(code)];
     if (!cache->internalField(static_cast<unsigned>(code))) {
-        auto* structure = createErrorStructure(vm, globalObject, data.type, data.name, data.code);
+        auto* structure = createErrorStructure(vm, globalObject, data.type, data.name);
         cache->internalField(static_cast<unsigned>(code)).set(vm, cache, structure);
     }
 
@@ -238,7 +234,7 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
                 return object;
         }
     }
-    return putOwnCode(vm, structure, JSC::ErrorInstance::create(vm, structure, messageString, cause, nullptr, JSC::RuntimeType::TypeNothing, data.type, true));
+    return putOwnCode(vm, JSC::ErrorInstance::create(vm, structure, messageString, cause, nullptr, JSC::RuntimeType::TypeNothing, data.type, true), data.code);
 }
 
 JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, const String& message)
@@ -261,12 +257,13 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
     if (auto* zigGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject))
         return createError(vm, zigGlobalObject, code, message, jsUndefined());
 
-    auto* structure = createErrorStructure(vm, globalObject, errors[static_cast<size_t>(code)].type, errors[static_cast<size_t>(code)].name, errors[static_cast<size_t>(code)].code);
+    const auto& data = errors[static_cast<size_t>(code)];
+    auto* structure = createErrorStructure(vm, globalObject, data.type, data.name);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     String messageString = message.isUndefined() ? String() : message.toWTFString(globalObject);
     if (scope.exception() && !vm.hasPendingTerminationException())
         (void)scope.tryClearException();
-    return putOwnCode(vm, structure, JSC::ErrorInstance::create(vm, structure, messageString, JSValue(), nullptr, JSC::RuntimeType::TypeNothing, errors[static_cast<size_t>(code)].type, true));
+    return putOwnCode(vm, JSC::ErrorInstance::create(vm, structure, messageString, JSValue(), nullptr, JSC::RuntimeType::TypeNothing, data.type, true), data.code);
 }
 
 JSC::JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, JSValue message, JSValue options)
@@ -1065,8 +1062,8 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_RangeError(JSC::ThrowScope& throwScope, JS
     JSValueToStringSafe(globalObject, builder, value, true);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
-    auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s, "ERR_INVALID_ARG_VALUE"_s);
-    auto* error = putOwnCode(vm, structure, JSC::ErrorInstance::create(vm, structure, builder.toString(), jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, ErrorType::RangeError, true));
+    auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s);
+    auto* error = putOwnCode(vm, JSC::ErrorInstance::create(vm, structure, builder.toString(), jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, ErrorType::RangeError, true), "ERR_INVALID_ARG_VALUE"_s);
     throwScope.throwException(globalObject, error);
     throwScope.release();
     return {};

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -54,9 +54,11 @@ JSC_DEFINE_HOST_FUNCTION(NodeError_proto_toString, (JSC::JSGlobalObject * global
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto thisVal = callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::strict());
 
+    // Node's toString closes over the code rather than reading `this.code`; ours is stashed on the callee.
+    auto code = callFrame->jsCallee()->getDirect(vm, WebCore::builtinNames(vm).codePrivateName());
+    if (!code) code = JSC::jsUndefined();
+
     auto name = thisVal.get(globalObject, vm.propertyNames->name);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto code = thisVal.get(globalObject, WebCore::builtinNames(vm).codePublicName());
     RETURN_IF_EXCEPTION(scope, {});
     auto message = thisVal.get(globalObject, vm.propertyNames->message);
     RETURN_IF_EXCEPTION(scope, {});
@@ -101,7 +103,7 @@ namespace Bun {
 using namespace JSC;
 using namespace WTF;
 
-static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name)
+static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name, WTF::ASCIILiteral code)
 {
     JSC::JSObject* prototype;
 
@@ -135,9 +137,12 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
         break;
     }
 
+    auto* toString = JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private);
+    toString->putDirect(vm, WebCore::builtinNames(vm).codePrivateName(), jsString(vm, String(code)), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
+
     // DontEnum like Node's NodeError prototype members, so `for (k in err)` sees only own properties.
     prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), JSC::PropertyAttribute::DontEnum | 0);
-    prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), JSC::PropertyAttribute::DontEnum | 0);
+    prototype->putDirect(vm, vm.propertyNames->toString, toString, JSC::PropertyAttribute::DontEnum | 0);
 
     return prototype;
 }
@@ -196,9 +201,9 @@ static ErrorCodeCache* errorCache(Zig::GlobalObject* globalObject)
 }
 
 // clang-format on
-static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name)
+static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, JSC::ErrorType type, WTF::ASCIILiteral name, WTF::ASCIILiteral code)
 {
-    auto* prototype = createErrorPrototype(vm, globalObject, type, name);
+    auto* prototype = createErrorPrototype(vm, globalObject, type, name, code);
     return ErrorInstance::createStructure(vm, globalObject, prototype);
 }
 
@@ -208,7 +213,7 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* cache = errorCache(globalObject);
     const auto& data = errors[static_cast<size_t>(code)];
     if (!cache->internalField(static_cast<unsigned>(code))) {
-        auto* structure = createErrorStructure(vm, globalObject, data.type, data.name);
+        auto* structure = createErrorStructure(vm, globalObject, data.type, data.name, data.code);
         cache->internalField(static_cast<unsigned>(code)).set(vm, cache, structure);
     }
 
@@ -256,7 +261,7 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
         return createError(vm, zigGlobalObject, code, message, jsUndefined());
 
     const auto& data = errors[static_cast<size_t>(code)];
-    auto* structure = createErrorStructure(vm, globalObject, data.type, data.name);
+    auto* structure = createErrorStructure(vm, globalObject, data.type, data.name, data.code);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     String messageString = message.isUndefined() ? String() : message.toWTFString(globalObject);
     if (scope.exception() && !vm.hasPendingTerminationException())
@@ -1060,7 +1065,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_RangeError(JSC::ThrowScope& throwScope, JS
     JSValueToStringSafe(globalObject, builder, value, true);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
-    auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s);
+    auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s, "ERR_INVALID_ARG_VALUE"_s);
     auto* error = putOwnCode(vm, JSC::ErrorInstance::create(vm, structure, builder.toString(), jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, ErrorType::RangeError, true), "ERR_INVALID_ARG_VALUE"_s);
     throwScope.throwException(globalObject, error);
     throwScope.release();

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -135,16 +135,14 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
         break;
     }
 
-    // Non-enumerable, like the members of Node's NodeError class prototype, so `for (k in err)`
-    // yields only the instance's own properties. `code` is one of those, see `putOwnCode`.
+    // DontEnum like Node's NodeError prototype members, so `for (k in err)` sees only own properties.
     prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), JSC::PropertyAttribute::DontEnum | 0);
     prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), JSC::PropertyAttribute::DontEnum | 0);
 
     return prototype;
 }
 
-// Node assigns `code` as a plain own property (`error.code = key` in lib/internal/errors.js),
-// so `Object.keys`, `JSON.stringify` and `{ ...err }` all carry it.
+// Node does `error.code = key` on the instance: an own, enumerable, writable property.
 static JSC::ErrorInstance* putOwnCode(JSC::VM& vm, JSC::ErrorInstance* error, WTF::ASCIILiteral code)
 {
     error->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -135,11 +135,24 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
         break;
     }
 
-    prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), 0);
-    prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);
-    prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), 0);
+    // Node's NodeError has no enumerable prototype properties, so `for (k in err)` yields only
+    // the instance's own `code` (and whatever a site adds). `code` lives here so every
+    // instance can share one string, see `putOwnCode`.
+    prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), JSC::PropertyAttribute::DontEnum | 0);
+    prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), JSC::PropertyAttribute::DontEnum | 0);
+    prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), JSC::PropertyAttribute::DontEnum | 0);
 
     return prototype;
+}
+
+// Node assigns `code` as a plain own property (`error.code = key` in lib/internal/errors.js),
+// so `Object.keys`, `JSON.stringify` and `{ ...err }` all carry it.
+static JSC::ErrorInstance* putOwnCode(JSC::VM& vm, JSC::Structure* structure, JSC::ErrorInstance* error)
+{
+    auto& codeName = WebCore::builtinNames(vm).codePublicName();
+    JSValue code = asObject(structure->storedPrototype())->getDirect(vm, codeName);
+    error->putDirect(vm, codeName, code, 0);
+    return error;
 }
 
 #include "ErrorCode+Data.h"
@@ -225,7 +238,7 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
                 return object;
         }
     }
-    return JSC::ErrorInstance::create(vm, structure, messageString, cause, nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
+    return putOwnCode(vm, structure, JSC::ErrorInstance::create(vm, structure, messageString, cause, nullptr, JSC::RuntimeType::TypeNothing, data.type, true));
 }
 
 JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, const String& message)
@@ -253,7 +266,7 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
     String messageString = message.isUndefined() ? String() : message.toWTFString(globalObject);
     if (scope.exception() && !vm.hasPendingTerminationException())
         (void)scope.tryClearException();
-    return JSC::ErrorInstance::create(vm, structure, messageString, JSValue(), nullptr, JSC::RuntimeType::TypeNothing, errors[static_cast<size_t>(code)].type, true);
+    return putOwnCode(vm, structure, JSC::ErrorInstance::create(vm, structure, messageString, JSValue(), nullptr, JSC::RuntimeType::TypeNothing, errors[static_cast<size_t>(code)].type, true));
 }
 
 JSC::JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, JSValue message, JSValue options)
@@ -1053,7 +1066,7 @@ JSC::EncodedJSValue INVALID_ARG_VALUE_RangeError(JSC::ThrowScope& throwScope, JS
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     auto* structure = createErrorStructure(vm, globalObject, ErrorType::RangeError, "RangeError"_s, "ERR_INVALID_ARG_VALUE"_s);
-    auto error = JSC::ErrorInstance::create(vm, structure, builder.toString(), jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, ErrorType::RangeError, true);
+    auto* error = putOwnCode(vm, structure, JSC::ErrorInstance::create(vm, structure, builder.toString(), jsUndefined(), nullptr, JSC::RuntimeType::TypeNothing, ErrorType::RangeError, true));
     throwScope.throwException(globalObject, error);
     throwScope.release();
     return {};

--- a/src/jsc/bindings/S3Error.cpp
+++ b/src/jsc/bindings/S3Error.cpp
@@ -45,7 +45,7 @@ SYSV_ABI JSC::EncodedJSValue S3Error__toErrorInstance(const S3Error* arg0,
             scope.clearException();
         } else {
             result->putDirect(vm, names.codePublicName(), code,
-                JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::DontEnum | 0);
+                JSC::PropertyAttribute::DontDelete | 0);
         }
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2871,7 +2871,7 @@ JSC::EncodedJSValue SystemError__toErrorInstanceWithInfoObject(const SystemError
     auto clientData = WebCore::clientData(vm);
 
     result->putDirect(vm, vm.propertyNames->name, jsString(vm, String("SystemError"_s)), JSC::PropertyAttribute::DontEnum | 0);
-    result->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, String("ERR_SYSTEM_ERROR"_s)), JSC::PropertyAttribute::DontEnum | 0);
+    result->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, String("ERR_SYSTEM_ERROR"_s)), 0);
 
     info->putDirect(vm, clientData->builtinNames().codePublicName(), jsString(vm, codeString), JSC::PropertyAttribute::DontDelete | 0);
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -428,8 +428,8 @@ JSPromise* invokeCallbackReturningPromiseFast(JSGlobalObject* globalObject, JSOb
 
 bool errorCodeIs(VM& vm, JSValue error, ASCIILiteral code)
 {
-    // Own or inherited *data* property only (Bun's coded errors keep `code` on a per-code
-    // prototype); structures' stored prototypes are followed, so no getter or proxy trap runs.
+    // Own or inherited *data* property only; structures' stored prototypes are followed, so no
+    // getter or proxy trap runs.
     JSValue codeValue;
     for (JSObject* object = error ? error.getObject() : nullptr; object && !codeValue; object = object->getPrototypeDirect().getObject())
         codeValue = object->getDirect(vm, WebCore::builtinNames(vm).codePublicName());

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -428,8 +428,7 @@ JSPromise* invokeCallbackReturningPromiseFast(JSGlobalObject* globalObject, JSOb
 
 bool errorCodeIs(VM& vm, JSValue error, ASCIILiteral code)
 {
-    // Own or inherited *data* property only; structures' stored prototypes are followed, so no
-    // getter or proxy trap runs.
+    // Data properties only (getDirect along the stored prototypes): no getter or proxy trap runs.
     JSValue codeValue;
     for (JSObject* object = error ? error.getObject() : nullptr; object && !codeValue; object = object->getPrototypeDirect().getObject())
         codeValue = object->getDirect(vm, WebCore::builtinNames(vm).codePublicName());

--- a/test/js/node/errors/error-code-enumerable.test.ts
+++ b/test/js/node/errors/error-code-enumerable.test.ts
@@ -55,6 +55,9 @@ test("ERR_* code is writable and deletable like in node", () => {
   expect(e.code).toBe("CUSTOM");
   delete e.code;
   expect(Object.hasOwn(e, "code")).toBe(false);
+  expect(e.code).toBeUndefined();
+  // The Node-style toString lives on the shared prototype and keeps working.
+  expect(capture(() => Buffer.alloc(-1)).toString()).toStartWith("RangeError [ERR_OUT_OF_RANGE]: ");
 });
 
 test("ERR_SYSTEM_ERROR code is enumerable next to info, errno and syscall", () => {
@@ -70,17 +73,21 @@ test("warning objects expose name, code and detail as enumerable properties", as
       bunExe(),
       "--no-warnings",
       "-e",
-      `process.on("warning", w => console.log(JSON.stringify({ keys: Object.keys(w), json: JSON.parse(JSON.stringify(w)) })));
-       process.emitWarning("w", { code: "MY_CODE", detail: "d" });`,
+      `const seen = [];
+       process.on("warning", w => seen.push({ keys: Object.keys(w), json: JSON.parse(JSON.stringify(w)) }));
+       process.emitWarning("w", { code: "MY_CODE", detail: "d" });
+       // Like Node, an Error passed in is emitted as is: no name, code or detail are added to it.
+       process.emitWarning(new Error("e"), { type: "DeprecationWarning", code: "DEP0XXX", detail: "d" });
+       process.on("exit", () => console.log(JSON.stringify(seen)));`,
     ],
     env: bunEnv,
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    keys: ["name", "code", "detail"],
-    json: { name: "Warning", code: "MY_CODE", detail: "d" },
-  });
+  expect(JSON.parse(stdout)).toEqual([
+    { keys: ["name", "code", "detail"], json: { name: "Warning", code: "MY_CODE", detail: "d" } },
+    { keys: [], json: {} },
+  ]);
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/errors/error-code-enumerable.test.ts
+++ b/test/js/node/errors/error-code-enumerable.test.ts
@@ -77,7 +77,7 @@ test("warning objects expose name, code and detail as enumerable properties", as
        process.on("warning", w => seen.push({ keys: Object.keys(w), json: JSON.parse(JSON.stringify(w)) }));
        process.emitWarning("w", { code: "MY_CODE", detail: "d" });
        // Like Node, an Error passed in is emitted as is: no name, code or detail are added to it.
-       process.emitWarning(new Error("e"), { type: "DeprecationWarning", code: "DEP0XXX", detail: "d" });
+       process.emitWarning(new Error("e"), { type: "DeprecationWarning", code: "DEP0199", detail: "d" });
        process.on("exit", () => console.log(JSON.stringify(seen)));`,
     ],
     env: bunEnv,

--- a/test/js/node/errors/error-code-enumerable.test.ts
+++ b/test/js/node/errors/error-code-enumerable.test.ts
@@ -53,11 +53,12 @@ test("ERR_* code is writable and deletable like in node", () => {
   const e = capture(() => Buffer.alloc(-1));
   e.code = "CUSTOM";
   expect(e.code).toBe("CUSTOM");
+  // Node's toString closes over the original code instead of reading this.code.
+  expect(e.toString()).toStartWith("RangeError [ERR_OUT_OF_RANGE]: ");
   delete e.code;
   expect(Object.hasOwn(e, "code")).toBe(false);
   expect(e.code).toBeUndefined();
-  // The Node-style toString lives on the shared prototype and keeps working.
-  expect(capture(() => Buffer.alloc(-1)).toString()).toStartWith("RangeError [ERR_OUT_OF_RANGE]: ");
+  expect(e.toString()).toStartWith("RangeError [ERR_OUT_OF_RANGE]: ");
 });
 
 test("ERR_SYSTEM_ERROR code is enumerable next to info, errno and syscall", () => {

--- a/test/js/node/errors/error-code-enumerable.test.ts
+++ b/test/js/node/errors/error-code-enumerable.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { EventEmitter } from "node:events";
+import os from "node:os";
+import util from "node:util";
+
+// Node assigns `code` (and the warning's name/code/detail) as plain enumerable own
+// properties (lib/internal/errors.js, lib/internal/process/warning.js). Structured
+// loggers and `JSON.stringify` rely on that.
+
+function capture(fn: () => unknown): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("did not throw");
+}
+
+test("ERR_* code is an own enumerable property", () => {
+  const e = capture(() => Buffer.alloc(-1));
+  expect(e.code).toBe("ERR_OUT_OF_RANGE");
+  expect(Object.getOwnPropertyDescriptor(e, "code")).toEqual({
+    value: "ERR_OUT_OF_RANGE",
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Object.keys(e)).toEqual(["code"]);
+  const forIn: string[] = [];
+  for (const k in e) forIn.push(k);
+  expect(forIn).toEqual(["code"]);
+  expect(JSON.stringify(e)).toBe('{"code":"ERR_OUT_OF_RANGE"}');
+  expect({ ...e }.code).toBe("ERR_OUT_OF_RANGE");
+  expect(util.inspect(e)).toContain("code: 'ERR_OUT_OF_RANGE'");
+});
+
+test("ERR_* code comes before the extra properties a site adds", () => {
+  const e = capture(() => new EventEmitter().emit("error", 42));
+  expect(e.code).toBe("ERR_UNHANDLED_ERROR");
+  expect(Object.keys(e)).toEqual(["code", "context"]);
+  expect(JSON.parse(JSON.stringify(e))).toEqual({ code: "ERR_UNHANDLED_ERROR", context: 42 });
+});
+
+test("ERR_INVALID_ARG_VALUE RangeError carries an own enumerable code", () => {
+  const e = capture(() => process.cpuUsage({ user: -1, system: 0 }));
+  expect(e.name).toBe("RangeError");
+  expect(e.code).toBe("ERR_INVALID_ARG_VALUE");
+  expect(Object.keys(e)).toEqual(["code"]);
+});
+
+test("ERR_* code is writable and deletable like in node", () => {
+  const e = capture(() => Buffer.alloc(-1));
+  e.code = "CUSTOM";
+  expect(e.code).toBe("CUSTOM");
+  delete e.code;
+  expect(Object.hasOwn(e, "code")).toBe(false);
+});
+
+test("ERR_SYSTEM_ERROR code is enumerable next to info, errno and syscall", () => {
+  const e = capture(() => os.setPriority(-1, 0));
+  expect(e.code).toBe("ERR_SYSTEM_ERROR");
+  expect(Object.keys(e).sort()).toEqual(["code", "errno", "info", "syscall"]);
+});
+
+test("warning objects expose name, code and detail as enumerable properties", async () => {
+  // A separate process: other test files in the same run can replace the "warning" listeners.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--no-warnings",
+      "-e",
+      `process.on("warning", w => console.log(JSON.stringify({ keys: Object.keys(w), json: JSON.parse(JSON.stringify(w)) })));
+       process.emitWarning("w", { code: "MY_CODE", detail: "d" });`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    keys: ["name", "code", "detail"],
+    json: { name: "Warning", code: "MY_CODE", detail: "d" },
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `code` on every `ERR_*` error is not an own enumerable property. `Object.keys(err)` is `[]`, `JSON.stringify(err)` is `{}`, `{ ...err }.code` is `undefined`. Node shows `{ code: 'ERR_OUT_OF_RANGE' }` in each case. `process.emitWarning()` objects (`name`/`code`/`detail`), `ERR_SYSTEM_ERROR` and `S3Error` have the same gap.
- The cause: `createErrorPrototype` (`src/jsc/bindings/ErrorCode.cpp:138`) put `code` on the cached per-code prototype, never on the instance. `for (k in err)` also leaked `name`, `code`, `toString` from there. The other three sites passed `DontEnum`.

### Fix
- `putOwnCode` puts the table's code on the instance as a plain own property at the three `ErrorInstance::create` sites in `ErrorCode.cpp`. The shared prototype keeps `name` and `toString`, now `DontEnum`. So `for...in` yields `code` alone and `delete err.code` leaves `undefined`, as in Node.
- `Process::emitWarning` assigns `name`/`code`/`detail` without `DontEnum`, and only on the Error it creates for a string warning. An Error passed in is emitted untouched, like Node's `createWarningObject` path.
- `code` on `ERR_SYSTEM_ERROR` and on `S3Error` drops `DontEnum`.
- Verified: `test/js/node/errors/error-code-enumerable.test.ts` (6 of 6 fail on 1.4.3, all pass here). More suites in the notes.

### Background
- Every `ERR_*` error, thrown from C++, Rust or built-in JS, goes through `ErrorCodeCache::createError`. It caches one `Structure` per code. Its prototype sits between the instance and `TypeError.prototype` (or `RangeError`, ...) and carries `name` and a Node-style `toString` (`Name [CODE]: message`). Node's `lib/internal/errors.js` has the same shape and does `error.code = key` on the instance.
- `putDirect(vm, name, value, 0)` creates the same writable, enumerable, configurable property as a plain JS assignment. `PropertyAttribute::DontEnum` hides it from `Object.keys`, `JSON.stringify`, spread and `for...in`.

<details><summary>Notes</summary>

- This supersedes #35926 (July, conflicting with main). That PR also dropped `DontDelete` from the errno-family `SystemError` properties. This one leaves those alone to keep the diff to the enumerability question.
- Before this change `emitWarning(anError, { code, detail })` attached a hidden `code`/`detail` to the caller's Error. Node does not touch it, so neither does Bun now.
- The code string is minted from the table literal on each creation instead of read back from the prototype. A user can reach the prototype with `Object.getPrototypeOf(err)` and delete or reassign properties on it, so reading from it is not safe.
- The uncaught-error printer output does not change: it prints ` code: "ERR_..."` from the instance. `util.inspect(err)` now appends `{ code: 'ERR_...' }` like Node.
- `e.toString()` still returns `RangeError [ERR_OUT_OF_RANGE]: ...` through the prototype `toString`. That function carries the code under a private name and reads it from the callee, like Node's closure over `key`, so the output survives `delete err.code` or a reassigned `err.code`.
- All internal `Process::emitWarning` callers (crypto deprecations, `process.binding('uv')`, MessagePort, timers, IPC, unhandled rejections) pass a string warning, so moving the `code`/`detail` assignment into the string branch does not change them.
- Other suites run with the debug build: `test/js/node/{errors,events,util,v8,url,os,assert}`, `test/js/node/buffer.test.js`, `test/js/node/process/process.test.js`, `test/js/bun/util/inspect.test.js`, `test/js/bun/util/inspect-error.test.js`, `test/js/bun/test/expect.test.js`, `test/js/bun/s3/s3-argument-validation.test.ts`, `test/js/web/console`, `test/js/node/util/node-inspect-tests`, and the vendored `test-process-warning.js`, `test-process-warnings.mjs`, `test-process-emitwarning.js`, `test-event-emitter-errors.js`, `test-common-expect-warning.js`, `test-assert-deep-with-error.js`. The only failures were pre-existing and environmental (`process.env.USER` unset in this container, timing tests under ASAN).
- Repro from the report:

```js
import util from 'node:util'; import { EventEmitter } from 'node:events';
const show = (l, e) => console.log(l, JSON.stringify({ code: e.code, keys: Object.keys(e), json: JSON.stringify(e), spread: ({ ...e }).code, inspectHasCode: util.inspect(e).includes(String(e.code)) }));
try { Buffer.alloc(-1); } catch (e) { show('Buffer.alloc(-1)   ', e); }
try { new EventEmitter().emit('error', 42); } catch (e) { show('ERR_UNHANDLED_ERROR', e); }
process.on('warning', (w) => show('warning            ', w)); process.emitWarning('w', { code: 'MY_CODE', detail: 'd' });
```

Before: `keys: []`, `json: "{}"`, `inspectHasCode: false` on all three. After: identical to Node (`["code"]`, `["code","context"]`, `["name","code","detail"]`).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/errors/error-code-enumerable.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/errors/error-code-enumerable.test.ts:
18 | }
19 | 
20 | test("ERR_* code is an own enumerable property", () => {
21 |   const e = capture(() => Buffer.alloc(-1));
22 |   expect(e.code).toBe("ERR_OUT_OF_RANGE");
23 |   expect(Object.getOwnPropertyDescriptor(e, "code")).toEqual({
                                                          ^
error: expect(received).toEqual(expected)

- {
-   "configurable": true,
-   "enumerable": true,
-   "value": "ERR_OUT_OF_RANGE",
-   "writable": true,
- }
+ undefined

- Expected  - 6
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/errors/error-code-enumerable.test.ts:23:54)
(fail) ERR_* code is an own enumerable property [23.58ms]
36 | });
37 | 
38 | test("ERR_* code comes before the extra properties a site adds", () => {
39 |   const e = capture(() => new EventEmitter().emit("error", 42));
40 |   expect(e.code).toBe("ERR_UNHANDLED_ERROR");
41 |   expect(Object.keys(e)).toEqual(["code", "conte
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/errors/error-code-enumerable.test.ts:
18 | }
19 | 
20 | test("ERR_* code is an own enumerable property", () => {
21 |   const e = capture(() => Buffer.alloc(-1));
22 |   expect(e.code).toBe("ERR_OUT_OF_RANGE");
23 |   expect(Object.getOwnPropertyDescriptor(e, "code")).toEqual({
                                                          ^
error: expect(received).toEqual(expected)

- {
-   "configurable": true,
-   "enumerable": true,
-   "value": "ERR_OUT_OF_RANGE",
-   "writable": true,
- }
+ undefined

- Expected  - 6
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/errors/error-code-enumerable.test.ts:23:54)
(fail) ERR_* code is an own enumerable property [0.38ms]
36 | });
37 | 
38 | test("ERR_* code comes before the extra properties a site adds", () => {
39 |   const e = capture(() => new EventEmitter().emit("error", 42));
40 |   expect(e.code).toBe("ERR_UNHANDLED_ERROR");
41 |   expect(Object.keys(e)).toEqual(["code", "context"]);
                              ^
error: expect(received).toEqual(expected)

  [
-   "code",
    "context",
  ]

- Expected  - 1
+ Received  + 0

      at <anonymous> (/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/errors/error-code-enumerable.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/errors/error-code-enumerable.test.ts:
(pass) ERR_* code is an own enumerable property [144.92ms]
(pass) ERR_* code comes before the extra properties a site adds [25.80ms]
(pass) ERR_INVALID_ARG_VALUE RangeError carries an own enumerable code [5.31ms]
(pass) ERR_* code is writable and deletable like in node [5.98ms]
(pass) ERR_SYSTEM_ERROR code is enumerable next to info, errno and syscall [6.19ms]
(pass) warning objects expose name, code and detail as enumerable properties [428.33ms]

 6 pass
 0 fail
 22 expect() calls
Ran 6 tests across 1 file. [2.65s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     83a4fe6e76
  features     lto, baseline

24 deps, 131 codegen, 2175 objects in 1341ms

ninja: Entering directory `/workspace/bun/build/release'
[1/2863] mkdir obj
[2/2863] mkdir pch
[3/2863] mkdir codegen
[4/2863] mkdir stamps
[5/2863] gen ErrorCode+*.h
[6/2863] fetch mimalloc
[mimalloc] up to date
[7/2863] fetch tinycc
[tinycc] up to date
[8/2863] fetch WebKit
[WebKit] up to date
[9/2863] gen bindgenv2
[10/2863] fetch icu
[icu] up to date
[11/2863] fetch zlib
[zlib] up to date
[12/2863] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[13/2863] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[14/2863] host-cc deps/tinycc/host-obj/conftest.c.o
[15/2863] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [145.00ms]
[16/2863] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[17/2863] gen .bind.ts → GeneratedBindings.cpp
[18/2863] gen lut ArrayConstructor.lut.h
[19/2863] gen CombinedDomains.json
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunProcess.cpp                   |  8 +-
 src/jsc/bindings/ErrorCode.cpp                    | 32 +++++---
 src/jsc/bindings/S3Error.cpp                      |  2 +-
 src/jsc/bindings/bindings.cpp                     |  2 +-
 test/js/node/errors/error-code-enumerable.test.ts | 93 +++++++++++++++++++++++
 5 files changed, 119 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/BunProcess.cpp                        2      0     18
src/jsc/bindings/ErrorCode.cpp                         2      2     18
src/jsc/bindings/S3Error.cpp                           1      1     18
src/jsc/bindings/bindings.cpp                          1      1     18
test/js/node/errors/error-code-enumerable.test.ts      1     11     16
```

</details>

<!-- robobun:evidence:end -->
