### PR TITLE
fetch: send the body's Content-Type for a zero-length typed body

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1428,7 +1428,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
     }
 
-    if headers.is_none() && body.has_body() && body.has_content_type_from_user() {
+    if headers.is_none() && body.has_content_type_from_user() {
         headers = Some(from_fetch_headers(
             None,
             any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -843,6 +843,45 @@ describe("fetch", () => {
     expect(await response2.text()).toBe("0");
   });
 
+  // The body's type (Blob.type, URLSearchParams, File) sets Content-Type
+  // independent of its length. A zero-length typed body must still carry it.
+  it.concurrent("content type is inferred from a zero-length typed body", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return Response.json({
+          type: req.headers.get("content-type"),
+          length: req.headers.get("content-length"),
+        });
+      },
+    });
+
+    const bodies = {
+      "URLSearchParams empty": new URLSearchParams(),
+      "URLSearchParams a=1": new URLSearchParams("a=1"),
+      "Blob empty": new Blob([], { type: "application/json" }),
+      "Blob 1 byte": new Blob(["{"], { type: "application/json" }),
+      "File empty": new File([], "a.txt", { type: "text/plain" }),
+      "Blob empty untyped": new Blob([]),
+    };
+    const results = Object.fromEntries(
+      await Promise.all(
+        Object.entries(bodies).map(async ([name, body]) => {
+          const res = await fetch(server.url, { method: "POST", body });
+          return [name, await res.json()] as const;
+        }),
+      ),
+    );
+    expect(results).toEqual({
+      "URLSearchParams empty": { type: "application/x-www-form-urlencoded;charset=UTF-8", length: "0" },
+      "URLSearchParams a=1": { type: "application/x-www-form-urlencoded;charset=UTF-8", length: "3" },
+      "Blob empty": { type: "application/json;charset=utf-8", length: "0" },
+      "Blob 1 byte": { type: "application/json;charset=utf-8", length: "1" },
+      "File empty": { type: "text/plain;charset=utf-8", length: "0" },
+      "Blob empty untyped": { type: null, length: "0" },
+    });
+  });
+
   it.concurrent("should work with ipv6 localhost", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### Problem
- `fetch(url, { method: "POST", body })` sends no `Content-Type` when `body` is a typed but zero-length source: `new URLSearchParams()`, `new Blob([], { type })`, `new File([], name, { type })`. The same body with one byte carries its type. Node sends the type at both lengths, and so do `new Request(url, { body }).headers` and `Bun.serve` responses in Bun.
- The cause is the header synthesis at `src/runtime/webcore/fetch.rs:1431`. It runs only when `body.has_body()`, and `HTTPRequestBody::has_body()` is `blob.size() > 0` for an in-memory blob. The branch that merges caller-supplied headers (`fetch.rs:1201`) has no size gate, so adding any unrelated header such as `{ "x-a": "1" }` made the `Content-Type` appear.

### Fix
- Drop the `has_body()` condition. The header is now derived whenever the body has a user-visible type (`has_content_type_from_user()`), which is the rule the other three paths already use.
- Untyped empty bodies (`""`, `new Blob([])`) still send no `Content-Type`: `has_content_type_from_user()` is false for them.
- Verified: `test/js/web/fetch/fetch.test.ts` ("content type is inferred from a zero-length typed body", fails on stock bun for the three empty typed rows). Also ran the rest of `fetch.test.ts`, `body.test.ts`, `content-length.test.js`, `fetch-args.test.ts`, `client-fetch.test.ts`.

### Background
- Fetch "extract a body" sets the request's MIME type from the source object (`URLSearchParams` gives `application/x-www-form-urlencoded;charset=UTF-8`, a `Blob` gives its `type`). Length plays no part.
- In `fetch_impl`, the body becomes an `HTTPRequestBody::AnyBlob`. When the caller passed no headers, `headers` is `None` and this block builds a `Headers` that holds only the derived `Content-Type`. `from_fetch_headers` appends it unless the caller already set one.
- Servers key their body parser on `Content-Type` (express `urlencoded()`/`json()`, FastAPI `Form`). Without it an empty form POST takes the "no parser" branch instead of "empty form".

<details><summary>Notes</summary>

Wire capture against a raw `node:net` listener, before and after:

```
                          stock bun 1.4.3          this PR / node v26
POST URLSearchParams()    CT <absent>  CL 0        application/x-www-form-urlencoded;charset=UTF-8  CL 0
POST Blob([], json)       CT <absent>  CL 0        application/json;charset=utf-8  CL 0
POST File([], txt)        CT <absent>  CL 0        text/plain;charset=utf-8  CL 0
POST (await new Response('', {headers:{'content-type':'text/x'}}).blob())
                          CT <absent>  CL 0        text/x  CL 0
POST ""                   CT <absent>  CL 0        unchanged (no type to derive)
POST Blob([])             CT <absent>  CL 0        unchanged
POST URLSearchParams() + headers {x-a: 1}
                          CT urlencoded CL 0       unchanged (this path never had the gate)
```

An empty `Bun.file()` body already carried its type before this change: a file-backed blob reports an unknown (non-zero) size until it is read, so `has_body()` was true.

GET/HEAD with an empty typed body: Bun does not reject it (`has_body()` is false, Node throws). After this change such a request carries the derived `Content-Type`, the same as `fetch(new Request(url, { method: "GET", body: new URLSearchParams() }))` and the with-headers path already did.

The only other `has_body()` caller is the GET/HEAD body rejection at `fetch.rs:1397`, which keeps its `size > 0` meaning.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->