### PR TITLE
pm version: detect a git repository when .git is a file

### DIFF
--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -306,9 +306,7 @@ impl PmVersionCommand {
         let mut path_buf = bun_paths::path_buffer_pool::get();
         let git_dir_path =
             path::join_abs_string_buf_z::<path_platform::Auto>(cwd, &mut path_buf.0, &[b".git"]);
-        // A linked worktree, a submodule, and `git init --separate-git-dir` all
-        // make `.git` a file that holds `gitdir: <path>`, so a directory check
-        // reports no repository there.
+        // `.git` is a file, not a directory, in a linked worktree or a submodule.
         if !bun_sys::exists_z(git_dir_path) {
             pm.options.git_tag_version = false;
             return Ok(());

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -306,10 +306,10 @@ impl PmVersionCommand {
         let mut path_buf = bun_paths::path_buffer_pool::get();
         let git_dir_path =
             path::join_abs_string_buf_z::<path_platform::Auto>(cwd, &mut path_buf.0, &[b".git"]);
-        if !matches!(
-            bun_sys::directory_exists_at(Fd::cwd(), git_dir_path),
-            Ok(true)
-        ) {
+        // A linked worktree, a submodule, and `git init --separate-git-dir` all
+        // make `.git` a file that holds `gitdir: <path>`, so a directory check
+        // reports no repository there.
+        if !bun_sys::exists_z(git_dir_path) {
             pm.options.git_tag_version = false;
             return Ok(());
         }

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -41,6 +41,19 @@ describe.concurrent("bun pm version", () => {
       env: bunEnv,
     }).exited;
 
+    // Signing needs a key that the machine running the test may not have.
+    await Bun.spawn({
+      cmd: ["git", "config", "commit.gpgsign", "false"],
+      cwd: testDir,
+      env: bunEnv,
+    }).exited;
+
+    await Bun.spawn({
+      cmd: ["git", "config", "tag.gpgsign", "false"],
+      cwd: testDir,
+      env: bunEnv,
+    }).exited;
+
     await Bun.spawn({
       cmd: ["git", "add", "package.json"],
       cwd: testDir,
@@ -337,6 +350,29 @@ describe.concurrent("bun pm version", () => {
       expect(tagOutput).toContain("v1.0.1");
 
       const { output: logOutput } = await runCommand(["git", "log", "--oneline"], testDir1);
+      expect(logOutput).toContain("v1.0.1");
+    });
+
+    it("creates git commits and tags inside a linked worktree", async () => {
+      const mainDir = await setupGitTest();
+      const worktreeDir = join(tempDirWithFiles(`version-${i++}`, { ".keep": "" }), "worktree");
+
+      const { code: addCode } = await runCommand(["git", "worktree", "add", worktreeDir, "-b", "release"], mainDir);
+      expect(addCode).toBe(0);
+
+      // A linked worktree has a `.git` file, not a `.git` directory.
+      expect(await Bun.file(join(worktreeDir, ".git")).text()).toStartWith("gitdir:");
+
+      const { output, error, code } = await runCommand([bunExe(), "pm", "version", "patch"], worktreeDir);
+
+      expect(error.trim()).toBe("");
+      expect(output.trim()).toBe("v1.0.1");
+      expect(code).toBe(0);
+
+      const { output: tagOutput } = await runCommand(["git", "tag", "-l"], worktreeDir);
+      expect(tagOutput).toContain("v1.0.1");
+
+      const { output: logOutput } = await runCommand(["git", "log", "--oneline"], worktreeDir);
       expect(logOutput).toContain("v1.0.1");
     });
 


### PR DESCRIPTION
### Problem

- `bun pm version patch` in a linked git worktree or a git submodule writes the new version to `package.json`, prints `v1.0.1`, and exits 0. It creates no commit and no tag. The documented default is that it creates both (`docs/pm/cli/pm.mdx:426`).
- The cause is `verify_git` (`src/runtime/cli/pm_version_command.rs:309`). It calls `directory_exists_at` on `<package dir>/.git` and turns `git_tag_version` off when that path is not a directory.

### Fix

- Test for existence with `exists_z`, so a `.git` file counts as a repository too.
- Correct because git itself treats a `.git` file that holds `gitdir: <path>` as a repository. npm makes the same check (`@npmcli/git` `is()` is `stat(cwd + '/.git')`), and `npm version patch` 11.16.0 commits and tags in the same worktree where bun does nothing.
- The check stays at the package directory. It does not walk up, so a `.git` in an ancestor directory still never applies.
- Verified: `test/cli/install/bun-pm-version.test.ts`, new worktree case (released bun fails it). The whole file passes, 25 tests.

### Background

- A linked worktree (`git worktree add`), a submodule, and `git init --separate-git-dir` have no `.git` directory. They have a `.git` file with one line: `gitdir: <path to the real git directory>`.
- `verify_git` decides two things: whether `bun pm version` commits and tags at all, and whether it runs the dirty working tree check first.
- `exists_z` is the cross-platform existence check (posix `access`, Windows `GetFileAttributesW`). `bun_sys::exists_at` reports `false` for a directory on Windows, so it does not fit here.

<details><summary>Notes</summary>

Probes, all on linux-x64 with git 2.x:

- Worktree, released bun 1.4.3-canary.1: `package.json` goes to 1.0.1, `git log` and `git tag -l` show nothing, exit code 0. `npm version patch` in the same worktree creates the `1.0.1` commit and the `v1.0.1` tag.
- Submodule (`.git` = `gitdir: ../../.git/modules/vendor/sub`), debug build with this change: commit `v2.0.1` and tag `v2.0.1` created, exit code 0.
- A nested package directory inside a repository (own `package.json`, no own `.git`) stays unchanged: bun and npm both skip git there, because each one looks for `.git` next to the `package.json` it bumps. That case is parity and this change does not touch it.

Second order effects:

- In a worktree the dirty working tree check now runs, so `bun pm version patch` with uncommitted changes there now fails with `Git working directory not clean.` instead of bumping silently. `--force` skips it, and npm's `enforceClean` behaves the same way.
- A `.git` file with content that git cannot parse now reaches `git status --porcelain`, which fails, and the command reports `Git working directory not clean.`. A broken `.git` directory already behaved that way, so the class of failure is not new.
- The test helper now sets `commit.gpgsign=false` and `tag.gpgsign=false` in the test repository. Without it the whole `git integration` block fails on any machine with commit signing on in the global git config.

</details>
