### PR TITLE
js_printer: write null for non-finite numbers in JSON output

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6913,7 +6913,11 @@ pub(crate) mod __gated_printer {
 
         pub(crate) fn print_number(&mut self, value: f64, level: Level) {
             let abs_value = value.abs();
-            if value.is_nan() {
+            if IS_JSON && !value.is_finite() {
+                // JSON has no token for these. Match JSON.stringify.
+                self.print_space_before_identifier();
+                self.print(b"null");
+            } else if value.is_nan() {
                 self.print_space_before_identifier();
                 self.print(b"NaN");
             } else if value.is_infinite() {
@@ -6934,7 +6938,7 @@ pub(crate) mod __gated_printer {
                 }
 
                 // If we are not running the symbol renamer, we must not print "Infinity".
-                if IS_JSON || (!self.options.minify_syntax && self.options.has_run_symbol_renamer) {
+                if !self.options.minify_syntax && self.options.has_run_symbol_renamer {
                     self.print(b"Infinity");
                 } else if self.options.minify_whitespace {
                     self.print(b"1/0");

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -432,52 +432,25 @@ impl PmPkgCommand {
     }
 
     fn format_json(expr: Expr, initial_indent: Option<usize>) -> Result<Box<[u8]>, Error> {
-        match &expr.data {
-            ExprData::EBoolean(b) => Ok(Box::<[u8]>::from(if b.value {
-                &b"true"[..]
-            } else {
-                &b"false"[..]
-            })),
-            ExprData::ENumber(n) => {
-                let mut v = Vec::new();
-                if n.value().floor() == n.value() {
-                    write!(&mut v, "{:.0}", n.value()).map_err(|_| crate::Error::WriteFailed)?;
-                } else {
-                    write!(&mut v, "{}", n.value()).map_err(|_| crate::Error::WriteFailed)?;
-                }
-                Ok(v.into_boxed_slice())
-            }
-            ExprData::ENull(_) => Ok(Box::<[u8]>::from(&b"null"[..])),
-            _ => {
-                let buffer_writer = js_printer::BufferWriter::init();
-                let mut printer = js_printer::BufferPrinter::init(buffer_writer);
+        let buffer_writer = js_printer::BufferWriter::init();
+        let mut printer = js_printer::BufferPrinter::init(buffer_writer);
 
-                js_printer::print_json(
-                    &mut printer,
-                    expr,
-                    &Source::init_empty_file(b"expression.json"),
-                    js_printer::PrintJsonOptions {
-                        mangled_props: None,
-                        indent: match initial_indent {
-                            Some(indent) => bun_ast::Indentation {
-                                scalar: indent,
-                                count: 0,
-                                ..Default::default()
-                            },
-                            None => bun_ast::Indentation {
-                                scalar: 2,
-                                count: 0,
-                                ..Default::default()
-                            },
-                        },
-                        ..Default::default()
-                    },
-                )?;
+        js_printer::print_json(
+            &mut printer,
+            expr,
+            &Source::init_empty_file(b"expression.json"),
+            js_printer::PrintJsonOptions {
+                mangled_props: None,
+                indent: bun_ast::Indentation {
+                    scalar: initial_indent.unwrap_or(2),
+                    count: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )?;
 
-                let written = printer.ctx.get_written();
-                Ok(Box::<[u8]>::from(written))
-            }
-        }
+        Ok(Box::<[u8]>::from(printer.ctx.get_written()))
     }
 
     fn get_json_value(

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -328,6 +328,44 @@ describe.concurrent("bun pm pkg", () => {
       expect(JSON.parse(content)).toEqual({ ...original, config: { limit: 1000000 } });
     });
 
+    it("should write null for numbers that overflow to Infinity, like JSON.stringify", async () => {
+      // `1e400` is valid JSON number syntax. It reads as Infinity, which has
+      // no JSON token. JSON.stringify (and npm) write it back as null.
+      using dir = tempDir("pm-pkg-nonfinite", {
+        "package.json": `{
+  "name": "n",
+  "version": "1.0.0",
+  "config": { "max": 1e400, "min": -1e999, "tiny": 1e-400, "ok": 1.5 }
+}`,
+      });
+
+      // Reading it back out goes through the same printer.
+      const before = await runPmPkg(["get", "config.max"], dir);
+      expect(before.output.trim()).toBe("null");
+      expect(before.error).toBe("");
+
+      // A --json value that overflows, plus a rewrite of the existing literals.
+      const { error, code } = await runPmPkg(["set", "limit=1e400", "low=-1e400", "--json"], dir);
+      expect(error).toBe("");
+      expect(code).toBe(0);
+
+      const content = await Bun.file(join(dir, "package.json")).text();
+      expect(content).not.toContain("Infinity");
+      expect(content).not.toContain("NaN");
+      expect(JSON.parse(content)).toEqual({
+        name: "n",
+        version: "1.0.0",
+        config: { max: null, min: null, tiny: 0, ok: 1.5 },
+        limit: null,
+        low: null,
+      });
+
+      // bun itself must still be able to read the file it wrote.
+      const after = await runPmPkg(["get", "config"], dir);
+      expect(JSON.parse(after.output)).toEqual({ max: null, min: null, tiny: 0, ok: 1.5 });
+      expect(after.error).toBe("");
+    });
+
     it("should write literal keys when setting with bracket notation", async () => {
       // Key-path segments parsed from a bracket path must stay alive until
       // the file is written; otherwise the printer serializes freed bytes.

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -526,6 +526,34 @@ describe.concurrent("bun pm version", () => {
         },
       });
     });
+
+    it("keeps the file valid JSON when a number literal overflows to Infinity", async () => {
+      // `1e400` is valid JSON syntax but reads as Infinity. The rewrite must
+      // not print the `Infinity` token, which no JSON parser accepts.
+      await using testDir = tempDir(`version-${i++}`, {
+        "package.json": `{
+  "name": "test",
+  "version": "1.0.0",
+  "config": { "max": 1e400, "min": -1e400 }
+}`,
+      });
+
+      const { output, error, code } = await runCommand(
+        [bunExe(), "pm", "version", "patch", "--no-git-tag-version"],
+        String(testDir),
+      );
+      expect(error).toBe("");
+      expect(output.trim()).toBe("v1.0.1");
+      expect(code).toBe(0);
+
+      const updated = await Bun.file(join(String(testDir), "package.json")).text();
+      expect(updated).not.toContain("Infinity");
+      expect(JSON.parse(updated)).toEqual({
+        name: "test",
+        version: "1.0.1",
+        config: { max: null, min: null },
+      });
+    });
   });
 
   describe("prerelease handling", () => {


### PR DESCRIPTION
### Problem
- The package.json writer prints a non-finite double as the JavaScript token `Infinity`, `-Infinity` or `NaN`. `"limit": Infinity` is not JSON. node, npm and bun's own manifest reader reject it, so `bun run` reports `error: Script not found` afterwards and bun cannot repair the file.
- A valid manifest triggers it: `1e400` is legal JSON syntax and reads as Infinity. `bun pm version patch`, `bun pm pkg set`, `bun add` and `bun init` then rewrite it as `Infinity`. The cause is `print_number` in `src/js_printer/lib.rs`: it printed `NaN` always and chose `Infinity` explicitly when `IS_JSON`.

### Fix
- In JSON mode, `print_number` writes `null` for a non-finite value. `JSON.stringify` does the same. npm 11 writes `"max": null` for the same manifest.
- `bun pm pkg get` formatted a bare number with Rust's float `Display` (`inf`). It now uses `print_json` for every value, so the two paths agree. Finite output is unchanged.
- Verified: new tests in `test/cli/install/bun-pm-pkg.test.ts` and `bun-pm-version.test.ts` fail on stock bun and pass here. Both full suites and the bundler `Infinity` folding tests pass.

### Background
- `print_json` is the one serializer behind every package.json rewrite (`pm pkg`, `pm version`, `add`, `init`, `pack`, the `publish` manifest). It runs the JS printer with the const generic `IS_JSON = true`. The bundler never sets it, so its `Infinity` / `1 / 0` output is untouched.
- The manifest reader parses numbers like `JSON.parse`: `1e400` becomes Infinity. The literal text is not kept, so the printer only sees the double.
- JSON has no spelling for NaN or the infinities. `JSON.stringify` maps all three to `null`.

<details><summary>Notes</summary>

- Repro on bun 1.4.2, canary and 1.3.14:
  ```sh
  printf '{"name":"n","version":"1.0.0","scripts":{"s":"echo hi"}}' > package.json
  bun pm pkg set --json limit=1e400; grep limit package.json   #   "limit": Infinity,
  bun run s                                                  # error: Script not found "s"
  printf '{"name":"n","version":"1.0.0","config":{"max":1e400}}' > package.json
  bun pm version patch --no-git-tag-version; grep max package.json   #   "max": Infinity,
  ```
- npm 11 on the second manifest: `npm pkg set y=1` rewrites `"max": null`; `npm pkg set --json z=1e400` writes `"z": null`; `npm pkg set --json w=NaN` errors (`"NaN" is not valid JSON`). Whether `bun pm pkg set --json` should reject non-JSON values like `NaN` the way npm does is a separate parser question and is not part of this change; with this change such a value at least cannot corrupt the file.
- Alternatives considered: erroring out of `print_json` would make `bun pm version patch` fail on a manifest every other tool accepts; printing a finite stand-in would silently change the value to a different number. `null` is the only choice with a reference implementation behind it.
- `1e-400` reads as 0 and prints as `0`, same as `JSON.parse`/`JSON.stringify`; unchanged here.
- The tests use only `1e400` / `-1e400` style inputs (valid JSON syntax) so they do not depend on how leniently `--json` values are parsed.
- Suites run: `test/cli/install/bun-pm-pkg.test.ts` (76 pass), `test/cli/install/bun-pm-version.test.ts` (25 pass), `bundler_minify.test.ts -t Infinity`, `bundler_edgecase.test.ts -t "ConstantFolding|InlinedConstEnumNaN"`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-pm-pkg.test.ts test/cli/install/bun-pm-version.test.ts
bun test v1.4.3 (f42e98025)

test/cli/install/bun-pm-pkg.test.ts:
(pass) bun pm pkg > get command > should get array elements with bracket notation [133.09ms]
(pass) bun pm pkg > get command > should get entire package.json when no args provided [160.23ms]
(pass) bun pm pkg > get command > should get a single property [216.83ms]
(pass) bun pm pkg > get command > should get nested properties with dot notation [176.80ms]
(pass) bun pm pkg > get command > should get multiple properties [205.31ms]
(pass) bun pm pkg > get command > should get object properties with bracket notation [125.53ms]
(pass) bun pm pkg > get command > should get array elements with dot notation (npm compatibility) [133.96ms]
(pass) bun pm pkg > get command > should get array elements without index (entire array) [128.31ms]
(pass) bun pm pkg > get command > should handle missing properties gracefully [141.02ms]
(pass) bun pm pkg > get command > should get array elements with dot numeric index 
... (truncated)

release without fix: 2 failed, 3 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/cli/install/bun-pm-pkg.test.ts:
(pass) bun pm pkg > get command > should get nested properties with dot notation [363.40ms]
(pass) bun pm pkg > get command > should get a single property [372.23ms]
(pass) bun pm pkg > get command > should get array elements with dot notation (npm compatibility) [362.88ms]
(pass) bun pm pkg > get command > should get multiple properties [371.66ms]
(pass) bun pm pkg > get command > should get array elements with bracket notation [367.51ms]
(pass) bun pm pkg > get command > should get entire package.json when no args provided [373.46ms]
(pass) bun pm pkg > get command > should get array elements without index (entire array) [376.94ms]
(pass) bun pm pkg > get command > should get array elements with dot numeric index [379.92ms]
(pass) bun pm pkg > get command > should get object properties with bracket notation [384.09ms]
(pass) bun pm pkg > get command > should handle missing properties gracefully [380.08ms]
(pass) bun pm pkg > get command > should handle mixed existing and missing properties [588.56ms]
(pass) bun pm pkg > get command > should handle boolean values [595.83ms]
(pass) bun pm pkg
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-pm-pkg.test.ts test/cli/install/bun-pm-version.test.ts
bun test v1.4.3 (f42e98025)

test/cli/install/bun-pm-pkg.test.ts:
(pass) bun pm pkg > get command > should get multiple properties [217.00ms]
(pass) bun pm pkg > get command > should get array elements with bracket notation [195.51ms]
(pass) bun pm pkg > get command > should get a single property [287.31ms]
(pass) bun pm pkg > get command > should get entire package.json when no args provided [255.17ms]
(pass) bun pm pkg > get command > should get nested properties with dot notation [365.08ms]
(pass) bun pm pkg > get command > should get array elements with dot notation (npm compatibility) [172.17ms]
(pass) bun pm pkg > get command > should get object properties with bracket notation [230.46ms]
(pass) bun pm pkg > get command > should get array elements with dot numeric index [280.80ms]
(pass) bun pm pkg > get command > should get array elements without index (entire array) [267.75ms]
(pass) bun pm pkg > get command > should handle missing properties gracefully 
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 6430ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/2006] cc obj/vendor/libarchive/libarchive/archive_virtual.c.o
[2/2006] cc obj/vendor/libarchive/libarchive/archive_version_details.c.o
[3/2006] cc obj/vendor/libarchive/libarchive/archive_write.c.o
[4/2006] cc obj/vendor/libarchive/libarchive/archive_write_disk_set_standard_lookup.c.o
[5/2006] cc obj/vendor/libarchive/libarchive/archive_write_open_file.c.o
[6/2006] cc obj/vendor/libarchive/libarchive/archive_write_add_filter.c.o
[7/2006] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[7/2006] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m compiler_builtins v0.1.160 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/compiler-builtins/compiler-builtins)
[1m[92m   Compiling[0m core v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core)
[1m[92m   Compiling[0m libc v0.2.185
[1m[92m   Compil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                   |  8 +++-
 src/runtime/cli/pm_pkg_command.rs       | 65 ++++++++++-----------------------
 test/cli/install/bun-pm-pkg.test.ts     | 38 +++++++++++++++++++
 test/cli/install/bun-pm-version.test.ts | 28 ++++++++++++++
 4 files changed, 91 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/js_printer/lib.rs                        2      3      9
src/runtime/cli/pm_pkg_command.rs            3      1      9
test/cli/install/bun-pm-pkg.test.ts          1      1      8
test/cli/install/bun-pm-version.test.ts      2      1      7
```

</details>

**root cause** · written by the author bot

The JSON printer reused the JavaScript number formatting path, so non-finite `f64` values were emitted as the bare tokens `NaN`, `Infinity`, and `1 / 0`, which are not valid JSON and made every rewritten `package.json` unparseable by strict readers, including bun itself. The fix gates `print_number` on `IS_JSON` and emits `null` for any non-finite value, matching `JSON.stringify` and npm 11 behavior, while leaving the bundler's JavaScript output untouched. `format_json` in the `pm pkg` command now routes scalars, objects, and arrays through the same JSON printer instead of its own float for…

<!-- robobun:evidence:end -->