### PR TITLE
spawnSync: restore the VM's event loop handle as soon as the wait is over

### DIFF
--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -9,7 +9,11 @@
 //! Implementation approach:
 //! - Creates a separate uws.Loop instance with its own kqueue/epoll fd (POSIX) or libuv loop (Windows)
 //! - Wraps it in a full jsc.EventLoop instance whose `uws_loop` is the isolated loop
-//! - Temporarily overrides vm.event_loop_handle to point to the isolated loop
+//! - Temporarily overrides vm.event_loop_handle to point to the isolated loop.
+//!   Poll and keep-alive accounting resolves its loop through that handle, so
+//!   the override must end before anything that can run GC finalizers of
+//!   main-loop objects (any JS allocation); `spawnSync` calls `cleanup` as soon
+//!   as its wait is over.
 //! - Minimal handler callbacks (wakeup/pre/post are no-ops)
 //!
 //! Similar to Node.js's approach in vendor/node/src/spawn_sync.cc but adapted for Bun's architecture.
@@ -100,6 +104,8 @@ pub struct SpawnSyncEventLoop {
     /// `prepare` overrides the VM's event_loop_handle; the original, restored
     /// by `cleanup`.
     original_event_loop_handle: VmEventLoopHandle,
+    /// Between `prepare` and `cleanup`: the VM's handle names this loop.
+    attached: bool,
 
     #[cfg(windows)]
     uv_timer: Option<NonNull<libuv::Timer>>,
@@ -159,6 +165,7 @@ impl SpawnSyncEventLoop {
         this.write(Self {
             uws_loop: loop_,
             original_event_loop_handle: None, // overwritten in `prepare`
+            attached: false,
             #[cfg(windows)]
             uv_timer: None,
             did_timeout: Cell::new(false),
@@ -288,6 +295,8 @@ impl SpawnSyncEventLoop {
         self.did_timeout.set(false);
         self.vm = vm;
 
+        debug_assert!(!self.attached, "spawnSync loop prepared twice");
+        self.attached = true;
         self.original_event_loop_handle = __bun_spawn_sync_vm_get_event_loop_handle(vm);
         #[cfg(unix)]
         let new_handle: VmEventLoopHandle = Some(self.uws_loop);
@@ -299,8 +308,13 @@ impl SpawnSyncEventLoop {
         __bun_spawn_sync_vm_set_event_loop_handle(vm, new_handle);
     }
 
-    /// Restore the original event loop handle after spawnSync completes
+    /// Restore the original event loop handle. Idempotent: `spawnSync` calls it
+    /// as soon as its wait is over, and again on every exit path.
     pub fn cleanup(&mut self, vm: *mut () /* SAFETY: erased *mut VirtualMachine */) {
+        if !self.attached {
+            return;
+        }
+        self.attached = false;
         __bun_spawn_sync_vm_set_event_loop_handle(vm, self.original_event_loop_handle);
 
         #[cfg(windows)]

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1068,6 +1068,8 @@ fn spawn_maybe_sync(
     // local so the closure's captured place is disjoint.
     let jsc_vm_ptr_cleanup = jsc_vm_ptr;
     scopeguard::defer! {
+        // Early returns before the wait; after the wait `cleanup` already ran
+        // and this is a no-op.
         if is_sync {
             // SAFETY: defer runs while `jsc_vm` (the thread VM) is still live.
             unsafe {
@@ -1967,6 +1969,11 @@ fn spawn_maybe_sync(
                 subprocess.close_readable_pipes();
             }
         }
+
+        // Restore the VM's loop before the JS allocations below: they can run
+        // finalizers, and a finalizer that releases a main-loop poll resolves
+        // `vm.event_loop_handle`. It must not debit this private loop.
+        sync_loop.cleanup(jsc_vm_ptr.cast());
     }
     if global_this.has_exception() {
         // e.g. a termination exception.

--- a/test/js/bun/spawn/spawnSync-finalizer-poll-fixture.js
+++ b/test/js/bun/spawn/spawnSync-finalizer-poll-fixture.js
@@ -1,0 +1,59 @@
+// A finalizer that runs while Bun.spawnSync() is on the stack must release its
+// poll on the main loop, not on the private loop spawnSync installs for the
+// call. The garbage here is what every file of a `bun test --isolate` worker
+// leaves behind: the previous global's process.stdout/stderr sinks, which are
+// FileSinks on a dup() of a piped stdio fd. Each holds one poll on the main
+// loop until its finalizer runs.
+//
+// Run with stderr as a pipe. With BUN_JSC_useConcurrentGC=0 and
+// BUN_JSC_sweepSynchronously=1, the collection that the spawnSync result
+// buffers start sweeps, and so finalizes, right there inside the call; without
+// them only some of the finalizers land inside a call.
+const { getEventLoopStats } = require("bun:internal-for-testing");
+const { heapStats } = require("bun:jsc");
+const { spawnSync } = require("node:child_process");
+
+const settle = () => new Promise(resolve => setImmediate(resolve));
+const liveSinks = () => heapStats().objectTypeCounts.FileSink ?? 0;
+const { BUN_JSC_useConcurrentGC, BUN_JSC_sweepSynchronously, ...childEnv } = process.env;
+
+Bun.gc(true);
+await settle();
+const basePolls = getEventLoopStats().numPolls;
+const baseSinks = liveSinks();
+
+const sinks = 40;
+for (let i = 0; i < sinks; i++) Bun.file(2).writer();
+const heldPolls = getEventLoopStats().numPolls - basePolls;
+if (heldPolls !== sinks) {
+  console.log("PRECONDITION " + JSON.stringify({ basePolls, heldPolls, sinks }));
+  process.exit(1);
+}
+
+// 2 MB of stdout per call: turning it into the result Buffer is the allocation
+// that starts a collection inside spawnSync.
+for (let i = 0; i < sinks; i++) {
+  const result = spawnSync("/bin/sh", ["-c", "head -c 2000000 /dev/zero"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    maxBuffer: 1 << 24,
+    env: childEnv,
+  });
+  if (result.error || result.status !== 0 || result.stdout.length !== 2000000) {
+    console.log("SPAWN " + JSON.stringify({ i, status: result.status, error: String(result.error) }));
+    process.exit(1);
+  }
+}
+
+Bun.gc(true);
+await settle();
+Bun.gc(true);
+await settle();
+const polls = getEventLoopStats().numPolls;
+const sinksLeft = liveSinks() - baseSinks;
+// Every sink is finalized by now. A poll count still above the baseline means
+// finalizers released their polls on some other loop.
+if (sinksLeft > 0 || polls !== basePolls) {
+  console.log("DRIFT " + JSON.stringify({ basePolls, polls, sinksLeft }));
+  process.exit(1);
+}
+console.log("OK");

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -143,20 +143,23 @@ describe.concurrent("spawnSync isolated event loop", () => {
     ["forced", { BUN_JSC_useConcurrentGC: "0", BUN_JSC_sweepSynchronously: "1" }],
     ["default", {}],
   ] as const) {
-    test.skipIf(isWindows)(`finalizers that run inside spawnSync release their polls on the main loop (${variant} GC timing)`, async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(import.meta.dir, "spawnSync-finalizer-poll-fixture.js")],
-        env: { ...bunEnv, ...gcEnv },
-        stdin: "ignore",
-        stdout: "pipe",
-        // A pipe, so that the fixture's sinks on fd 2 take a poll.
-        stderr: "pipe",
-      });
+    test.skipIf(isWindows)(
+      `finalizers that run inside spawnSync release their polls on the main loop (${variant} GC timing)`,
+      async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), join(import.meta.dir, "spawnSync-finalizer-poll-fixture.js")],
+          env: { ...bunEnv, ...gcEnv },
+          stdin: "ignore",
+          stdout: "pipe",
+          // A pipe, so that the fixture's sinks on fd 2 take a poll.
+          stderr: "pipe",
+        });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
-    });
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+      },
+    );
   }
 
   test("spawnSync under GC pressure with a worker and a server keeps the main loop balanced and exits", async () => {

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { join } from "node:path";
 
 describe.concurrent("spawnSync isolated event loop", () => {
@@ -133,6 +133,31 @@ describe.concurrent("spawnSync isolated event loop", () => {
     expect(stdout).toBe("OK\n");
     expect(exitCode).toBe(0);
   });
+
+  // "forced": the collection that spawnSync's result buffers start sweeps and
+  // finalizes on the spot, so every dead sink is finalized inside a call.
+  // "default": GC timing left alone; some finalizers still land inside a call.
+  // POSIX only: the fixture's garbage is FileSinks that poll a dup() of a piped
+  // stderr, which is what process.stdout/stderr are there.
+  for (const [variant, gcEnv] of [
+    ["forced", { BUN_JSC_useConcurrentGC: "0", BUN_JSC_sweepSynchronously: "1" }],
+    ["default", {}],
+  ] as const) {
+    test.skipIf(isWindows)(`finalizers that run inside spawnSync release their polls on the main loop (${variant} GC timing)`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "spawnSync-finalizer-poll-fixture.js")],
+        env: { ...bunEnv, ...gcEnv },
+        stdin: "ignore",
+        stdout: "pipe",
+        // A pipe, so that the fixture's sinks on fd 2 take a poll.
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+    });
+  }
 
   test("spawnSync under GC pressure with a worker and a server keeps the main loop balanced and exits", async () => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
Closed in favor of #40078, which fixes the same root cause. This branch keeps a smaller alternative and a deterministic fixture, described in https://github.com/oven-sh/bun/pull/40078#issuecomment-5582591410.

### Problem
- `test/js/bun/perf/linker-order.test.ts` (`function tracer > records exact entries, and keeps them across an exec'd child`) timed out after 90 s in the `bun test --parallel` batch on the aarch64 glibc lanes (builds 110996, 111195, 111496, 111536) and passed alone.
- The test's `spawnSync(llvm-nm)` spun: `Bun.spawnSync` points `vm.event_loop_handle` at a private loop until the call returns, and it built its result (JS allocations) before restoring it. A GC finalizer that ran there and released a main-loop poll (`FilePoll::deinit` resolves `vm.event_loop_handle`) debited the private loop. With the private loop at -2, the next spawnSync read `num_polls == 0` with its pidfd and stdout still armed, and `us_loop_run_bun_tick` returned before `epoll_wait` on every turn.
- The finalized objects were the `process.stdout`/`process.stderr` sinks that every file of an `--isolate` worker leaves behind (FileSinks polling a dup of the worker's stdio socket).

### Fix
- Restore the handle right after the wait loop, before any JS value is created; `SpawnSyncEventLoop::cleanup` is idempotent so the scope guard still covers early returns.
- Verified: `test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts` (two new cases, both fail on an unfixed build and pass with the change), plus the spawn, spawnSync and child_process suites.
