### PR TITLE
sys: copy a cross-filesystem move into a temporary file beside the destination, then rename over it

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7674,34 +7674,7 @@ pub fn move_file_z_with_handle(
             renameat(from_dir, filename, to_dir, destination)
         }
         Err(e) if e.get_errno() == E::EXDEV => {
-            // Cross-device: full `copyFileZSlowWithHandle`.
-            #[cfg(unix)]
-            let st = fstat(from_handle)?;
-            // Unlink dest first — fixes ETXTBUSY on Linux.
-            let _ = unlinkat(to_dir, destination);
-            let dst = openat(
-                to_dir,
-                destination,
-                O::WRONLY | O::CREAT | O::CLOEXEC | O::TRUNC,
-                0o644,
-            )?;
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            {
-                // Preallocation is best-effort.
-                let _ = safe_libc::fallocate(dst.native(), 0, 0, st.st_size);
-            }
-            // Seek input to 0 — caller may have left offset at EOF after writing.
-            let _ = lseek(from_handle, 0, libc::SEEK_SET);
-            let r = copy_file(from_handle, dst);
-            // Only stamp mode/owner on success; on copy error
-            // the partially-written dest keeps its openat() defaults.
-            #[cfg(unix)]
-            if r.is_ok() {
-                let _ = safe_libc::fchmod(dst.native(), st.st_mode);
-                let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
-            }
-            let _ = close(dst);
-            r?;
+            copy_file_z_slow_with_handle(from_handle, to_dir, destination)?;
             let _ = unlinkat(from_dir, filename);
             Ok(())
         }
@@ -8903,7 +8876,7 @@ pub fn move_file_z(from_dir: Fd, filename: &ZStr, to_dir: Fd, destination: &ZStr
         Err(e) => Err(e),
     }
 }
-/// `moveFileZSlow`: open source, unlink, copy to dest.
+/// `moveFileZSlow`: open source, copy to dest, unlink source.
 pub(crate) fn move_file_z_slow(
     from_dir: Fd,
     filename: &ZStr,
@@ -8916,12 +8889,21 @@ pub(crate) fn move_file_z_slow(
         O::RDONLY | O::CLOEXEC,
         if cfg!(windows) { 0 } else { 0o644 },
     )?;
-    let _ = unlinkat(from_dir, filename);
     let r = copy_file_z_slow_with_handle(in_handle, to_dir, destination);
     let _ = close(in_handle);
+    if r.is_ok() {
+        let _ = unlinkat(from_dir, filename);
+    }
     r
 }
-/// `copyFileZSlowWithHandle` (POSIX read/write fallback arm).
+/// `copyFileZSlowWithHandle`: the cross-device arm of the move helpers.
+///
+/// Copies `in_handle` into a hidden temporary file in the directory of
+/// `destination`, stamps the source mode and owner on it, then renames it over
+/// `destination`. So `destination` is the old file or the complete new file at
+/// every moment: a copy that fails part-way (ENOSPC) removes the temporary
+/// file and leaves `destination` as it was. A running executable at
+/// `destination` is never opened for write, so Linux cannot answer ETXTBSY.
 pub(crate) fn copy_file_z_slow_with_handle(
     in_handle: Fd,
     to_dir: Fd,
@@ -8929,30 +8911,66 @@ pub(crate) fn copy_file_z_slow_with_handle(
 ) -> Maybe<()> {
     #[cfg(unix)]
     let st = fstat(in_handle)?;
-    // Unlink dest first — fixes ETXTBUSY on Linux.
-    let _ = unlinkat(to_dir, destination);
-    let dst = openat(
-        to_dir,
-        destination,
-        O::WRONLY | O::CREAT | O::CLOEXEC | O::TRUNC,
-        0o644,
-    )?;
+    let mut temp_buf = bun_paths::path_buffer_pool::get();
+    let (dst, temp) = create_temp_file_beside(to_dir, destination, &mut temp_buf)?;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         // Preallocation is best-effort.
         let _ = safe_libc::fallocate(dst.native(), 0, 0, st.st_size);
     }
     let _ = lseek(in_handle, 0, libc::SEEK_SET);
-    let r = copy_file(in_handle, dst);
-    // Only stamp mode/owner on success; on copy error the
-    // partially-written dest keeps its openat() defaults.
+    let mut r = copy_file(in_handle, dst);
     #[cfg(unix)]
     if r.is_ok() {
         let _ = safe_libc::fchmod(dst.native(), st.st_mode);
         let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
     }
+    // Windows renames by opening the source with DELETE access, so close first.
     let _ = close(dst);
+    if r.is_ok() {
+        r = renameat(to_dir, temp, to_dir, destination);
+    }
+    if r.is_err() {
+        let _ = unlinkat(to_dir, temp);
+    }
     r
+}
+/// Creates `<dir of destination>/.<random>.tmp` with `O_EXCL`, relative to
+/// `to_dir` like `destination` itself, and returns its fd and that name.
+fn create_temp_file_beside<'a>(
+    to_dir: Fd,
+    destination: &ZStr,
+    buf: &'a mut bun_paths::PathBuffer,
+) -> Maybe<(Fd, &'a ZStr)> {
+    let dest = destination.as_bytes();
+    let name_too_long = || Error::from_code(E::ENAMETOOLONG, Tag::open).with_path(dest);
+    let seps: &[u8] = if cfg!(windows) { b"/\\" } else { b"/" };
+    let dir_len = bun_core::strings::last_index_of_any(dest, seps).map_or(0, |i| i + 1);
+    if dir_len >= buf.0.len() {
+        return Err(name_too_long());
+    }
+    buf.0[..dir_len].copy_from_slice(&dest[..dir_len]);
+    let mut attempt = 0;
+    loop {
+        let name_len = bun_paths::fs::FileSystem::tmpname(
+            b"tmp",
+            &mut buf.0[dir_len..],
+            bun_core::fast_random(),
+        )
+        .map_err(|_| name_too_long())?
+        .len();
+        let len = dir_len + name_len;
+        match openat(
+            to_dir,
+            ZStr::from_buf(&buf.0[..], len),
+            O::WRONLY | O::CREAT | O::EXCL | O::CLOEXEC,
+            0o600,
+        ) {
+            Ok(fd) => return Ok((fd, ZStr::from_buf(&buf.0[..], len))),
+            Err(e) if e.get_errno() == E::EEXIST && attempt < 3 => attempt += 1,
+            Err(e) => return Err(e),
+        }
+    }
 }
 /// `renameatZ` alias (bun_install reaches for it as the NUL-terminated form).
 #[inline]
@@ -8985,7 +9003,8 @@ pub(crate) fn move_file_z_slow_maybe(
 
 /// `renameatConcurrently`. Tries an atomic NOREPLACE rename,
 /// then EXCHANGE, then a racy delete-tree + rename. With `move_fallback` set,
-/// an EXDEV result falls through to a slow open/copy.
+/// an EXDEV result falls through to a copy into a temporary file beside the
+/// destination that is then renamed over it.
 pub fn renameat_concurrently(
     from_dir_fd: Fd,
     from: &ZStr,
@@ -9028,9 +9047,11 @@ pub(crate) fn renameat_concurrently_without_fallback(
                     ..Default::default()
                 },
             ) {
-                // if ENOENT don't retry
                 Err(err) => {
-                    if err.get_errno() == E::ENOENT {
+                    // ENOENT: nothing to retry. EXDEV: the mounts differ, so
+                    // deleting the destination below cannot help and would
+                    // only destroy it before the caller's copy fallback runs.
+                    if matches!(err.get_errno(), E::ENOENT | E::EXDEV) {
                         return Err(err);
                     }
                     err

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9086,6 +9086,17 @@ pub(crate) fn renameat_concurrently_without_fallback(
             }
         }
 
+        // A plain rename replaces a file or an empty directory atomically. It
+        // also reports EXDEV before anything is deleted where the flagged
+        // renames above are not supported (ENOSYS on FreeBSD, EINVAL on some
+        // filesystems). On Windows the first attempt already was a plain rename.
+        #[cfg(not(windows))]
+        match renameat(from_dir_fd, from, to_dir_fd, to) {
+            Ok(()) => break 'attempt,
+            Err(err) if matches!(err.get_errno(), E::ENOENT | E::EXDEV) => return Err(err),
+            Err(_) => {}
+        }
+
         //  sad path: let's try to delete the folder and then rename it
         if to_dir_fd.is_valid() {
             let _ = Dir::borrow(&to_dir_fd).delete_tree(to.as_bytes());

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8896,9 +8896,7 @@ pub(crate) fn move_file_z_slow(
     }
     r
 }
-/// `copyFileZSlowWithHandle`, the cross-device arm of the move helpers: copy
-/// into a temporary file beside `destination`, then rename it over
-/// `destination`, so a failed copy leaves `destination` as it was.
+/// `copyFileZSlowWithHandle`: copy to a temp file beside `destination`, then rename over it.
 pub(crate) fn copy_file_z_slow_with_handle(
     in_handle: Fd,
     to_dir: Fd,
@@ -9079,8 +9077,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
             }
         }
 
-        // Replaces a file or empty dir atomically, and sees EXDEV before the
-        // delete when the flagged renames are unsupported (ENOSYS, EINVAL).
+        // Sees EXDEV before the delete when renameat2 is unsupported (ENOSYS, EINVAL).
         #[cfg(not(windows))]
         match renameat(from_dir_fd, from, to_dir_fd, to) {
             Ok(()) => break 'attempt,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8896,14 +8896,9 @@ pub(crate) fn move_file_z_slow(
     }
     r
 }
-/// `copyFileZSlowWithHandle`: the cross-device arm of the move helpers.
-///
-/// Copies `in_handle` into a hidden temporary file in the directory of
-/// `destination`, stamps the source mode and owner on it, then renames it over
-/// `destination`. So `destination` is the old file or the complete new file at
-/// every moment: a copy that fails part-way (ENOSPC) removes the temporary
-/// file and leaves `destination` as it was. A running executable at
-/// `destination` is never opened for write, so Linux cannot answer ETXTBSY.
+/// `copyFileZSlowWithHandle`, the cross-device arm of the move helpers: copy
+/// into a temporary file beside `destination`, then rename it over
+/// `destination`, so a failed copy leaves `destination` as it was.
 pub(crate) fn copy_file_z_slow_with_handle(
     in_handle: Fd,
     to_dir: Fd,
@@ -8924,8 +8919,10 @@ pub(crate) fn copy_file_z_slow_with_handle(
     if r.is_ok() {
         let _ = safe_libc::fchmod(dst.native(), st.st_mode);
         let _ = safe_libc::fchown(dst.native(), st.st_uid, st.st_gid);
+        // Deferred write errors must fail the move here, not vanish in close().
+        r = fsync(dst);
     }
-    // Windows renames by opening the source with DELETE access, so close first.
+    // Close before the rename: on Windows the rename opens `temp` for DELETE.
     let _ = close(dst);
     if r.is_ok() {
         r = renameat(to_dir, temp, to_dir, destination);
@@ -8935,8 +8932,7 @@ pub(crate) fn copy_file_z_slow_with_handle(
     }
     r
 }
-/// Creates `<dir of destination>/.<random>.tmp` with `O_EXCL`, relative to
-/// `to_dir` like `destination` itself, and returns its fd and that name.
+/// Creates `<dirname(destination)>/.<random>.tmp` with `O_EXCL` under `to_dir`.
 fn create_temp_file_beside<'a>(
     to_dir: Fd,
     destination: &ZStr,
@@ -9003,8 +8999,7 @@ pub(crate) fn move_file_z_slow_maybe(
 
 /// `renameatConcurrently`. Tries an atomic NOREPLACE rename,
 /// then EXCHANGE, then a racy delete-tree + rename. With `move_fallback` set,
-/// an EXDEV result falls through to a copy into a temporary file beside the
-/// destination that is then renamed over it.
+/// an EXDEV result falls through to copy + rename beside the destination.
 pub fn renameat_concurrently(
     from_dir_fd: Fd,
     from: &ZStr,
@@ -9048,9 +9043,7 @@ pub(crate) fn renameat_concurrently_without_fallback(
                 },
             ) {
                 Err(err) => {
-                    // ENOENT: nothing to retry. EXDEV: the mounts differ, so
-                    // deleting the destination below cannot help and would
-                    // only destroy it before the caller's copy fallback runs.
+                    // Neither is fixed by deleting the destination below.
                     if matches!(err.get_errno(), E::ENOENT | E::EXDEV) {
                         return Err(err);
                     }
@@ -9086,10 +9079,8 @@ pub(crate) fn renameat_concurrently_without_fallback(
             }
         }
 
-        // A plain rename replaces a file or an empty directory atomically. It
-        // also reports EXDEV before anything is deleted where the flagged
-        // renames above are not supported (ENOSYS on FreeBSD, EINVAL on some
-        // filesystems). On Windows the first attempt already was a plain rename.
+        // Replaces a file or empty dir atomically, and sees EXDEV before the
+        // delete when the flagged renames are unsupported (ENOSYS, EINVAL).
         #[cfg(not(windows))]
         match renameat(from_dir_fd, from, to_dir_fd, to) {
             Ok(()) => break 'attempt,

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -2,10 +2,26 @@ import { spawn } from "bun";
 import { upgrade_test_helpers } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { bunExe, bunEnv as env, isMusl, isWindows, tempDir, tls, tmpdirSync } from "harness";
-import { existsSync, statSync } from "node:fs";
+import { accessSync, constants, existsSync, linkSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
 import { copyFile, writeFile } from "node:fs/promises";
 import { basename, join } from "path";
 const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
+
+// A writable directory on a different filesystem than the test temp dir. With
+// BUN_TMPDIR pointed at it, the rename of the staged binary into place fails
+// with EXDEV and `bun upgrade` takes the copy fallback.
+const crossDeviceRoot: string | null = (() => {
+  if (isWindows) return null;
+  const tmpDev = statSync(tmpdirSync()).dev;
+  for (const candidate of ["/dev/shm", "/tmp", "/var/tmp", `/run/user/${process.getuid?.()}`]) {
+    try {
+      if (statSync(candidate).dev === tmpDev) continue;
+      accessSync(candidate, constants.W_OK);
+      return candidate;
+    } catch {}
+  }
+  return null;
+})();
 
 // Cover every platform/arch/abi/cpu combination so the asset list matches
 // whichever target this test runs on. Non-matching names are ignored.
@@ -24,9 +40,11 @@ function allAssetNames(profile = false) {
 }
 
 // Build a minimal ZIP archive with a single stored (uncompressed) entry.
-// `unzip -o` on POSIX restores the mode from the Unix external-attrs field;
-// Expand-Archive on Windows ignores it.
+// `unzip -o` on POSIX restores the mode from the Unix external-attrs field
+// (file-type bits included: 0o120000 makes the entry a symlink whose target is
+// `data`); Expand-Archive on Windows ignores it.
 function makeZipStored(entryName: string, data: Buffer, unixMode: number): Buffer {
+  if ((unixMode & 0o170000) === 0) unixMode |= 0o100000;
   const nameBytes = Buffer.from(entryName, "utf8");
   const crc = Bun.hash.crc32(data);
   const size = data.length;
@@ -81,7 +99,7 @@ function makeZipStored(entryName: string, data: Buffer, unixMode: number): Buffe
   u16(0);
   u16(0);
   u16(0);
-  u32((0o100000 | unixMode) << 16);
+  u32(unixMode << 16);
   u32(0); // LFH offset
   raw(nameBytes);
 
@@ -100,9 +118,10 @@ function makeZipStored(entryName: string, data: Buffer, unixMode: number): Buffe
 
 // Write a release zip for the current target that, once unpacked, yields an
 // executable at the path `bun upgrade` verifies. On POSIX a shell script is
-// enough because `unzip` preserves the mode bits; on Windows the verify step
-// spawns `bun.exe` directly, so the archive has to carry a real PE image.
-async function writeFakeReleaseZip(outPath: string, version: string): Promise<void> {
+// enough because `unzip` preserves the mode bits (or, with `symlinkTo`, a
+// symlink to an executable elsewhere); on Windows the verify step spawns
+// `bun.exe` directly, so the archive has to carry a real PE image.
+async function writeFakeReleaseZip(outPath: string, version: string, symlinkTo?: string): Promise<void> {
   const os = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux";
   const arch = process.arch === "arm64" ? "aarch64" : "x64";
   const abi = isMusl ? "-musl" : "";
@@ -110,6 +129,8 @@ async function writeFakeReleaseZip(outPath: string, version: string): Promise<vo
   if (isWindows) {
     const exe = Buffer.from(await Bun.file(bunExe()).arrayBuffer());
     await writeFile(outPath, makeZipStored(`${folder}/bun.exe`, exe, 0o755));
+  } else if (symlinkTo !== undefined) {
+    await writeFile(outPath, makeZipStored(`${folder}/bun`, Buffer.from(symlinkTo), 0o120755));
   } else {
     const script = Buffer.from(`#!/bin/sh\nprintf '%s\\n' '${version}'\n`);
     await writeFile(outPath, makeZipStored(`${folder}/bun`, script, 0o755));
@@ -295,6 +316,70 @@ it("completes against a locally-served release with the system temp dir held ope
   // takes the "already on the latest" exit instead.
   expect(stderr).toMatch(/Upgraded\.|already on the latest/);
   expect(exitCode).toBe(0);
+});
+
+describe.concurrent("with the staging directory on another filesystem", () => {
+  // Runs `bun upgrade --stable` with BUN_TMPDIR on the other filesystem, so the
+  // rename of the verified binary into place fails with EXDEV and the copy
+  // fallback runs. The staged `bun` is a symlink to the `newBun` script in
+  // `cwd`: the verify step can then execute it even when the other filesystem
+  // is mounted noexec (Docker's /dev/shm is), and the copy reads through it.
+  async function upgradeAcrossDevices(newBun: string) {
+    const cwd = tmpdirSync();
+    const execPath = join(cwd, basename(bunExe()));
+    try {
+      linkSync(bunExe(), execPath);
+    } catch {
+      await copyFile(bunExe(), execPath);
+    }
+    await writeFile(join(cwd, "new-bun"), newBun, { mode: 0o755 });
+    const zipPath = join(cwd, "release.zip");
+    await writeFakeReleaseZip(zipPath, "9.9.9", join(cwd, "new-bun"));
+    // Not under the harness temp dir on purpose: it has to be the other filesystem.
+    const stagingRoot = mkdtempSync(join(crossDeviceRoot!, "bun-upgrade-xdev-"));
+    try {
+      using server = startReleaseServer({ tagName: "bun-v9.9.9", zipPath });
+      await using proc = Bun.spawn({
+        cmd: [execPath, "upgrade", "--stable"],
+        cwd,
+        stdout: null,
+        stdin: "pipe",
+        stderr: "pipe",
+        env: { ...server.env, BUN_TMPDIR: stagingRoot },
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      // Whatever happened, the directory that holds the binary has no leftover
+      // temporary file, and the path of the binary names something executable.
+      expect(readdirSync(cwd).sort()).toEqual([basename(execPath), "new-bun", "release.zip"].sort());
+      expect(statSync(execPath).mode & 0o111).not.toBe(0);
+      return { stderr, exitCode, execPath };
+    } finally {
+      rmSync(stagingRoot, { recursive: true, force: true });
+    }
+  }
+
+  it.skipIf(!crossDeviceRoot)("installs the new binary", async () => {
+    const { stderr, exitCode, execPath } = await upgradeAcrossDevices(`#!/bin/sh\nprintf '%s\\n' '9.9.9'\n`);
+    expect(stderr).not.toContain("error:");
+    expect(stderr).toContain("Upgraded.");
+    expect(await Bun.file(execPath).text()).toStartWith("#!/bin/sh\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(!crossDeviceRoot)("keeps the current binary when copying the new one into place fails", async () => {
+    // `bun upgrade` runs the staged binary once to verify it, then moves it
+    // into place. This one swaps the staged path ($0, relative to the staging
+    // directory it runs in) for a directory, so the copy that follows the EXDEV
+    // rename failure gets EISDIR on its first read, after the destination side
+    // is set up. A disk that fills up fails at the same point.
+    const { stderr, exitCode, execPath } = await upgradeAcrossDevices(
+      `#!/bin/sh\nrm -f -- "$0" && mkdir -- "$0" || exit 1\nprintf '%s\\n' '9.9.9'\n`,
+    );
+    expect(stderr).toContain("Failed to move new version of Bun");
+    // The binary that ran the upgrade is still there, complete.
+    expect(statSync(execPath).size).toBe(statSync(bunExe()).size);
+    expect(exitCode).toBe(1);
+  });
 });
 
 it("recreates the staging directory in the temp dir instead of reusing a pre-existing one", async () => {


### PR DESCRIPTION
### Problem
- A move onto another filesystem fails with EXDEV, so bun copies. If the copy fails part-way (ENOSPC), a truncated 0644 file is left under the final name and the previous file is gone: `failed to rename .../.386ab76859b70278-00000000.bun-build to /dev/shm/app: ENOSPC`. `bun upgrade`, `bun build --compile --outfile` and `bun patch --commit` reach this.
- The cause is the shared EXDEV arm in `src/sys/lib.rs` (`copy_file_z_slow_with_handle`, duplicated in `move_file_z_with_handle`): `unlinkat(dest)`, `openat(dest, O_TRUNC, 0644)`, copy. `move_file_z` lost the destination even earlier: `renameat_concurrently_without_fallback` ran `delete_tree(dest)` for a retry that fails with EXDEV again.

### Fix
- `copy_file_z_slow_with_handle` copies into `.<random>.tmp` beside the destination (`O_EXCL`, same dirfd), stamps mode and owner, `fsync`s, then renames it over the destination. On failure it unlinks the temporary file. `move_file_z_slow` unlinks the source only after success.
- `renameat_concurrently_without_fallback` returns EXDEV at once, like ENOENT, and tries a plain `rename` before `delete_tree` (that is where EXDEV shows up when `renameat2` is unsupported). Deleting the destination cannot make a cross-mount rename succeed.
- Correct because the destination name changes only through `rename(2)` inside one directory: it is the previous file or the complete new one. Nothing opens a running executable for write (the old reason to unlink first: ETXTBSY).
- Verified: `test/cli/install/bun-upgrade.test.ts` (two new tests, stock bun fails the second). The whole file passes. `cargo check -p bun_sys` passes for Windows, macOS, FreeBSD and Android.

### Background
- `rename(2)` is atomic only inside one filesystem. `bun upgrade` stages the download in `$BUN_TMPDIR` or `$TMPDIR`, often tmpfs, while `~/.bun/bin` is not.
- Callers: `move_file_z` (upgrade, lcov writer), `move_file_z_with_handle` (compile outfile, `Tmpfile`), `renameat_concurrently` (install, patch).
- #39713 stages the compile outfile in its own directory, which also avoids the double copy. This change covers the other callers.

<details><summary>Notes</summary>

The new tests point `BUN_TMPDIR` at a writable directory on another filesystem (`/dev/shm`, else `/tmp`, `/var/tmp`, `/run/user/<uid>`; skipped when none differs from the test temp dir, and on Windows). The staged `bun` in the fake release zip is a symlink to a script in the test directory, so the verify step runs even when that filesystem is mounted `noexec` (Docker's `/dev/shm`). The failure test's script replaces the staged path with a directory while the verify step runs it, so the copy after the EXDEV failure gets EISDIR on its first read. That is the same point where ENOSPC hits.

Stock bun 1.4.3, failure test: the binary that ran the upgrade is replaced by a 40 byte file with mode 0644. With this change: untouched, same size, still executable, and no temporary file is left in either directory.

Manual probe for the compile caller, cwd on overlayfs, `--outfile /dev/shm/x/app` (64 MB tmpfs) over an existing `app`: stock bun leaves a 66031616 byte 0644 `app` and a full tmpfs. This change prints the same ENOSPC error and leaves the previous `app` and a free tmpfs.

Behavior that changes on purpose: a cross-filesystem move into a directory the user cannot create files in now fails with EACCES instead of truncating the destination in place. A same-filesystem move into that directory already fails the same way.

Windows takes the same arm when `NtSetInformationFile` answers `STATUS_NOT_SAME_DEVICE`. The temporary file is closed before the rename because the rename opens it with DELETE access.
</details>
