### PR TITLE
Do not abort at startup when fd 1 or 2 is an O_PATH descriptor

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -732,7 +732,8 @@ extern "C" void bun_initialize_process()
             err = dup2(devNullFd_, target_fd);
         } while (err < 0 && errno == EINTR);
 
-        if (err != 0) [[unlikely]] {
+        // dup2 returns target_fd on success, which is nonzero for 1 and 2.
+        if (err < 0) [[unlikely]] {
             abort();
         }
     };

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1719,3 +1719,30 @@ it.if(parentThp() === "1")("spawned children keep the system THP policy", async 
   expect(thpEnabled(readFileSync("/proc/self/status", "utf8"))).toBe("1");
   expect(exitCode).toBe(0);
 });
+
+// isatty() reports EBADF for an O_PATH descriptor. Startup takes that as a
+// closed fd and replaces it with /dev/null. That must not abort the process.
+describe.if(isLinux)("startup with an O_PATH descriptor on", () => {
+  const O_PATH = 0o10000000;
+  for (const slot of ["stdout", "stderr"] as const) {
+    it(slot, async () => {
+      const fd = openSync("/", O_PATH);
+      try {
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", "console.log('ok'); console.error('err')"],
+          env: bunEnv,
+          [slot]: fd,
+          [slot === "stdout" ? "stderr" : "stdout"]: "pipe",
+        });
+        const [out, exitCode] = await Promise.all([
+          (slot === "stdout" ? proc.stderr : proc.stdout).text(),
+          proc.exited,
+        ]);
+        expect(out).toBe(slot === "stdout" ? "err\n" : "ok\n");
+        expect(exitCode).toBe(0);
+      } finally {
+        closeSync(fd);
+      }
+    });
+  }
+});


### PR DESCRIPTION
### Problem
- Any bun invocation, even `bun --version`, dies with `panic: abort() called` (SIGABRT) when fd 1 or fd 2 is an `O_PATH` descriptor. Node starts normally in the same setup.
- The cause is `setDevNullFd` in `bun_initialize_process` (`src/jsc/bindings/c-bindings.cpp:735`). `isatty()` fails with EBADF on an `O_PATH` fd, so startup treats the fd as closed and runs `dup2(devNullFd_, target_fd)`. `dup2` returns the target fd on success. The code checked `if (err != 0) abort()`, so success on fd 1 or 2 aborted. Only fd 0 could pass.

### Fix
- Check `err < 0` instead of `err != 0`.
- A really closed fd never reached the `dup2`: `open("/dev/null")` lands on the lowest free number, which is the target itself, and the lambda returns early. That is why closed stdio always worked and only an occupied-but-EBADF fd (O_PATH) hit the abort.
- Verified: `test/js/bun/spawn/spawn.test.ts` (new `startup with an O_PATH descriptor on stdout|stderr`, both fail on 1.4.3 with SIGABRT). Ran the whole file.

### Background
- `bun_initialize_process` runs before the runtime starts. For each of fd 0, 1, 2 it calls `isatty()`. On EBADF it points the fd at `/dev/null` so later code can assume the three stdio fds exist.
- An `O_PATH` descriptor (Linux) refers to a filesystem object but permits no I/O. `ioctl(TCGETS)`, `read` and `write` on it fail with EBADF even though the fd number is occupied.

<details><summary>Notes</summary>

Repro on 1.4.3:

```python
import os, subprocess
fd = os.open("/tmp", os.O_PATH)
subprocess.run(["bun", "--version"], stdout=fd).returncode   # -6
subprocess.run(["bun", "--version"], stderr=fd, stdout=subprocess.PIPE).returncode   # -6
```

With this change both exit 0. Writes to the O_PATH slot go to `/dev/null`, the same as before for fd 0. Whether an open-but-EBADF fd should be replaced at all (node leaves it and lets writes fail with EBADF) is a separate question. This PR only removes the abort.

One unrelated test in the file, `gcTick > spawn > stdout can be read`, timed out at 5 s once in the nested `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD` re-run on a loaded debug ASAN host. It spawns 10 children at once and is not touched here.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->