### PR TITLE
spawn: hand children blocking stdio and IPC fds, keep dup2 sources clear of stdio slots

### DIFF
--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -606,6 +606,24 @@ struct PosixSpawnFdGuard {
 }
 
 #[cfg(unix)]
+impl PosixSpawnFdGuard {
+    /// The fd to pass to `dup2` as the source for a stdio slot. File actions
+    /// run in slot order in the child, so a source that sits at or below the
+    /// highest slot (`max_slot`) can be closed or overwritten by an earlier
+    /// slot's action (the `close` of an "ignore" slot, another slot's `dup2`)
+    /// before its own `dup2` runs. Move such a source above every slot first,
+    /// like libuv does.
+    fn source_above_slots(&mut self, max_slot: i32, src: Fd) -> bun_sys::Result<Fd> {
+        if src.native() > max_slot {
+            return Ok(src);
+        }
+        let moved = bun_sys::dup_at_least(src, max_slot + 1)?;
+        self.to_close_at_end.push(moved);
+        Ok(moved)
+    }
+}
+
+#[cfg(unix)]
 impl Drop for PosixSpawnFdGuard {
     fn drop(&mut self) {
         if self.on_error {
@@ -725,6 +743,9 @@ pub unsafe fn spawn_process_posix(
     let _ = attr.set(flags as _);
     let _ = attr.reset_signals();
 
+    // Highest child fd that a file action targets: stderr, or the last extra slot.
+    let max_slot: FdT = FdT::try_from(2 + options.extra_fds.len()).unwrap();
+
     if let Some(ipc) = options.ipc {
         actions.inherit(ipc)?;
         spawned.ipc = Some(ipc);
@@ -763,14 +784,21 @@ pub unsafe fn spawn_process_posix(
                     actions.dup2(dup2.to.to_fd(), dup2.out.to_fd())?;
                 }
             }
-            PosixStdio::Inherit => {
+            PosixStdio::Inherit => match bun_sys::get_fcntl_flags(fileno) {
                 // A closed slot would inherit whatever fd is created later at that number (e.g. the ipc socketpair); libuv gives it /dev/null.
-                if bun_sys::get_fcntl_flags(fileno).is_err() {
+                Err(_) => {
                     actions.open_z(fileno, c"/dev/null", flag | bun_sys::O::CREAT as u32, 0o664)?;
-                } else {
+                }
+                Ok(fl) => {
+                    // O_NONBLOCK lives on the open file description, so one that
+                    // `process.stdout` set on a pipe reaches the child, where a
+                    // plain write(2) then fails with EAGAIN. libuv clears it too.
+                    if fl & bun_sys::O::NONBLOCK as bun_sys::FcntlInt != 0 {
+                        let _ = bun_sys::update_nonblocking(fileno, false);
+                    }
                     actions.inherit(fileno)?;
                 }
-            }
+            },
             PosixStdio::Ipc | PosixStdio::Ignore => {
                 actions.open_z(fileno, c"/dev/null", flag | bun_sys::O::CREAT as u32, 0o664)?;
             }
@@ -797,7 +825,11 @@ pub unsafe fn spawn_process_posix(
 
                         cleanup.to_close_on_error.push(fd);
                         cleanup.to_set_cloexec.push(fd);
-                        actions.dup2(fd, fileno)?;
+                        let src = match cleanup.source_above_slots(max_slot, fd) {
+                            Ok(src) => src,
+                            Err(e) => return Ok(Err(e)),
+                        };
+                        actions.dup2(src, fileno)?;
                         set_spawned_stdio(&mut spawned, i, fd);
                         spawned.memfds[i] = true;
                         continue 'stdio;
@@ -878,15 +910,24 @@ pub unsafe fn spawn_process_posix(
                     }
                 }
 
-                actions.dup2(fds[1], fileno)?;
-                if fds[1] != fileno {
+                let src = match cleanup.source_above_slots(max_slot, fds[1]) {
+                    Ok(src) => src,
+                    Err(e) => return Ok(Err(e)),
+                };
+                actions.dup2(src, fileno)?;
+                if src == fds[1] {
                     actions.close(fds[1])?;
                 }
 
                 set_spawned_stdio(&mut spawned, i, fds[0]);
             }
             PosixStdio::Pipe(fd) => {
-                actions.dup2(*fd, fileno)?;
+                let _ = bun_sys::update_nonblocking(*fd, false);
+                let src = match cleanup.source_above_slots(max_slot, *fd) {
+                    Ok(src) => src,
+                    Err(e) => return Ok(Err(e)),
+                };
+                actions.dup2(src, fileno)?;
                 set_spawned_stdio(&mut spawned, i, *fd);
             }
             PosixStdio::SocketFd => {
@@ -928,24 +969,31 @@ pub unsafe fn spawn_process_posix(
                 extra_fds.push(ExtraPipe::Unavailable);
             }
             PosixStdio::Ipc | PosixStdio::Buffer | PosixStdio::SocketFd => {
-                let is_ipc = matches!(ipc, PosixStdio::Ipc);
+                // Both ends start blocking. Only the parent's end goes
+                // nonblocking: the child's end is handed over as is, so a
+                // child that is not bun or node (a plain write(2) on the IPC
+                // fd) gets a blocking socket, like libuv hands out.
                 let fds: [Fd; 2] =
-                    match bun_sys::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, is_ipc) {
+                    match bun_sys::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, false) {
                         Ok(p) => p,
                         Err(e) => return Ok(Err(e)),
                     };
 
-                if !options.sync && !is_ipc {
+                cleanup.to_close_at_end.push(fds[1]);
+                cleanup.to_close_on_error.push(fds[0]);
+
+                if !options.sync {
                     if let Err(e) = bun_sys::set_nonblocking(fds[0]) {
                         return Ok(Err(e));
                     }
                 }
 
-                cleanup.to_close_at_end.push(fds[1]);
-                cleanup.to_close_on_error.push(fds[0]);
-
-                actions.dup2(fds[1], fileno)?;
-                if fds[1] != fileno {
+                let src = match cleanup.source_above_slots(max_slot, fds[1]) {
+                    Ok(src) => src,
+                    Err(e) => return Ok(Err(e)),
+                };
+                actions.dup2(src, fileno)?;
+                if src == fds[1] {
                     actions.close(fds[1])?;
                 }
                 // SocketFd: push as OwnedFd here so every error path between
@@ -958,7 +1006,11 @@ pub unsafe fn spawn_process_posix(
                 extra_fds.push(ExtraPipe::OwnedFd(fds[0]));
             }
             PosixStdio::Pipe(fd) => {
-                actions.dup2(*fd, fileno)?;
+                let src = match cleanup.source_above_slots(max_slot, *fd) {
+                    Ok(src) => src,
+                    Err(e) => return Ok(Err(e)),
+                };
+                actions.dup2(src, fileno)?;
                 // The fd was supplied by the caller (a number in the stdio array) and is
                 // not owned by us. Record it so `stdio[N]` returns the caller's fd, but
                 // mark it unowned so finalizeStreams leaves it open.

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -793,7 +793,7 @@ pub unsafe fn spawn_process_posix(
                     // O_NONBLOCK lives on the open file description, so one that
                     // `process.stdout` set on a pipe reaches the child, where a
                     // plain write(2) then fails with EAGAIN. libuv clears it too.
-                    if fl & bun_sys::O::NONBLOCK as bun_sys::FcntlInt != 0 {
+                    if (fl & bun_sys::O::NONBLOCK as bun_sys::FcntlInt) != 0 {
                         let _ = bun_sys::update_nonblocking(fileno, false);
                     }
                     actions.inherit(fileno)?;

--- a/test/js/bun/spawn/fixtures/fd-nonblock-probe.js
+++ b/test/js/bun/spawn/fixtures/fd-nonblock-probe.js
@@ -3,21 +3,21 @@
 // Must not touch process.stdout/process.stderr/process.send: those set
 // O_NONBLOCK on their own fds.
 import { dlopen } from "bun:ffi";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 let isNonblocking;
-if (process.platform === "linux") {
+if (existsSync("/proc/self/fdinfo")) {
   isNonblocking = fd => {
     const flags = readFileSync(`/proc/self/fdinfo/${fd}`, "utf8").match(/^flags:\s*([0-7]+)/m)[1];
     return (parseInt(flags, 8) & 0o4000) !== 0;
   };
 } else {
-  const { fcntl } = dlopen("libSystem.B.dylib", {
+  // F_GETFL is 3 everywhere; O_NONBLOCK is 4 on the BSDs and macOS.
+  const libc = process.platform === "darwin" ? "libSystem.B.dylib" : "libc.so.7";
+  const { fcntl } = dlopen(libc, {
     fcntl: { args: ["i32", "i32", "i32"], returns: "i32" },
   }).symbols;
-  const F_GETFL = 3;
-  const O_NONBLOCK = 4;
-  isNonblocking = fd => (fcntl(fd, F_GETFL, 0) & O_NONBLOCK) !== 0;
+  isNonblocking = fd => (fcntl(fd, 3, 0) & 4) !== 0;
 }
 
 const out = process.argv

--- a/test/js/bun/spawn/fixtures/fd-nonblock-probe.js
+++ b/test/js/bun/spawn/fixtures/fd-nonblock-probe.js
@@ -1,0 +1,27 @@
+// Prints "<fd>:blocking" or "<fd>:nonblocking" for each fd number in argv.
+// The flag is read before anything writes, so this process cannot change it.
+// Must not touch process.stdout/process.stderr/process.send: those set
+// O_NONBLOCK on their own fds.
+import { dlopen } from "bun:ffi";
+import { readFileSync } from "node:fs";
+
+let isNonblocking;
+if (process.platform === "linux") {
+  isNonblocking = fd => {
+    const flags = readFileSync(`/proc/self/fdinfo/${fd}`, "utf8").match(/^flags:\s*([0-7]+)/m)[1];
+    return (parseInt(flags, 8) & 0o4000) !== 0;
+  };
+} else {
+  const { fcntl } = dlopen("libSystem.B.dylib", {
+    fcntl: { args: ["i32", "i32", "i32"], returns: "i32" },
+  }).symbols;
+  const F_GETFL = 3;
+  const O_NONBLOCK = 4;
+  isNonblocking = fd => (fcntl(fd, F_GETFL, 0) & O_NONBLOCK) !== 0;
+}
+
+const out = process.argv
+  .slice(2)
+  .map(arg => `${arg}:${isNonblocking(Number(arg)) ? "nonblocking" : "blocking"}`)
+  .join(" ");
+console.log(out);

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1719,3 +1719,134 @@ it.if(parentThp() === "1")("spawned children keep the system THP policy", async 
   expect(thpEnabled(readFileSync("/proc/self/status", "utf8"))).toBe("1");
   expect(exitCode).toBe(0);
 });
+
+// O_NONBLOCK lives on the open file description, so a flag bun sets on its
+// own stdout or on a socketpair end reaches any child that shares it. A child
+// that is not bun or node then fails a plain write(2) with EAGAIN.
+describe.skipIf(!isPosix)("file status flags handed to the child", () => {
+  const probe = join(import.meta.dir, "fixtures", "fd-nonblock-probe.js");
+
+  it.concurrent("stdout and stderr inherited after the parent used process.stdout/stderr are blocking", async () => {
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write("out\\n");
+         process.stderr.write("err\\n");
+         const r = Bun.spawnSync([process.execPath, ${JSON.stringify(probe)}, "1", "2"], { stdout: "inherit", stderr: "inherit" });
+         process.exit(r.exitCode);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("out\n1:blocking 2:blocking\n");
+    expect(stderr).toBe("err\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("the ipc fd is blocking", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), probe, "3"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      ipc() {},
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("3:blocking\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("a plain tool writing more than the pipe holds succeeds on inherited stdout", async () => {
+    // The user-visible shape of the test above: with fd 1 nonblocking, head
+    // gets EAGAIN as soon as it outruns this reader and exits 1 with a short
+    // count. (If the reader keeps up, head never sees a full pipe, so the
+    // flag probe above is the deterministic check.)
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write("start\\n");
+         const r = Bun.spawnSync(["head", "-c", "1000000", "/dev/zero"], { stdout: "inherit", stderr: "inherit" });
+         process.stderr.write("rc=" + r.exitCode + "\\n");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.bytes(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("rc=0\n");
+    expect(stdout.byteLength).toBe("start\n".length + 1000000);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(!isPosix)("stdio source fds that are also slot numbers", () => {
+  // File actions run in slot order in the child. The source fd of a later
+  // slot must survive the actions of the slots before it (the close of an
+  // "ignore" slot, the dup2 onto another slot) even when its fd number is one
+  // of those slots. Each case runs in a fresh process so the source fds are
+  // low, known numbers.
+  async function run(script: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.concurrent("a pipe after many ignore slots", async () => {
+    const slots = 60;
+    const result = await run(`
+      const fs = require("fs");
+      const proc = Bun.spawn({
+        cmd: [process.execPath, "-e", "require('fs').writeSync(${slots}, 'hi')"],
+        stdio: ["ignore", "inherit", "inherit", ...Array(${slots - 3}).fill("ignore"), "pipe"],
+      });
+      const fd = proc.stdio[${slots}];
+      const exitCode = await proc.exited;
+      const buf = Buffer.alloc(16);
+      const n = fs.readSync(fd, buf);
+      console.log(JSON.stringify({ sourceBelowSlot: fd < ${slots}, exitCode, data: buf.toString("utf8", 0, n) }));
+    `);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({ sourceBelowSlot: true, exitCode: 0, data: "hi" });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it.concurrent("a caller fd after many ignore slots", async () => {
+    using dir = tempDir("spawn-high-slot", {});
+    const slots = 60;
+    const file = join(String(dir), "out.txt");
+    const result = await run(`
+      const fs = require("fs");
+      const fd = fs.openSync(${JSON.stringify(file)}, "w");
+      const proc = Bun.spawn({
+        cmd: [process.execPath, "-e", "require('fs').writeSync(${slots}, 'hi')"],
+        stdio: ["ignore", "inherit", "inherit", ...Array(${slots - 3}).fill("ignore"), fd],
+      });
+      console.log(JSON.stringify({ sourceBelowSlot: fd < ${slots}, exitCode: await proc.exited }));
+    `);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual({ sourceBelowSlot: true, exitCode: 0 });
+    expect(readFileSync(file, "utf8")).toBe("hi");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it.concurrent("fd 2 at stdout and fd 1 at stderr swap them", async () => {
+    const result = await run(`
+      const proc = Bun.spawn({
+        cmd: [process.execPath, "-e", "require('fs').writeSync(1, 'to-fd-1,'); require('fs').writeSync(2, 'to-fd-2,')"],
+        stdio: ["ignore", 2, 1],
+      });
+      await proc.exited;
+    `);
+    expect({ stdout: result.stdout, stderr: result.stderr }).toEqual({ stdout: "to-fd-2,", stderr: "to-fd-1," });
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isPosix } from "harness";
 import { execSync, spawn } from "node:child_process";
 import { once } from "node:events";
+import { join } from "node:path";
 
 const CHILD_PROCESS_FILE = import.meta.dir + "/spawned-child.js";
 const OUT_FILE = import.meta.dir + "/stdio-test-out.txt";
@@ -164,5 +165,64 @@ describe("child.stdin", () => {
       ret: false,
       cbCode: "ERR_STREAM_DESTROYED",
     });
+  });
+});
+
+describe.skipIf(!isPosix)("stdio handed to the child", () => {
+  // Prints whether O_NONBLOCK is set on each fd number given in argv.
+  const probe = join(import.meta.dir, "..", "..", "bun", "spawn", "fixtures", "fd-nonblock-probe.js");
+
+  it.concurrent("inherited stdio and the ipc fd are blocking after the parent used process.stdout", async () => {
+    // The parent's fd 1 and 2 are pipes here. process.stdout.write() sets
+    // O_NONBLOCK on the shared open file description; a child that is not
+    // bun or node then fails a plain write(2) with EAGAIN once the pipe fills.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { spawnSync, spawn } = require("node:child_process");
+         process.stdout.write("out\\n");
+         process.stderr.write("err\\n");
+         const sync = spawnSync(process.execPath, [${JSON.stringify(probe)}, "0", "1", "2"], { stdio: "inherit" });
+         if (sync.status !== 0) process.exit(sync.status ?? 1);
+         const child = spawn(process.execPath, [${JSON.stringify(probe)}, "1", "2", "3"], { stdio: ["inherit", "inherit", "inherit", "ipc"] });
+         child.on("exit", code => process.exit(code ?? 1));`,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("err\n");
+    expect(stdout).toBe("out\n0:blocking 1:blocking 2:blocking\n1:blocking 2:blocking 3:blocking\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("a pipe slot after many ignore slots", async () => {
+    // Run in a fresh process so the pipe's source fd is a low number, below
+    // the slot it is dup2'd to. The close of each "ignore" slot used to hit it,
+    // and spawn() then threw EBADF synchronously.
+    const slots = 60;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { spawn, spawnSync } = require("node:child_process");
+         const stdio = ["ignore", "ignore", "ignore", ...Array(${slots - 3}).fill("ignore"), "pipe"];
+         const sync = spawnSync("true", [], { stdio });
+         console.log("spawnSync:", sync.error?.code ?? "ok", sync.status);
+         const child = spawn("true", [], { stdio });
+         child.on("error", e => console.log("error event", e.code));
+         child.on("exit", code => console.log("spawn:", code));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("spawnSync: ok 0\nspawn: 0\n");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- Once `process.stdout` is touched on a pipe, fd 1's open file description is `O_NONBLOCK`. A `stdio: "inherit"` child that is a plain tool then fails with `seq: write error: Resource temporarily unavailable`, and `execSync` throws.
- The IPC socketpair was `SOCK_NONBLOCK` on both ends. A non-JS child's plain `write(2)` on `NODE_CHANNEL_FD` is short and the message is lost.
- File actions run in slot order. A `dup2` source whose number is also a lower slot was closed or replaced first: `[..., 12 x "ignore", "pipe"]` gave `EBADF`, and `["ignore", 2, 1]` did not swap.

### Fix
All in `spawn_process_posix` (`src/spawn_sys/spawn_process.rs`):
- Slots 0-2, `Inherit` and caller fds: clear `O_NONBLOCK` before the spawn, as libuv does (`uv__process_child_init`).
- Create the IPC pair blocking. Set `O_NONBLOCK` on the parent's end only, like libuv. Bun and node children set it themselves.
- `source_above_slots`: `F_DUPFD_CLOEXEC` a source that is at or below the highest slot to above it. The parent closes the copy after the spawn.
- Verified: the new tests in `spawn.test.ts` and `child-process-stdio.test.js` fail on 1.4.3 and pass here. No new failures in `test/js/bun/spawn/*`, the child_process and IPC suites, `bunshell.test.ts`.

### Background
- `O_NONBLOCK` belongs to the open file description, which `dup2` and `fork` share. Every process on the same pipe end sees the flag.
- `process.stdout` on a pipe sets the flag so the event loop can drive writes (`src/io/openForWriting.rs`).
- Cost, as in node: after an inherit spawn the parent's fd 1 stays blocking. A `process.stdout.write` larger than the free pipe space stalls the JS thread until the reader drains, and a late reader can deadlock. Current bun returns `false` and buffers. Numbers in Notes.

<details><summary>Notes</summary>

Repros (bun 1.4.3, Linux):

```sh
cat > t.mjs <<'EOF'
import { spawnSync, execSync } from 'node:child_process';
process.stdout.write('start\n');
const r = spawnSync('seq', ['1', '300000'], { stdio: 'inherit' });
process.stderr.write(`seq exit=${r.status}\n`);
try { execSync('seq 1 300000', { stdio: 'inherit' }) } catch (e) { process.stderr.write('execSync THREW\n') }
EOF
bun t.mjs | { sleep 2; wc -c; }    # seq: write error ... / seq exit=1 / execSync THREW / 4102
node t.mjs | { sleep 2; wc -c; }   # seq exit=0 / 3977796
```

```js
// IPC: child fd 3 was O_NONBLOCK, python wrote 219264 of 4000012 bytes, parent received 0 messages.
spawn('python3', ['-c', py], { stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
```

```js
// EBADF: close(3)..close(14) ran before dup2(11, 15).
spawnSync('true', [], { stdio: ['inherit', 'inherit', 'inherit', ...Array(12).fill('ignore'), 'pipe'] });
```

Cost of clearing the shared flag, measured. A 1 MiB `process.stdout.write` into a pipe whose reader starts 3 s late:

| | no inherit spawn before | after one `stdio: 'inherit'` spawn |
| --- | --- | --- |
| bun 1.4.3 | returns `false` after 1 ms | returns `false` after 1 ms |
| this branch (debug build) | returns `false` after 7 ms | returns `true` after 1376 ms, a 10 ms timer fires at 1430 ms |
| node 26.3 | returns `false` after 1 ms | returns `true` after 2964 ms, a 10 ms timer fires at 2975 ms |

Both block until the reader starts. The debug build starts later, so less of the 3 s is left.

The write-before-read shape from the review of #33560: a parent writes a 512 KiB request before it reads, and the child logs one line, runs one `stdio: 'inherit'` spawn, then echoes stdin to stdout. bun 1.4.3 completes. This branch deadlocks. node 26.3 deadlocks. Without the inherit spawn all three complete. A reviewer of #33560 rejected a change that made `process.stdout` blocking in every case for this reason. Here it happens only after an inherit spawn, which is where node has it too.

What this does not cover: the flag is cleared at spawn time. If the parent uses `process.stdout` for the first time while an async inherit child still runs, the flag is set again on the shared description and the child sees it (`flags: 04001` in the child, on bun 1.4.3, this branch, and node 26.3 alike). `spawnSync` and `execSync` have no such window.

Both limits come from the flag being shared. A stdout writer that does not depend on `O_NONBLOCK` removes them: `send(MSG_DONTWAIT)` for sockets, `pwritev2(RWF_NOWAIT)` for pipes where the kernel has it, poll-guarded writes elsewhere (`write_to_blocking_pipe` in `src/io/PipeWriter.rs`). Then bun does not set the flag on stdio at all. That changes the stdout write path and is not part of this PR.

Why the parent side: the clear has to cover both the Linux vfork path (`posix_spawn_bun` in `bun-spawn.cpp`) and macOS `posix_spawn` file actions, which cannot run `fcntl`. The description is shared, so clearing it in the parent or in the child is the same operation.

When a socketpair child end is moved above the slots, no explicit `close` action is added for the original: it is `SOCK_CLOEXEC` on Linux and `FD_CLOEXEC` plus `POSIX_SPAWN_CLOEXEC_DEFAULT` on macOS, and an explicit close could land on a slot number that a later action targets. In the common case (no extra fds, sources above fd 2) no extra syscalls happen.

The probe fixture `test/js/bun/spawn/fixtures/fd-nonblock-probe.js` reads `/proc/self/fdinfo` when it exists and otherwise calls `fcntl(F_GETFL)` through `bun:ffi`. It does not touch `process.stdout`, which would set the flag itself.

Pre-existing failures in this container, identical on main: `spawn-pipe-leak.test.ts`, two `spawnsync-isolated-event-loop` tests, `spawn_waiter_thread.test.ts`, three `child_process.test.ts` tests, three `process-stdio.test.ts` stdin tests.

Related: #33560 (console writer retries on EAGAIN, keeps the flag), #33827 (restores the flag at exit, the after-exit direction of the same family), #36653 (accepts fd 0-2 at any slot and has a similar save-aside for caller fds).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->
