### PR TITLE
transpiler cache: require an absolute XDG_CACHE_HOME and HOME

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -635,7 +635,10 @@ impl RuntimeTranspilerCache {
         // that `absBufZ` used.
         let top = FileSystem::instance().top_level_dir;
 
-        if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
+        if let Some(dir) = env_var::XDG_CACHE_HOME
+            .get()
+            .filter(|d| paths::is_absolute(d))
+        {
             let parts: &[&[u8]] = &[dir, b"bun", b"@t@"];
             return path_handler::join_abs_string_buf_z::<platform::Loose>(
                 top,
@@ -649,7 +652,7 @@ impl RuntimeTranspilerCache {
         {
             // On a mac, default to ~/Library/Caches/bun/*
             // This is different than ~/.bun/install/cache, and not configurable by the user.
-            if let Some(home) = env_var::HOME.get() {
+            if let Some(home) = env_var::HOME.get().filter(|d| paths::is_absolute(d)) {
                 let parts: &[&[u8]] = &[home, b"Library/", b"Caches/", b"bun", b"@t@"];
                 return path_handler::join_abs_string_buf_z::<platform::Loose>(
                     top,
@@ -660,7 +663,7 @@ impl RuntimeTranspilerCache {
             }
         }
 
-        if let Some(dir) = env_var::HOME.get() {
+        if let Some(dir) = env_var::HOME.get().filter(|d| paths::is_absolute(d)) {
             let parts: &[&[u8]] = &[dir, b".bun", b"install", b"cache", b"@t@"];
             return path_handler::join_abs_string_buf_z::<platform::Loose>(
                 top,

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -240,6 +240,26 @@ describe("transpiler cache", () => {
     expect(existsSync(join(temp_dir, "bun"))).toBeFalse();
     expect(existsSync(join(temp_dir, "relxdg"))).toBeFalse();
   });
+  test.each([
+    ["an empty", ""],
+    ["a relative", "relhome"],
+  ])("disables the cache for %s HOME instead of caching next to the project", async (_label, home) => {
+    writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "home-not-absolute"));
+
+    // HOME is the last candidate, so a value that is not absolute leaves no
+    // cache location and the cache is disabled.
+    expect(
+      await bunRun(join(temp_dir, "a.js"), {
+        ...env,
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined,
+        XDG_CACHE_HOME: undefined,
+        HOME: home,
+        USERPROFILE: home,
+      }),
+    ).toSpawn("home-not-absolute");
+
+    expect(readdirSync(temp_dir)).toEqual(["a.js"]);
+  });
   test("works if the cache is not user-readable", async () => {
     mkdirSync(cache_dir, { recursive: true });
     writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "b"));

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -12,7 +12,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
-import { bunEnv, bunExe, bunRun, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, bunRun, isMacOS, isWindows, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "path";
 
@@ -209,6 +209,36 @@ describe("transpiler cache", () => {
     // A per-user cache location still works.
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("no-tmpdir-cache");
     expect(newCacheCount()).toBe(1);
+  });
+  test.each([
+    ["an empty", ""],
+    ["a relative", "relxdg"],
+  ])("ignores %s XDG_CACHE_HOME instead of caching next to the project", async (_label, xdg_cache_home) => {
+    writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "xdg-not-absolute"));
+
+    // The XDG base directory specification requires an absolute path, so the
+    // next candidate in the chain is HOME.
+    const home = join(temp_dir, "home");
+    mkdirSync(home, { recursive: true });
+    const home_cache = isMacOS
+      ? join(home, "Library", "Caches", "bun", "@t@")
+      : join(home, ".bun", "install", "cache", "@t@");
+
+    expect(
+      await bunRun(join(temp_dir, "a.js"), {
+        ...env,
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined,
+        XDG_CACHE_HOME: xdg_cache_home,
+        HOME: home,
+        USERPROFILE: home,
+      }),
+    ).toSpawn("xdg-not-absolute");
+
+    expect(readdirSync(home_cache)).toHaveLength(1);
+    // The cwd is not a cache location: neither `bun/@t@` (empty value) nor
+    // `relxdg/bun/@t@` (relative value) may appear in the project.
+    expect(existsSync(join(temp_dir, "bun"))).toBeFalse();
+    expect(existsSync(join(temp_dir, "relxdg"))).toBeFalse();
   });
   test("works if the cache is not user-readable", async () => {
     mkdirSync(cache_dir, { recursive: true });


### PR DESCRIPTION
### Problem
- `really_get_cache_dir` (`src/jsc/RuntimeTranspilerCache.rs:636`) joins the value of `XDG_CACHE_HOME` or `HOME` onto the top level directory. A value that is not absolute resolves against the working directory, so the runtime transpiler cache is written inside the project.
- Verified on 1.4.3-canary.1 (f42e98025): `XDG_CACHE_HOME= bun ./big.ts` creates `./bun/@t@/<hash>.pile`, and `XDG_CACHE_HOME=relxdg bun ./big.ts` creates `./relxdg/bun/@t@/`. An empty `HOME` writes `./.bun/install/cache/@t@`.
- `env_var::XDG_CACHE_HOME.get()` returns `Some("")` for an empty value, so an empty value counts as set.

### Fix
- Each of the three arms (`XDG_CACHE_HOME`, `HOME` on macOS, `HOME`) takes the value only when `bun_paths::is_absolute` accepts it, and falls through otherwise.
- The XDG base directory specification requires an absolute path and says to ignore a relative one. An empty value is not absolute, so it reads as unset. Nothing changes for an absolute value.
- A cache entry is executed as code, so the directory has to stay per-user. The working directory is shared with whoever can write the project.
- Verified: `test/cli/run/transpiler-cache.test.ts`, four new cases (an empty and a relative value for each of `XDG_CACHE_HOME` and `HOME`), all four fail on the released bun. The full file passes. Also ran `bun-pm`, `npmrc`, `patch`, `bunx`, `bun-add` and the global directory subset of `bun-install-registry`.

### Background
- The runtime transpiler cache stores transpiled output for a file of 4 KB or more in a `@t@` directory, keyed by a content hash. A later run with the same hash loads that output instead of parsing the file.
- `really_get_cache_dir` picks the directory once per thread, from the first candidate that answers: `BUN_RUNTIME_TRANSPILER_CACHE_PATH`, `XDG_CACHE_HOME`, `HOME`. It returns 0 to mean the cache is disabled.
- `join_abs_string_buf_z(top, [value, ...])` is bun's `path.resolve`. An absolute part replaces the base. A relative part is appended to it, which is how the value ended up under the working directory.

<details><summary>Notes</summary>

Found while checking a report about environment derived paths. The same report named several other sites, which two open PRs already cover, so this PR is only the three arms above.

- #39781 fixes the sites that pass an environment value as the join *base*. That is a different defect: `join_abs_string_buf` requires an absolute base, and with a relative one the POSIX branch prefixes `/` and normalizes from the second byte, so the first byte of the value is lost. On 1.4.3-canary.1 `BUN_INSTALL=.bun bun pm bin -g` resolves the global install directory to `/bun/install/global`, `BUN_INSTALL=relbun` gives `/elbun/install/global`, and `XDG_CACHE_HOME=relxdg` gives `/elxdg/.bun/install/global`. `bun add -g` creates that directory. That PR does not touch `RuntimeTranspilerCache.rs`.
- #40705 rewrites `really_get_cache_dir` to add a `<tmpdir>/bun-<euid>/@t@` fallback when no per-user directory is available. It leaves the `XDG_CACHE_HOME` and `HOME` arms as they are, so it needs a rebase against this change, or this change folded in.

`HOME` is `USERPROFILE` on Windows (`env_var::HOME`), so both tests set both names. The macOS arm uses `$HOME/Library/Caches/bun/@t@`, so the test branches on `isMacOS`.

One unrelated flake during the runs: `defines are part of the cache key > --drop invalidates cache` timed out at its 5 s limit on a loaded machine, and passed on the next run.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->