### PR TITLE
FileSink: count a buffered chunk once in the byte total end() reports

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -581,8 +581,7 @@ pub trait PosixStreamingWriterParent {
     /// per-tag dispatch in `bun_runtime::dispatch::__bun_run_file_poll`
     /// recovers `*mut PosixStreamingWriter<Self>` from this.
     const POLL_OWNER_TAG: PollTag;
-    /// `amount` is what reached the fd in this step: 0 when a chunk was only
-    /// buffered (reported with `Drained` so the parent can schedule a flush).
+    /// `amount`: bytes that reached the fd in this call (0 for a chunk that was only buffered).
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
@@ -851,11 +850,10 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         debug_assert!(!self.is_done);
 
         if self.should_buffer(0) {
-            // Nothing reached the fd; the call lets the parent schedule its auto-flush.
+            // Buffered only: 0 bytes reached the fd. Lets the parent schedule its auto-flush.
             self.parent_on_write(0, WriteStatus::Drained);
             Self::register_poll(self);
 
-            // Buffered, but reported as written to the caller.
             return WriteResult::Wrote(buf_len);
         }
 
@@ -913,8 +911,7 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 return WriteResult::Err(sys::Error::oom());
             }
 
-            // Nothing reached the fd yet (amount 0); the call gives the parent
-            // a chance to register deferred tasks (onAutoFlush).
+            // Buffered only: 0 bytes reached the fd. Lets the parent schedule its auto-flush.
             self.parent_on_write(0, WriteStatus::Drained);
             Self::register_poll(self);
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -581,6 +581,9 @@ pub trait PosixStreamingWriterParent {
     /// per-tag dispatch in `bun_runtime::dispatch::__bun_run_file_poll`
     /// recovers `*mut PosixStreamingWriter<Self>` from this.
     const POLL_OWNER_TAG: PollTag;
+    /// `amount` is what reached the fd in this step: 0 when a chunk was only
+    /// buffered (reported with `Drained` so the parent can schedule a flush).
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus);
@@ -848,9 +851,11 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         debug_assert!(!self.is_done);
 
         if self.should_buffer(0) {
-            self.parent_on_write(buf_len, WriteStatus::Drained);
+            // Nothing reached the fd; the call lets the parent schedule its auto-flush.
+            self.parent_on_write(0, WriteStatus::Drained);
             Self::register_poll(self);
 
+            // Buffered, but reported as written to the caller.
             return WriteResult::Wrote(buf_len);
         }
 
@@ -908,9 +913,9 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
                 return WriteResult::Err(sys::Error::oom());
             }
 
-            // noop, but need this to have a chance
-            // to register deferred tasks (onAutoFlush)
-            self.parent_on_write(buf.len(), WriteStatus::Drained);
+            // Nothing reached the fd yet (amount 0); the call gives the parent
+            // a chance to register deferred tasks (onAutoFlush).
+            self.parent_on_write(0, WriteStatus::Drained);
             Self::register_poll(self);
 
             // it's buffered, but should be reported as written to

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -33,6 +33,7 @@ pub struct FileSink {
     ref_count: Cell<u32>,
     pub(crate) writer: JsCell<IOWriter>,
     pub(crate) event_loop_handle: EventLoopHandle,
+    /// Bytes that reached the fd. A buffered chunk counts once a drain pushes it out.
     pub(crate) written: Cell<usize>,
     pub(crate) pending: JsCell<streams::WritablePending>,
     pub(crate) source: JsCell<streams::SourceHandle>,
@@ -61,7 +62,7 @@ pub struct FileSink {
     /// the stream or the write.
     stream_done: JsCell<bun_jsc::JSPromiseStrong>,
     stream_error: JsCell<Option<streams::StreamError>>,
-    /// Bytes accepted since `pipe_stream` (`written` counts buffered bytes again when flushed).
+    /// Bytes accepted since `pipe_stream`, buffered ones included (`written` only has drained ones).
     pub(crate) stream_bytes: Cell<Option<u64>>,
 
     /// Strong reference to the JS wrapper object to prevent GC from collecting it
@@ -885,11 +886,13 @@ impl FileSink {
                     (*this).auto_flusher.with_mut(|a| a.registered.set(false));
                     return false;
                 }
-                WriteResult::Done(_) => {
+                WriteResult::Done(amount_drained) => {
+                    (*this).written.set((*this).written.get() + amount_drained);
                     (*this).update_ref(false);
                     (*this).run_pending_later();
                 }
                 WriteResult::Wrote(amount_drained) => {
+                    (*this).written.set((*this).written.get() + amount_drained);
                     if amount_drained == amount_buffered {
                         (*this).update_ref(false);
                         (*this).run_pending_later();
@@ -900,7 +903,8 @@ impl FileSink {
                         }
                     }
                 }
-                _ => {
+                WriteResult::Pending(amount_drained) => {
+                    (*this).written.set((*this).written.get() + amount_drained);
                     return true;
                 }
             }
@@ -1247,6 +1251,7 @@ impl FileSink {
 
         match flush_result {
             WriteResult::Done(written) => {
+                self.written.set(self.written.get() + written);
                 self.update_ref(false);
                 self.writer.with_mut(|w| w.end());
                 if has_pending {
@@ -1315,6 +1320,7 @@ impl FileSink {
                 sys::Result::Ok(unsafe { (*promise_result).to_js() })
             }
             WriteResult::Wrote(written) => {
+                self.written.set(self.written.get() + written);
                 self.writer.with_mut(|w| w.end());
                 if has_pending {
                     // SAFETY: JsCell — see the `Done` arm above.

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -486,11 +486,13 @@ describe("FileSink end() after a failed flush counts only bytes that reached the
   });
 
   // A regular file that runs out of space part-way: RLIMIT_FSIZE makes write(2)
-  // fail with EFBIG once the file is 64 * 512 bytes long (bun ignores SIGXFSZ).
-  // 32 KiB is a whole number of flushes for both buffer sizes (4 KiB, 16 KiB
-  // on macOS arm64), so the limit is hit exactly at a flush boundary.
+  // fail with EFBIG once the file is `ulimit -f 32` long (bun ignores SIGXFSZ).
+  // That is 16 KiB where sh counts 512-byte blocks (dash, bash in POSIX mode)
+  // and 32 KiB where it counts KiB (macOS /bin/sh). Both are a whole number of
+  // flushes for either buffer size (4 KiB, 16 KiB on macOS arm64), so the limit
+  // is hit exactly at a flush boundary, and 64 KiB of writes pass it either way.
   it.skipIf(!isPosix)("some bytes written (RLIMIT_FSIZE)", async () => {
-    const dir = tmpdirSync();
+    using dir = tempDir("filesink-rlimit", {});
     const script = /* js */ `
       const { statSync } = require("node:fs");
       const path = process.argv[1];
@@ -510,14 +512,17 @@ describe("FileSink end() after a failed flush counts only bytes that reached the
       console.log(JSON.stringify({ end, size: statSync(path).size, codes }));
     `;
     await using proc = Bun.spawn({
-      cmd: ["sh", "-c", `ulimit -f 64 && exec "$@"`, "sh", bunExe(), "-e", script, join(dir, "out.bin")],
+      cmd: ["sh", "-c", `ulimit -f 32 && exec "$@"`, "sh", bunExe(), "-e", script, join(String(dir), "out.bin")],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual({ end: 64 * 512, size: 64 * 512, codes: ["EFBIG"] });
+    const { end, size, codes } = JSON.parse(stdout);
+    expect(codes).toEqual(["EFBIG"]);
+    expect([16 * 1024, 32 * 1024]).toContain(size);
+    expect(end).toBe(size);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -451,6 +451,77 @@ it.skipIf(!isPosix)(
   },
 );
 
+// Chunks below the writer's buffer size are coalesced before they reach
+// write(2). Once the sink's end-of-tick flush has failed, `end()` reports the
+// bytes written so far. That count must include a coalesced chunk once, when it
+// reaches the fd, not a second time when it was buffered: on a full disk the
+// old count kept growing while nothing was written.
+describe("FileSink end() after a failed flush counts only bytes that reached the fd", () => {
+  // The failed end-of-tick flush leaves the sink closed. The first end() after
+  // it may report that error instead of a count; the count comes after.
+  async function endedWith(sink: ReturnType<ReturnType<typeof Bun.file>["writer"]>) {
+    try {
+      return await sink.end();
+    } catch {
+      return await sink.end();
+    }
+  }
+
+  // /dev/full takes the open() and fails every write(2) with ENOSPC.
+  it.skipIf(!isLinux)("nothing written (/dev/full)", async () => {
+    const sink = Bun.file("/dev/full").writer();
+    const chunk = Buffer.alloc(1024, "x");
+    const results: unknown[] = [];
+    for (let i = 0; i < 8; i++) {
+      results.push(sink.write(chunk));
+    }
+    // The first chunks are buffered and reported as written; the write that
+    // fills the buffer flushes it and is the first to see ENOSPC.
+    expect(results.slice(0, 3)).toEqual([1024, 1024, 1024]);
+    const settled = await Promise.allSettled(results.slice(3));
+    expect(settled.map(s => (s.status === "rejected" ? s.reason?.code : s))).toEqual(Array(5).fill("ENOSPC"));
+    // One loop turn: the end-of-tick flush fails too and closes the sink.
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(await endedWith(sink)).toBe(0);
+  });
+
+  // A regular file that runs out of space part-way: RLIMIT_FSIZE makes write(2)
+  // fail with EFBIG once the file is 64 * 512 bytes long (bun ignores SIGXFSZ).
+  // 32 KiB is a whole number of flushes for both buffer sizes (4 KiB, 16 KiB
+  // on macOS arm64), so the limit is hit exactly at a flush boundary.
+  it.skipIf(!isPosix)("some bytes written (RLIMIT_FSIZE)", async () => {
+    const dir = tmpdirSync();
+    const script = /* js */ `
+      const { statSync } = require("node:fs");
+      const path = process.argv[1];
+      const sink = Bun.file(path).writer();
+      const chunk = Buffer.alloc(1024, "x");
+      const results = [];
+      for (let i = 0; i < 64; i++) results.push(sink.write(chunk));
+      const settled = await Promise.allSettled(results);
+      const codes = [...new Set(settled.filter(s => s.status === "rejected").map(s => s.reason.code))];
+      await new Promise(resolve => setImmediate(resolve));
+      let end;
+      try {
+        end = await sink.end();
+      } catch {
+        end = await sink.end();
+      }
+      console.log(JSON.stringify({ end, size: statSync(path).size, codes }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `ulimit -f 64 && exec "$@"`, "sh", bunExe(), "-e", script, join(dir, "out.bin")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ end: 64 * 512, size: 64 * 512, codes: ["EFBIG"] });
+    expect(exitCode).toBe(0);
+  });
+});
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(


### PR DESCRIPTION
### Problem
- A `Bun.file(path).writer()` fed chunks smaller than its 4 KiB buffer on a full disk: `await writer.end()` resolves `461824` while the file is 262144 bytes (1024 writes of 1 KiB with 256 KiB free). On `/dev/full`, `end()` resolves `3072` with nothing written. 1.3.x returned 0 there. 1.4 returns `FileSink.written` once the end-of-tick auto-flush has failed (#35278 marks the sink done), and that counter is wrong.
- The cause is in `PosixStreamingWriter::write` (`src/io/PipeWriter.rs`): a chunk that is only buffered is reported to the parent as `on_write(chunk.len(), Drained)`, and the bytes are reported again by `on_write(n, ..)` when a later write pushes the buffer to the fd. `FileSink::on_write` adds both to `written`. Chunks that were buffered and then dropped by a failed flush stay counted too.

### Fix
- The two buffered-only notifications pass `0` as the amount. They exist so that the parent can register its auto-flush (`FileSink`) or note the buffered state (`Terminal`, which ignores the amount). `on_write`'s amount now always means bytes that reached the fd.
- `FileSink::on_auto_flush` and the `Done`/`Wrote` arms of `end_from_js` add what their own `flush()` drained to `written`, as `flush_from_js` and `end()` already do. `writer.flush()` drains without calling `on_write`, so before this the buffered-time credit was what kept `written` right on that path.
- Correct because every byte now enters `written` exactly once, at the moment a `write(2)` accepted it: through `on_write` for drains the writer runs, or through the flush result for drains FileSink runs. Windows is unaffected: its writer only calls `on_write` from the completion callback and its `flush()` returns `Pending(0)`.
- Verified: `test/js/bun/util/filesink.test.ts`, new block `FileSink end() after a failed flush counts only bytes that reached the fd` (`/dev/full` on Linux, `RLIMIT_FSIZE` on POSIX; 1.4.3 reports 3072 for 0 bytes and 31744 for 16384 bytes). The rest of the file, the spawn stdin suites, `process-stdio`, `bunshell` and `terminal` tests pass.

### Background
- `FileSink` (`src/runtime/webcore/FileSink.rs`) is the object behind `Bun.file(x).writer()`, `proc.stdin` and the `fs.WriteStream` fast path. It owns a `StreamingWriter` (`src/io/PipeWriter.rs`) that buffers chunks below `CHUNK_SIZE` (4 KiB, 16 KiB on macOS arm64) and writes the buffer out when a chunk fills it, from a poll callback, or from `flush()`.
- The writer reports progress to its parent through `on_write(amount, status)`. `FileSink` keeps `written` from it and returns that number from `end()` when the sink is already done. A sink becomes done early when the auto-flush that runs after each JS turn hits a write error.
- `write()` still returns the chunk length for a buffered chunk. Only the internal notification changed, not what callers of `write()` see.

<details><summary>Notes</summary>

- `end()` has two result shapes that this PR keeps: when it performs the final flush itself it returns what that flush wrote, when the sink is already done it returns the running total. Only the total was wrong.
- A short `write(2)` followed by a hard error in the same loop (`try_write_with_write_fn`) still reports `Err` and drops the short count, so after an unaligned `ENOSPC` the total can be low by less than one buffer. Reporting those bytes as `Pending` was tried and reverted: `end()`'s `Pending` arm waits for a poll that a regular file never gets.
- Whether the error of a failed background flush reaches the caller at all is #41568. The new tests call `end()` a second time if the first call throws, so they hold with and without it.
- Reported in the full-disk census (ledger #29534). The repro there gives `{ endResolved: 461824, bytesOnDisk: 262144 }` on 1.4.3 and `{ endResolved: 262144, bytesOnDisk: 262144 }` with this change. With 255 KiB free (not a multiple of 4 KiB) it gives `{ endResolved: 258048, bytesOnDisk: 261120 }`: the 3072 bytes of the short write before `EFBIG` are the gap described above.
</details>

