### PR TITLE
node:http: emit 'error' for a captured rejection on a non-'request' Server event

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -509,11 +509,7 @@ Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, event, ..
       break;
     }
     default:
-      // net.Server.prototype[EventEmitter.captureRejectionSymbol].apply(this, arguments);
-      //   .apply(this, arguments);
-      const { 1: res } = args;
-      res?.socket?.destroy();
-      break;
+      require("node:net").Server.prototype[EventEmitter.captureRejectionSymbol].$apply(this, arguments);
   }
 };
 

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6558,9 +6558,7 @@ Http2Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, even
       break;
     }
     default:
-      // args.unshift(err, event);
-      // ReflectApply(net.Server.prototype[EventEmitter.captureRejectionSymbol], this, args);
-      break;
+      net.Server.prototype[EventEmitter.captureRejectionSymbol].$call(this, err, event, ...args);
   }
 };
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2618,20 +2618,23 @@ it("ClientRequest.destroy(err) with a throwing error listener still tears down; 
 });
 
 it("captureRejections: a rejecting async listener on a Server event other than 'request' emits 'error'", async () => {
-  // node: http.Server's [captureRejectionSymbol] handles 'request' itself and
-  // hands every other event to net.Server's handler, whose default is
-  // this.emit('error', err). The rejection must not be dropped.
+  // node: http.Server's and Http2Server's [captureRejectionSymbol] handle
+  // 'request' (and 'stream') themselves and hand every other event to
+  // net.Server's handler, whose default is this.emit('error', err). The
+  // rejection must not be dropped.
   const script = `
     const events = require("node:events");
     events.captureRejections = true;
     const http = require("node:http");
-    const server = http.createServer();
-    server.on("error", err => console.log("error event: " + err.message));
+    const http2 = require("node:http2");
     process.on("unhandledRejection", err => console.log("unhandledRejection: " + err.message));
-    server.on("custom", async () => {
-      throw new Error("custom-rejects");
-    });
-    server.emit("custom");
+    for (const [name, server] of [["http", http.createServer()], ["http2", http2.createServer()]]) {
+      server.on("error", err => console.log(name + " error event: " + err.message));
+      server.on("custom", async () => {
+        throw new Error(name + " custom-rejects");
+      });
+      server.emit("custom");
+    }
     // rejection (microtask) -> nextTick -> 'error'; all settle within one turn.
     setImmediate(() => setImmediate(() => console.log("done")));
   `;
@@ -2644,7 +2647,11 @@ it("captureRejections: a rejecting async listener on a Server event other than '
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   // node v26.3.0 verified.
-  expect(stdout.trim().split("\n")).toEqual(["error event: custom-rejects", "done"]);
+  expect(stdout.trim().split("\n")).toEqual([
+    "http error event: http custom-rejects",
+    "http2 error event: http2 custom-rejects",
+    "done",
+  ]);
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2617,6 +2617,37 @@ it("ClientRequest.destroy(err) with a throwing error listener still tears down; 
   expect(exitCode).toBe(0);
 });
 
+it("captureRejections: a rejecting async listener on a Server event other than 'request' emits 'error'", async () => {
+  // node: http.Server's [captureRejectionSymbol] handles 'request' itself and
+  // hands every other event to net.Server's handler, whose default is
+  // this.emit('error', err). The rejection must not be dropped.
+  const script = `
+    const events = require("node:events");
+    events.captureRejections = true;
+    const http = require("node:http");
+    const server = http.createServer();
+    server.on("error", err => console.log("error event: " + err.message));
+    process.on("unhandledRejection", err => console.log("unhandledRejection: " + err.message));
+    server.on("custom", async () => {
+      throw new Error("custom-rejects");
+    });
+    server.emit("custom");
+    // rejection (microtask) -> nextTick -> 'error'; all settle within one turn.
+    setImmediate(() => setImmediate(() => console.log("done")));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // node v26.3.0 verified.
+  expect(stdout.trim().split("\n")).toEqual(["error event: custom-rejects", "done"]);
+  expect(exitCode).toBe(0);
+});
+
 it("keep-alive socket reused after a 304 response still frames the next response body", async () => {
   // The native per-request reset must clear the 204/304 no-body flag, or the
   // 200 that follows a 304 on the same connection is sent with no framing


### PR DESCRIPTION
### Problem
- With `events.captureRejections = true`, an async listener that rejects on an `http.Server` event other than `'request'` is lost: no `'error'` event and no `unhandledRejection`. `Http2Server` has the same hole for events other than `'stream'`/`'request'`. `net.Server`, `ChildProcess`, streams and plain emitters route the rejection to `'error'` like node.
- The cause is the `default:` branch of `Server.prototype[EventEmitter.captureRejectionSymbol]` in `src/js/node/_http_server.ts` (and the same arm in `src/js/node/http2.ts`). The delegation to `net.Server`'s handler was commented out. The http version destructured `res` from `args[1]`, which is `undefined` for a custom event, and the http2 version did nothing.

```js
import events from "node:events";
events.captureRejections = true;
const http = await import("node:http");
const s = http.createServer();
s.on("error", e => console.log("error:", e.message));
s.on("zz", async () => { throw new Error("custom-rejects"); });
s.emit("zz");
// node v26.3.0: error: custom-rejects      bun 1.4.3: (nothing)
```

### Fix
- Both `default:` branches call `net.Server.prototype[captureRejectionSymbol]` with `(err, event, ...args)`, as node's `lib/_http_server.js` and `lib/internal/http2/core.js` do. That handler destroys the socket for `'connection'`/`'secureConnection'` and emits `'error'` for everything else.
- In `_http_server.ts`, `node:net` is required lazily in that branch, so loading `node:http` does not pull in `node:net` earlier than before. `http2.ts` already imports it.
- Verified: `test/js/node/http/node-http.test.ts` ("captureRejections: a rejecting async listener on a Server event other than 'request' emits 'error'", covers `http` and `http2`, fails on bun 1.4.3). Also ran the node `test-http-server-capture-rejections`, `test-http2-capture-rejection`, `test-net-server-capture-rejection`, `test-tls-server-capture-rejection` and `test-event-capture-rejections` tests.

### Background
- `captureRejections` makes `EventEmitter.emit` attach a rejection handler to the promise an async listener returns. On rejection it calls `emitter[Symbol.for('nodejs.rejection')](err, eventName, ...args)` when the emitter defines one, else it emits `'error'`.
- `http.Server` and `Http2Server` define that hook so a rejecting `'request'` (or `'stream'`) handler answers 500, or destroys the response if headers went out. Every other event is meant to fall through to `net.Server`'s hook. In bun `http.Server` extends `EventEmitter` directly rather than `net.Server`, so that hook is not on its prototype chain and has to be called explicitly. `Http2Server` does extend `net.Server` but overrides the hook, so it also has to call up.
