### PR TITLE
Report an error instead of aborting when a user-supplied path does not fit a path buffer

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -64,6 +64,7 @@ pub fn do_patch_commit(
     log_level: LogLevel,
 ) -> Result<Option<PatchCommitResult>, crate::Error> {
     let mut folder_path_buf = bun_paths::path_buffer_pool::get();
+    let mut package_json_path_buf = bun_paths::path_buffer_pool::get();
     let mut lockfile: Box<Lockfile> = Box::default();
     let log = manager.log_mut();
     match lockfile.load_from_cwd::<true>(Some(manager), log) {
@@ -161,8 +162,13 @@ pub fn do_patch_commit(
     let mut iterator = tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(&lockfile);
     let (changes_dir, pkg): (Vec<u8>, Package) = match arg_kind {
         PatchArgKind::Path => 'result: {
-            let package_json_path =
-                resolve_path::join_z::<platform::Auto>(&[argument, b"package.json"]);
+            let Some(package_json_path) = resolve_path::join_z_buf_checked::<platform::Auto>(
+                &mut package_json_path_buf[..],
+                &[argument, b"package.json"],
+            ) else {
+                Output::err_generic("path is too long: {}", (bun_fmt::quote(argument),));
+                Global::crash();
+            };
             let package_json_source: bun_ast::Source =
                 match bun_ast::to_source(package_json_path, Default::default()) {
                     Ok(s) => s,
@@ -566,8 +572,11 @@ pub fn do_patch_commit(
         _ => unreachable!("patch_features must be Commit in doPatchCommit"),
     };
 
-    let path_in_patches_dir =
-        resolve_path::join_z::<platform::Posix>(&[patches_dir, patch_filename]);
+    let mut path_in_patches_dir_spill = Vec::new();
+    let path_in_patches_dir = resolve_path::join_z_spill::<platform::Posix>(
+        &mut path_in_patches_dir_spill,
+        &[patches_dir, patch_filename],
+    );
 
     // mkdir-p syscall is used here, no JS surface; route directly through
     // `bun_sys::mkdir_recursive` to avoid the `bun_runtime` dep cycle.
@@ -595,10 +604,12 @@ pub fn do_patch_commit(
     }
 
     let patchfile_path: Box<[u8]> = Box::<[u8]>::from(path_in_patches_dir.as_bytes());
-    let _ = sys::unlink(resolve_path::join_z::<platform::Auto>(&[
-        changes_dir,
-        b".bun-patch-tag",
-    ]));
+    if let Some(tag_path) = resolve_path::join_z_buf_checked::<platform::Auto>(
+        &mut pathbuf[..],
+        &[changes_dir, b".bun-patch-tag"],
+    ) {
+        let _ = sys::unlink(tag_path);
+    }
 
     Ok(Some(PatchCommitResult {
         patch_key: patch_key.into_boxed_slice(),
@@ -703,6 +714,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     let arg_kind: PatchArgKind = PatchArgKind::from_arg(argument);
 
     let mut folder_path_buf = bun_paths::path_buffer_pool::get();
+    let mut package_json_path_buf = bun_paths::path_buffer_pool::get();
 
     #[cfg(windows)]
     let mut win_normalizer = bun_paths::path_buffer_pool::get();
@@ -735,8 +747,13 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     let (cache_dir, cache_dir_subpath, module_folder, pkg_name): (Fd, &[u8], Vec<u8>, Vec<u8>) =
         match arg_kind {
             PatchArgKind::Path => 'brk: {
-                let package_json_path =
-                    resolve_path::join_z::<platform::Auto>(&[argument, b"package.json"]);
+                let Some(package_json_path) = resolve_path::join_z_buf_checked::<platform::Auto>(
+                    &mut package_json_path_buf[..],
+                    &[argument, b"package.json"],
+                ) else {
+                    Output::err_generic("path is too long: {}", (bun_fmt::quote(argument),));
+                    Global::crash();
+                };
                 let package_json_source: bun_ast::Source =
                     match bun_ast::to_source(package_json_path, Default::default()) {
                         Ok(s) => s,

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -984,27 +984,22 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     }
 
     if not_in_workspace_root {
-        let mut bufn = bun_paths::path_buffer_pool::get();
+        let mut spill = Vec::new();
+        let abs_module_folder = resolve_path::join_spill::<platform::Posix>(
+            &mut spill,
+            &[
+                FileSystem::instance().top_level_dir_without_trailing_slash(),
+                module_folder,
+            ],
+        );
         bun_core::pretty!(
             "\nTo patch <b>{}<r>, edit the following folder:\n\n  <cyan>{}<r>\n",
             bstr::BStr::new(pkg_name),
-            bstr::BStr::new(resolve_path::join_string_buf::<platform::Posix>(
-                &mut bufn[..],
-                &[
-                    FileSystem::instance().top_level_dir_without_trailing_slash(),
-                    module_folder
-                ]
-            )),
+            bstr::BStr::new(abs_module_folder),
         );
         bun_core::pretty!(
             "\nOnce you're done with your changes, run:\n\n  <cyan>bun patch --commit '{}'<r>\n",
-            bstr::BStr::new(resolve_path::join_string_buf::<platform::Posix>(
-                &mut bufn[..],
-                &[
-                    FileSystem::instance().top_level_dir_without_trailing_slash(),
-                    module_folder
-                ]
-            )),
+            bstr::BStr::new(abs_module_folder),
         );
     } else {
         bun_core::pretty!(
@@ -1442,9 +1437,10 @@ fn path_argument_relative_to_root_workspace_package(
     let workspace_res = &lockfile.packages.items_resolution()[workspace_package_id as usize];
     let workspace_str = *workspace_res.workspace();
     let rel_path: &[u8] = workspace_str.slice(lockfile.buffers.string_bytes.as_slice());
-    Some(Box::<[u8]>::from(resolve_path::join::<platform::Posix>(&[
-        rel_path, argument,
-    ])))
+    let mut spill = Vec::new();
+    Some(Box::<[u8]>::from(
+        resolve_path::join_spill::<platform::Posix>(&mut spill, &[rel_path, argument]),
+    ))
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/src/install/PackageManager/workspace_selection.rs
+++ b/src/install/PackageManager/workspace_selection.rs
@@ -4,7 +4,7 @@ use bstr::BStr;
 use bun_collections::{DynamicBitSet, HashMap, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, strings};
 use bun_paths::path_buffer_pool;
-use bun_paths::resolve_path::{join_abs_string_buf, platform};
+use bun_paths::resolve_path::{join_abs_string_buf, join_abs_string_buf_checked, platform};
 
 use crate::bun_fs::FileSystem;
 use crate::dependency::Behavior;
@@ -103,12 +103,13 @@ fn parse(raw: &[u8], original_cwd: &[u8], path_buf: &mut [u8]) -> Selector {
     }
 
     let resolve = |part: &[u8], path_buf: &mut [u8]| -> Box<[u8]> {
-        strings::without_trailing_slash(join_abs_string_buf::<platform::Posix>(
-            original_cwd,
-            path_buf,
-            &[part],
-        ))
-        .into()
+        let Some(joined) =
+            join_abs_string_buf_checked::<platform::Posix>(original_cwd, path_buf, &[part])
+        else {
+            Output::err_generic("--filter \"{}\" path is too long", (BStr::new(raw),));
+            Global::crash();
+        };
+        strings::without_trailing_slash(joined).into()
     };
 
     let base = if remain == b"*" || remain == b"**" {

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -2697,11 +2697,11 @@ fn resolve_local_image_path(src: &[u8], base_dir: Option<&[u8]>) -> Option<Box<[
     // Percent-decode the path so file:///foo/bar%20baz works.
     let decoded = bun_url::PercentEncoding::decode_alloc(path).ok()?;
 
-    // Resolve to an absolute path. bun.path.joinAbsString returns a
-    // slice in a threadlocal buffer — dupe it before leaving this fn.
-    // Prefer the markdown file's directory when provided; otherwise fall
-    // back to cwd so `Bun.markdown.ansi()` callers without a source path
-    // still work.
+    // Resolve to an absolute path. Prefer the markdown file's directory
+    // when provided; otherwise fall back to cwd so `Bun.markdown.ansi()`
+    // callers without a source path still work. A path that does not fit
+    // a PathBuffer cannot exist on disk, so it is skipped like a missing
+    // file.
     let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let base: &[u8] = if let Some(d) = base_dir {
         d
@@ -2711,16 +2711,17 @@ fn resolve_local_image_path(src: &[u8], base_dir: Option<&[u8]>) -> Option<Box<[
             Err(_) => return None,
         }
     };
-    let joined =
-        bun_paths::resolve_path::join_abs_string::<bun_paths::platform::Auto>(base, &[&decoded]);
-    let abs = Box::<[u8]>::from(joined);
+    let mut abs_buf = bun_paths::path_buffer_pool::get();
+    let abs_z = bun_paths::resolve_path::join_abs_string_buf_z_checked::<bun_paths::platform::Auto>(
+        base,
+        &mut abs_buf[..],
+        &[&decoded],
+    )?;
     // Stat instead of plain exists() so a directory like `./assets/` gets
     // rejected. bun.sys.exists wraps access(path, F_OK) which returns true
     // for any entry, including directories — and emitKittyImageFile sets
     // q=2 so the terminal silently drops directory paths without falling
     // through to alt text.
-    let mut zbuf = bun_paths::path_buffer_pool::get();
-    let abs_z = bun_paths::resolve_path::z(&abs, &mut zbuf);
     match bun_sys::stat(abs_z) {
         Ok(s) => {
             if !bun_sys::S::ISREG(s.st_mode as _) {
@@ -2729,7 +2730,7 @@ fn resolve_local_image_path(src: &[u8], base_dir: Option<&[u8]>) -> Option<Box<[
         }
         Err(_) => return None,
     }
-    Some(abs)
+    Some(Box::<[u8]>::from(abs_z.as_bytes()))
 }
 
 // ========================================

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -2697,9 +2697,7 @@ fn resolve_local_image_path(src: &[u8], base_dir: Option<&[u8]>) -> Option<Box<[
     // Percent-decode the path so file:///foo/bar%20baz works.
     let decoded = bun_url::PercentEncoding::decode_alloc(path).ok()?;
 
-    // Resolve against the markdown file's directory, or the cwd for
-    // `Bun.markdown.ansi()` callers. A result longer than a PathBuffer cannot
-    // exist on disk and is skipped like a missing file.
+    // Relative to the markdown file's directory, else the cwd (`Bun.markdown.ansi()`).
     let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let base: &[u8] = if let Some(d) = base_dir {
         d

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -2697,11 +2697,9 @@ fn resolve_local_image_path(src: &[u8], base_dir: Option<&[u8]>) -> Option<Box<[
     // Percent-decode the path so file:///foo/bar%20baz works.
     let decoded = bun_url::PercentEncoding::decode_alloc(path).ok()?;
 
-    // Resolve to an absolute path. Prefer the markdown file's directory
-    // when provided; otherwise fall back to cwd so `Bun.markdown.ansi()`
-    // callers without a source path still work. A path that does not fit
-    // a PathBuffer cannot exist on disk, so it is skipped like a missing
-    // file.
+    // Resolve against the markdown file's directory, or the cwd for
+    // `Bun.markdown.ansi()` callers. A result longer than a PathBuffer cannot
+    // exist on disk and is skipped like a missing file.
     let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let base: &[u8] = if let Some(d) = base_dir {
         d

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -193,38 +193,42 @@ impl CompileTarget {
         version_str: &'a ZStr,
         _env: &mut bun_dotenv::Loader,
         needs_download: &mut bool,
-    ) -> &'a ZStr {
+    ) -> Result<&'a ZStr, crate::Error> {
         if self.is_default() {
             'brk: {
                 let Ok(self_exe_path) = bun_core::self_exe_path() else {
                     break 'brk;
                 };
+                if self_exe_path.len() >= buf.len() {
+                    return Err(crate::Error::BufferTooSmall);
+                }
                 buf[..self_exe_path.len()].copy_from_slice(self_exe_path.as_bytes());
                 buf[self_exe_path.len()] = 0;
                 *needs_download = false;
                 // SAFETY: buf[self_exe_path.len()] == 0 written above
-                return ZStr::from_buf(&buf[..], self_exe_path.len());
+                return Ok(ZStr::from_buf(&buf[..], self_exe_path.len()));
             }
         }
 
         if bun_sys::exists_at(Fd::cwd(), version_str) {
             *needs_download = false;
-            return version_str;
+            return Ok(version_str);
         }
 
         // T1 fallback ignores `_env` (full env-override chain lives in bun_install).
         let cache_dir = bun_sys::fetch_cache_directory_path();
-        let dest = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
+        let dest = path::resolve_path::join_abs_string_buf_z_checked::<path::platform::Auto>(
             path::fs::FileSystem::instance().top_level_dir(),
             &mut buf[..],
             &[cache_dir.as_slice(), version_str.as_bytes()],
-        );
+        )
+        .ok_or(crate::Error::BufferTooSmall)?;
 
         if bun_sys::exists_at(Fd::cwd(), dest) {
             *needs_download = false;
         }
 
-        dest
+        Ok(dest)
     }
 
     // `download_to_path` moved up to `bun_standalone_graph` so it can name

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1476,9 +1476,8 @@ pub fn join_z_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -
     join_z_buf::<P>(&mut spill[..], parts)
 }
 
-/// Like [`join_z_buf`], but returns `None` when the normalized result (plus
-/// its NUL) does not fit `buf`. Use this when `parts` may contain
-/// user-controlled input of arbitrary length.
+/// [`join_z_buf`] for parts of user-controlled length: `None` when the
+/// normalized result plus its NUL does not fit `buf`.
 pub fn join_z_buf_checked<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
@@ -1725,8 +1724,8 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     Some(&buf[..len])
 }
 
-/// [`join_abs_string_buf_checked`] with a NUL terminator: `None` when the
-/// normalized result plus its NUL does not fit `buf`.
+/// [`join_abs_string_buf_checked`], NUL-terminated: `None` when the result
+/// plus its NUL does not fit `buf`.
 pub fn join_abs_string_buf_z_checked<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1476,6 +1476,28 @@ pub fn join_z_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -
     join_z_buf::<P>(&mut spill[..], parts)
 }
 
+/// Like [`join_z_buf`], but returns `None` when the normalized result (plus
+/// its NUL) does not fit `buf`. Use this when `parts` may contain
+/// user-controlled input of arbitrary length.
+pub fn join_z_buf_checked<'a, P: PlatformT>(
+    buf: &'a mut [u8],
+    parts: &[&[u8]],
+) -> Option<&'a ZStr> {
+    let needed = join_needed(parts);
+    if needed <= buf.len() {
+        return Some(join_z_buf::<P>(buf, parts));
+    }
+    let mut scratch = vec![0u8; needed];
+    let joined = join_string_buf::<P>(&mut scratch, parts);
+    let len = joined.len();
+    if len + 1 > buf.len() {
+        return None;
+    }
+    buf[..len].copy_from_slice(joined);
+    buf[len] = 0;
+    Some(ZStr::from_buf(buf, len))
+}
+
 pub fn join_z_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a ZStr {
     // reshaped for borrowck — capture buf base ptr before sub-borrow
     let buf_base = buf.as_mut_ptr();
@@ -1701,6 +1723,30 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     let len = joined.len();
     buf[..len].copy_from_slice(joined);
     Some(&buf[..len])
+}
+
+/// [`join_abs_string_buf_checked`] with a NUL terminator: `None` when the
+/// normalized result plus its NUL does not fit `buf`.
+pub fn join_abs_string_buf_z_checked<'a, P: PlatformT>(
+    cwd: &'a [u8],
+    buf: &'a mut [u8],
+    parts: &[&[u8]],
+) -> Option<&'a ZStr> {
+    let buf_base = buf.as_ptr();
+    let capacity = buf.len().checked_sub(1)?;
+    let (buf_backed, len) = {
+        let joined = join_abs_string_buf_checked::<P>(cwd, &mut buf[..capacity], parts)?;
+        (joined.as_ptr() == buf_base, joined.len())
+    };
+    if !buf_backed {
+        // No parts: the result is `cwd` itself.
+        if len > capacity {
+            return None;
+        }
+        buf[..len].copy_from_slice(&cwd[..len]);
+    }
+    buf[len] = 0;
+    Some(ZStr::from_buf(buf, len))
 }
 
 pub fn join_abs_string_buf_z<'a, P: PlatformT>(
@@ -2659,6 +2705,52 @@ mod tests {
             join_string_buf::<platform::Posix>(&mut out, &[b"", b""]),
             b"."
         );
+    }
+
+    #[test]
+    fn join_z_buf_checked_reports_results_that_do_not_fit() {
+        let mut out = [0u8; 16];
+        let joined = join_z_buf_checked::<platform::Posix>(&mut out, &[b"foo", b"bar"]).unwrap();
+        assert_eq!(joined.as_bytes_with_nul(), b"foo/bar\0");
+        // Fits exactly: 15 bytes plus the NUL.
+        assert!(
+            join_z_buf_checked::<platform::Posix>(&mut out, &[b"aaaaaaa", b"bbbbbbb"]).is_some()
+        );
+        assert!(
+            join_z_buf_checked::<platform::Posix>(&mut out, &[b"aaaaaaaa", b"bbbbbbb"]).is_none()
+        );
+        // `..` segments shorten a result whose unnormalized form is too long.
+        let long = vec![b'x'; 64];
+        let joined =
+            join_z_buf_checked::<platform::Posix>(&mut out, &[&long, b"..", b"ok"]).unwrap();
+        assert_eq!(joined.as_bytes(), b"ok");
+    }
+
+    #[test]
+    fn join_abs_string_buf_z_checked_reports_results_that_do_not_fit() {
+        let mut out = [0u8; 16];
+        let joined =
+            join_abs_string_buf_z_checked::<platform::Posix>(b"/cwd", &mut out, &[b"a/b"]).unwrap();
+        assert_eq!(joined.as_bytes_with_nul(), b"/cwd/a/b\0");
+        assert!(
+            join_abs_string_buf_z_checked::<platform::Posix>(b"/cwd", &mut out, &[b"0123456789"])
+                .is_some()
+        );
+        assert!(
+            join_abs_string_buf_z_checked::<platform::Posix>(b"/cwd", &mut out, &[b"01234567890"])
+                .is_none()
+        );
+        let long = vec![b'x'; 64];
+        let joined = join_abs_string_buf_z_checked::<platform::Posix>(
+            b"/cwd",
+            &mut out,
+            &[&long, b"..", b"ok"],
+        )
+        .unwrap();
+        assert_eq!(joined.as_bytes(), b"/cwd/ok");
+        let joined =
+            join_abs_string_buf_z_checked::<platform::Posix>(b"/cwd", &mut out, &[]).unwrap();
+        assert_eq!(joined.as_bytes(), b"/cwd");
     }
 
     #[test]

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1476,8 +1476,7 @@ pub fn join_z_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -
     join_z_buf::<P>(&mut spill[..], parts)
 }
 
-/// [`join_z_buf`] for parts of user-controlled length: `None` when the
-/// normalized result plus its NUL does not fit `buf`.
+/// [`join_z_buf`]; `None` when the normalized result plus its NUL does not fit `buf`.
 pub fn join_z_buf_checked<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
@@ -1724,8 +1723,7 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     Some(&buf[..len])
 }
 
-/// [`join_abs_string_buf_checked`], NUL-terminated: `None` when the result
-/// plus its NUL does not fit `buf`.
+/// [`join_abs_string_buf_checked`] plus a NUL; `None` when that does not fit `buf`.
 pub fn join_abs_string_buf_z_checked<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1428,7 +1428,7 @@ pub fn join_z<P: PlatformT>(parts: &[&[u8]]) -> &'static ZStr {
 
 #[inline]
 fn join_needed(parts: &[&[u8]]) -> usize {
-    parts.iter().map(|p| p.len() + 1).sum::<usize>() + 1
+    parts.iter().map(|p| p.len() + 1).sum::<usize>().max(1) + 1
 }
 
 /// [`join_z_buf`] into `buf` when the result fits, otherwise into `spill`

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4027,24 +4027,32 @@ impl<'a> Resolver<'a> {
                 None => return Ok(None),
             };
 
-        if result.has_base_url() {
-            // this might leak
-            if !bun_paths::is_absolute(&result.base_url) {
-                // NOTE: `base_url: Box<[u8]>` owns its bytes, so
-                // copy `abs_buf`'s thread-local result directly instead of
-                // double-copying through the `dirname_store` arena.
-                let abs = self
-                    .fs_ref()
-                    .abs_buf(&[file_dir, &result.base_url[..]], bufs!(tsconfig_base_url));
-                result.base_url = Box::from(abs);
-            }
+        if result.has_base_url() && !bun_paths::is_absolute(&result.base_url) {
+            // NOTE: `base_url: Box<[u8]>` owns its bytes, so
+            // copy `abs_buf`'s thread-local result directly instead of
+            // double-copying through the `dirname_store` arena.
+            let Some(abs) = self
+                .fs_ref()
+                .abs_buf_checked(&[file_dir, &result.base_url[..]], bufs!(tsconfig_base_url))
+            else {
+                let _ = self.log_mut().add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "\"baseUrl\" in {} is too long",
+                        bun_core::fmt::quote(key_path)
+                    ),
+                );
+                return Ok(None);
+            };
+            result.base_url = Box::from(abs);
         }
 
         if result.paths.count() > 0
             && (result.base_url_for_paths.is_empty()
                 || !bun_paths::is_absolute(&result.base_url_for_paths))
         {
-            // this might leak
+            // `base_url` is empty or the bounds-checked result from above, so this fits.
             let abs = self
                 .fs_ref()
                 .abs_buf(&[file_dir, &result.base_url[..]], bufs!(tsconfig_base_url));
@@ -4780,8 +4788,13 @@ impl<'a> Resolver<'a> {
 
                         if !bun_paths::is_absolute(absolute_original_path) {
                             let parts: [&[u8]; 2] = [abs_base_url, original_path.as_ref()];
-                            absolute_original_path =
-                                self.fs_ref().abs_buf(&parts, bufs!(tsconfig_path_abs));
+                            let Some(abs) = self
+                                .fs_ref()
+                                .abs_buf_checked(&parts, bufs!(tsconfig_path_abs))
+                            else {
+                                continue;
+                            };
+                            absolute_original_path = abs;
                         }
 
                         if self

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4028,9 +4028,7 @@ impl<'a> Resolver<'a> {
             };
 
         if result.has_base_url() && !bun_paths::is_absolute(&result.base_url) {
-            // NOTE: `base_url: Box<[u8]>` owns its bytes, so
-            // copy `abs_buf`'s thread-local result directly instead of
-            // double-copying through the `dirname_store` arena.
+            // `base_url` owns its bytes, so copy the buffer result into it directly.
             let Some(abs) = self
                 .fs_ref()
                 .abs_buf_checked(&[file_dir, &result.base_url[..]], bufs!(tsconfig_base_url))

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -90,17 +90,16 @@ mod bun_paths {
     pub(super) fn dirname_platform(p: &[u8], platform: Platform) -> &[u8] {
         dispatch_platform!(platform, |P| ::bun_paths::resolve_path::dirname::<P>(p))
     }
-    /// Port of `bun.path.joinAbsStringBuf` (value-dispatched).
-    pub(super) fn join_abs_string_buf<'b>(
+    /// `resolve_path::join_abs_string_buf_checked` (value-dispatched).
+    pub(super) fn join_abs_string_buf_checked<'b>(
         cwd: &'b [u8],
         buf: &'b mut [u8],
         parts: &[&[u8]],
         platform: Platform,
-    ) -> &'b [u8] {
-        dispatch_platform!(
-            platform,
-            |P| ::bun_paths::resolve_path::join_abs_string_buf::<P>(cwd, buf, parts)
-        )
+    ) -> Option<&'b [u8]> {
+        dispatch_platform!(platform, |P| {
+            ::bun_paths::resolve_path::join_abs_string_buf_checked::<P>(cwd, buf, parts)
+        })
     }
     pub(super) fn join_abs(cwd: &[u8], platform: Platform, part: &[u8]) -> &'static [u8] {
         // NOTE: `resolve_path::join_abs` ties the result lifetime to `cwd`, but the
@@ -4029,21 +4028,26 @@ impl<'a> Resolver<'a> {
 
         if result.has_base_url() && !bun_paths::is_absolute(&result.base_url) {
             // `base_url` owns its bytes, so copy the buffer result into it directly.
-            let Some(abs) = self
+            match self
                 .fs_ref()
                 .abs_buf_checked(&[file_dir, &result.base_url[..]], bufs!(tsconfig_base_url))
-            else {
-                let _ = self.log_mut().add_error_fmt(
-                    None,
-                    bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "\"baseUrl\" in {} is too long",
-                        bun_core::fmt::quote(key_path)
-                    ),
-                );
-                return Ok(None);
-            };
-            result.base_url = Box::from(abs);
+            {
+                Some(abs) => result.base_url = Box::from(abs),
+                None => {
+                    let _ = self.log_mut().add_warning_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "Ignoring \"baseUrl\" in {} because it is too long",
+                            bun_core::fmt::quote(key_path)
+                        ),
+                    );
+                    result.base_url = Box::default();
+                    if result.paths.count() > 0 {
+                        result.base_url_for_paths = Box::from(b".".as_slice());
+                    }
+                }
+            }
         }
 
         if result.paths.count() > 0
@@ -6503,12 +6507,22 @@ impl<'a> Resolver<'a> {
                     );
                     while !current.extends.is_empty() {
                         let ts_dir_name = Dirname::dirname(&current.abs_path);
-                        let abs_path = ResolvePath::join_abs_string_buf(
+                        let Some(abs_path) = ResolvePath::join_abs_string_buf_checked(
                             ts_dir_name,
                             bufs!(tsconfig_path_abs),
                             &[ts_dir_name, &current.extends],
                             bun_paths::Platform::AUTO,
-                        );
+                        ) else {
+                            let _ = self.log_mut().add_debug_fmt(
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                format_args!(
+                                    "tsconfig.json extends {} is too long",
+                                    bun_core::fmt::quote(&current.extends)
+                                ),
+                            );
+                            break;
+                        };
                         let parent_config_maybe: Option<*mut TSConfigJSON> =
                             match self.parse_tsconfig(abs_path, FD::INVALID) {
                                 Ok(v) => v.map(bun_core::heap::into_raw),

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -27,7 +27,7 @@ use bun_jsc::bun_string_jsc;
 use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue, LogJsc as _};
 use bun_options_types::WindowsOptions;
 use bun_options_types::schema::api;
-use bun_paths::resolve_path::{join_abs_string, join_abs_string_buf, platform};
+use bun_paths::resolve_path::{join_abs_string_buf, join_abs_string_spill, platform};
 use bun_paths::{self as paths, SEP};
 use bun_ptr::{BackRef, RefCount, RefPtr};
 use bun_standalone_graph::StandaloneModuleGraph::{
@@ -702,16 +702,20 @@ impl JSBundleCompletionTask {
                 let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
 
                 let mut to_assign_on_sourcemap = JSValue::ZERO;
+                // Written relative to the outdir fd, so the absolute path can exceed a PathBuffer.
+                let mut path_spill = Vec::new();
                 for (i, output_file) in output_files.iter_mut().enumerate() {
                     let path: Box<[u8]> = if !outdir.is_empty() {
                         if outdir_is_abs {
-                            Box::from(join_abs_string::<platform::Auto>(
+                            Box::from(join_abs_string_spill::<platform::Auto>(
                                 &outdir,
+                                &mut path_spill,
                                 &[&output_file.dest_path],
                             ))
                         } else {
-                            Box::from(join_abs_string::<platform::Auto>(
+                            Box::from(join_abs_string_spill::<platform::Auto>(
                                 top_level_dir,
+                                &mut path_spill,
                                 &[&dir, &outdir, &output_file.dest_path],
                             ))
                         }

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -413,9 +413,14 @@ impl PmPkgCommand {
                             pkg_dir = cwd;
                         }
                         let mut buf = bun_paths::path_buffer_pool::get();
-                        let full_path = path::resolve_path::join_abs_string_buf_z::<
+                        let Some(full_path) = path::resolve_path::join_abs_string_buf_z_checked::<
                             path::platform::Auto,
-                        >(pkg_dir, &mut buf, &[bin_path]);
+                        >(
+                            pkg_dir, &mut buf, &[bin_path]
+                        ) else {
+                            bun_core::warn!("bin path is too long: {}", bstr::BStr::new(bin_path));
+                            continue;
+                        };
 
                         if !bun_sys::exists_z(full_path) {
                             bun_core::warn!("No bin file found at {}", bstr::BStr::new(bin_path));

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -199,10 +199,12 @@ impl History {
         }
 
         let mut path_buf = bun_paths::path_buffer_pool::get();
-        let path = path::resolve_path::join_z_buf::<path::platform::Auto>(
+        let Some(path) = path::resolve_path::join_z_buf_checked::<path::platform::Auto>(
             &mut path_buf,
             &[home_path, HISTORY_FILENAME],
-        );
+        ) else {
+            return Ok(());
+        };
         self.file_path = Some(Box::<[u8]>::from(path.as_bytes()));
 
         let content: Box<[u8]> = match sys::File::read_from(Fd::cwd(), path) {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2754,12 +2754,14 @@ impl RunCommand {
             };
             let cwd_len = cwd.as_bytes().len();
             cwd_buf[cwd_len] = paths::SEP;
-            let joined = paths::resolve_path::join_abs_string_buf::<paths::platform::Auto>(
-                &cwd_buf[..cwd_len + 1],
-                &mut script_name_buf.0,
-                &[target],
-            );
-            if joined.is_empty() {
+            let Some(joined) = paths::resolve_path::join_abs_string_buf_checked::<
+                paths::platform::Auto,
+            >(
+                &cwd_buf[..cwd_len + 1], &mut script_name_buf.0, &[target]
+            ) else {
+                return false;
+            };
+            if joined.is_empty() || joined.len() >= MAX_PATH_BYTES {
                 return false;
             }
             joined.len()

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -57,7 +57,11 @@ pub(crate) fn write_coverage_report(coord: &mut Coordinator, opts: &mut CodeCove
     }
     reports.sort_unstable_by(|a, b| a.source_url.cmp(&b.source_url));
     if let Err(err) = print_coverage_reports(opts, &reports) {
-        Output::err(err, "Failed to write lcov.info", ());
+        Output::err(
+            err,
+            "Failed to write lcov.info to {}",
+            (bstr::BStr::new(&opts.reports_directory),),
+        );
         coord.aborted.get_or_insert(1);
     }
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -897,17 +897,25 @@ impl JunitReporter {
 
         let mut junit_path_buf = bun_paths::path_buffer_pool::get();
 
-        junit_path_buf[..path.len()].copy_from_slice(path);
-        junit_path_buf[path.len()] = 0;
+        let opened = if path.len() >= junit_path_buf.len() {
+            Err(
+                bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
+                    .with_path(path),
+            )
+        } else {
+            junit_path_buf[..path.len()].copy_from_slice(path);
+            junit_path_buf[path.len()] = 0;
 
-        // SAFETY: junit_path_buf[path.len()] == 0 written above
-        let zpath = bun_core::ZStr::from_buf(&junit_path_buf[..], path.len());
-        match File::openat(
-            Fd::cwd(),
-            zpath,
-            bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
-            0o664,
-        ) {
+            // SAFETY: junit_path_buf[path.len()] == 0 written above
+            let zpath = bun_core::ZStr::from_buf(&junit_path_buf[..], path.len());
+            File::openat(
+                Fd::cwd(),
+                zpath,
+                bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
+                0o664,
+            )
+        };
+        match opened {
             bun_sys::Result::Err(err) => {
                 Output::err(
                     crate::Error::JUnitReportFailed,
@@ -1502,7 +1510,11 @@ impl CommandLineReporter {
         let mut reports: Vec<CodeCoverageReport<'static>> = Vec::new();
         Self::for_each_coverage_report(vm, opts, |report| reports.push(report.into_owned()));
         if let Err(err) = print_coverage_reports(opts, &reports) {
-            Output::err(err, "Failed to write lcov.info", ());
+            Output::err(
+                err,
+                "Failed to write lcov.info to {}",
+                (bstr::BStr::new(&opts.reports_directory),),
+            );
             Global::exit(1);
         }
     }
@@ -1653,12 +1665,24 @@ fn write_lcov_report(
         ".lcov.info.{}.tmp",
         bun_core::fmt::hex_lower(&rand)
     );
+    let too_long = || {
+        bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::open)
+            .with_path(&opts.reports_directory)
+    };
     let mut buf = bun_paths::path_buffer_pool::get();
-    let tmp_path = resolve_path::join_abs_string_buf_z::<bun_path::platform::Auto>(
+    let tmp_path = resolve_path::join_abs_string_buf_z_checked::<bun_path::platform::Auto>(
         relative_dir,
         &mut buf,
         &[&opts.reports_directory, &tmpname],
-    );
+    )
+    .ok_or_else(too_long)?;
+    let mut final_buf = bun_paths::path_buffer_pool::get();
+    let final_path = resolve_path::join_abs_string_buf_z_checked::<bun_path::platform::Auto>(
+        relative_dir,
+        &mut final_buf,
+        &[&opts.reports_directory, b"lcov.info"],
+    )
+    .ok_or_else(too_long)?;
     let file = File::openat(
         Fd::cwd(),
         tmp_path,
@@ -1668,15 +1692,7 @@ fn write_lcov_report(
     let written = file.write_all(&contents);
     drop(file);
     let moved = match written {
-        Ok(()) => bun_sys::move_file_z(
-            Fd::cwd(),
-            tmp_path,
-            Fd::cwd(),
-            resolve_path::join_abs_string_z::<bun_path::platform::Auto>(
-                relative_dir,
-                &[&opts.reports_directory, b"lcov.info"],
-            ),
-        ),
+        Ok(()) => bun_sys::move_file_z(Fd::cwd(), tmp_path, Fd::cwd(), final_path),
         err => err,
     };
     if moved.is_err() {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1495,28 +1495,22 @@ impl CommandLineReporter {
         }
     }
 
+    /// Errors only from writing `lcov.info`; the caller fails the run.
     pub(crate) fn generate_code_coverage(
         &mut self,
         vm: &mut VirtualMachine,
         opts: &mut CodeCoverageOptions,
-    ) {
+    ) -> bun_sys::Result<()> {
         let _trace = bun::perf::trace("TestCommand.printCodeCoverage");
         if ByteRangeMapping::map().is_none_or(|m| {
             // SAFETY: see `for_each_coverage_report`.
             unsafe { m.as_ref() }.is_empty()
         }) {
-            return;
+            return Ok(());
         }
         let mut reports: Vec<CodeCoverageReport<'static>> = Vec::new();
         Self::for_each_coverage_report(vm, opts, |report| reports.push(report.into_owned()));
-        if let Err(err) = print_coverage_reports(opts, &reports) {
-            Output::err(
-                err,
-                "Failed to write lcov.info to {}",
-                (bstr::BStr::new(&opts.reports_directory),),
-            );
-            Global::exit(1);
-        }
+        print_coverage_reports(opts, &reports)
     }
 }
 
@@ -2442,6 +2436,7 @@ impl TestCommand {
         Output::flush();
 
         let mut failed_to_find_any_tests = false;
+        let mut failed_to_write_coverage = false;
 
         if test_files.is_empty() && !pass_with_no_tests_from_filter {
             failed_to_find_any_tests = true;
@@ -2516,7 +2511,14 @@ impl TestCommand {
             pretty_error!("\n");
 
             if coverage_options.enabled && !ran_parallel {
-                reporter.generate_code_coverage(vm, &mut coverage_options);
+                if let Err(err) = reporter.generate_code_coverage(vm, &mut coverage_options) {
+                    Output::err(
+                        err,
+                        "Failed to write lcov.info to {}",
+                        (bstr::BStr::new(&coverage_options.reports_directory),),
+                    );
+                    failed_to_write_coverage = true;
+                }
             }
 
             // `Summary` is `Copy`; take a value snapshot so the `&mut` from
@@ -2683,6 +2685,7 @@ impl TestCommand {
                 && coverage_options.fractions.failing
                 && coverage_options.fail_on_low_coverage)
             || !write_snapshots_success
+            || failed_to_write_coverage
             || reporter.jest.unhandled_errors_between_tests > 0
         {
             vm.exit_handler.exit_code = 1;

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -53,6 +53,23 @@ impl Snapshots {
     #[cfg(not(windows))]
     const SNAPSHOTS_DIR_NAME: &'static [u8] = b"__snapshots__/";
 
+    /// Appends `parts` to `buf` at `*pos` and NUL-terminates. `None` when the
+    /// result does not fit in `buf`.
+    fn append_path_z<'b>(buf: &'b mut [u8], pos: &mut usize, parts: &[&[u8]]) -> Option<&'b ZStr> {
+        let end = parts
+            .iter()
+            .try_fold(*pos, |acc, part| acc.checked_add(part.len()))?;
+        if end >= buf.len() {
+            return None;
+        }
+        for part in parts {
+            buf[*pos..*pos + part.len()].copy_from_slice(part);
+            *pos += part.len();
+        }
+        buf[*pos] = 0;
+        Some(ZStr::from_buf(buf, *pos))
+    }
+
     pub(crate) fn init(update_snapshots: bool) -> Snapshots {
         Snapshots {
             update_snapshots,
@@ -255,17 +272,12 @@ impl Snapshots {
         let mut snapshot_file_path_buf = bun_paths::path_buffer_pool::get();
         let buf = snapshot_file_path_buf.0.as_mut_slice();
         let mut pos = 0usize;
-        buf[pos..pos + dir_path.len()].copy_from_slice(dir_path);
-        pos += dir_path.len();
-        buf[pos..pos + Self::SNAPSHOTS_DIR_NAME.len()].copy_from_slice(Self::SNAPSHOTS_DIR_NAME);
-        pos += Self::SNAPSHOTS_DIR_NAME.len();
-        buf[pos..pos + test_filename.len()].copy_from_slice(test_filename);
-        pos += test_filename.len();
-        buf[pos..pos + b".snap".len()].copy_from_slice(b".snap");
-        pos += b".snap".len();
-        buf[pos] = 0;
-        // SAFETY: buf[pos] == 0 written above
-        let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
+        let snapshot_file_path = Self::append_path_z(
+            buf,
+            &mut pos,
+            &[dir_path, Self::SNAPSHOTS_DIR_NAME, test_filename, b".snap"],
+        )
+        .ok_or(crate::Error::FailedToOpenSnapshotFile)?;
 
         let source = bun_ast::Source::init_path_string(
             snapshot_file_path.as_bytes(),
@@ -847,17 +859,12 @@ impl Snapshots {
             let mut snapshot_file_path_buf = bun_paths::path_buffer_pool::get();
             let buf = snapshot_file_path_buf.0.as_mut_slice();
             let mut pos = 0usize;
-            buf[pos..pos + dir_path.len()].copy_from_slice(dir_path);
-            pos += dir_path.len();
-            buf[pos..pos + Self::SNAPSHOTS_DIR_NAME.len()]
-                .copy_from_slice(Self::SNAPSHOTS_DIR_NAME);
-            pos += Self::SNAPSHOTS_DIR_NAME.len();
+            let snapshot_dir_path =
+                Self::append_path_z(buf, &mut pos, &[dir_path, Self::SNAPSHOTS_DIR_NAME])
+                    .ok_or(crate::Error::FailedToOpenSnapshotFile)?;
 
             let cached_dir = self.snapshot_dir_path;
             if cached_dir.is_none() || !strings::eql_long(dir_path, cached_dir.unwrap(), true) {
-                buf[pos] = 0;
-                // SAFETY: buf[pos] == 0 written above
-                let snapshot_dir_path = ZStr::from_buf(&buf[..], pos);
                 match bun_sys::mkdir(snapshot_dir_path, 0o777) {
                     bun_sys::Result::Ok(()) => {
                         self.snapshot_dir_path = Some(dir_path);
@@ -871,13 +878,8 @@ impl Snapshots {
                 }
             }
 
-            buf[pos..pos + test_filename.len()].copy_from_slice(test_filename);
-            pos += test_filename.len();
-            buf[pos..pos + b".snap".len()].copy_from_slice(b".snap");
-            pos += b".snap".len();
-            buf[pos] = 0;
-            // SAFETY: buf[pos] == 0 written above
-            let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
+            let snapshot_file_path = Self::append_path_z(buf, &mut pos, &[test_filename, b".snap"])
+                .ok_or(crate::Error::FailedToOpenSnapshotFile)?;
 
             let mut flags: i32 = bun_sys::O::CREAT | bun_sys::O::RDWR;
             if self.update_snapshots {

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -53,8 +53,7 @@ impl Snapshots {
     #[cfg(not(windows))]
     const SNAPSHOTS_DIR_NAME: &'static [u8] = b"__snapshots__/";
 
-    /// Appends `parts` to `buf` at `*pos` and NUL-terminates. `None` when the
-    /// result does not fit in `buf`.
+    /// Appends `parts` at `*pos` and NUL-terminates; `None` when the result does not fit `buf`.
     fn append_path_z<'b>(buf: &'b mut [u8], pos: &mut usize, parts: &[&[u8]]) -> Option<&'b ZStr> {
         let end = parts
             .iter()

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2435,7 +2435,17 @@ pub fn target_executable(
         let version_zstr = ZStr::from_slice_with_nul(&version_str[..]);
 
         let mut needs_download: bool = true;
-        let dest_z = target.exe_path(&mut exe_path_buf, version_zstr, env, &mut needs_download);
+        let dest_z =
+            match target.exe_path(&mut exe_path_buf, version_zstr, env, &mut needs_download) {
+                Ok(dest) => dest,
+                Err(_) => {
+                    return Err(CompileError::fmt(format_args!(
+                        "Cache directory for '{}' is too long (File name too long): {}",
+                        target,
+                        bstr::BStr::new(&bun_sys::fetch_cache_directory_path())
+                    )));
+                }
+            };
 
         if needs_download {
             if let Err(e) = download_to_path(target, env, dest_z) {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -7,6 +7,7 @@ import {
   bunRun,
   isASAN,
   isDebug,
+  isLinux,
   isMacOS,
   isWindows,
   tempDir,
@@ -650,6 +651,56 @@ describe("Bun.build", () => {
     expect(blob.loader).toBe("jsx");
     expect(blob.sourcemap).toBe(null);
     Bun.gc(true);
+  });
+
+  // macOS cannot open an outdir longer than its PATH_MAX (1024) in the first place.
+  test.skipIf(!isLinux)("BuildArtifact.path of an output whose absolute path is longer than PATH_MAX", async () => {
+    using dir = tempDir("build-artifact-long-path", { "e.js": "export default 1;" });
+    const cwd = String(dir);
+    // 200-byte components, `length` bytes in total.
+    const components = (length: number, char: string) => {
+      const parts: string[] = [];
+      let remaining = length;
+      while (remaining > 201) {
+        parts.push(Buffer.alloc(200, char).toString());
+        remaining -= 201;
+      }
+      parts.push(Buffer.alloc(remaining, char).toString());
+      return parts.join("/");
+    };
+    // Each piece is a legal path on its own; only outdir + "/" + the rendered
+    // name passes PATH_MAX. The bundler writes the file relative to the open
+    // outdir, so it exists.
+    const outdir = join(cwd, "o", components(2600 - cwd.length - 3, "d"));
+    const nameDir = components(1587, "n");
+    writeFileSync(
+      join(cwd, "build.mjs"),
+      `const result = await Bun.build(${JSON.stringify({
+        entrypoints: [join(cwd, "e.js")],
+        outdir,
+        naming: nameDir + "/[name].[ext]",
+        throw: false,
+      })});
+      console.log(JSON.stringify({
+        success: result.success,
+        logs: result.logs.map(log => log.message),
+        paths: result.outputs.map(output => output.path),
+      }));`,
+    );
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.mjs"],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const expectedPath = join(outdir, nameDir, "e.js");
+    expect(expectedPath.length).toBeGreaterThan(4096);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ success: true, logs: [], paths: [expectedPath] });
+    expect(exitCode).toBe(0);
   });
 
   test("BuildArtifact properties sourcemap", async () => {

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -197,29 +197,34 @@ server.close();`,
     ).toThrowErrorMatchingInlineSnapshot(`"Unknown compile target: bun-invalid-platform"`);
   });
 
-  test("cross-compile with a cache directory longer than PATH_MAX fails with a clean error", async () => {
-    using dir = tempDir("build-compile-long-cache-dir", {
-      "s.js": `console.log(1);`,
-    });
-    // The cross-compile target binary is cached under $BUN_INSTALL_CACHE_DIR (or
-    // $BUN_INSTALL, or $HOME). 4220 bytes of valid components: the cache path is
-    // built (and used to abort the process) before anything is downloaded.
-    const longDir = "/" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
-    const target = process.platform === "win32" ? "bun-linux-x64" : "bun-windows-x64";
+  // A PathBuffer holds 98302 bytes on Windows, so the path would fit there and
+  // the build would go on to download the target.
+  test.skipIf(isWindows)(
+    "cross-compile with a cache directory longer than PATH_MAX fails with a clean error",
+    async () => {
+      using dir = tempDir("build-compile-long-cache-dir", {
+        "s.js": `console.log(1);`,
+      });
+      // The cross-compile target binary is cached under $BUN_INSTALL_CACHE_DIR (or
+      // $HOME). 4220 bytes of valid components: the cache path is built (and used
+      // to abort the process) before anything is downloaded.
+      const longDir = "/" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+      const target = "bun-windows-x64";
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "s.js", "--compile", `--target=${target}`, "--outfile", "w"],
-      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: longDir },
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "s.js", "--compile", `--target=${target}`, "--outfile", "w"],
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: longDir },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout + stderr).toContain(`Cache directory for '${target}-v`);
-    expect(stdout + stderr).toContain("is too long (File name too long)");
-    expect(exitCode).toBe(1);
-  });
+      expect(stdout + stderr).toContain(`Cache directory for '${target}-v`);
+      expect(stdout + stderr).toContain("is too long (File name too long)");
+      expect(exitCode).toBe(1);
+    },
+  );
 
   // One compile per test: each compile copies the whole bun binary (~1 GB under debug+ASAN),
   // which by itself takes a good part of the default per-test timeout.

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -197,6 +197,30 @@ server.close();`,
     ).toThrowErrorMatchingInlineSnapshot(`"Unknown compile target: bun-invalid-platform"`);
   });
 
+  test("cross-compile with a cache directory longer than PATH_MAX fails with a clean error", async () => {
+    using dir = tempDir("build-compile-long-cache-dir", {
+      "s.js": `console.log(1);`,
+    });
+    // The cross-compile target binary is cached under $BUN_INSTALL_CACHE_DIR (or
+    // $BUN_INSTALL, or $HOME). 4220 bytes of valid components: the cache path is
+    // built (and used to abort the process) before anything is downloaded.
+    const longDir = "/" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+    const target = process.platform === "win32" ? "bun-linux-x64" : "bun-windows-x64";
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "s.js", "--compile", `--target=${target}`, "--outfile", "w"],
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: longDir },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout + stderr).toContain(`Cache directory for '${target}-v`);
+    expect(stdout + stderr).toContain("is too long (File name too long)");
+    expect(exitCode).toBe(1);
+  });
+
   // One compile per test: each compile copies the whole bun binary (~1 GB under debug+ASAN),
   // which by itself takes a good part of the default per-test timeout.
   test.each(["output/nested/app1", "app2", "a/b/c/d/app3"])(

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -14,21 +14,37 @@ describe("error messages", () => {
   // A PathBuffer holds 98302 bytes on Windows; a command line cannot carry a path that long.
   test.skipIf(isWindows)("'bun patch' with a path longer than PATH_MAX reports an error", async () => {
     await using dir = tempDir("bun-patch-long-path", {
-      "package.json": JSON.stringify({ name: "t" }),
+      "package.json": JSON.stringify({ name: "t", workspaces: ["pkgs/*"] }),
+      "pkgs/a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
     });
     // 4220 bytes of valid components; joining `<arg>/package.json` into a
     // fixed-size path buffer used to abort the process.
     const arg = "node_modules/" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "patch", arg],
-      env: bunEnv,
-      cwd: dir,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain(`error: path is too long: "${arg}"`);
-    expect(exitCode).toBe(1);
+    async function run(cwd: string, ...args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args],
+        env: bunEnv,
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stderr, exitCode };
+    }
+
+    // From the workspace root.
+    let result = await run(String(dir), "patch", arg);
+    expect(result.stderr).toContain(`error: path is too long: "${arg}"`);
+    expect(result.exitCode).toBe(1);
+
+    // From a workspace member: the argument is first rewritten relative to the
+    // root (needs a lockfile that knows the workspace).
+    result = await run(String(dir), "install");
+    expect(result.stderr).not.toContain("error:");
+    expect(result.exitCode).toBe(0);
+    result = await run(join(String(dir), "pkgs", "a"), "patch", arg);
+    expect(result.stderr).toContain(`error: path is too long: "pkgs/a/${arg}"`);
+    expect(result.exitCode).toBe(1);
   });
 
   test("'bun patch' with no package name shows a usage example", async () => {

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -11,6 +11,25 @@ const platformPath = (path: string) => path;
 setDefaultTimeout(1000 * 60 * 5);
 
 describe("error messages", () => {
+  test("'bun patch' with a path longer than PATH_MAX reports an error", async () => {
+    await using dir = tempDir("bun-patch-long-path", {
+      "package.json": JSON.stringify({ name: "t" }),
+    });
+    // 4220 bytes of valid components; joining `<arg>/package.json` into a
+    // fixed-size path buffer used to abort the process.
+    const arg = "node_modules/" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "patch", arg],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(`error: path is too long: "${arg}"`);
+    expect(exitCode).toBe(1);
+  });
+
   test("'bun patch' with no package name shows a usage example", async () => {
     await using dir = tempDir("bun-patch-noarg", {
       "package.json": JSON.stringify({ name: "t" }),

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,7 +1,7 @@
 import { $, ShellOutput } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { lstatSync, readFileSync } from "fs";
-import { bunEnv, bunExe, isASAN, tempDir, VerdaccioRegistry } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir, VerdaccioRegistry } from "harness";
 import { isAbsolute, join, sep } from "path";
 
 const expectNoError = (o: ShellOutput) => expect(o.stderr.toString()).not.toContain("error");
@@ -11,7 +11,8 @@ const platformPath = (path: string) => path;
 setDefaultTimeout(1000 * 60 * 5);
 
 describe("error messages", () => {
-  test("'bun patch' with a path longer than PATH_MAX reports an error", async () => {
+  // A PathBuffer holds 98302 bytes on Windows; a command line cannot carry a path that long.
+  test.skipIf(isWindows)("'bun patch' with a path longer than PATH_MAX reports an error", async () => {
     await using dir = tempDir("bun-patch-long-path", {
       "package.json": JSON.stringify({ name: "t" }),
     });

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 async function runPmPkg(args: string[], cwd: string, expectSuccess = true) {
@@ -918,7 +918,8 @@ describe.concurrent("bun pm pkg", () => {
       expect((await readPkg(multiIssueDir)).name).toBe("multiple-issues-package");
     });
 
-    it("should warn instead of crashing on a bin path longer than PATH_MAX", async () => {
+    // A PathBuffer holds 98302 bytes on Windows; package.json would need a 96 KB bin value.
+    it.skipIf(isWindows)("should warn instead of crashing on a bin path longer than PATH_MAX", async () => {
       // 4220 bytes of valid components; joining it with the package directory
       // into a fixed-size path buffer used to abort the process.
       const binPath = "./" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/") + ".js";

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -918,6 +918,20 @@ describe.concurrent("bun pm pkg", () => {
       expect((await readPkg(multiIssueDir)).name).toBe("multiple-issues-package");
     });
 
+    it("should warn instead of crashing on a bin path longer than PATH_MAX", async () => {
+      // 4220 bytes of valid components; joining it with the package directory
+      // into a fixed-size path buffer used to abort the process.
+      const binPath = "./" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/") + ".js";
+      using longBinDir = tempDir("pm-pkg-long-bin", {
+        "package.json": JSON.stringify({ name: "LONG-BIN-PACKAGE", version: "1.0.0", bin: { b: binPath } }, null, 2),
+      });
+
+      const { error, code } = await runPmPkg(["fix"], longBinDir);
+      expect(error).toContain(`bin path is too long: ${binPath}`);
+      expect(code).toBe(0);
+      expect((await readPkg(longBinDir)).name).toBe("long-bin-package");
+    });
+
     it("should not crash on empty bin object", async () => {
       using emptyBinDir = tempDir("pm-pkg-empty-bin", {
         "package.json": JSON.stringify({ name: "EMPTY-BIN-PACKAGE", version: "1.0.0", bin: {} }, null, 2),

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -950,7 +950,8 @@ describe("selectors", () => {
     runInCwdFailure(graph_root, "...", "present", /is missing a workspace name or path/);
   });
 
-  test("a path longer than the path buffer is rejected, not a crash", () => {
+  // A PathBuffer holds 98302 bytes on Windows; a command line cannot carry a path that long.
+  test.skipIf(isWindows)("a path longer than the path buffer is rejected, not a crash", () => {
     // 4220 bytes of valid components; joining it with the cwd into a
     // fixed-size path buffer used to abort the process.
     const long = "./" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -950,6 +950,13 @@ describe("selectors", () => {
     runInCwdFailure(graph_root, "...", "present", /is missing a workspace name or path/);
   });
 
+  test("a path longer than the path buffer is rejected, not a crash", () => {
+    // 4220 bytes of valid components; joining it with the cwd into a
+    // fixed-size path buffer used to abort the process.
+    const long = "./" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+    runInCwdFailure(graph_root, long, "present", /error: --filter "\.\/a.*" path is too long/);
+  });
+
   test("dependency order is kept inside a relation selection", () => {
     using dir = tempDir("filter-selectors-order", {
       dep0: {

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -325,6 +325,26 @@ describe("bun <file.md>", () => {
   // followed by unbreakable text (no literal spaces) that forces a wrap
   // BEFORE any external space appears — so lastIndexOfChar(' ') has
   // nothing else to return.
+  test("local image whose path exceeds PATH_MAX falls back to alt text on a kitty terminal", async () => {
+    // Resolving `![..](./<5000 bytes>.png)` against the cwd wrote past the
+    // 4 KiB thread-local join buffer and aborted the process.
+    const src = "./" + Buffer.alloc(5000, "a").toString() + ".png";
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.stdout.write(Bun.markdown.ansi(${JSON.stringify(`![my image](${src})\n`)}, { kittyGraphics: true }))`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // stderr intentionally not asserted: ASAN builds emit a warning there.
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("my image");
+    expect(exitCode).toBe(0);
+  });
+
   test("table link with space in URL keeps OSC 8 sequences intact", () => {
     const source = "| Col |\n" + "|---|\n" + "| [c](<https://host/my file.png>)longunbreakabletailtextxx |\n";
     const out = Bun.markdown.ansi(source, { hyperlinks: true, columns: 25 });

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -43,7 +43,8 @@ describe("bun", () => {
 
   // `./<long>` and absolute paths were length-checked; the `../` and `~` arm
   // joined the argument with the cwd into a fixed-size path buffer unchecked.
-  test.each([["../"], ["run", "../"]])(
+  // A PathBuffer holds 98302 bytes on Windows; a command line cannot carry a path that long.
+  test.skipIf(isWindows).each([["../"], ["run", "../"]])(
     "a %s-prefixed path longer than PATH_MAX is a module-not-found error",
     (...args) => {
       const prefix = args.pop();

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -40,6 +40,29 @@ describe("bun", () => {
     expect(stderr.toString()).toMatch(/Script not found/);
     expect(exitCode).toBe(1);
   });
+
+  // `./<long>` and absolute paths were length-checked; the `../` and `~` arm
+  // joined the argument with the cwd into a fixed-size path buffer unchecked.
+  test.each([["../"], ["run", "../"]])(
+    "a %s-prefixed path longer than PATH_MAX is a module-not-found error",
+    (...args) => {
+      const prefix = args.pop();
+      const long = prefix + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+      using dir = tempDir("run-long-dotdot", {
+        "package.json": JSON.stringify({ name: "p", scripts: { hi: "echo hi" } }),
+      });
+      const { exitCode, stdout, stderr } = spawnSync({
+        cwd: String(dir),
+        cmd: [bunExe(), ...args, long],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(stdout.toString()).toBeEmpty();
+      expect(stderr.toString()).toContain(`error: Module not found "${long}"`);
+      expect(exitCode).toBe(1);
+    },
+  );
 });
 
 test.if(isWindows)("[windows] A file in drive root runs", async () => {

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
 
@@ -57,10 +57,14 @@ export class Y {
   );
 });
 
-test("lcov reporter reports a --coverage-dir longer than PATH_MAX instead of crashing", async () => {
+// A PathBuffer holds 98302 bytes on Windows; a command line cannot carry a path that long.
+test.skipIf(isWindows)("lcov reporter reports a --coverage-dir longer than PATH_MAX instead of crashing", async () => {
+  // Coverage of a non-test module, so there is a report to write in release
+  // builds too (those skip test files by default).
   using dir = tempDir("cov-long-dir", {
     "package.json": "{}",
-    "a.test.ts": `import { test, expect } from "bun:test"; test("ok", () => { expect(1).toBe(1); });`,
+    "math.ts": `export function add(a: number, b: number) { return a + b; }`,
+    "a.test.ts": `import { test, expect } from "bun:test"; import { add } from "./math"; test("ok", () => { expect(add(1, 1)).toBe(2); });`,
   });
   // 4220 bytes of valid components; joining `<dir>/lcov.info` into a
   // fixed-size path buffer used to abort the process after the tests had run.
@@ -73,7 +77,7 @@ test("lcov reporter reports a --coverage-dir longer than PATH_MAX instead of cra
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toContain("(pass) ok");
+  expect(stderr).toContain("1 pass");
   expect(stderr).toContain("Failed to write lcov.info to aaaa");
   expect(stderr).toContain("ENAMETOOLONG");
   expect(exitCode).toBe(1);

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -57,6 +57,28 @@ export class Y {
   );
 });
 
+test("lcov reporter reports a --coverage-dir longer than PATH_MAX instead of crashing", async () => {
+  using dir = tempDir("cov-long-dir", {
+    "package.json": "{}",
+    "a.test.ts": `import { test, expect } from "bun:test"; test("ok", () => { expect(1).toBe(1); });`,
+  });
+  // 4220 bytes of valid components; joining `<dir>/lcov.info` into a
+  // fixed-size path buffer used to abort the process after the tests had run.
+  const coverageDir = Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=lcov", `--coverage-dir=${coverageDir}`, "./a.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("(pass) ok");
+  expect(stderr).toContain("Failed to write lcov.info to aaaa");
+  expect(stderr).toContain("ENAMETOOLONG");
+  expect(exitCode).toBe(1);
+});
+
 test("coverage excludes node_modules directory", () => {
   using dir = tempDir("cov", {
     "node_modules/pi/index.js": `

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1864,6 +1864,17 @@ describe.skipIf(isWindows).concurrent("REPL history file permissions", () => {
   });
 });
 
+test("skips the history file when $HOME is longer than PATH_MAX", async () => {
+  // 4220 bytes, each component short enough to be a valid name. The directory
+  // does not exist; the REPL used to abort while joining `$HOME/.bun_repl_history`
+  // into a fixed-size path buffer.
+  const home = "/" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+  const { outputs, stderr, exitCode } = await runRepl(["1 + 1", ".exit"], { home });
+  expect(outputs).toEqual(["2"]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 // `bun --interactive` boots the full node:repl + readline + acorn stack; on a
 // debug+asan build that is ~4–5s per spawn, so the 5s default is too tight.
 const interactiveTimeout = 20_000;

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -240,6 +240,30 @@ describe.concurrent("long import path overflow", () => {
     // Walk-up loop indexed into a fixed [256]DirEntryResolveQueueItem
     await run(String(dir), `\`/\${"a/".repeat(300)}x\``);
   });
+
+  // The other direction: a short import with a tsconfig whose `baseUrl` is
+  // itself longer than a PathBuffer (parse_tsconfig for a relative one,
+  // match_tsconfig_paths for an absolute one). Every component is a valid name.
+  it.each(["./", "/"])("tsconfig baseUrl longer than PATH_MAX (prefix %s)", async prefix => {
+    const baseUrl = prefix + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
+    using dir = tempDir("resolve-long-baseurl", {
+      "package.json": `{"name": "test", "version": "0.0.0"}`,
+      "node_modules/.keep": "",
+      "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl, paths: { "somebare/*": ["./lib/*"] } } }),
+      "e.ts": `import x from "somebare/y"; console.log(x);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "e.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(`Cannot find module 'somebare/y'`);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
 });
 
 // matchTSConfigPaths sliced `path[prefix.len()..path.len() - suffix.len()]`

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -267,6 +267,26 @@ describe.concurrent("long import path overflow", () => {
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
+
+  it("tsconfig extends longer than PATH_MAX", async () => {
+    const parent = "./" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/") + ".json";
+    using dir = tempDir("resolve-long-extends", {
+      "package.json": `{"name": "test", "version": "0.0.0"}`,
+      "tsconfig.json": JSON.stringify({ extends: parent, compilerOptions: {} }),
+      "e.ts": `console.log("ok");`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "e.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
 });
 
 // matchTSConfigPaths sliced `path[prefix.len()..path.len() - suffix.len()]`

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -242,14 +242,17 @@ describe.concurrent("long import path overflow", () => {
   });
 
   // The other direction: a short import with a tsconfig whose `baseUrl` is
-  // itself longer than a PathBuffer (parse_tsconfig for a relative one,
-  // match_tsconfig_paths for an absolute one). Every component is a valid name.
+  // itself longer than a PathBuffer. A relative one is joined with the tsconfig
+  // directory in parse_tsconfig; an absolute one is joined with an exact `paths`
+  // target in match_tsconfig_paths. Every component is a valid name.
   it.each(["./", "/"])("tsconfig baseUrl longer than PATH_MAX (prefix %s)", async prefix => {
     const baseUrl = prefix + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/");
     using dir = tempDir("resolve-long-baseurl", {
       "package.json": `{"name": "test", "version": "0.0.0"}`,
       "node_modules/.keep": "",
-      "tsconfig.json": JSON.stringify({ compilerOptions: { baseUrl, paths: { "somebare/*": ["./lib/*"] } } }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { baseUrl, paths: { "somebare/y": ["./lib/y.ts"], "somebare/*": ["./lib/*"] } },
+      }),
       "e.ts": `import x from "somebare/y"; console.log(x);`,
     });
     await using proc = Bun.spawn({

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -1,7 +1,8 @@
 import { $ } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, DirectoryTree, isDebug, tempDir, tempDirWithFiles } from "harness";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, DirectoryTree, isDebug, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { join } from "path";
 
 function test1000000(arg1: any, arg218718132: any) {}
 
@@ -957,4 +958,35 @@ test("write snapshot from filter", async () => {
   expect(await Bun.file(dir + "/mytests/snap.test.ts").text()).toBe(sver("a", true));
   expect(await Bun.file(dir + "/mytests/snap2.test.ts").text()).toBe(sver("b", true));
   expect(await Bun.file(dir + "/mytests/more/testing.test.ts").text()).toBe(sver("TEST", true));
+});
+
+test.skipIf(isWindows)("snapshot file path longer than PATH_MAX fails the test instead of crashing", async () => {
+  using dir = tempDir("snapshot-long-path", {});
+  let deep = String(dir);
+  const component = Buffer.alloc(100, "a").toString();
+  while (deep.length + 1 + component.length <= 3980) {
+    deep = join(deep, component);
+    mkdirSync(deep);
+  }
+  // `<deep>/<sub>/snapx.test.ts` is 4080 bytes: under PATH_MAX, but
+  // `<dir>/__snapshots__/snapx.test.ts.snap` is not.
+  const sub = Buffer.alloc(4080 - deep.length - 1 - "/snapx.test.ts".length, "b").toString();
+  mkdirSync(join(deep, sub));
+  writeFileSync(
+    join(deep, sub, "snapx.test.ts"),
+    `import { test, expect } from "bun:test";\ntest("snap", () => { expect(1).toMatchSnapshot(); });\n`,
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", `./${sub}/snapx.test.ts`],
+    env: bunEnv,
+    cwd: deep,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("Failed to open snapshot file for test file: ");
+  expect(stderr).toContain("snapx.test.ts");
+  expect(stdout + stderr).toContain("1 fail");
+  expect(exitCode).toBe(1);
 });

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, DirectoryTree, isDebug, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, DirectoryTree, isDebug, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 function test1000000(arg1: any, arg218718132: any) {}
@@ -960,17 +960,19 @@ test("write snapshot from filter", async () => {
   expect(await Bun.file(dir + "/mytests/more/testing.test.ts").text()).toBe(sver("TEST", true));
 });
 
+// A PathBuffer holds 98302 bytes on Windows; directories that deep cannot be created.
 test.skipIf(isWindows)("snapshot file path longer than PATH_MAX fails the test instead of crashing", async () => {
+  const pathMax = isMacOS ? 1024 : 4096;
   using dir = tempDir("snapshot-long-path", {});
   let deep = String(dir);
   const component = Buffer.alloc(100, "a").toString();
-  while (deep.length + 1 + component.length <= 3980) {
+  while (deep.length + 1 + component.length <= pathMax - 116) {
     deep = join(deep, component);
     mkdirSync(deep);
   }
-  // `<deep>/<sub>/snapx.test.ts` is 4080 bytes: under PATH_MAX, but
-  // `<dir>/__snapshots__/snapx.test.ts.snap` is not.
-  const sub = Buffer.alloc(4080 - deep.length - 1 - "/snapx.test.ts".length, "b").toString();
+  // `<deep>/<sub>/snapx.test.ts` is 16 bytes under PATH_MAX, so
+  // `<deep>/<sub>/__snapshots__/snapx.test.ts.snap` is over it.
+  const sub = Buffer.alloc(pathMax - 16 - deep.length - 1 - "/snapx.test.ts".length, "b").toString();
   mkdirSync(join(deep, sub));
   writeFileSync(
     join(deep, sub, "snapx.test.ts"),

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -608,6 +608,27 @@ describe("junit reporter", () => {
     expect(longPathCase.failure[0]._).toContain(`at fromLongPath (${longPath}:1:`);
     expect(pathCase.failure[0]._).toContain("at fromPath (generated.js:1:");
   });
+
+  it("reports a --reporter-outfile longer than PATH_MAX instead of crashing", async () => {
+    using dir = tempDir("junit-long-outfile", {
+      "package.json": "{}",
+      "a.test.js": `import { test, expect } from "bun:test"; test("ok", () => { expect(1).toBe(1); });`,
+    });
+    // 4220 bytes of valid components; copying it into the fixed-size path
+    // buffer used to abort the process after the tests had run.
+    const outfile = "./" + Array(21).fill(Buffer.alloc(200, "a").toString()).join("/") + ".xml";
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", outfile, "a.test.js"], {
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("Failed to write JUnit report to ./aaaa");
+    expect(stderr).toContain("ENAMETOOLONG");
+    expect(exitCode).toBe(0);
+  });
 });
 
 function filterJunitXmlOutput(xmlContent) {

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
 const xml2js = require("xml2js");
@@ -609,7 +609,8 @@ describe("junit reporter", () => {
     expect(pathCase.failure[0]._).toContain("at fromPath (generated.js:1:");
   });
 
-  it("reports a --reporter-outfile longer than PATH_MAX instead of crashing", async () => {
+  // A PathBuffer holds 98302 bytes on Windows; a command line cannot carry a path that long.
+  it.skipIf(isWindows)("reports a --reporter-outfile longer than PATH_MAX instead of crashing", async () => {
     using dir = tempDir("junit-long-outfile", {
       "package.json": "{}",
       "a.test.js": `import { test, expect } from "bun:test"; test("ok", () => { expect(1).toBe(1); });`,


### PR DESCRIPTION
### Problem
- A user-supplied path longer than a `PathBuffer` (4096 bytes on Linux) aborts the process: `panic: range end index 4110 out of range for slice of length 4095`, exit 134. Twelve doors reach it, for example a tsconfig `baseUrl`, a deep test file with `toMatchSnapshot()`, `bun patch <path>`, and `Bun.build` with a long `outdir` plus `naming`. The Notes table lists all. 1.3.14 printed an error.
- Each site joins the input into a fixed buffer through an unchecked `bun_paths` helper such as `join_abs_string_buf_z`, or a raw `copy_from_slice`, with no length check.

### Fix
- Add `join_z_buf_checked` and `join_abs_string_buf_z_checked` to `resolve_path.rs`. They return `None` when the result plus its NUL does not fit. #39658 uses the same names.
- Each site calls a checked helper and takes its existing error path, or a `*_spill` helper where the long result is valid. No path is truncated.
- Not touched: sites from the same sweep with open PRs (#38784, #38390, #37478, #38753).
- Verified: one new test per site, in the existing files. Each fails on 1.4.3-canary and passes here. Self-reviewed: 8 concerns, 5 addressed, 3 nits declined (Notes).

### Background
- `PathBuffer` is `[u8; MAX_PATH_BYTES]`. One syscall rejects a longer path with `ENAMETOOLONG`, but a file created relative to an open directory can still exist there (the `Bun.build` case).
- A `*_checked` helper allocates scratch space only when the unnormalized input is too long, so `..` segments that normalize down still succeed. A `*_spill` helper grows into a `Vec` instead.
- #39658 bounds-checks the normalizer itself. This PR is the caller side.

<details><summary>Notes</summary>

What a user now sees, per site:

| Door | File | Result |
| --- | --- | --- |
| tsconfig `compilerOptions.baseUrl` (relative) | `resolver.rs` `parse_tsconfig` | warning `Ignoring "baseUrl" in "<tsconfig>" because it is too long`; the rest of the tsconfig still applies (`paths` then resolve against the tsconfig directory, as when `baseUrl` is absent), then the normal `Cannot find module` |
| tsconfig `extends` | `resolver.rs` `dir_info_uncached` (extends chain) | debug log, the parent is skipped like an unreadable one |
| tsconfig absolute `baseUrl` + exact `paths` key | `resolver.rs` `match_tsconfig_paths` | target skipped, like the wildcard branch already does |
| test file path 4078..4095 bytes + `toMatchSnapshot()` | `snapshot.rs` `get_snapshot_file`, `parse_file` | `Failed to open snapshot file for test file: <path>`, the test fails, exit 1 |
| `BUN_INSTALL_CACHE_DIR`/`HOME` + `bun build --compile --target=<other>` | `compile_target.rs` `exe_path`, `StandaloneModuleGraph.rs` `target_executable` | `Cache directory for '<target>' is too long (File name too long): <dir>`, exit 1, before any download |
| `HOME` + `bun repl` | `repl.rs` `History::load` | REPL runs without a history file |
| `bun ../<long>`, `bun run ../<long>` | `run_command.rs` `maybe_open_with_bun_js` | `error: Module not found "<arg>"`, exit 1 (same as the already-guarded `./<long>`) |
| `bun test --reporter-outfile=<long>` | `test_command.rs` `JunitReporter::write_to_file` | `ENAMETOOLONG: ... Failed to write JUnit report to <path>` (exit code unchanged, #41466 makes it 1) |
| `bun test --coverage-dir=<long>` (lcov) | `test_command.rs` `write_lcov_report`, `generate_code_coverage` | `ENAMETOOLONG: ... Failed to write lcov.info to <dir>`, then the test summary, exit 1. The failure now sets the exit code instead of calling `Global::exit(1)` on the spot, so the run leaves through the normal VM exit path (the old early exit skipped `BUN_DESTRUCT_VM_ON_EXIT` teardown and tripped LeakSanitizer on the ASAN lane). The `--parallel` coordinator already did it this way; its message now names the directory too. |
| `bun --filter ./<long> run x` | `workspace_selection.rs` `parse` | `error: --filter "<arg>" path is too long`, exit 1 |
| `bun pm pkg fix` with a long `bin` value | `pm_pkg_command.rs` `exec_fix` | `warn: bin path is too long: <value>`, continues, exit 0 (like a missing bin file) |
| `bun patch <long>` (and `--commit`), from the root or a workspace member | `patchPackage.rs` `prepare_patch`, `do_patch_commit`, `path_argument_relative_to_root_workspace_package` | `error: path is too long: "<arg>"`, exit 1. The workspace-relative rewrite, the patches-dir join and the printed folder use the `*_spill` helpers. |
| `Bun.build({ outdir, naming })`, each piece legal, `outdir + "/" + rendered name` over 4095 bytes | `js_bundle_completion_task.rs` `on_complete` | The bundler writes the file relative to the open outdir, so it exists. `BuildArtifact.path` now holds the full path (`join_abs_string_spill`) and the build reports `success: true`. Before, the process aborted after the file was on disk. `bun build` (CLI) was already clean. |
| `![x](./<long>.png)` with Kitty graphics | `ansi_renderer.rs` `resolve_local_image_path` | falls back to alt text, like a missing file |

The Windows `PathBuffer` holds 98302 bytes (32767 UTF-16 units as UTF-8), so a command line or a package.json field cannot overflow it; the CLI-door tests are skipped there. The snapshot test sizes its directory chain from the platform `PATH_MAX` (1024 on macOS).

`join_needed` (the size bound behind `join_z_buf_checked` and the `join*_spill` helpers) now reserves room for the `.` result of an empty part list plus its NUL.

Self-review findings addressed: the `.`-result bound above, dropping the whole tsconfig for an over-long `baseUrl` (now a field-level warning like the other `compilerOptions` problems), and three more unchecked joins of the same user input (`extends`, the `bun patch` argument when run from a workspace member, and the folder `bun patch` prints). Declined: the `{}` vs `{f}` format style in `patchPackage.rs`, a cwd of 4084..4095 bytes in `pm pkg` `find_package_json` (cwd-length handling is #38363's subject), and naming `top_level_dir` in the cross-compile message.

Tests added: `test/js/bun/resolve/resolve-error.test.ts`, `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts`, `test/bundler/bun-build-compile.test.ts`, `test/js/bun/repl/repl.test.ts`, `test/cli/run/run_command.test.ts`, `test/js/junit-reporter/junit.test.js`, `test/cli/test/coverage.test.ts`, `test/cli/run/filter-workspace.test.ts`, `test/cli/install/bun-pm-pkg.test.ts`, `test/cli/install/bun-patch.test.ts`, `test/cli/run/markdown-entrypoint.test.ts`, `test/bundler/bun-build-api.test.ts` (Linux only: macOS cannot open an outdir over its 1024-byte `PATH_MAX`). The long input is `Array(21).fill("a".repeat(200)).join("/")` (4220 bytes, every component a valid name), so nothing depends on the OS accepting a long component.

Sites from the same sweep that still abort and are owned by other open PRs: `bun pm pack`/`bun publish` `files` and `bin` entries (#38784), `BUN_INSTALL_CACHE_DIR`/bunfig cache dir in the package manager (#38390), `Bun.build({ compile: { outfile } })` (#37478), `bun publish ./<long>.tgz` (#38753).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/junit-reporter/junit.test.js, test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts, test/js/bun/resolve/resolve-error.test.ts, test/js/bun/repl/repl.test.ts, test/cli/test/coverage.test.ts, test/cli/run/run_command.test.ts, test/cli/run/filter-workspace.test.ts, test/cli/install/bun-pm-pkg.test.ts, test/cli/install/bun-patch.test.ts, test/bundler/bun-build-compile.test.ts, test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
