### PR TITLE
docs, bun-types: describe how Bun.write and FileSink treat an existing file

### DIFF
--- a/docs/runtime/file-io.mdx
+++ b/docs/runtime/file-io.mdx
@@ -163,7 +163,7 @@ await Bun.write("out/other/file.txt", "data", { createPath: false }); // rejects
 
 When the destination is a path or a `Bun.file(path)`, `Bun.write` replaces the file's contents: after the write, the file holds exactly the bytes of `data`, even if it was longer before. The file is written in place, so it keeps its inode, hard links, and permissions.
 
-When the destination is a file descriptor (`Bun.file(fd)`), `Bun.write` writes at the descriptor's current position and does not truncate the file. Open the descriptor with the flags you need (for example `"a"` to append) and close it yourself.
+When the destination is a file descriptor (`Bun.file(fd)`), `Bun.write` writes at the descriptor's current position and leaves the rest of the file as it is. One exception: an empty `data` (an empty string, `TypedArray`, or `Blob`) truncates the file to zero length. Open the descriptor with the flags you need (for example `"a"` to append) and close it yourself.
 
 `Bun.write` is not atomic. Another process can observe a partially written file, and two writes to the same path at the same time can interleave their bytes. This is not specific to Bun. It is how writes to a shared path work. When readers must never see a partial file, write to a temporary path in the same directory and rename it over the destination:
 

--- a/docs/runtime/file-io.mdx
+++ b/docs/runtime/file-io.mdx
@@ -78,9 +78,9 @@ await Bun.file("logs.json").delete();
 
 ## Writing files (`Bun.write()`)
 
-`Bun.write(destination, data): Promise<number>`
+`Bun.write(destination, data, options?): Promise<number>`
 
-The `Bun.write` function is a multi-tool for writing payloads of all kinds to disk.
+The `Bun.write` function is a multi-tool for writing payloads of all kinds to disk. It resolves with the number of bytes written.
 
 The first argument is the `destination`, which can be any of the following:
 
@@ -152,6 +152,29 @@ const response = await fetch("https://bun.com");
 await Bun.write("index.html", response);
 ```
 
+By default, `Bun.write` creates the destination's parent directories if they do not exist. Pass `createPath: false` to get an `ENOENT` error instead.
+
+```ts
+await Bun.write("out/nested/dir/file.txt", "data"); // creates out/nested/dir/
+await Bun.write("out/other/file.txt", "data", { createPath: false }); // rejects with ENOENT
+```
+
+### Overwriting an existing file
+
+When the destination is a path or a `Bun.file(path)`, `Bun.write` replaces the file's contents: after the write, the file holds exactly the bytes of `data`, even if it was longer before. The file is written in place, so it keeps its inode, hard links, and permissions.
+
+When the destination is a file descriptor (`Bun.file(fd)`), `Bun.write` writes at the descriptor's current position and does not truncate the file. Open the descriptor with the flags you need (for example `"a"` to append) and close it yourself.
+
+`Bun.write` is not atomic. Another process can observe a partially written file, and two writes to the same path at the same time can interleave their bytes. This is not specific to Bun. It is how writes to a shared path work. When readers must never see a partial file, write to a temporary path in the same directory and rename it over the destination:
+
+```ts
+import { rename } from "node:fs/promises";
+
+const tmp = `config.json.${process.pid}.tmp`;
+await Bun.write(tmp, JSON.stringify(config));
+await rename(tmp, "config.json"); // atomic on the same filesystem
+```
+
 ---
 
 ## Incremental writing with `FileSink`
@@ -161,6 +184,18 @@ Bun provides a native incremental file writing API called `FileSink`. To retriev
 ```ts
 const file = Bun.file("output.txt");
 const writer = file.writer();
+```
+
+Calling `.writer()` opens the file right away, and creates it if it does not exist (the parent directory must exist). Writing starts at the beginning of the file. `FileSink` has no append mode. To append, open the file in append mode with `node:fs` and create the writer from the file descriptor:
+
+```ts
+import { openSync, closeSync } from "node:fs";
+
+const fd = openSync("app.log", "a");
+const writer = Bun.file(fd).writer();
+writer.write("one more line\n");
+await writer.end();
+closeSync(fd); // the writer does not close a descriptor that you opened
 ```
 
 To incrementally write to the file, call `.write()`.
@@ -280,6 +315,10 @@ interface Bun {
   write(
     destination: string | number | BunFile | URL,
     input: string | Blob | ArrayBuffer | SharedArrayBuffer | TypedArray | Response,
+    options?: {
+      createPath?: boolean; // default true
+      mode?: number;
+    },
   ): Promise<number>;
 }
 
@@ -292,6 +331,10 @@ interface BunFile {
   arrayBuffer(): Promise<ArrayBuffer>;
   json(): Promise<any>;
   bytes(): Promise<Uint8Array>;
+  write(
+    input: string | Blob | ArrayBuffer | SharedArrayBuffer | TypedArray | Response,
+    options?: { createPath?: boolean },
+  ): Promise<number>;
   writer(params?: { highWaterMark?: number }): FileSink;
   exists(): Promise<boolean>;
   delete(): Promise<void>;

--- a/docs/runtime/file-io.mdx
+++ b/docs/runtime/file-io.mdx
@@ -170,7 +170,7 @@ When the destination is a file descriptor (`Bun.file(fd)`), `Bun.write` writes a
 ```ts
 import { rename } from "node:fs/promises";
 
-const tmp = `config.json.${process.pid}.tmp`;
+const tmp = `config.json.${crypto.randomUUID()}.tmp`; // unique per write, same directory as the destination
 await Bun.write(tmp, JSON.stringify(config));
 await rename(tmp, "config.json"); // atomic on the same filesystem
 ```

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2124,6 +2124,11 @@ declare module "bun" {
    *
    * If `destination` exists, it must be a regular file or symlink to a file. If `destination`'s directory does not exist, it is created by default.
    *
+   * An existing file is overwritten in place and truncated to the new length. It keeps its inode, hard links, and
+   * permissions. A file descriptor destination (`Bun.file(fd)`) is written at its current position and is not
+   * truncated. The write is not atomic: concurrent writers to one path can interleave. For an atomic replace, write
+   * to a temporary path and `rename()` it over the destination.
+   *
    * @category File System
    *
    * @param destination The file or file path to write to
@@ -2698,6 +2703,19 @@ declare module "bun" {
 
     /**
      * Incremental writer for files and pipes.
+     *
+     * For a path-backed `BunFile`, this opens the file immediately and creates
+     * it if it does not exist (the parent directory must exist). Writes start
+     * at the beginning of the file. There is no append mode: to append, open
+     * the file with `fs.openSync(path, "a")` and call `Bun.file(fd).writer()`.
+     * The writer does not close a file descriptor that you passed in.
+     *
+     * @example
+     * ```ts
+     * const writer = Bun.file("output.txt").writer();
+     * writer.write("hello\n");
+     * await writer.end();
+     * ```
      */
     writer(options?: { highWaterMark?: number }): FileSink;
 
@@ -2743,7 +2761,16 @@ declare module "bun" {
      */
     write(
       data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer | Request | Response | BunFile | ReadableStream,
-      options?: { highWaterMark?: number },
+      options?: {
+        /**
+         * If `true`, create the parent directory if it doesn't exist.
+         *
+         * If `false`, the write rejects when the directory doesn't exist.
+         *
+         * @default true
+         */
+        createPath?: boolean;
+      },
     ): Promise<number>;
 
     /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2126,8 +2126,9 @@ declare module "bun" {
    *
    * An existing file is overwritten in place and truncated to the new length. It keeps its inode, hard links, and
    * permissions. A file descriptor destination (`Bun.file(fd)`) is written at its current position and is not
-   * truncated. The write is not atomic: concurrent writers to one path can interleave. For an atomic replace, write
-   * to a temporary path and `rename()` it over the destination.
+   * truncated, except that an empty `input` truncates it to zero length. The write is not atomic: concurrent writers
+   * to one path can interleave. For an atomic replace, write to a temporary path and `rename()` it over the
+   * destination.
    *
    * @category File System
    *

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -886,7 +886,7 @@ describe("@types/bun integration test", () => {
         },
         {
           code: 2353,
-          line: "globals.ts:307:5",
+          line: "globals.ts:311:5",
           message: "Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
         },
         {

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -40,6 +40,10 @@ expectAssignable<Bun.ZlibCompressionOptions>({ windowBits: -11 });
 // Other
 expectType<Promise<number>>(Bun.write("test.json", "lol"));
 expectType<Promise<number>>(Bun.write("test.json", new ArrayBuffer(32)));
+expectType<Promise<number>>(Bun.write("test.json", "lol", { createPath: false, mode: 0o600 }));
+expectType<Promise<number>>(Bun.file("test.json").write("lol", { createPath: false }));
+// @ts-expect-error BunFile.write() does not read highWaterMark
+Bun.file("test.json").write("lol", { highWaterMark: 1024 });
 expectType<URL>(Bun.pathToFileURL("/foo/bar.txt"));
 expectType<string>(Bun.fileURLToPath(new URL("file:///foo/bar.txt")));
 


### PR DESCRIPTION
### Problem
- `docs/runtime/file-io.mdx` and `bun.d.ts` do not say what `Bun.write` does to an existing destination: that a path destination is overwritten in place and truncated, that an fd destination (`Bun.file(fd)`) is written at its position and not truncated, and that the write is not atomic. Two concurrent `Bun.write(dest, ...)` calls of different sizes leave a mix of both payloads (verified on 1.4.3-canary with `Bun.file` sources and with 20 MiB `Uint8Array` sources).
- The `FileSink` section does not say that `file.writer()` opens and creates the file at call time, writes from the start, and has no append mode. `writer({ append: true })` and `writer({ flags: "a" })` are accepted and ignored. Append is the open request #10473 / #5821.
- `BunFile.write(data, options)` is typed as `{ highWaterMark?: number }`. The runtime never reads that key. It reads `createPath` (`Blob.rs` `do_write`), which the type rejects.

### Fix
- file-io.mdx: document `createPath`, add an "Overwriting an existing file" subsection (in place, fd semantics, not atomic, temp file + `rename()` example), describe what `.writer()` does at call time and how to append today (`Bun.file(fs.openSync(path, "a")).writer()`, the writer does not close your fd), and add `options` and `BunFile.write()` to the Reference block.
- bun.d.ts: the same facts on the first `Bun.write` overload and on `BunFile.writer()`. `BunFile.write()` options become `{ createPath?: boolean }`.
- No runtime change. Every statement was checked against 1.4.3-canary (f42e98025) with strace or file bytes.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts` (fixture gains `Bun.write(..., { createPath, mode })`, `file.write(..., { createPath })`, and a `@ts-expect-error` on `{ highWaterMark }`).

### Background
- `Bun.write(path, data)` opens the path `O_WRONLY|O_CREAT` (plus `O_TRUNC` or a trailing `ftruncate`, depending on the size path) and writes. Open-then-write is two steps, so a second writer's truncate can land between them. That is inherent to writing a shared path, not a Bun defect, and the fix for callers is temp file + rename.
- `file.writer()` goes through `FileSink::Options::flags()` = `O_NONBLOCK|O_CLOEXEC|O_CREAT|O_WRONLY`. Whether it should also truncate is #25968 / #31737. This PR does not state either way, so it stays correct whichever way that lands.
- The fd-destination rule ("we only truncate if it's a path; if it's a file descriptor, we assume they want manual control") is the existing comment in `write_string_to_file_fast`, and matches Node's `fs.writeFile(fd)`. The one exception today is an empty input (`truncate = NEEDS_OPEN || input.is_empty()`), which the docs now state; #32890 would remove it.

<details><summary>Notes</summary>

- Dropping `highWaterMark` from `BunFile.write()`'s options type makes an object literal with that key a type error. The key never did anything at runtime.
- `mode` appears in the mdx Reference signature because `Bun.write` accepts and range-checks it today. Whether every input kind honors it is #32885.
- Related open PRs that change behavior in this area and may want a docs line when they land: #31737 (writer truncation), #32859 / #38186 (copy onto itself), #32885 (`mode`), #32890 (empty source on fd destinations), #41209 (sliced `Bun.file` sources).

</details>

