### PR TITLE
libarchive: mask tar directory modes instead of narrowing them through i32

### DIFF
--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1427,26 +1427,14 @@ fn open_output_file(
 }
 
 fn make_directory(entry: &mut lib::Entry, dest_fd: Fd, path: OSPathZ, path_slice: &[OSPathChar]) {
-    let mut mode = i32::try_from(entry.perm()).expect("int cast");
-    // if dirs are readable, then they should be listable
-    // https://github.com/npm/node-tar/blob/main/lib/mode-fix.js
-    if (mode & 0o400) != 0 {
-        mode |= 0o100;
-    }
-    if (mode & 0o40) != 0 {
-        mode |= 0o10;
-    }
-    if (mode & 0o4) != 0 {
-        mode |= 0o1;
-    }
     #[cfg(windows)]
     {
         let _ = bun_sys::make_path::make_path::<u16>(Dir::borrow(&dest_fd), &path[..]);
-        let _ = (path_slice, mode);
+        let _ = (entry, path_slice);
     }
     #[cfg(not(windows))]
     {
-        match bun_sys::mkdirat_z(dest_fd, path, Mode::try_from(mode).expect("int cast")) {
+        match bun_sys::mkdirat_z(dest_fd, path, bun_libarchive::directory_mode(entry.perm())) {
             Ok(()) => {}
             Err(e) => match e.get_errno() {
                 bun_sys::E::EEXIST | bun_sys::E::ENOTDIR => {}

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -973,6 +973,25 @@ impl Drop for BufferReadStream {
     }
 }
 
+/// `mkdirat` mode for a directory entry. `perm` is whatever the header
+/// encoded (a GNU base-256 field need not fit in `0o7777`), so mask it, then
+/// make readable directories listable like node-tar does:
+/// https://github.com/npm/node-tar/blob/main/lib/mode-fix.js
+#[cfg(not(windows))]
+pub fn directory_mode(perm: bun_sys::Mode) -> bun_sys::Mode {
+    let mut mode = perm & 0o7777;
+    if (mode & 0o400) != 0 {
+        mode |= 0o100;
+    }
+    if (mode & 0o40) != 0 {
+        mode |= 0o10;
+    }
+    if (mode & 0o4) != 0 {
+        mode |= 0o1;
+    }
+    mode
+}
+
 /// Validates that a symlink target doesn't escape the extraction directory.
 /// Returns true if the symlink is safe (target stays within extraction dir),
 /// false if it would escape (e.g., via ../ traversal or absolute path).
@@ -1586,39 +1605,20 @@ impl Archiver {
 
                     match kind {
                         bun_sys::FileKind::Directory => {
-                            // SAFETY: entry valid
-                            let mut mode = i32::try_from(lib::Entry::opaque_ref(entry).perm())
-                                .expect("int cast");
-
-                            // if dirs are readable, then they should be listable
-                            // https://github.com/npm/node-tar/blob/main/lib/mode-fix.js
-                            if (mode & 0o400) != 0 {
-                                mode |= 0o100;
-                            }
-                            if (mode & 0o40) != 0 {
-                                mode |= 0o10;
-                            }
-                            if (mode & 0o4) != 0 {
-                                mode |= 0o1;
-                            }
-
                             #[cfg(windows)]
                             {
                                 make_path_u16(dir, path_slice)?;
-                                let _ = mode;
                             }
                             #[cfg(not(windows))]
                             {
+                                // SAFETY: entry valid
+                                let mode = directory_mode(lib::Entry::opaque_ref(entry).perm());
                                 // SAFETY: normalized_buf[path_slice.len()] == 0 (written above),
                                 // so path_slice is a NUL-terminated [:0]u8.
                                 let path_z: &ZStr = unsafe {
                                     ZStr::from_raw(path_slice.as_ptr(), path_slice.len())
                                 };
-                                match bun_sys::mkdirat_z(
-                                    dir_fd,
-                                    path_z,
-                                    bun_sys::Mode::try_from(mode).expect("int cast"),
-                                ) {
+                                match bun_sys::mkdirat_z(dir_fd, path_z, mode) {
                                     Ok(()) => {}
                                     Err(err) => {
                                         // It's possible for some tarballs to return a directory twice, with and

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1134,7 +1134,7 @@ impl TaskContext for FilesContext {
                     let blob = unsafe { &mut *blob_ptr };
                     blob.is_jsdom_file.set(true);
                     blob.name.set(bun_core::String::clone_utf8(&entry.path));
-                    blob.last_modified.set((entry.mtime * 1000) as f64);
+                    blob.last_modified.set(entry.mtime as f64 * 1000.0);
 
                     let name_js = blob.name.get().to_js(global)?;
                     let blob_js = blob.to_js(global);

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -26,10 +26,11 @@ function octal(n: number, width: number): string {
   return n.toString(8).padStart(width - 1, "0") + "\0";
 }
 
-function tarHeader(name: string, size: number, type: "0" | "5" | "x" | "g"): Buffer {
+function tarHeader(name: string, size: number, type: "0" | "5" | "x" | "g", mode?: Uint8Array): Buffer {
   const buf = Buffer.alloc(512, 0);
   buf.write(name, 0, 100, "utf8");
   buf.write(octal(0o644, 8), 100); // mode
+  if (mode) buf.set(mode.subarray(0, 8), 100); // raw 8-byte field, e.g. GNU base-256
   buf.write(octal(0, 8), 108); // uid
   buf.write(octal(0, 8), 116); // gid
   buf.write(octal(size, 12), 124); // size
@@ -950,4 +951,88 @@ test("streaming extract skips a damaged header block and extracts the entries af
     expect([path, got.length, got.equals(body)]).toEqual([path, body.length, true]);
   }
   expect(exitCode).toBe(0);
+});
+
+// Unlike registry tarballs, a `github:` tarball has its directory entries
+// created, with the mode libarchive reports for them. A GNU base-256 mode
+// field can set bits far above the twelve mode bits; both extractors must
+// drop those instead of aborting on them.
+test.concurrent.each([
+  ["streaming", {}],
+  ["buffered", { BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1" }],
+] as const)("installs a github tarball whose directory mode field exceeds the mode bits (%s)", async (label, env) => {
+  // base-256: marker bit in the first byte, then 2^31 | 0o755 big-endian.
+  const wideMode = Buffer.from([0x80, 0, 0, 0, 0x80, 0, 0x01, 0xed]);
+  const root = "owner-repo-abc1234";
+  const index = Buffer.from("module.exports = 'ok';\n");
+  // Incompressible bulk so the body spans many reads and streaming commits.
+  const bulk = Buffer.alloc(256 * 1024);
+  let seed = createHash("sha256").update("wide-mode").digest();
+  for (let off = 0; off < bulk.length; off += 32) {
+    seed.copy(bulk, off);
+    seed = createHash("sha256").update(seed).digest();
+  }
+  const tgz = gzipSync(
+    Buffer.concat([
+      tarHeader(`${root}/`, 0, "5"),
+      ...tarFile(`${root}/package.json`, Buffer.from(JSON.stringify({ name: "wide-mode-pkg", version: "1.0.0" }))),
+      tarHeader(`${root}/lib/`, 0, "5", wideMode),
+      ...tarFile(`${root}/lib/index.js`, index),
+      ...tarFile(`${root}/bulk.bin`, bulk),
+      Buffer.alloc(1024, 0),
+    ]),
+  );
+
+  // node:http so the body carries a Content-Length and is still drip-fed.
+  const server = createServer((req, res) => {
+    if (new URL(req.url!, "http://x").pathname !== "/repos/owner/repo/tarball/abc1234") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    res.setHeader("content-type", "application/gzip");
+    res.setHeader("content-length", String(tgz.length));
+    req.socket.setNoDelay(true);
+    let i = 0;
+    const step = () => {
+      if (i >= tgz.length) {
+        res.end();
+        return;
+      }
+      res.write(tgz.subarray(i, Math.min(i + 4096, tgz.length)));
+      i += 4096;
+      setImmediate(step);
+    };
+    step();
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    using dir = tempDir("streaming-extract-wide-dir-mode", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "wide-mode-pkg": "github:owner/repo#abc1234" },
+      }),
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir), {
+      ...env,
+      GITHUB_API_URL: `http://127.0.0.1:${(server.address() as { port: number }).port}`,
+      BUN_INSTALL_STREAMING_MIN_SIZE: "1024",
+    });
+    expect(stderr).not.toContain("error:");
+    if (label === "streaming") {
+      expect(stderr).toContain("Streamed ");
+    } else {
+      expect(stderr).not.toContain("Streamed ");
+    }
+    const pkgRoot = join(String(dir), "node_modules", "wide-mode-pkg");
+    expect(statSync(join(pkgRoot, "lib")).isDirectory()).toBe(true);
+    expect(readFileSync(join(pkgRoot, "lib", "index.js")).equals(index)).toBe(true);
+    expect(readFileSync(join(pkgRoot, "bulk.bin")).equals(bulk)).toBe(true);
+    expect(exitCode).toBe(0);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
 });

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -5,16 +5,25 @@ import { join } from "path";
 
 // Minimal ustar tarball builder (pathnames must be <100 bytes). `name` accepts
 // a Buffer so tests can put raw, non-UTF-8 byte sequences into the name field.
-function ustarHeader(name: string | Buffer, size: number, typeflag: string = "0"): Buffer {
+// `fields` overwrites the raw 8-byte mode / 12-byte mtime fields, for values the
+// octal text form cannot hold (see `base256`).
+function ustarHeader(
+  name: string | Buffer,
+  size: number,
+  typeflag: string = "0",
+  fields: { mode?: Uint8Array; mtime?: Uint8Array } = {},
+): Buffer {
   const nameBytes = typeof name === "string" ? Buffer.from(name) : name;
   if (nameBytes.length > 99) throw new Error("ustar name too long: " + name);
   const h = Buffer.alloc(512);
   nameBytes.copy(h, 0);
   h.write("0000644\0", 100);
+  if (fields.mode) h.set(fields.mode.subarray(0, 8), 100);
   h.write("0000000\0", 108);
   h.write("0000000\0", 116);
   h.write(size.toString(8).padStart(11, "0") + "\0", 124);
   h.write("00000000000\0", 136);
+  if (fields.mtime) h.set(fields.mtime.subarray(0, 12), 136);
   h.write("        ", 148);
   h.write(typeflag, 156);
   h.write("ustar\0", 257);
@@ -28,6 +37,20 @@ function ustarHeader(name: string | Buffer, size: number, typeflag: string = "0"
 function ustarEntry(name: string | Buffer, data: Buffer): Buffer {
   const pad = Buffer.alloc((512 - (data.length % 512)) % 512);
   return Buffer.concat([ustarHeader(name, data.length), data, pad]);
+}
+
+// GNU tar base-256 ("binary") form of a numeric header field: the top bit of
+// the first byte set, then `value` as big-endian two's complement in the rest.
+// Writers use it when a value does not fit the field's octal digits, so a
+// reader can see numbers far outside what the field normally carries.
+function base256(value: bigint, width: number): Uint8Array {
+  const out = new Uint8Array(width);
+  for (let i = width - 1; i >= 0; i--) {
+    out[i] = Number(value & 0xffn);
+    value >>= 8n;
+  }
+  out[0] |= 0x80;
+  return out;
 }
 
 function buildTarball(entries: Array<{ name: string | Buffer; data: Buffer | string }>): Uint8Array {
@@ -576,6 +599,48 @@ describe("Bun.Archive", () => {
           rmSync(windowsAbsPath, { force: true });
         }
       }
+    });
+
+    test("extracts entries whose mode field has bits above the permission bits", async () => {
+      // libarchive hands back whatever the header's mode field encoded, and a
+      // base-256 field can encode far more than the 12 mode bits. Only the
+      // permission bits may reach mkdirat()/openat(); the rest are dropped.
+      const high = 1n << 31n;
+      const tarball = Buffer.concat([
+        ustarHeader("dir/", 0, "5", { mode: base256(high | 0o755n, 8) }),
+        ustarHeader("dir/inner.txt", 5, "0", { mode: base256(high | 0o644n, 8) }),
+        Buffer.concat([Buffer.from("inner"), Buffer.alloc(512 - 5)]),
+        ustarEntry("top.txt", Buffer.from("top")),
+        Buffer.alloc(1024),
+      ]);
+
+      using dir = tempDir("archive-extract-wide-mode", {
+        "input.tar": tarball,
+        "extract.ts": `
+          const fs = require("node:fs");
+          const count = await new Bun.Archive(fs.readFileSync("input.tar")).extract("out");
+          console.log(JSON.stringify({
+            count,
+            dir: fs.statSync("out/dir").isDirectory(),
+            inner: fs.readFileSync("out/dir/inner.txt", "utf8"),
+            top: fs.readFileSync("out/top.txt", "utf8"),
+          }));
+        `,
+      });
+
+      // In a child process: the failure mode is a process abort.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "extract.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ count: 3, dir: true, inner: "inner", top: "top" });
+      expect(exitCode).toBe(0);
     });
   });
 
@@ -1491,6 +1556,42 @@ describe("Bun.Archive", () => {
 
       expect(file!.lastModified).toBeGreaterThanOrEqual(beforeTime);
       expect(file!.lastModified).toBeLessThanOrEqual(afterTime);
+    });
+
+    test("lastModified is computed without overflow for any mtime the header can encode", async () => {
+      // A base-256 mtime field holds a full signed 64-bit value; seconds to
+      // milliseconds must not go through a 64-bit integer multiply.
+      const tarball = Buffer.concat([
+        ustarHeader("huge.txt", 0, "0", { mtime: base256(1n << 62n, 12) }),
+        ustarHeader("negative.txt", 0, "0", { mtime: base256(-1n, 12) }),
+        ustarHeader("epoch.txt", 0, "0"),
+        Buffer.alloc(1024),
+      ]);
+
+      using dir = tempDir("archive-files-wide-mtime", { "input.tar": tarball });
+
+      // In a child process: the failure mode is a process abort.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const files = await new Bun.Archive(await Bun.file("input.tar").bytes()).files();
+           console.log(JSON.stringify(Object.fromEntries([...files].map(([name, file]) => [name, file.lastModified]))));`,
+        ],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        "huge.txt": 2 ** 62 * 1000,
+        "negative.txt": -1000,
+        "epoch.txt": 0,
+      });
+      expect(exitCode).toBe(0);
     });
 
     test("throws with non-string glob argument", async () => {


### PR DESCRIPTION
### Problem
- A tar directory entry whose mode field encodes 2^31 or more aborts extraction with `panic: int cast: TryFromIntError(PosOverflow)`. This kills `Bun.Archive#extract()`, `bun create <owner>/<repo>`, and `bun install` of a `github:` dependency. 1.3.14 extracted the same bytes. Linux only (`mode_t` is 16 bits elsewhere).
- Cause: `src/libarchive/lib.rs:1590` and `src/install/TarballStream.rs:1430` both did `i32::try_from(entry.perm()).expect("int cast")`. A GNU base-256 mode field holds up to 63 bits and libarchive passes them through.
- Sibling: `Archive#files()` computed `lastModified` as `(mtime * 1000) as f64` (`src/runtime/api/Archive.rs:1137`). An mtime of 2^54 or more overflows i64: a panic on debug builds, a wrapped value on release.

### Fix
- Keep the mode as `Mode` (u32) throughout. A shared `bun_libarchive::directory_mode()` masks it to `0o7777` and applies the node-tar `mode-fix.js` fix-up both sites already had. `mode-fix.js` starts with the same mask.
- Do the milliseconds multiply in f64.
- Correct because `mkdir(2)` honors at most the low 12 bits, so every representable mode reaches the kernel unchanged. Only impossible high bits are dropped.
- Verified: `test/js/bun/archive.test.ts` (2 new tests), `test/cli/install/bun-install-streaming-extract.test.ts` (streaming and buffered). All fail on 1.4.3-canary, pass here. Self-reviewed.

### Background
- ustar numeric fields are octal text. GNU base-256 sets the top bit of the first byte and stores the value big-endian in the rest, so an 8-byte field carries 63 bits.
- `bun install` has a buffered extractor (`extract_to_dir`) and a streaming one (`TarballStream.rs`) for large responses. Both skip directory entries for registry tarballs and create them for `github:` tarballs.

<details><summary>Notes</summary>

- Repro (JS only), from the report:
  ```js
  const h = new Uint8Array(1536), enc = new TextEncoder();
  h.set(enc.encode("d/"), 0); h.set([0x80, 0, 0, 0, 0x80, 0, 0, 0], 100); // mode = base-256 2^31
  h.set(enc.encode("00000000000\0" + "00000000000\0"), 124); h[156] = 0x35; // size 0, mtime 0, dir
  h.set(enc.encode("ustar\0" + "00"), 257); h.fill(32, 148, 156);
  let s = 0; for (let i = 0; i < 512; i++) s += h[i];
  h.set(enc.encode(s.toString(8).padStart(6, "0") + "\0 "), 148);
  console.log(await new Bun.Archive(h).extract("out")); // 1.4.x: panic; with this PR: 1
  ```
- The install arm was confirmed on both paths: with `BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL=1` the panic comes from `extract_to_dir`, without it from `TarballStream::make_directory`.
- Why `0o7777` and not `0o777`: it is the mask node-tar applies to header modes, and it leaves the on-disk result identical to 1.3 for every representable mode (the kernel already drops setuid/setgid on `mkdir`; Linux keeps the sticky bit, macOS keeps only `0777`). The file arms keep their existing `0o777` mask, which is there so an archive cannot create setuid files.
- The remaining `expect("int cast")` calls in these functions convert values that are already range-checked (`read >= 0`, `size >= 0` from an i64) and cannot fail on 64-bit targets.
- Also ran the rest of both test files and `test/cli/install/symlink-path-traversal.test.ts`.
- `bun run rust:check-all x86_64-pc-windows-msvc aarch64-apple-darwin` passes. The helper and its callers are `cfg(not(windows))`; Windows keeps using `make_path`.

</details>
