### PR TITLE
sql: check the transaction guard prefix without copying the query

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -354,8 +354,7 @@ function hasKeywordAt(query: string, start: number, keyword: string): boolean {
   return true;
 }
 
-// Index of the first character at or after `start` that is not space, \t,
-// \n, \v, \f or \r: the whitespace the Postgres and MySQL lexers skip.
+// Skips the whitespace the Postgres and MySQL lexers skip: space, \t, \n, \v, \f, \r.
 function skipWhitespace(query: string, start: number): number {
   const len = query.length;
   let i = start;
@@ -367,9 +366,7 @@ function skipWhitespace(query: string, start: number): number {
   return i;
 }
 
-// True when the query starts a transaction (BEGIN or START TRANSACTION, any
-// case, after leading whitespace). Only reads the prefix: this runs on every
-// pooled query, and ORM generated queries are long.
+// Reads only the prefix: this runs on every pooled query, and ORM generated queries are long.
 function startsTransaction(query: string): boolean {
   const i = skipWhitespace(query, 0);
   if (hasKeywordAt(query, i, "BEGIN")) return true;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -354,19 +354,29 @@ function hasKeywordAt(query: string, start: number, keyword: string): boolean {
   return true;
 }
 
+// Index of the first character at or after `start` that is not space, \t,
+// \n, \v, \f or \r: the whitespace the Postgres and MySQL lexers skip.
+function skipWhitespace(query: string, start: number): number {
+  const len = query.length;
+  let i = start;
+  while (i < len) {
+    const c = query.charCodeAt(i);
+    if (c === 32 || (c >= 9 && c <= 13)) i++;
+    else break;
+  }
+  return i;
+}
+
 // True when the query starts a transaction (BEGIN or START TRANSACTION, any
 // case, after leading whitespace). Only reads the prefix: this runs on every
 // pooled query, and ORM generated queries are long.
 function startsTransaction(query: string): boolean {
-  const len = query.length;
-  let i = 0;
-  while (i < len) {
-    const c = query.charCodeAt(i);
-    // space, \t, \n, \v, \f, \r
-    if (c === 32 || (c >= 9 && c <= 13)) i++;
-    else break;
-  }
-  return hasKeywordAt(query, i, "BEGIN") || hasKeywordAt(query, i, "START TRANSACTION");
+  const i = skipWhitespace(query, 0);
+  if (hasKeywordAt(query, i, "BEGIN")) return true;
+  if (!hasKeywordAt(query, i, "START")) return false;
+  const afterStart = i + 5;
+  const j = skipWhitespace(query, afterStart);
+  return j > afterStart && hasKeywordAt(query, j, "TRANSACTION");
 }
 
 function getHelperCommandFromDetect(query: string, anyAndAllMeanIn: boolean): SQLCommand {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -342,6 +342,33 @@ function detectCommand(query: string, anyAndAllMeanIn: boolean): SQLCommand {
   return command;
 }
 
+function hasKeywordAt(query: string, start: number, keyword: string): boolean {
+  const len = keyword.length;
+  if (query.length - start < len) return false;
+  for (let i = 0; i < len; i++) {
+    let c = query.charCodeAt(start + i);
+    // ASCII lowercase to uppercase
+    if (c >= 97 && c <= 122) c -= 32;
+    if (c !== keyword.charCodeAt(i)) return false;
+  }
+  return true;
+}
+
+// True when the query starts a transaction (BEGIN or START TRANSACTION, any
+// case, after leading whitespace). Only reads the prefix: this runs on every
+// pooled query, and ORM generated queries are long.
+function startsTransaction(query: string): boolean {
+  const len = query.length;
+  let i = 0;
+  while (i < len) {
+    const c = query.charCodeAt(i);
+    // space, \t, \n, \v, \f, \r
+    if (c === 32 || (c >= 9 && c <= 13)) i++;
+    else break;
+  }
+  return hasKeywordAt(query, i, "BEGIN") || hasKeywordAt(query, i, "START TRANSACTION");
+}
+
 function getHelperCommandFromDetect(query: string, anyAndAllMeanIn: boolean): SQLCommand {
   const command = detectCommand(query, anyAndAllMeanIn);
   // only selectIn, insert, update, updateSet are allowed
@@ -988,11 +1015,8 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
 
   protected checkUnsafeTransaction(sql: string, flags: number) {
     if (!(flags & SQLQueryFlags.allowUnsafeTransaction)) {
-      if (this.connectionInfo.max !== 1) {
-        const upperCaseSqlString = sql.toUpperCase().trim();
-        if (upperCaseSqlString.startsWith("BEGIN") || upperCaseSqlString.startsWith("START TRANSACTION")) {
-          throw this.unsafeTransactionError();
-        }
+      if (this.connectionInfo.max !== 1 && startsTransaction(sql)) {
+        throw this.unsafeTransactionError();
       }
     }
   }

--- a/test/js/sql/sql-unsafe-transaction-guard.test.ts
+++ b/test/js/sql/sql-unsafe-transaction-guard.test.ts
@@ -27,6 +27,10 @@ describe.each(adapters)("%s unsafe transaction guard", (_adapter, code, makeSql)
       "START TRANSACTION",
       "start transaction",
       "\v\fStart Transaction read only",
+      // the servers accept any whitespace between the two keywords
+      "START\tTRANSACTION",
+      "start  transaction",
+      "START\nTRANSACTION",
     ]) {
       const err = await sql.unsafe(query).catch(e => e);
       expect(err.code, JSON.stringify(query)).toBe(code);
@@ -35,7 +39,18 @@ describe.each(adapters)("%s unsafe transaction guard", (_adapter, code, makeSql)
 
   test("does not reject other queries", async () => {
     await using sql = makeSql(2);
-    for (const query of ["select * from beginners", "commit", "-- begin\nselect 1", "", "   ", "BEG", "start"]) {
+    for (const query of [
+      "select * from beginners",
+      "commit",
+      "-- begin\nselect 1",
+      "",
+      "   ",
+      "BEG",
+      "start",
+      "START ",
+      "STARTTRANSACTION",
+      "start transactio",
+    ]) {
       const err = await sql.unsafe(query).catch(e => e);
       expect(err.code, JSON.stringify(query)).not.toBe(code);
     }
@@ -45,36 +60,5 @@ describe.each(adapters)("%s unsafe transaction guard", (_adapter, code, makeSql)
     await using sql = makeSql(1);
     const err = await sql.unsafe("begin").catch(e => e);
     expect(err.code).not.toBe(code);
-  });
-
-  test("cost does not grow with the query length", async () => {
-    await using sql = makeSql(2);
-    // Both queries reject at the guard. The long one carries 1 MiB of
-    // trailing comment that the guard has no reason to read.
-    const short = "begin";
-    const long = "begin -- " + Buffer.alloc(1 << 20, "x").toString();
-    const reject = async (query: string) => {
-      const err = await sql.unsafe(query).catch(e => e);
-      expect(err.code).toBe(code);
-    };
-    for (let i = 0; i < 20; i++) {
-      await reject(short);
-      await reject(long);
-    }
-
-    let shortNs = Infinity;
-    let longNs = Infinity;
-    for (let round = 0; round < 5; round++) {
-      let start = Bun.nanoseconds();
-      for (let i = 0; i < 50; i++) await reject(short);
-      shortNs = Math.min(shortNs, Bun.nanoseconds() - start);
-
-      start = Bun.nanoseconds();
-      for (let i = 0; i < 50; i++) await reject(long);
-      longNs = Math.min(longNs, Bun.nanoseconds() - start);
-    }
-    // Before the fix the guard uppercased the whole query, so the long
-    // query cost around 100x the short one.
-    expect(longNs / shortNs).toBeLessThan(8);
   });
 });

--- a/test/js/sql/sql-unsafe-transaction-guard.test.ts
+++ b/test/js/sql/sql-unsafe-transaction-guard.test.ts
@@ -1,0 +1,80 @@
+// A pooled connection (max > 1) rejects a query that starts a transaction
+// outside sql.begin() or sql.reserve(). The guard runs before any connection
+// is attempted, so these tests need no live server: the URLs point at a closed
+// port that is never dialed for a rejected query.
+// https://github.com/oven-sh/bun/issues/41740
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+
+const adapters: [string, string, (max: number) => SQL][] = [
+  [
+    "postgres",
+    "ERR_POSTGRES_UNSAFE_TRANSACTION",
+    max => new SQL("postgres://bun_sql_test@127.0.0.1:1/bun_sql_test", { max }),
+  ],
+  ["mysql", "ERR_MYSQL_UNSAFE_TRANSACTION", max => new SQL("mysql://bun_sql_test@127.0.0.1:1/bun_sql_test", { max })],
+];
+
+describe.each(adapters)("%s unsafe transaction guard", (_adapter, code, makeSql) => {
+  test("rejects BEGIN and START TRANSACTION in any case, after leading whitespace", async () => {
+    await using sql = makeSql(2);
+    for (const query of [
+      "BEGIN",
+      "begin",
+      "  Begin  ",
+      "\n\t begin",
+      "\r\nBEGIN TRANSACTION",
+      "START TRANSACTION",
+      "start transaction",
+      "\v\fStart Transaction read only",
+    ]) {
+      const err = await sql.unsafe(query).catch(e => e);
+      expect(err.code, JSON.stringify(query)).toBe(code);
+    }
+  });
+
+  test("does not reject other queries", async () => {
+    await using sql = makeSql(2);
+    for (const query of ["select * from beginners", "commit", "-- begin\nselect 1", "", "   ", "BEG", "start"]) {
+      const err = await sql.unsafe(query).catch(e => e);
+      expect(err.code, JSON.stringify(query)).not.toBe(code);
+    }
+  });
+
+  test("does not reject BEGIN when the pool has a single connection", async () => {
+    await using sql = makeSql(1);
+    const err = await sql.unsafe("begin").catch(e => e);
+    expect(err.code).not.toBe(code);
+  });
+
+  test("cost does not grow with the query length", async () => {
+    await using sql = makeSql(2);
+    // Both queries reject at the guard. The long one carries 1 MiB of
+    // trailing comment that the guard has no reason to read.
+    const short = "begin";
+    const long = "begin -- " + Buffer.alloc(1 << 20, "x").toString();
+    const reject = async (query: string) => {
+      const err = await sql.unsafe(query).catch(e => e);
+      expect(err.code).toBe(code);
+    };
+    for (let i = 0; i < 20; i++) {
+      await reject(short);
+      await reject(long);
+    }
+
+    let shortNs = Infinity;
+    let longNs = Infinity;
+    for (let round = 0; round < 5; round++) {
+      let start = Bun.nanoseconds();
+      for (let i = 0; i < 50; i++) await reject(short);
+      shortNs = Math.min(shortNs, Bun.nanoseconds() - start);
+
+      start = Bun.nanoseconds();
+      for (let i = 0; i < 50; i++) await reject(long);
+      longNs = Math.min(longNs, Bun.nanoseconds() - start);
+    }
+    // Before the fix the guard uppercased the whole query, so the long
+    // query cost around 100x the short one.
+    expect(longNs / shortNs).toBeLessThan(8);
+  });
+});


### PR DESCRIPTION
### Problem
- `checkUnsafeTransaction` (`src/js/internal/sql/shared.ts`) ran `sql.toUpperCase().trim()` on the whole query, then tested a prefix of at most 17 characters (`BEGIN` or `START TRANSACTION`). It runs on every query on a pool with `max !== 1`, so its cost grew with the query length. The reporter measured it at 3.3% of CPU on a Drizzle server.
- User code cannot skip the check. Only `sql.begin()` and `sql.reserve()` set `SQLQueryFlags.allowUnsafeTransaction`.
- The old compare also required exactly one space between `START` and `TRANSACTION`. `START\tTRANSACTION` passed the guard and opened a transaction on a random pooled connection.

### Fix
- `startsTransaction` skips leading ASCII whitespace with `charCodeAt`, then compares the next characters to `BEGIN`, or to `START`, whitespace, `TRANSACTION`, with ASCII case folding. It reads only the prefix and allocates nothing.
- The result is the same as before for every input that Postgres or MySQL lex as a transaction start. Both lexers treat only ASCII whitespace as whitespace, and keywords are ASCII. Unicode whitespace (for example U+00A0) before `BEGIN`, or `begın` with a dotless i, no longer trigger the guard. Those are syntax errors in the server and start no transaction.
- Verified: `test/js/sql/sql-unsafe-transaction-guard.test.ts` (new, needs no database, the whitespace cases fail on the old code). Also `test/js/sql/sql-pool-transaction-isolation.test.ts`, `sql-reserve-abort.test.ts`, `sql-helpers-validation.test.ts`, `sql-prepare-false.test.ts`, `wire-frames.test.ts`, and the guard tests in `sql-mysql.transactions.test.ts`.
- Self-reviewed: 3 concerns raised, 3 addressed (the semantics change is stated above, the test placement matches `sql-helpers-validation.test.ts`, the timing assertion is gone and the numbers are below).

### Background
- `Bun.sql` pools connections. A `BEGIN` sent through the pool can land on a different connection than the next query, so the client rejects it with `ERR_POSTGRES_UNSAFE_TRANSACTION` or `ERR_MYSQL_UNSAFE_TRANSACTION` unless the query comes from `sql.begin()` or `sql.reserve()`.
- The guard runs in `createQueryHandle`, before any connection is dialed. A rejected query never touches the network. The new test uses that: it points at a closed port and only ever observes the guard.

<details><summary>Notes</summary>

Measured cost of the guard, released bun 1.4.3, linux x64, per call:

| query chars | before | after |
| --- | --- | --- |
| 172 | 187 ns | 25 ns |
| 1072 | 753 ns | 24 ns |
| 10072 | 4676 ns | 23 ns |

Whole-query rejection of `begin` against `begin -- ` plus 1 MiB of comment, minimum of 5 rounds of 50: released bun 57x to 87x slower for the long query, debug+ASAN build before the fix 30x, after the fix 1.0x.

An earlier revision asserted that ratio in the test. The whitespace cases (`START\tTRANSACTION`, `start  transaction`, `START\nTRANSACTION`) now give the test a behaviour difference against the old code, so the timing assertion was removed.

`detectCommand` in the same file also lowercases the whole query. It runs only when a `sql(...)` helper is interpolated, and it searches backwards through the query for the nearest keyword, so it is a different problem and stays out of this PR.

The `SQLResultArray` spread that the reporter mentions is also out of scope here.

</details>
