### PR TITLE
init: report a scaffold file that cannot be written and exit 1

### DIFF
--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -781,17 +781,7 @@ impl InitCommand {
             template.write_to_package_json(&mut fields, &bump)?;
         }
 
-        'write_package_json: {
-            let (fd, created_close): (Fd, Option<bun_sys::CloseOnDrop>) = match package_json_file
-                .as_ref()
-            {
-                Some(f) => (f.handle(), None),
-                None => {
-                    let fd = bun_sys::File::create(Fd::cwd(), b"package.json", true)?.into_raw();
-                    (fd, Some(bun_sys::CloseOnDrop::new(fd)))
-                }
-            };
-            let _close = created_close;
+        {
             let mut buffer_writer = js_printer::BufferWriter::init();
             buffer_writer.append_newline = true;
             let mut package_json_writer = js_printer::BufferPrinter::init(buffer_writer);
@@ -810,37 +800,33 @@ impl InitCommand {
                 },
             );
             if let Err(err) = print_result {
-                bun_core::pretty_errorln!(
-                    "package.json failed to write due to error {}",
-                    err.name(),
-                );
-                package_json_file = None;
-                break 'write_package_json;
+                Output::err(err, "failed to write package.json", ());
+                Global::exit(1);
             }
             let written = package_json_writer.ctx.get_written();
-            if let Err(err) = bun_sys::File::borrow(&fd).write_all(written) {
-                bun_core::pretty_errorln!(
-                    "package.json failed to write due to error {}",
-                    bstr::BStr::new(err.name()),
-                );
-                package_json_file = None;
-                break 'write_package_json;
-            }
-            if let Err(err) =
-                bun_sys::ftruncate(fd, i64::try_from(written.len()).expect("int cast"))
-            {
-                bun_core::pretty_errorln!(
-                    "package.json failed to write due to error {}",
-                    bstr::BStr::new(err.name()),
-                );
-                package_json_file = None;
-                break 'write_package_json;
+            let write_result = match package_json_file.as_ref() {
+                // Read with `pread`, so the offset is still 0.
+                Some(file) => file.write_all(written).and_then(|()| {
+                    bun_sys::ftruncate(
+                        file.handle(),
+                        i64::try_from(written.len()).expect("int cast"),
+                    )
+                }),
+                None => Assets::write_new_file(
+                    b"package.json",
+                    bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
+                    written,
+                ),
+            };
+            if let Err(err) = write_result {
+                Assets::failed(err, b"package.json");
             }
         }
 
         if steps.write_gitignore {
-            let _ = Assets::create(b".gitignore", Assets::GITIGNORE, &[]);
-            // suppressed
+            if let Err(err) = Assets::create(b".gitignore", Assets::GITIGNORE, &[]) {
+                Assets::failed(err, b".gitignore");
+            }
         }
 
         match template {
@@ -849,7 +835,7 @@ impl InitCommand {
                     Template::create_agent_rule();
                 }
 
-                if package_json_file.is_some() && !did_load_package_json {
+                if !did_load_package_json {
                     bun_core::prettyln!(" + <r><d>package.json<r>");
                     Output::flush();
                 }
@@ -864,41 +850,36 @@ impl InitCommand {
                         }
                     }
 
-                    let mut ep_z = fields.entry_point.clone();
-                    ep_z.push(0);
-                    let ep_zstr = ZStr::from_slice_with_nul(&ep_z[..]);
-                    // SAFETY: ep_z[len-1] == 0 written above
-                    let _ = Assets::create_new(ep_zstr, b"console.log(\"Hello via Bun!\");");
-                    // suppress
+                    if let Err(err) =
+                        Assets::create_new(&fields.entry_point, b"console.log(\"Hello via Bun!\");")
+                    {
+                        Assets::failed(err, &fields.entry_point);
+                    }
                 }
 
                 if steps.write_tsconfig {
-                    'brk: {
-                        let extname = bun_paths::extension(&fields.entry_point);
-                        let loader = options::DEFAULT_LOADERS
-                            .get(extname)
-                            .copied()
-                            .unwrap_or(bun_ast::Loader::Ts);
-                        let filename: &[u8] = if loader.is_type_script() {
-                            b"tsconfig.json"
-                        } else {
-                            b"jsconfig.json"
-                        };
-                        if Assets::create_full(
-                            Assets::TSCONFIG_JSON,
-                            filename,
-                            " (for editor autocomplete)",
-                            &[],
-                        )
-                        .is_err()
-                        {
-                            break 'brk;
-                        }
+                    let extname = bun_paths::extension(&fields.entry_point);
+                    let loader = options::DEFAULT_LOADERS
+                        .get(extname)
+                        .copied()
+                        .unwrap_or(bun_ast::Loader::Ts);
+                    let filename: &[u8] = if loader.is_type_script() {
+                        b"tsconfig.json"
+                    } else {
+                        b"jsconfig.json"
+                    };
+                    if let Err(err) = Assets::create_full(
+                        Assets::TSCONFIG_JSON,
+                        filename,
+                        " (for editor autocomplete)",
+                        &[],
+                    ) {
+                        Assets::failed(err, filename);
                     }
                 }
 
                 if steps.write_readme {
-                    let _ = Assets::create(
+                    if let Err(err) = Assets::create(
                         b"README.md",
                         Assets::README_MD,
                         &[
@@ -906,8 +887,9 @@ impl InitCommand {
                             (b"bunVersion", Environment::VERSION_STRING.as_bytes()),
                             (b"entryPoint", fields.entry_point.as_slice()),
                         ],
-                    );
-                    // suppressed
+                    ) {
+                        Assets::failed(err, b"README.md");
+                    }
                 }
 
                 if !fields.entry_point.is_empty() && !did_load_package_json {
@@ -954,82 +936,43 @@ impl Assets {
     pub(crate) const README_MD: &'static [u8] = include_bytes!("init/README.default.md");
     pub(crate) const README2_MD: &'static [u8] = include_bytes!("init/README2.default.md");
 
-    /// Create a new asset file, overriding anything that already exists. Known
-    /// assets will have their contents pre-populated; otherwise the file will be empty.
-    ///
-    /// Takes the asset bytes directly; `asset_name` is the filename.
-    fn create(
-        asset_name: &[u8],
-        asset: &'static [u8],
-        args: &[(&[u8], &[u8])],
-    ) -> Result<(), Error> {
-        let is_template = !args.is_empty();
-        Self::create_full_inner(asset, asset_name, "", is_template, args)
+    /// Create an asset file, replacing anything that already exists. With
+    /// `args`, `asset` is a template and `{[name]s}` placeholders are substituted.
+    fn create(filename: &[u8], asset: &[u8], args: &[(&[u8], &[u8])]) -> bun_sys::Result<()> {
+        Self::create_full(asset, filename, "", args)
     }
 
-    pub(crate) fn create_with_contents(
-        asset_name: &[u8],
-        contents: &'static [u8],
-        args: &[(&[u8], &[u8])],
-    ) -> Result<(), Error> {
-        let is_template = !args.is_empty();
-        Self::create_full_with_contents(asset_name, contents, "", is_template, args)
-    }
-
-    fn create_new(filename: &ZStr, contents: &[u8]) -> Result<(), Error> {
-        // Create parent dirs then open.
-        if let Some(dir) = bun_core::dirname(filename.as_bytes()) {
+    /// Like [`create`](Self::create), but fails with `EEXIST` instead of
+    /// replacing an existing file, and creates missing parent directories.
+    fn create_new(filename: &[u8], contents: &[u8]) -> bun_sys::Result<()> {
+        if let Some(dir) = bun_core::dirname(filename) {
             if !dir.is_empty() && dir != b"." {
                 let _ = bun_sys::Dir::cwd().make_path(dir);
             }
         }
-        let file = bun_sys::File::openat(
-            Fd::cwd(),
-            filename.as_bytes(),
+        Self::write_new_file(
+            filename,
             bun_sys::O::CREAT | bun_sys::O::EXCL | bun_sys::O::WRONLY,
-            0o666,
+            contents,
         )?;
 
-        file.write_all(contents)?;
-
-        bun_core::prettyln!(" + <r><d>{}<r>", bstr::BStr::new(filename.as_bytes()));
+        bun_core::prettyln!(" + <r><d>{}<r>", bstr::BStr::new(filename));
         Output::flush();
         Ok(())
     }
 
     fn create_full(
-        // content of known asset
-        asset: &'static [u8],
-        // name of asset file to create
+        asset: &[u8],
         filename: &[u8],
         // optionally add a suffix to the end of the `+ filename` message. Must have a leading space.
         message_suffix: &'static str,
         args: &[(&[u8], &[u8])],
-    ) -> Result<(), Error> {
-        let is_template = !args.is_empty();
-        Self::create_full_inner(asset, filename, message_suffix, is_template, args)
-    }
-
-    fn create_full_inner(
-        asset: &'static [u8],
-        filename: &[u8],
-        message_suffix: &'static str,
-        is_template: bool,
-        args: &[(&[u8], &[u8])],
-    ) -> Result<(), Error> {
-        let file = bun_sys::File::openat(
-            Fd::cwd(),
-            filename,
-            bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
-            0o666,
-        )?;
-
-        // Write contents of known assets to the new file. Template assets get formatted.
-        if is_template {
-            let buf = bun_fmt::substitute_named(asset, args);
-            file.write_all(&buf)?;
+    ) -> bun_sys::Result<()> {
+        let flags = bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC;
+        if args.is_empty() {
+            Self::write_new_file(filename, flags, asset)?;
         } else {
-            file.write_all(asset)?;
+            Self::write_new_file(filename, flags, &bun_fmt::substitute_named(asset, args))?;
         }
         bun_core::prettyln!(
             " + <r><d>{}{}<r>",
@@ -1040,38 +983,30 @@ impl Assets {
         Ok(())
     }
 
-    fn create_full_with_contents(
-        // name of asset file to create
-        filename: &[u8],
-        contents: &'static [u8],
-        // optionally add a suffix to the end of the `+ filename` message. Must have a leading space.
-        message_suffix: &'static str,
-        // Treat the asset as a format string, using `args` to populate it. Only applies to known assets.
-        is_template: bool,
-        // Format arguments
-        args: &[(&[u8], &[u8])],
-    ) -> Result<(), Error> {
-        let file = bun_sys::File::openat(
-            Fd::cwd(),
-            filename,
-            bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
-            0o666,
-        )?;
-
-        if is_template {
-            let buf = bun_fmt::substitute_named(contents, args);
-            file.write_all(&buf)?;
-        } else {
-            file.write_all(contents)?;
+    /// Open `filename` with `flags` and write all of `contents` to it. When the
+    /// write fails the file is removed again, so that nothing half-written is
+    /// left under its name and a rerun (which skips existing files) creates it.
+    fn write_new_file(filename: &[u8], flags: i32, contents: &[u8]) -> bun_sys::Result<()> {
+        let file = bun_sys::File::openat(Fd::cwd(), filename, flags, 0o666)
+            .map_err(|err| err.with_path(filename))?;
+        let result = file.write_all(contents);
+        drop(file);
+        if result.is_err() {
+            let mut filename_z = filename.to_vec();
+            filename_z.push(0);
+            let _ = bun_sys::unlinkat(Fd::cwd(), ZStr::from_slice_with_nul(&filename_z));
         }
+        result.map_err(|err| err.with_path(filename))
+    }
 
-        bun_core::prettyln!(
-            " + <r><d>{}{}<r>",
-            bstr::BStr::new(filename),
-            message_suffix,
+    /// Report a scaffold file that could not be written and exit(1).
+    fn failed(err: bun_sys::Error, filename: &[u8]) -> ! {
+        Output::err(
+            err,
+            "failed to write <b>{}<r>",
+            (bstr::BStr::new(filename),),
         );
-        Output::flush();
-        Ok(())
+        Global::exit(1);
     }
 }
 
@@ -1463,6 +1398,15 @@ impl Template {
     }
 
     fn create_agent_rule() {
+        /// Whether the rule was created. One that already exists is left alone.
+        fn create_rule(path: &[u8], contents: &[u8]) -> bool {
+            match Assets::create_new(path, contents) {
+                Ok(()) => true,
+                Err(err) if err.get_errno() == bun_sys::E::EEXIST => false,
+                Err(err) => Assets::failed(err, path),
+            }
+        }
+
         let mut create_claude_md = Self::is_claude_code_installed()
             // Never overwrite CLAUDE.md
             && !exists(b"CLAUDE.md");
@@ -1475,28 +1419,11 @@ impl Template {
             } else {
                 template_file.path
             };
-            let asset_path_z = {
-                let mut v = asset_path.to_vec();
-                v.push(0);
-                v
-            };
-            let result = Assets::create_new(
-                ZStr::from_slice_with_nul(&asset_path_z[..]),
-                // SAFETY: asset_path_z[len-1] == 0 written above
-                template_file.contents,
-            );
-            if result.is_err() {
-                if create_claude_md {
-                    create_claude_md = false;
-                    // If installing the CLAUDE.md fails for some reason, fall back to installing the cursor rule.
-                    let mut tp = template_file.path.to_vec();
-                    tp.push(0);
-                    let _ = Assets::create_new(
-                        ZStr::from_slice_with_nul(&tp[..]),
-                        // SAFETY: tp[len-1] == 0 written above
-                        template_file.contents,
-                    );
-                }
+            let created = create_rule(asset_path, template_file.contents);
+            if !created && create_claude_md {
+                // CLAUDE.md appeared in the meantime: install the plain cursor rule instead.
+                create_claude_md = false;
+                create_rule(template_file.path, template_file.contents);
             }
 
             #[cfg(not(windows))]
@@ -1506,7 +1433,7 @@ impl Template {
                 // sync if you change it locally. we use a symlink for the cursor
                 // rule in this case so that the github UI for CLAUDE.md (which may
                 // appear prominently in repos) doesn't show a file path.
-                if result.is_ok() && create_claude_md {
+                if created && create_claude_md {
                     'symlink_cursor_rule: {
                         create_claude_md = false;
                         let _ = bun_sys::Dir::cwd().make_path(b".cursor/rules");
@@ -1541,11 +1468,7 @@ impl Template {
                 None => 0,
             };
 
-            let _ = Assets::create_new(
-                ZStr::from_static(b"CLAUDE.md\0"),
-                // SAFETY: literal is NUL-terminated
-                &Self::AGENT_RULE[end_of_frontmatter..],
-            );
+            create_rule(b"CLAUDE.md", &Self::AGENT_RULE[end_of_frontmatter..]);
         }
     }
 
@@ -1629,7 +1552,7 @@ impl Template {
             let contents = file.contents;
 
             let result = if path == b"README.md" {
-                Assets::create_with_contents(
+                Assets::create(
                     b"README.md",
                     contents,
                     &[
@@ -1638,28 +1561,17 @@ impl Template {
                     ],
                 )
             } else {
-                let mut p = path.to_vec();
-                p.push(0);
-                Assets::create_new(
-                    ZStr::from_slice_with_nul(&p[..]),
-                    // SAFETY: p[len-1] == 0 written above
-                    contents,
-                )
+                Assets::create_new(path, contents)
             };
             if let Err(err) = result {
-                if matches!(err, crate::Error::Sys(bun_errno::SystemErrno::EEXIST)) {
+                if err.get_errno() == bun_sys::E::EEXIST {
                     bun_core::prettyln!(
                         " ○ <r><yellow>{}<r> (already exists, skipping)",
                         bstr::BStr::new(path),
                     );
                     Output::flush();
                 } else {
-                    Output::err(
-                        err,
-                        "failed to create file: '{s}'",
-                        &[&bstr::BStr::new(path)],
-                    );
-                    Global::crash();
+                    Assets::failed(err, path);
                 }
             }
         }

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -1000,8 +1000,7 @@ impl Assets {
         result.map_err(|err| err.with_path(filename))
     }
 
-    /// Whether the file was created. One that already exists is left as it is; any other
-    /// failure is reported and exits.
+    /// Whether the file was created; an existing one is left alone, any other failure exits.
     fn check(result: bun_sys::Result<()>, filename: &[u8]) -> bool {
         match result {
             Ok(()) => true,

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -824,9 +824,10 @@ impl InitCommand {
         }
 
         if steps.write_gitignore {
-            if let Err(err) = Assets::create(b".gitignore", Assets::GITIGNORE, &[]) {
-                Assets::failed(err, b".gitignore");
-            }
+            Assets::check(
+                Assets::create(b".gitignore", Assets::GITIGNORE, &[]),
+                b".gitignore",
+            );
         }
 
         match template {
@@ -850,11 +851,13 @@ impl InitCommand {
                         }
                     }
 
-                    if let Err(err) =
-                        Assets::create_new(&fields.entry_point, b"console.log(\"Hello via Bun!\");")
-                    {
-                        Assets::failed(err, &fields.entry_point);
-                    }
+                    Assets::check(
+                        Assets::create_new(
+                            &fields.entry_point,
+                            b"console.log(\"Hello via Bun!\");",
+                        ),
+                        &fields.entry_point,
+                    );
                 }
 
                 if steps.write_tsconfig {
@@ -868,28 +871,30 @@ impl InitCommand {
                     } else {
                         b"jsconfig.json"
                     };
-                    if let Err(err) = Assets::create_full(
-                        Assets::TSCONFIG_JSON,
+                    Assets::check(
+                        Assets::create_full(
+                            Assets::TSCONFIG_JSON,
+                            filename,
+                            " (for editor autocomplete)",
+                            &[],
+                        ),
                         filename,
-                        " (for editor autocomplete)",
-                        &[],
-                    ) {
-                        Assets::failed(err, filename);
-                    }
+                    );
                 }
 
                 if steps.write_readme {
-                    if let Err(err) = Assets::create(
+                    Assets::check(
+                        Assets::create(
+                            b"README.md",
+                            Assets::README_MD,
+                            &[
+                                (b"name", fields.name.as_slice()),
+                                (b"bunVersion", Environment::VERSION_STRING.as_bytes()),
+                                (b"entryPoint", fields.entry_point.as_slice()),
+                            ],
+                        ),
                         b"README.md",
-                        Assets::README_MD,
-                        &[
-                            (b"name", fields.name.as_slice()),
-                            (b"bunVersion", Environment::VERSION_STRING.as_bytes()),
-                            (b"entryPoint", fields.entry_point.as_slice()),
-                        ],
-                    ) {
-                        Assets::failed(err, b"README.md");
-                    }
+                    );
                 }
 
                 if !fields.entry_point.is_empty() && !did_load_package_json {
@@ -936,12 +941,12 @@ impl Assets {
     pub(crate) const README_MD: &'static [u8] = include_bytes!("init/README.default.md");
     pub(crate) const README2_MD: &'static [u8] = include_bytes!("init/README2.default.md");
 
-    /// Create or replace an asset file. With `args`, `{[name]s}` placeholders in `asset` are substituted.
+    /// Create an asset file (`EEXIST` if it exists). With `args`, `{[name]s}` placeholders are substituted.
     fn create(filename: &[u8], asset: &[u8], args: &[(&[u8], &[u8])]) -> bun_sys::Result<()> {
         Self::create_full(asset, filename, "", args)
     }
 
-    /// Like [`create`](Self::create), but fails with `EEXIST` for an existing file; creates parent dirs.
+    /// Like [`create`](Self::create) without substitution; creates missing parent directories.
     fn create_new(filename: &[u8], contents: &[u8]) -> bun_sys::Result<()> {
         if let Some(dir) = bun_core::dirname(filename) {
             if !dir.is_empty() && dir != b"." {
@@ -966,7 +971,7 @@ impl Assets {
         message_suffix: &'static str,
         args: &[(&[u8], &[u8])],
     ) -> bun_sys::Result<()> {
-        let flags = bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC;
+        let flags = bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::EXCL;
         if args.is_empty() {
             Self::write_new_file(filename, flags, asset)?;
         } else {
@@ -993,6 +998,16 @@ impl Assets {
             let _ = bun_sys::unlinkat(Fd::cwd(), ZStr::from_slice_with_nul(&filename_z));
         }
         result.map_err(|err| err.with_path(filename))
+    }
+
+    /// Whether the file was created. One that already exists is left as it is; any other
+    /// failure is reported and exits.
+    fn check(result: bun_sys::Result<()>, filename: &[u8]) -> bool {
+        match result {
+            Ok(()) => true,
+            Err(err) if err.get_errno() == bun_sys::E::EEXIST => false,
+            Err(err) => Self::failed(err, filename),
+        }
     }
 
     /// Report a scaffold file that could not be written and exit(1).
@@ -1394,13 +1409,8 @@ impl Template {
     }
 
     fn create_agent_rule() {
-        /// Whether the rule was created. One that already exists is left alone.
         fn create_rule(path: &[u8], contents: &[u8]) -> bool {
-            match Assets::create_new(path, contents) {
-                Ok(()) => true,
-                Err(err) if err.get_errno() == bun_sys::E::EEXIST => false,
-                Err(err) => Assets::failed(err, path),
-            }
+            Assets::check(Assets::create_new(path, contents), path)
         }
 
         let mut create_claude_md = Self::is_claude_code_installed()

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -401,6 +401,7 @@ impl InitCommand {
 
         let mut package_json_file: Option<bun_sys::File> =
             bun_sys::File::openat(destination_dir, b"package.json", bun_sys::O::RDWR, 0).ok();
+        let package_json_existed = package_json_file.is_some();
         let mut package_json_contents: MutableString = MutableString::init_empty();
         bun_ast::initialize_store();
         // Arena for JSON parse / Expr building.
@@ -812,9 +813,18 @@ impl InitCommand {
                         i64::try_from(written.len()).expect("int cast"),
                     )
                 }),
+                // Exists but could not be read or is not a JSON object: start it over in place.
+                None if package_json_existed => bun_sys::File::openat(
+                    Fd::cwd(),
+                    b"package.json",
+                    bun_sys::O::WRONLY | bun_sys::O::TRUNC,
+                    0,
+                )
+                .and_then(|file| file.write_all(written))
+                .map_err(|err| err.with_path(b"package.json")),
                 None => Assets::write_new_file(
                     b"package.json",
-                    bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
+                    bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::EXCL,
                     written,
                 ),
             };
@@ -986,7 +996,7 @@ impl Assets {
         Ok(())
     }
 
-    /// A file whose write fails is removed again, so a rerun (which skips existing files) creates it.
+    /// `flags` include `O_EXCL`; a file whose write fails is removed again so a rerun creates it.
     fn write_new_file(filename: &[u8], flags: i32, contents: &[u8]) -> bun_sys::Result<()> {
         let file = bun_sys::File::openat(Fd::cwd(), filename, flags, 0o666)
             .map_err(|err| err.with_path(filename))?;

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -936,14 +936,12 @@ impl Assets {
     pub(crate) const README_MD: &'static [u8] = include_bytes!("init/README.default.md");
     pub(crate) const README2_MD: &'static [u8] = include_bytes!("init/README2.default.md");
 
-    /// Create an asset file, replacing anything that already exists. With
-    /// `args`, `asset` is a template and `{[name]s}` placeholders are substituted.
+    /// Create or replace an asset file. With `args`, `{[name]s}` placeholders in `asset` are substituted.
     fn create(filename: &[u8], asset: &[u8], args: &[(&[u8], &[u8])]) -> bun_sys::Result<()> {
         Self::create_full(asset, filename, "", args)
     }
 
-    /// Like [`create`](Self::create), but fails with `EEXIST` instead of
-    /// replacing an existing file, and creates missing parent directories.
+    /// Like [`create`](Self::create), but fails with `EEXIST` for an existing file; creates parent dirs.
     fn create_new(filename: &[u8], contents: &[u8]) -> bun_sys::Result<()> {
         if let Some(dir) = bun_core::dirname(filename) {
             if !dir.is_empty() && dir != b"." {
@@ -983,9 +981,7 @@ impl Assets {
         Ok(())
     }
 
-    /// Open `filename` with `flags` and write all of `contents` to it. When the
-    /// write fails the file is removed again, so that nothing half-written is
-    /// left under its name and a rerun (which skips existing files) creates it.
+    /// A file whose write fails is removed again, so a rerun (which skips existing files) creates it.
     fn write_new_file(filename: &[u8], flags: i32, contents: &[u8]) -> bun_sys::Result<()> {
         let file = bun_sys::File::openat(Fd::cwd(), filename, flags, 0o666)
             .map_err(|err| err.with_path(filename))?;

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -502,3 +502,68 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
   });
 });
+
+// A scaffold file that cannot be written (full disk) must fail `bun init`
+// instead of being left behind empty with exit code 0. bun ignores SIGXFSZ,
+// so under `ulimit -f <512-byte blocks>` a write past the limit fails with
+// EFBIG, which takes the same path as ENOSPC.
+describe.skipIf(isWindows)("bun init when a file cannot be written", () => {
+  async function init(cwd: string, fileSizeLimitBlocks?: number) {
+    const cmd =
+      fileSizeLimitBlocks === undefined
+        ? [bunExe(), "init", "-y"]
+        : ["sh", "-c", `ulimit -f ${fileSizeLimitBlocks} && exec "$@"`, "sh", bunExe(), "init", "-y"];
+    await using proc = Bun.spawn({ cmd, cwd, env: initEnv, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function files(dir: string) {
+    return Object.fromEntries(readdirSync(dir).map(name => [name, fs.statSync(path.join(dir, name)).size]));
+  }
+
+  test.concurrent("package.json: reports the error, removes the empty file, exits 1", async () => {
+    using dir = tempDir("bun-init-enospc-package-json", {});
+    // No file may grow past 0 bytes: the very first write fails.
+    const { stderr, exitCode } = await init(String(dir), 0);
+    expect(stderr).toContain("EFBIG");
+    expect(stderr).toContain("failed to write package.json");
+    expect(files(String(dir))).toEqual({});
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent(
+    "template file: reports the error, removes the partial file, exits 1, and a rerun completes the scaffold",
+    async () => {
+      using dir = tempDir("bun-init-enospc-template", {});
+      // 512 bytes per file: package.json, .gitignore and index.ts fit,
+      // tsconfig.json (735 bytes) does not.
+      {
+        const { stdout, stderr, exitCode } = await init(String(dir), 1);
+        expect(stderr).toContain("EFBIG");
+        expect(stderr).toContain("failed to write tsconfig.json");
+        expect(stdout).not.toContain("tsconfig.json");
+        const written = files(String(dir));
+        expect(written).toEqual({
+          ".gitignore": expect.any(Number),
+          "index.ts": expect.any(Number),
+          "package.json": expect.any(Number),
+        });
+        expect(Object.values(written)).not.toContain(0);
+        expect(exitCode).toBe(1);
+      }
+      // With space available again the missing files are created. package.json
+      // already lists the dependencies, so no `bun install` runs.
+      {
+        const { stdout, stderr, exitCode } = await init(String(dir));
+        expect(stderr).not.toContain("failed to write");
+        expect(stdout).toContain("+ tsconfig.json");
+        expect(stdout).toContain("+ README.md");
+        const written = files(String(dir));
+        expect(written).toMatchObject({ "tsconfig.json": expect.any(Number), "README.md": expect.any(Number) });
+        expect(Object.values(written)).not.toContain(0);
+        expect(exitCode).toBe(0);
+      }
+    },
+  );
+});

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -505,21 +505,32 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
 
 // A scaffold file that cannot be written (full disk) must fail `bun init`
 // instead of being left behind empty with exit code 0. bun ignores SIGXFSZ,
-// so under `ulimit -f <512-byte blocks>` a write past the limit fails with
-// EFBIG, which takes the same path as ENOSPC.
+// so under `ulimit -f N` a write past the limit fails with EFBIG, which takes
+// the same path as ENOSPC. N is in 512-byte blocks, or KiB with macOS /bin/sh.
 describe.skipIf(isWindows)("bun init when a file cannot be written", () => {
+  // The Cursor rule (.cursor/rules/*.mdc, > 2 KiB) is the one template file
+  // larger than 1 KiB, so it is the file that `ulimit -f 1` stops everywhere.
+  const env = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "0", CLAUDE_CODE_AGENT_RULE_DISABLED: "1", CURSOR_TRACE_ID: "1" };
+  const rule = ".cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc";
+
   async function init(cwd: string, fileSizeLimitBlocks?: number) {
     const cmd =
       fileSizeLimitBlocks === undefined
         ? [bunExe(), "init", "-y"]
         : ["sh", "-c", `ulimit -f ${fileSizeLimitBlocks} && exec "$@"`, "sh", bunExe(), "init", "-y"];
-    await using proc = Bun.spawn({ cmd, cwd, env: initEnv, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+    await using proc = Bun.spawn({ cmd, cwd, env, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout, stderr, exitCode };
   }
 
+  /** Every file below `dir` with its size (directories themselves are left out). */
   function files(dir: string) {
-    return Object.fromEntries(readdirSync(dir).map(name => [name, fs.statSync(path.join(dir, name)).size]));
+    return Object.fromEntries(
+      readdirSync(dir, { recursive: true, encoding: "utf8" })
+        .map(name => [name, fs.statSync(path.join(dir, name))] as const)
+        .filter(([, stat]) => stat.isFile())
+        .map(([name, stat]) => [name, stat.size]),
+    );
   }
 
   test.concurrent("package.json: reports the error, removes the empty file, exits 1", async () => {
@@ -536,19 +547,15 @@ describe.skipIf(isWindows)("bun init when a file cannot be written", () => {
     "template file: reports the error, removes the partial file, exits 1, and a rerun completes the scaffold",
     async () => {
       using dir = tempDir("bun-init-enospc-template", {});
-      // 512 bytes per file: package.json, .gitignore and index.ts fit,
-      // tsconfig.json (735 bytes) does not.
+      // package.json and .gitignore fit under the limit and are written first;
+      // the rule comes next and does not fit.
       {
         const { stdout, stderr, exitCode } = await init(String(dir), 1);
         expect(stderr).toContain("EFBIG");
-        expect(stderr).toContain("failed to write tsconfig.json");
-        expect(stdout).not.toContain("tsconfig.json");
+        expect(stderr).toContain("failed to write " + rule);
+        expect(stdout).not.toContain(rule);
         const written = files(String(dir));
-        expect(written).toEqual({
-          ".gitignore": expect.any(Number),
-          "index.ts": expect.any(Number),
-          "package.json": expect.any(Number),
-        });
+        expect(written).toEqual({ ".gitignore": expect.any(Number), "package.json": expect.any(Number) });
         expect(Object.values(written)).not.toContain(0);
         expect(exitCode).toBe(1);
       }
@@ -557,10 +564,16 @@ describe.skipIf(isWindows)("bun init when a file cannot be written", () => {
       {
         const { stdout, stderr, exitCode } = await init(String(dir));
         expect(stderr).not.toContain("failed to write");
-        expect(stdout).toContain("+ tsconfig.json");
-        expect(stdout).toContain("+ README.md");
+        for (const name of [rule, "index.ts", "tsconfig.json", "README.md"]) {
+          expect(stdout).toContain("+ " + name);
+        }
         const written = files(String(dir));
-        expect(written).toMatchObject({ "tsconfig.json": expect.any(Number), "README.md": expect.any(Number) });
+        expect(written).toMatchObject({
+          [rule]: expect.any(Number),
+          "index.ts": expect.any(Number),
+          "tsconfig.json": expect.any(Number),
+          "README.md": expect.any(Number),
+        });
         expect(Object.values(written)).not.toContain(0);
         expect(exitCode).toBe(0);
       }


### PR DESCRIPTION
### Problem
- `bun init -y` on a full filesystem exits 0 and leaves `index.ts`, `tsconfig.json`, `README.md` and `CLAUDE.md` as 0-byte files. The `open()` succeeds, the single `write()` returns `ENOSPC`, and nothing reports it. A second `bun init -y` after space is freed does not repair them, because existing files are skipped.
- The cause is the call sites in `InitCommand::exec` and `Template::create_agent_rule` (`src/runtime/cli/init_command.rs`). They drop the `Result` of `Assets::create` / `create_new` / `create_full` with `let _ =` or `break`. The `package.json` arm printed `package.json failed to write due to error ENOSPC` and went on to exit 0. An `open()` failure (inode exhaustion) surfaced as `error: An internal error occurred (ENOSPC)` with no file name.

### Fix
- The three `Assets` helpers share one `write_new_file(filename, flags, contents)`. Every scaffold file is created with `O_EXCL`. When `write_all` fails it unlinks the file it just created, so nothing empty is left under the final name and a rerun creates it.
- A file that already exists is never opened for writing and is never a reason to exit 1 (`Assets::check` treats `EEXIST` as "leave it"). Only a file that `bun init` creates itself and cannot fill is fatal: `ENOSPC: No space left on device: failed to write tsconfig.json (write)`, then `exit(1)`. The React `README.md` was the one template file that overwrote an existing copy (it used `O_TRUNC` to get placeholder substitution); it is now skipped like the other template files.
- `package.json` is serialized before the file is opened. A new `package.json` goes through the same writer (`O_EXCL`, removed again if the write fails). A pre-existing one, including one that could not be read or is not a JSON object, is rewritten in place and never unlinked (see Notes).
- Verified: `test/cli/init/init.test.ts`, new block `bun init when a file cannot be written` (2 tests, both fail on 1.4.3). The rest of the file passes with the debug build.

### Background
- `bun init` writes `package.json` first, then `.gitignore`, the agent rule, the entry point, `tsconfig.json`, `README.md`, then runs `bun install`. Each later file is only written when it does not exist yet, which is why a 0-byte leftover blocks a rerun.
- bun ignores `SIGXFSZ` at startup, so a write past `RLIMIT_FSIZE` fails with `EFBIG`. The tests run `bun init -y` under `sh -c 'ulimit -f N'` (512-byte blocks): `0` fails the `package.json` write, `1` lets `package.json` and `.gitignore` through and fails the Cursor rule (> 2 KiB), which is larger than the limit whether `sh` counts 512-byte blocks or KiB (macOS). `EFBIG` takes the same path as `ENOSPC`.
- `Output::err` with a `bun_sys::Error` prints `CODE: description: message (syscall)`, the same shape the lcov writer uses for a full disk.

<details><summary>Notes</summary>

- ` + package.json` was never printed for a newly created `package.json`: the port kept `package_json_file` as `None` after creating the file, while the Zig original assigned it. The line is now printed whenever init wrote a fresh `package.json` (`!did_load_package_json`).
- A pre-existing `package.json` is still overwritten in place and truncated afterwards. Making that atomic (temp file + rename) is what #39689 / #39701 do; this PR does not depend on them. If the in-place rewrite fails, init now exits 1 with the file name instead of continuing.
- #38474 makes the nested `bun install` failure fatal. That is a separate decision and is not included here. With this change the install is never reached when a scaffold file failed.
- Manual check of the open-failure path: `bun init -y` in a directory the user cannot write prints `EACCES: Permission denied: failed to write package.json (open)` and exits 1.
- Reported in the full-disk census (ledger #29533, #29535).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/init/init.test.ts

<!-- robobun:evidence:end -->
