### PR TITLE
Bun.CSRF: document and test what expiresIn: 0 and maxAge: 0 do

### DIFF
--- a/docs/runtime/csrf.mdx
+++ b/docs/runtime/csrf.mdx
@@ -36,12 +36,12 @@ const token = Bun.CSRF.generate("my-secret-key");
 - `secret` (string, optional) — The secret key used to sign the token. If not provided, Bun generates a random in-memory default secret (unique per thread).
 - `options` (object, optional):
 
-| Option      | Type     | Default       | Description                                                                                                                                                 |
-| ----------- | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `expiresIn` | `number` | `86400000`    | Milliseconds until the token expires. Defaults to 24 hours.                                                                                                 |
-| `encoding`  | `string` | `"base64url"` | Token encoding format: `"base64"`, `"base64url"`, or `"hex"`.                                                                                               |
-| `algorithm` | `string` | `"sha256"`    | HMAC algorithm: `"sha256"`, `"sha384"`, `"sha512"`, `"sha512-256"`, `"blake2b256"`, or `"blake2b512"`.                                                      |
-| `sessionId` | `string` | (none)        | Binds the token to the requesting principal (session ID, user ID, or equivalent). The token only verifies when you pass the same `sessionId` to `verify()`. |
+| Option      | Type     | Default       | Description                                                                                                                                                                           |
+| ----------- | -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `expiresIn` | `number` | `86400000`    | Milliseconds until the token expires, embedded in the token. Defaults to 24 hours. `0` embeds no expiry. `verify()` also applies its own `maxAge`, see [Token expiry](#token-expiry). |
+| `encoding`  | `string` | `"base64url"` | Token encoding format: `"base64"`, `"base64url"`, or `"hex"`.                                                                                                                         |
+| `algorithm` | `string` | `"sha256"`    | HMAC algorithm: `"sha256"`, `"sha384"`, `"sha512"`, `"sha512-256"`, `"blake2b256"`, or `"blake2b512"`.                                                                                |
+| `sessionId` | `string` | (none)        | Binds the token to the requesting principal (session ID, user ID, or equivalent). The token only verifies when you pass the same `sessionId` to `verify()`.                           |
 
 **Returns:** `string` — the encoded token.
 
@@ -78,7 +78,7 @@ const isValid = Bun.CSRF.verify(token, { secret: "my-secret-key" });
 | Option      | Type     | Default       | Description                                                                                                                                                                                                     |
 | ----------- | -------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `secret`    | `string` | (auto)        | The secret used to sign the token. If not provided, uses the same in-memory default as `generate()`.                                                                                                            |
-| `maxAge`    | `number` | `86400000`    | Maximum token age in milliseconds, independent of the token's own `expiresIn`.                                                                                                                                  |
+| `maxAge`    | `number` | `86400000`    | Maximum token age in milliseconds that `verify()` accepts, checked in addition to the token's own `expiresIn`. `0` turns off this check.                                                                        |
 | `encoding`  | `string` | `"base64url"` | Must match the encoding used during `generate()`.                                                                                                                                                               |
 | `algorithm` | `string` | `"sha256"`    | Must match the algorithm used during `generate()`.                                                                                                                                                              |
 | `sessionId` | `string` | (none)        | Must match the `sessionId` used during `generate()`. A token bound to one principal fails verification for any other principal. A token generated without a `sessionId` fails verification when you supply one. |
@@ -99,6 +99,28 @@ const isValid2 = Bun.CSRF.verify(token, {
   maxAge: 60 * 1000, // reject tokens older than 1 minute
 });
 ```
+
+---
+
+## Token expiry
+
+`verify()` checks the age of a token twice, both times against the timestamp that `generate()` embedded in it. A token must pass both checks:
+
+- The token's own `expiresIn`, chosen by `generate()`. `expiresIn: 0` embeds no expiry.
+- The verifier's `maxAge`, 24 hours by default. `maxAge: 0` turns off this check.
+
+So a token is accepted for the shorter of the two durations. To accept tokens that are older than 24 hours, pass a `maxAge` at least as long as the `expiresIn` they were generated with:
+
+```ts title="expiry.ts" icon="/icons/typescript.svg"
+const WEEK = 7 * 24 * 60 * 60 * 1000;
+
+const token = Bun.CSRF.generate("my-secret", { sessionId: "user-session-id", expiresIn: WEEK });
+
+// Without maxAge, verify() rejects this token once it is 24 hours old
+const isValid = Bun.CSRF.verify(token, { secret: "my-secret", sessionId: "user-session-id", maxAge: WEEK });
+```
+
+A token generated with `expiresIn: 0` and verified with `maxAge: 0` never expires. Avoid this: rotating the secret is then the only way to invalidate it.
 
 ---
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2766,7 +2766,12 @@ declare module "bun" {
 
   interface CSRFGenerateOptions {
     /**
-     * The number of milliseconds until the token expires. 0 means the token never expires.
+     * The number of milliseconds the token is valid for, counted from when it
+     * was generated. The value is embedded in the token. `0` embeds no expiry.
+     *
+     * `verify()` also rejects tokens older than its own `maxAge` (24 hours by
+     * default). A token with a longer `expiresIn`, or with `0`, only verifies
+     * past 24 hours when `verify()` gets a `maxAge` to match.
      * @default 24 * 60 * 60 * 1000 (24 hours)
      */
     expiresIn?: number;
@@ -2811,7 +2816,10 @@ declare module "bun" {
     algorithm?: CSRFAlgorithm;
 
     /**
-     * The number of milliseconds until the token expires. 0 means the token never expires.
+     * The maximum token age, in milliseconds, that `verify()` accepts, counted
+     * from when the token was generated. This check runs in addition to the
+     * `expiresIn` embedded in the token: a token must pass both. `0` turns off
+     * this check, so that only the token's own `expiresIn` applies.
      * @default 24 * 60 * 60 * 1000 (24 hours)
      */
     maxAge?: number;

--- a/test/js/bun/util/csrf.test.ts
+++ b/test/js/bun/util/csrf.test.ts
@@ -1,5 +1,6 @@
 import { CSRF, type CSRFAlgorithm } from "bun";
 import { describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
 describe("Bun.CSRF", () => {
   const secret = "this-is-my-super-secure-secret-key";
 
@@ -97,6 +98,40 @@ describe("Bun.CSRF", () => {
     // Ensure that expiration works properly
     await Bun.sleep(100);
     expect(CSRF.verify(token, { secret })).toBe(false);
+  });
+
+  // verify() checks the token age twice: against the expiresIn embedded in the
+  // token, and against its own maxAge (24 hours by default). 0 turns a check off.
+  test("expiresIn: 0 and maxAge: 0 each turn off one of the two expiry checks", () => {
+    const HOUR = 60 * 60 * 1000;
+    // A token is timestamp (8) | nonce (16) | expiresIn (8) | HMAC over those 32
+    // bytes. Sign one that was issued `age` ms ago, so that nothing has to sleep.
+    const tokenIssued = (age: number, expiresIn: number) => {
+      const payload = Buffer.alloc(32);
+      payload.writeBigUInt64BE(BigInt(Date.now() - age), 0);
+      crypto.getRandomValues(payload.subarray(8, 24));
+      payload.writeBigUInt64BE(BigInt(expiresIn), 24);
+      const signature = createHmac("sha256", secret).update(payload).digest();
+      return Buffer.concat([payload, signature]).toString("base64url");
+    };
+    expect(CSRF.verify(tokenIssued(0, 24 * HOUR), { secret })).toBe(true);
+    expect(CSRF.verify(tokenIssued(0, 24 * HOUR), { secret: "wrong-secret" })).toBe(false);
+
+    // expiresIn: 0 embeds no expiry. The default maxAge still rejects the token after 24 hours.
+    expect(Buffer.from(CSRF.generate(secret, { expiresIn: 0 }), "base64url").readBigUInt64BE(24)).toBe(0n);
+    const noExpiry = tokenIssued(25 * HOUR, 0);
+    expect(CSRF.verify(noExpiry, { secret })).toBe(false);
+    expect(CSRF.verify(noExpiry, { secret, maxAge: 48 * HOUR })).toBe(true);
+    expect(CSRF.verify(noExpiry, { secret, maxAge: 0 })).toBe(true);
+
+    // An expiresIn longer than 24 hours only helps when verify() gets a maxAge to match.
+    const twoDays = tokenIssued(25 * HOUR, 48 * HOUR);
+    expect(CSRF.verify(twoDays, { secret })).toBe(false);
+    expect(CSRF.verify(twoDays, { secret, maxAge: 48 * HOUR })).toBe(true);
+
+    // maxAge: 0 turns off only the verifier's check. The embedded expiresIn still applies.
+    expect(CSRF.verify(twoDays, { secret, maxAge: 0 })).toBe(true);
+    expect(CSRF.verify(tokenIssued(2 * HOUR, 1 * HOUR), { secret, maxAge: 0 })).toBe(false);
   });
 
   test("token format doesn't affect verification", () => {


### PR DESCRIPTION
### Problem
- `Bun.CSRF.verify()` checks the token age twice: against the `expiresIn` embedded in the token, and against its own `maxAge` (24 hours by default). `0` turns off one check each. Nothing user-facing says this correctly.
- `packages/bun-types/bun.d.ts:2769` says `expiresIn: 0` "means the token never expires". It does not: `verify(token, { secret })` rejects that token once it is 24 hours old, because of the `maxAge` default. The `maxAge` JSDoc (`bun.d.ts:2814`) is a copy of the `expiresIn` one. `docs/runtime/csrf.mdx` mentions neither `0` nor the 24 hour cap, so an `expiresIn` longer than 24 hours silently does nothing without a matching `maxAge`.

### Fix
- `docs/runtime/csrf.mdx`: a "Token expiry" section that states the two checks, what `0` does for each, and how to accept tokens older than 24 hours. The option tables point at it.
- `bun.d.ts`: rewrite both JSDoc blocks to match the behavior.
- `test/js/bun/util/csrf.test.ts`: one new test pins the matrix. It signs tokens with a past timestamp (`node:crypto` HMAC over the 32 byte payload), so it checks the 24 hour boundary without sleeping.
- No behavior change. `0` has meant "off" since #18045. Verified: `bun bd test test/js/bun/util/csrf.test.ts` (32 pass), `USE_SYSTEM_BUN=1` on 1.4.3 (32 pass, the new test passes there too since it documents existing behavior), and `test/integration/bun-types/bun-types.test.ts`.

### Background
- A token is `timestamp (8) | nonce (16) | expiresIn (8, big-endian u64) | HMAC(secret, those 32 bytes [|| sessionId])`, then base64url, base64, or hex.
- `bun_csrf::verify` (`src/csrf/lib.rs:204-228`) skips the embedded-expiry check when that field is `0`, and skips the `maxAge` check when `max_age_ms` is `0`. Both compare `now` against the embedded timestamp.
- #41219 (open) covers the `NaN` case for the same two options. This PR does not touch `src/` and does not conflict with it.

<details><summary>Notes</summary>

Behavior matrix on 1.4.3 and main, with a token signed `age` ago:

```
age   expiresIn  verify maxAge   result
0     24h        default (24h)   true
25h   0          default (24h)   false   <- "never expires" per the old JSDoc
25h   0          48h             true
25h   0          0               true
25h   48h        default (24h)   false   <- expiresIn > 24h needs a maxAge to match
25h   48h        48h             true
25h   48h        0               true
2h    1h         0               false   <- maxAge: 0 does not override the embedded expiry
```

Not changed here, for a maintainer to decide:

- Whether `expiresIn: 0` / `maxAge: 0` should keep meaning "off", or be rejected so that a computed `0` fails closed (the same argument #41219 makes for `NaN`).
- Whether `verify()` should default `maxAge` to "off" so that the token's own `expiresIn` is authoritative. Today the default caps every token at 24 hours regardless of what `generate()` asked for.
- `verify()` accepts a token whose embedded timestamp is in the future (no not-before check). Out of scope.

</details>
