### PR TITLE
server.fetch(): pass the server as the handler's second argument, accept a URL

### DIFF
--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -612,10 +612,11 @@ interface Server extends Disposable {
   reload(options: Serve.Options<undefined>): Server;
 
   /**
-   * Make a request to the running server.
-   * Useful for testing or internal routing.
+   * Call the server's fetch handler in-process, without a socket.
+   * The handler receives (request, server). Does not go through `routes`.
    */
-  fetch(request: Request | string): Response | Promise<Response>;
+  fetch(request: Request): Promise<Response>;
+  fetch(url: string | URL, init?: RequestInit): Promise<Response>;
 
   /**
    * Upgrade an HTTP request to a WebSocket connection.

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -981,13 +981,19 @@ declare module "bun" {
     reload<R extends string>(options: Serve.Options<WebSocketData, R>): Server<WebSocketData>;
 
     /**
-     * Mock the fetch handler for a running server.
+     * Call this server's `fetch` handler with a request, in-process and
+     * without a socket. The handler receives `(request, server)` as it does
+     * for a real request.
      *
-     * This feature is not fully implemented: it doesn't normalize URLs
-     * consistently in all cases and it doesn't always call the `error`
-     * handler.
+     * A string or `URL` becomes a `GET` request unless `init` says otherwise.
+     * A bare path such as `"/foo"` is resolved against the server's origin.
+     *
+     * This feature is not fully implemented: the request does not go through
+     * `routes`, URLs are not normalized consistently in all cases, and the
+     * `error` handler is not always called.
      */
-    fetch(request: Request | string): Response | Promise<Response>;
+    fetch(request: Request): Promise<Response>;
+    fetch(url: string | URL, init?: RequestInit): Promise<Response>;
 
     /**
      * Upgrade a {@link Request} to a {@link ServerWebSocket}

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2237,8 +2237,7 @@ where
         ctx: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // Like fetch(): an exception raised while reading the arguments
-        // rejects the returned promise instead of escaping the call.
+        // Like fetch(): an argument error rejects the promise instead of throwing.
         let result = self.on_fetch_impl(ctx, callframe);
         Fetch::reject_on_exception(ctx, result)
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2272,8 +2272,39 @@ where
         // TODO: set Host header
         // TODO: set User-Agent header
         // TODO: unify with fetch() implementation.
-        let existing_request: Box<Request> = if first_arg.is_string() {
-            let url_utf8 = arguments[0].to_utf8(ctx)?;
+        let existing_request: Box<Request> = if let Some(request_) = first_arg
+            .is_object()
+            .then(|| <Request as bun_jsc::JsClass>::from_js(first_arg))
+            .flatten()
+        {
+            // SAFETY: JsClass::from_js returns a live *mut Request.
+            // NOTE: `Request::clone()` (Request.rs:1627) seeds a fully-initialized
+            // sentinel and calls `clone_into(.., preserve_url=false)`.
+            unsafe { (*request_).clone(ctx)? }
+        } else {
+            // A string is used as given, so a bare path can be joined onto this
+            // server's origin below. Any other object (a URL, or anything with
+            // a string form) goes through its href, as it does for fetch().
+            let url_utf8 = if first_arg.is_string() {
+                first_arg.to_utf8(ctx)?
+            } else {
+                let href = if first_arg.is_object() {
+                    <jsc::URL as jsc::URLJsc>::href_from_js(first_arg, ctx)?
+                } else {
+                    BunString::DEAD
+                };
+                if href.tag() == bun_core::Tag::Dead {
+                    let fetch_error = Fetch::fetch_type_error_string(first_arg);
+                    let err =
+                        jsc::ErrorCode::INVALID_ARG_TYPE.fmt(ctx, format_args!("{}", fetch_error));
+                    return Ok(
+                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                            ctx, err,
+                        ),
+                    );
+                }
+                href.into_utf8()
+            };
             let temp_url_str = url_utf8.slice();
 
             if temp_url_str.is_empty() {
@@ -2350,21 +2381,6 @@ where
                 crate::webcore::body::hive_alloc(body),
                 method,
             ))
-        } else if let Some(request_) = first_arg
-            .is_object()
-            .then(|| <Request as bun_jsc::JsClass>::from_js(first_arg))
-            .flatten()
-        {
-            // SAFETY: JsClass::from_js returns a live *mut Request.
-            // NOTE: `Request::clone()` (Request.rs:1627) seeds a fully-initialized
-            // sentinel and calls `clone_into(.., preserve_url=false)`.
-            unsafe { (*request_).clone(ctx)? }
-        } else {
-            let fetch_error = Fetch::fetch_type_error_string(first_arg);
-            let err = jsc::ErrorCode::INVALID_ARG_TYPE.fmt(ctx, format_args!("{}", fetch_error));
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(ctx, err),
-            );
         };
 
         // `Request::to_js` stores `self as *mut
@@ -2379,8 +2395,10 @@ where
         // SAFETY: `request` was just allocated via `heap::alloc`; ownership
         // transfers to the JS wrapper inside `to_js`.
         let request_value = unsafe { (*request).to_js(&global_this) };
+        let this_value = self.js_value_assert_alive();
+        // Same `(request, server)` signature as a request that arrives on a socket.
         let response_value =
-            match on_request.call(&global_this, self.js_value_assert_alive(), &[request_value]) {
+            match on_request.call(&global_this, this_value, &[request_value, this_value]) {
                 Ok(v) => v,
                 Err(err) => global_this.take_exception(err),
             };

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2278,13 +2278,9 @@ where
             .flatten()
         {
             // SAFETY: JsClass::from_js returns a live *mut Request.
-            // NOTE: `Request::clone()` (Request.rs:1627) seeds a fully-initialized
-            // sentinel and calls `clone_into(.., preserve_url=false)`.
             unsafe { (*request_).clone(ctx)? }
         } else {
-            // A string is used as given, so a bare path can be joined onto this
-            // server's origin below. Any other object (a URL, or anything with
-            // a string form) goes through its href, as it does for fetch().
+            // A string skips href parsing so that a bare path ("/foo") can be joined below.
             let url_utf8 = if first_arg.is_string() {
                 first_arg.to_utf8(ctx)?
             } else {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2237,6 +2237,13 @@ where
         ctx: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
+        // Like fetch(): an exception raised while reading the arguments
+        // rejects the returned promise instead of escaping the call.
+        let result = self.on_fetch_impl(ctx, callframe);
+        Fetch::reject_on_exception(ctx, result)
+    }
+
+    fn on_fetch_impl(&mut self, ctx: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         jsc::mark_binding!();
 
         if self.config.on_request.is_empty() {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -310,7 +310,7 @@ fn bun_fetch(ctx: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
 
 /// WHATWG fetch step 3: an exception thrown while processing `input`/`init`
 /// rejects the returned promise; `fetch()` never throws synchronously.
-fn reject_on_exception(
+pub(crate) fn reject_on_exception(
     global_this: &JSGlobalObject,
     result: JsResult<JSValue>,
 ) -> JsResult<JSValue> {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -366,6 +366,16 @@ describe.concurrent("Server", () => {
     const hrefLike = { toString: () => url.href };
     // @ts-expect-error
     expect(await (await server.fetch(hrefLike)).text()).toBe(`GET ${url.href}`);
+    // A string form that throws rejects the promise; server.fetch() itself does not throw.
+    const throwing = {
+      toString: () => {
+        throw new Error("no href");
+      },
+    };
+    // @ts-expect-error
+    const rejected = server.fetch(throwing);
+    expect(rejected).toBeInstanceOf(Promise);
+    await expect(rejected).rejects.toThrow("no href");
   });
 
   test("server.fetch passes the server as the handler's second argument", async () => {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -352,6 +352,47 @@ describe.concurrent("Server", () => {
     }
   });
 
+  test("server.fetch should work with a URL object", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response(`${req.method} ${req.url}`);
+      },
+    });
+    const url = new URL("/from-url?x=1", server.url);
+    expect(await (await server.fetch(url)).text()).toBe(`GET ${url.href}`);
+    expect(await (await server.fetch(url, { method: "POST", body: "b" })).text()).toBe(`POST ${url.href}`);
+    // Any other object goes through its string form, as with fetch().
+    const hrefLike = { toString: () => url.href };
+    // @ts-expect-error
+    expect(await (await server.fetch(hrefLike)).text()).toBe(`GET ${url.href}`);
+  });
+
+  test("server.fetch passes the server as the handler's second argument", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        return Response.json({
+          argc: arguments.length,
+          isThis: srv === this,
+          isServer: srv === server,
+          // The documented `fetch(req, server) { server.upgrade(req) ... }`
+          // shape must not throw for a socketless request.
+          upgrade: srv.upgrade(req),
+          requestIP: srv.requestIP(req),
+        });
+      },
+      websocket: { message() {} },
+    });
+    expect(await (await server.fetch("/")).json()).toEqual({
+      argc: 2,
+      isThis: true,
+      isServer: true,
+      upgrade: false,
+      requestIP: null,
+    });
+  });
+
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### Problem
- `server.fetch()` called the `fetch` handler with the request only. The documented `fetch(req, server)` shape saw `server === undefined`, so a handler that calls `server.upgrade(req)` threw `TypeError: undefined is not an object (evaluating 'server.upgrade')` under `server.fetch()` and nowhere else.
- `server.fetch(new URL(...))` rejected with `fetch() expects a string, but received Object`, although `fetch()` accepts a `URL`.
- Cause: `on_fetch` (`src/runtime/server/server_body.rs`) passed `&[request_value]` to the handler and only accepted a string or a `Request` as the first argument.

### Fix
- Pass the server as the second argument (it was already `this`), the same as a request that arrives on a socket.
- For an object that is not a `Request`, take its href through `URL.href_from_js` like `fetch()` does, so a `URL` works, `init` included. Strings keep their path-joining behavior. Other primitives still reject with the same message.
- An exception while reading the arguments (a `toString()` that throws, a throwing `method` getter) now rejects the returned promise through the same `reject_on_exception` helper `fetch()` uses, instead of escaping `server.fetch()` as a synchronous throw.
- Types: `Server.fetch` is declared as two overloads, `(request: Request)` and `(url: string | URL, init?: RequestInit)`, returning `Promise<Response>` (the implementation always returns a promise). The doc comment and `docs/runtime/http/server.mdx` now also say that `routes` are not consulted.
- Verified: `test/js/bun/http/bun-server.test.ts` (two new `server.fetch` tests, both fail on 1.4.3). Also the rest of that file, `bun-serve-fetch-invalid-args.test.ts`, `bun-serve-routes.test.ts` and the `bun-types` test.

### Background
- `server.fetch(input, init?)` runs the server's `fetch` handler in-process, without a socket. A string without a hostname is treated as a path and joined onto the server's origin; anything else is used as given. The `Request` it builds has no request context, so `requestIP` returns `null`, `upgrade` returns `false` and `timeout` is a no-op for it.
- Not changed here: `server.fetch()` still bypasses `routes` and the `error` handler, and the joined origin uses the configured port (#39027 fixes the port).
