### PR TITLE
docs(sql): say that multi-statement files are atomic on PostgreSQL only

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -444,6 +444,14 @@ const result = await sql.file("query.sql", [1, 2, 3]);
 
 With the SQLite adapter, parameters can also be an object of named parameters (`:name`, `$name`, or `@name` placeholders), the same form `sql.unsafe` accepts below.
 
+<Note>
+  A file or string with more than one statement is atomic only on PostgreSQL, which runs a multi-statement query as
+  one implicit transaction. MySQL and SQLite run the statements one at a time, so the statements before a failing one
+  stay applied. To apply a multi-statement file atomically on SQLite, run it inside a transaction:
+  `await sql.begin(tx => tx.file("migration.sql"))`. On MySQL this only covers DML: DDL statements such as
+  `CREATE TABLE` commit implicitly and cannot be rolled back.
+</Note>
+
 ### Unsafe Queries
 
 `sql.unsafe` executes raw SQL strings. Use it with caution: it does not escape user input. Without parameters, the string can contain more than one command.

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -445,11 +445,11 @@ const result = await sql.file("query.sql", [1, 2, 3]);
 With the SQLite adapter, parameters can also be an object of named parameters (`:name`, `$name`, or `@name` placeholders), the same form `sql.unsafe` accepts below.
 
 <Note>
-  A file or string with more than one statement is atomic only on PostgreSQL, which runs a multi-statement query as
-  one implicit transaction. MySQL and SQLite run the statements one at a time, so the statements before a failing one
-  stay applied. To apply a multi-statement file atomically on SQLite, run it inside a transaction:
-  `await sql.begin(tx => tx.file("migration.sql"))`. On MySQL this only covers DML: DDL statements such as
-  `CREATE TABLE` commit implicitly and cannot be rolled back.
+  A file or string with more than one statement is atomic only on PostgreSQL, which runs a multi-statement query as one
+  implicit transaction. MySQL and SQLite run the statements one at a time, so the statements before a failing one stay
+  applied. To apply a multi-statement file atomically on SQLite, run it inside a transaction: `await sql.begin(tx =>
+  tx.file("migration.sql"))`. On MySQL this only covers DML: DDL statements such as `CREATE TABLE` commit implicitly and
+  cannot be rolled back.
 </Note>
 
 ### Unsafe Queries

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -445,11 +445,11 @@ const result = await sql.file("query.sql", [1, 2, 3]);
 With the SQLite adapter, parameters can also be an object of named parameters (`:name`, `$name`, or `@name` placeholders), the same form `sql.unsafe` accepts below.
 
 <Note>
-  A file or string with more than one statement is atomic only on PostgreSQL, which runs a multi-statement query as one
-  implicit transaction. MySQL and SQLite run the statements one at a time, so the statements before a failing one stay
-  applied. To apply a multi-statement file atomically on SQLite, run it inside a transaction: `await sql.begin(tx =>
-  tx.file("migration.sql"))`. On MySQL this only covers DML: DDL statements such as `CREATE TABLE` commit implicitly and
-  cannot be rolled back.
+  Outside a transaction, a file or string with more than one statement is atomic only on PostgreSQL, which runs a
+  multi-statement query as one implicit transaction. MySQL and SQLite run the statements one at a time, so the
+  statements before a failing one stay applied. To apply a multi-statement file atomically on SQLite, run it inside a
+  transaction: `await sql.begin(tx => tx.file("migration.sql"))`. On MySQL this only covers DML: DDL statements such as
+  `CREATE TABLE` commit implicitly and cannot be rolled back.
 </Note>
 
 ### Unsafe Queries


### PR DESCRIPTION
### Problem
- `sql.file("migration.sql")`, `sql.unsafe("a; b; c")`, and ``sql`a; b; c`.simple()`` read adapter-neutral in the docs, but a failure in statement 2 leaves different states behind. PostgreSQL applies nothing, because the driver sends one simple-protocol Query and the server runs it as one implicit transaction. MySQL and SQLite apply statement 1 and then reject.

### Fix
- Add a note under "Queries in files" in `docs/runtime/sql.mdx`: multi-statement files are atomic on PostgreSQL only, wrap them in `sql.begin()` on SQLite, and on MySQL that only covers DML because DDL commits implicitly.
- Verified against local PostgreSQL 16, MariaDB, and SQLite with `insert 1; insert <fails>; insert 2`, bare and inside `sql.begin()`, plus a `CREATE TABLE` variant for the MySQL implicit-commit sentence.

### Background
- With no parameters these three entry points send the whole string as one query. PostgreSQL documents that a multi-statement simple Query runs as a single transaction unless it contains explicit transaction control. MySQL runs each statement with autocommit. The SQLite adapter prepares and steps the statements one by one.
