### PR TITLE
Report unhandled rejections from promises that native APIs return already rejected

### DIFF
--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -32,13 +32,6 @@ unsafe extern "C" {
         arg0: &JSGlobalObject,
         js_value1: JSValue,
     ) -> *mut JSPromise;
-    /// **DEPRECATED** This function does not notify the VM about the rejection,
-    /// meaning it will not trigger unhandled rejection handling. Use
-    /// `JSC__JSPromise__rejectedPromise` instead.
-    safe fn JSC__JSPromise__rejectedPromiseValue(
-        arg0: &JSGlobalObject,
-        js_value1: JSValue,
-    ) -> JSValue;
     safe fn JSC__JSPromise__resolvedPromise(
         arg0: &JSGlobalObject,
         js_value1: JSValue,
@@ -232,10 +225,8 @@ impl JSPromise {
             return value;
         }
 
-        if value.is_any_error() {
-            return Self::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global, value,
-            );
+        if let Some(err) = value.to_error() {
+            return Self::rejected_promise(global, err).to_js();
         }
 
         Self::resolved_promise_value(global, value)
@@ -285,7 +276,9 @@ impl JSPromise {
         JSC__JSPromise__resolvedPromiseValue(global, value)
     }
 
-    /// Create a new rejected promise rejecting to a given value.
+    /// Create a new rejected promise rejecting to a given value. The rejection
+    /// is registered with the VM's rejection tracker, so it is reported as
+    /// unhandled unless a handler is attached before the microtask checkpoint.
     ///
     /// Note: If you want the result as a `JSValue`, use `rejected_promise().to_js()` instead.
     pub fn rejected_promise(global: &JSGlobalObject, value: JSValue) -> &mut JSPromise {
@@ -293,15 +286,16 @@ impl JSPromise {
         JSPromise::opaque_mut(JSC__JSPromise__rejectedPromise(global, value))
     }
 
-    /// **DEPRECATED** use `rejected_promise` instead.
-    ///
-    /// Create a new rejected promise without notifying the VM. Unhandled
-    /// rejections created this way will not trigger unhandled rejection handling.
-    pub fn dangerously_create_rejected_promise_value_without_notifying_vm(
+    /// Create a new promise rejected with the exception `err` proves is pending,
+    /// taking it off the VM. The reason is converted the way [`reject`](Self::reject)
+    /// converts it; a termination propagates instead of becoming a reason.
+    pub fn rejected_promise_with_caught_exception(
         global: &JSGlobalObject,
-        value: JSValue,
-    ) -> JSValue {
-        JSC__JSPromise__rejectedPromiseValue(global, value)
+        err: JsError,
+    ) -> JsResult<&mut JSPromise> {
+        let promise = Self::create(global);
+        promise.reject(global, Err(err))?;
+        Ok(promise)
     }
 
     /// Fulfill an existing promise with the value.

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -276,9 +276,7 @@ impl JSPromise {
         JSC__JSPromise__resolvedPromiseValue(global, value)
     }
 
-    /// Create a new rejected promise rejecting to a given value. The rejection
-    /// is registered with the VM's rejection tracker, so it is reported as
-    /// unhandled unless a handler is attached before the microtask checkpoint.
+    /// Create a new rejected promise. The rejection tracker sees it, like `Promise.reject()`.
     ///
     /// Note: If you want the result as a `JSValue`, use `rejected_promise().to_js()` instead.
     pub fn rejected_promise(global: &JSGlobalObject, value: JSValue) -> &mut JSPromise {
@@ -286,9 +284,8 @@ impl JSPromise {
         JSPromise::opaque_mut(JSC__JSPromise__rejectedPromise(global, value))
     }
 
-    /// Create a new promise rejected with the exception `err` proves is pending,
-    /// taking it off the VM. The reason is converted the way [`reject`](Self::reject)
-    /// converts it; a termination propagates instead of becoming a reason.
+    /// Create a new promise rejected with the pending exception behind `err`, the
+    /// way [`reject`](Self::reject) takes it. A termination propagates instead.
     pub fn rejected_promise_with_caught_exception(
         global: &JSGlobalObject,
         err: JsError,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5157,20 +5157,6 @@ void JSC__VM__throwError(JSC::VM* vm_, JSC::JSGlobalObject* arg1, JSC::EncodedJS
     scope.throwException(arg1, exception);
 }
 
-/// **DEPRECATED** This function does not notify the VM about the rejection,
-/// meaning it will not trigger unhandled rejection handling. Use JSC__JSPromise__rejectedPromise instead.
-JSC::EncodedJSValue JSC__JSPromise__rejectedPromiseValue(JSC::JSGlobalObject* globalObject,
-    JSC::EncodedJSValue JSValue1)
-{
-    auto& vm = JSC::getVM(globalObject);
-    JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
-    promise->setFlags(static_cast<uint16_t>(JSC::JSPromise::Status::Rejected));
-    promise->setSlot(vm, JSC::JSValue::decode(JSValue1));
-    JSC::ensureStillAliveHere(promise);
-    JSC::ensureStillAliveHere(JSC::JSValue::decode(JSValue1));
-    return JSC::JSValue::encode(promise);
-}
-
 JSC::EncodedJSValue JSC__JSPromise__resolvedPromiseValue(JSC::JSGlobalObject* globalObject,
     JSC::EncodedJSValue JSValue1)
 {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -124,7 +124,6 @@ CPP_DECL JSC::JSPromise* JSC__JSPromise__create(JSC::JSGlobalObject* arg0);
 CPP_DECL void JSC__JSPromise__reject(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL void JSC__JSPromise__rejectAsHandled(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL JSC::JSPromise* JSC__JSPromise__rejectedPromise(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);
-CPP_DECL JSC::EncodedJSValue JSC__JSPromise__rejectedPromiseValue(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);
 CPP_DECL void JSC__JSPromise__rejectOnNextTickWithHandled(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2, bool arg3);
 CPP_DECL void JSC__JSPromise__resolve(JSC::JSPromise* arg0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL JSC::JSPromise* JSC__JSPromise__resolvedPromise(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1152,12 +1152,8 @@ fn resolve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JS
     let value = match do_resolve(global_object, callframe.arguments()) {
         Ok(v) => v,
         Err(e) => {
-            let err = global_object.take_error(e);
             return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_object,
-                    err,
-                ),
+                JSPromise::rejected_promise_with_caught_exception(global_object, e)?.to_js(),
             );
         }
     };

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1371,10 +1371,7 @@ impl Subprocess<'_> {
             ),
             Status::Err(err) => {
                 let js_err = err.to_js(global_this);
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    js_err,
-                )
+                JSPromise::rejected_promise(global_this, js_err).to_js()
             }
             _ => {
                 let promise = JSPromise::create(global_this).to_js();

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2240,26 +2240,24 @@ where
         jsc::mark_binding!();
 
         if self.config.on_request.is_empty() {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    ctx,
-                    ctx.create_error_instance(format_args!(
-                        "fetch() requires the server to have a fetch handler"
-                    )),
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(
+                ctx,
+                ctx.create_error_instance(format_args!(
+                    "fetch() requires the server to have a fetch handler"
+                )),
+            )
+            .to_js());
         }
 
         let arguments = callframe.arguments();
         if arguments.is_empty() {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    ctx,
-                    ctx.create_error_instance(format_args!(
-                        "fetch() expects a string but received no arguments."
-                    )),
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(
+                ctx,
+                ctx.create_error_instance(format_args!(
+                    "fetch() expects a string but received no arguments."
+                )),
+            )
+            .to_js());
         }
 
         let mut headers: Option<HeadersRef> = None;
@@ -2277,14 +2275,13 @@ where
             let temp_url_str = url_utf8.slice();
 
             if temp_url_str.is_empty() {
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        ctx,
-                        ctx.create_error_instance(format_args!(
-                            "fetch() URL must not be a blank string."
-                        )),
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(
+                    ctx,
+                    ctx.create_error_instance(format_args!(
+                        "fetch() URL must not be a blank string."
+                    )),
+                )
+                .to_js());
             }
 
             let mut url = URL::parse(temp_url_str);
@@ -2333,11 +2330,11 @@ where
                 if let Some(body__) = opts.fast_get(ctx, jsc::BuiltinName::Body)? {
                     match Blob::get::<true, false>(ctx, body__) {
                         Ok(new_blob) => body = BodyValue::Blob(new_blob),
-                        Err(_) => {
-                            return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                ctx,
-                                ctx.create_error_instance(format_args!("fetch() received invalid body")),
-                            ));
+                        Err(err) => {
+                            return Ok(JSPromise::rejected_promise_with_caught_exception(
+                                ctx, err,
+                            )?
+                            .to_js());
                         }
                     }
                 }
@@ -2362,9 +2359,7 @@ where
         } else {
             let fetch_error = Fetch::fetch_type_error_string(first_arg);
             let err = jsc::ErrorCode::INVALID_ARG_TYPE.fmt(ctx, format_args!("{}", fetch_error));
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(ctx, err),
-            );
+            return Ok(JSPromise::rejected_promise(ctx, err).to_js());
         };
 
         // `Request::to_js` stores `self as *mut
@@ -2382,25 +2377,21 @@ where
         let response_value =
             match on_request.call(&global_this, self.js_value_assert_alive(), &[request_value]) {
                 Ok(v) => v,
-                Err(err) => global_this.take_exception(err),
+                Err(err) => {
+                    return Ok(JSPromise::rejected_promise_with_caught_exception(ctx, err)?.to_js());
+                }
             };
 
-        if response_value.is_any_error() {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    ctx,
-                    response_value,
-                ),
-            );
+        if let Some(err) = response_value.to_error() {
+            return Ok(JSPromise::rejected_promise(ctx, err).to_js());
         }
 
         if response_value.is_empty_or_undefined_or_null() {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    ctx,
-                    ctx.create_error_instance(format_args!("fetch() returned an empty value")),
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(
+                ctx,
+                ctx.create_error_instance(format_args!("fetch() returned an empty value")),
+            )
+            .to_js());
         }
 
         if response_value.as_any_promise().is_some() {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1371,12 +1371,11 @@ impl BlobExt for Blob {
     ) -> JsResult<JSValue> {
         let extra_options = options.extra_options;
         let Some(store) = self.store.get().clone() else {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    global_this.create_error_instance(format_args!("Blob is detached")),
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(
+                global_this,
+                global_this.create_error_instance(format_args!("Blob is detached")),
+            )
+            .to_js());
         };
 
         if self.is_s3() {
@@ -1386,12 +1385,11 @@ impl BlobExt for Blob {
             let aws_options = match s3.get_credentials_with_options(extra_options, global_this) {
                 Ok(o) => o,
                 Err(err) => {
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            global_this.take_exception(err),
-                        ),
-                    );
+                    return Ok(JSPromise::rejected_promise_with_caught_exception(
+                        global_this,
+                        err,
+                    )?
+                    .to_js());
                 }
             };
 
@@ -1430,12 +1428,11 @@ impl BlobExt for Blob {
         }
 
         if !matches!(store.data, store::Data::File(_)) {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    global_this.create_error_instance(format_args!("Blob is read-only")),
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(
+                global_this,
+                global_this.create_error_instance(format_args!("Blob is read-only")),
+            )
+            .to_js());
         }
 
         let file_sink: RefPtr<webcore::FileSink> = 'brk_sink: {
@@ -1466,10 +1463,11 @@ impl BlobExt for Blob {
                     match result {
                         bun_sys::Result::Ok(result) => result,
                         bun_sys::Result::Err(err) => {
-                            return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                            return Ok(JSPromise::rejected_promise(
                                 global_this,
                                 err.with_path(path).to_js(global_this),
-                            ));
+                            )
+                            .to_js());
                         }
                     }
                 };
@@ -1522,10 +1520,7 @@ impl BlobExt for Blob {
                 });
                 if let bun_sys::Result::Err(err) = started {
                     return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err.to_js(global_this),
-                        ),
+                        JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js(),
                     );
                 }
 
@@ -1564,10 +1559,7 @@ impl BlobExt for Blob {
 
                 if let bun_sys::Result::Err(err) = sink.start(&stream_start) {
                     return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err.to_js(global_this),
-                        ),
+                        JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js(),
                     );
                 }
                 break 'brk_sink sink;
@@ -1591,12 +1583,7 @@ impl BlobExt for Blob {
         assignment_result.ensure_still_alive();
 
         if let Some(err) = assignment_result.to_error() {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
         }
 
         if !assignment_result.is_empty_or_undefined_or_null() {
@@ -1637,20 +1624,16 @@ impl BlobExt for Blob {
                     jsc::js_promise::Status::Rejected => {
                         readable_stream.cancel(global_this)?;
                         promise.set_handled(global_this.vm());
-                        return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                        return Ok(JSPromise::rejected_promise(
                             global_this,
                             promise.result(global_this.vm()),
-                        ));
+                        )
+                        .to_js());
                     }
                 }
             } else {
                 readable_stream.cancel(global_this)?;
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        assignment_result,
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(global_this, assignment_result).to_js());
             }
         }
         let written = file_sink.stream_bytes.get().unwrap_or(0);
@@ -4208,7 +4191,7 @@ pub trait MkdirpTarget {
 // ──────────────────────────────────────────────────────────────────────────
 
 fn body_used_rejection(global: &JSGlobalObject) -> JSValue {
-    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+    JSPromise::rejected_promise(
         global,
         global
             .err(
@@ -4217,6 +4200,7 @@ fn body_used_rejection(global: &JSGlobalObject) -> JSValue {
             )
             .to_js(),
     )
+    .to_js()
 }
 
 #[derive(Default, Clone, Copy)]
@@ -4341,12 +4325,7 @@ fn write_file_with_empty_source_to_destination(
                 }
 
                 *err = sys_error_with_path_like(err, &file.pathlike);
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        ctx,
-                        err.to_js(ctx),
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(ctx, err.to_js(ctx)).to_js());
             }
         }
         store::Data::S3(s3) => {
@@ -4354,12 +4333,7 @@ fn write_file_with_empty_source_to_destination(
             let aws_options = match s3.get_credentials_with_options(options.extra_options, ctx) {
                 Ok(o) => o,
                 Err(err) => {
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            ctx,
-                            ctx.take_exception(err),
-                        ),
-                    );
+                    return Ok(JSPromise::rejected_promise_with_caught_exception(ctx, err)?.to_js());
                 }
             };
 
@@ -4538,14 +4512,11 @@ pub(crate) fn write_file_with_source_destination(
         )? {
             return destination_blob.pipe_readable_stream_to_blob(ctx, stream, options);
         } else {
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    ctx,
-                    ctx.create_error_instance(format_args!(
-                        "Failed to stream bytes from s3 bucket"
-                    )),
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(
+                ctx,
+                ctx.create_error_instance(format_args!("Failed to stream bytes from s3 bucket")),
+            )
+            .to_js());
         }
     } else if destination_type == store::DataTag::Bytes && source_type == store::DataTag::Bytes {
         // If this is bytes <> bytes, we can just duplicate it
@@ -4568,12 +4539,7 @@ pub(crate) fn write_file_with_source_destination(
         let aws_options = match s3.get_credentials_with_options(options.extra_options, ctx) {
             Ok(o) => o,
             Err(err) => {
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        ctx,
-                        ctx.take_exception(err),
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise_with_caught_exception(ctx, err)?.to_js());
             }
         };
         let proxy_owned = http_proxy_href(ctx);
@@ -4610,10 +4576,13 @@ pub(crate) fn write_file_with_source_destination(
                             core::ptr::null_mut(),
                         );
                     } else {
-                        return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                        return Ok(JSPromise::rejected_promise(
                             ctx,
-                            ctx.create_error_instance(format_args!("Failed to stream bytes to s3 bucket")),
-                        ));
+                            ctx.create_error_instance(format_args!(
+                                "Failed to stream bytes to s3 bucket"
+                            )),
+                        )
+                        .to_js());
                     }
                 } else {
                     struct Wrapper {
@@ -4706,14 +4675,13 @@ pub(crate) fn write_file_with_source_destination(
                         core::ptr::null_mut(),
                     );
                 } else {
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            ctx,
-                            ctx.create_error_instance(format_args!(
-                                "Failed to stream bytes to s3 bucket"
-                            )),
-                        ),
-                    );
+                    return Ok(JSPromise::rejected_promise(
+                        ctx,
+                        ctx.create_error_instance(format_args!(
+                            "Failed to stream bytes to s3 bucket"
+                        )),
+                    )
+                    .to_js());
                 }
             }
         }
@@ -4939,10 +4907,7 @@ pub(crate) fn write_file_internal(
                     // borrow of the body value is live.
                     let _ = unsafe { (*body_value).use_() };
                     Ok(ControlFlow::Break(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err_js,
-                        ),
+                        JSPromise::rejected_promise(global_this, err_js).to_js(),
                     ))
                 }
                 BodyTag::Locked => {
@@ -5048,10 +5013,7 @@ pub(crate) fn write_file_internal(
                                 // live borrow of the value.
                                 let _ = unsafe { (*body_value).use_() };
                                 return Ok(ControlFlow::Break(
-                                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                        global_this,
-                                        err_js,
-                                    ),
+                                    JSPromise::rejected_promise(global_this, err_js).to_js(),
                                 ));
                             }
                             // SAFETY: the match borrow ended with the pattern; no other borrow is live.
@@ -5281,10 +5243,11 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
                     *needs_async = true;
                     return JSValue::ZERO;
                 }
-                return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                return JSPromise::rejected_promise(
                     global_this,
                     err.with_path(pathlike.path().slice()).to_js(global_this),
-                );
+                )
+                .to_js();
             }
         }
     };
@@ -5329,10 +5292,7 @@ fn write_string_to_file_fast<const NEEDS_OPEN: bool>(
                     } else {
                         err.with_path(pathlike.path().slice()).to_js(global_this)
                     };
-                    return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        err_js,
-                    );
+                    return JSPromise::rejected_promise(global_this, err_js).to_js();
                 }
             }
         }
@@ -5369,10 +5329,11 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
                     *_needs_async = true;
                     return JSValue::ZERO;
                 }
-                return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                return JSPromise::rejected_promise(
                     global_this,
                     err.with_path(pathlike.path().slice()).to_js(global_this),
-                );
+                )
+                .to_js();
             }
         }
     };
@@ -5404,10 +5365,7 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
                 } else {
                     err.with_path(pathlike.path().slice()).to_js(global_this)
                 };
-                return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err_js,
-                );
+                return JSPromise::rejected_promise(global_this, err_js).to_js();
             }
         }
     }

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -936,12 +936,7 @@ impl ByteStream {
                 b.clear();
                 b.shrink_to_fit();
             });
-            return Ok(
-                jsc::JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err_js,
-                ),
-            );
+            return Ok(jsc::JSPromise::rejected_promise(global_this, err_js).to_js());
         }
 
         if let Some(blob_) = self.to_any_blob() {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -163,10 +163,7 @@ fn data_url_response(url: BunString, global_this: &JSGlobalObject) -> JSValue {
             None => {
                 let err =
                     global_this.create_error_instance(format_args!("failed to fetch the data URL"));
-                return JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                );
+                return JSPromise::rejected_promise(global_this, err).to_js();
             }
         }
     };
@@ -337,7 +334,7 @@ fn reject_on_exception(
             }
         },
     };
-    Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(global_this, err))
+    Ok(JSPromise::rejected_promise(global_this, err).to_js())
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -375,12 +372,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::MISSING_ARGS,
             format_args!("fetch() expects a string but received no arguments."),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     let mut headers: Option<Headers> = None;
@@ -514,12 +506,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::INVALID_URL,
             format_args!("fetch() URL must not be a blank string."),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     if url_str.starts_with_ascii(b"data:") {
@@ -536,12 +523,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 jsc::ErrorCode::INVALID_URL,
                 format_args!("fetch() URL is invalid"),
             );
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
         }
     };
     let mut url_proxy_buffer = owned_url.into_href().into_vec();
@@ -873,11 +855,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                 jsc::ErrorCode::INVALID_ARG_VALUE,
                                 format_args!("fetch() proxy URL is invalid"),
                             );
-                            return Ok(
-                                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                    global_this, err,
-                                ),
-                            );
+                            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
                         }
                         let mut buffer: Vec<u8> = Vec::with_capacity(url_proxy_buffer.len());
                         buffer.extend_from_slice(&url_proxy_buffer);
@@ -909,9 +887,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                         format_args!("fetch() proxy URL is invalid"),
                                     );
                                     return Ok(
-                                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                                            global_this, err,
-                                        ),
+                                        JSPromise::rejected_promise(global_this, err).to_js(),
                                     );
                                 }
                                 let mut buffer: Vec<u8> =
@@ -979,12 +955,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     jsc::ErrorCode::INVALID_ARG_TYPE,
                     format_args!("signal is not of type AbortSignal."),
                 );
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        err,
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(global_this, err).to_js());
             }
         }
 
@@ -1007,12 +978,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     jsc::ErrorCode::INVALID_ARG_TYPE,
                     format_args!("signal is not of type AbortSignal."),
                 );
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        err,
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(global_this, err).to_js());
             }
         }
 
@@ -1214,12 +1180,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::INVALID_ARG_VALUE,
             format_args!("fetch() cannot use a proxy with a unix socket."),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     // This is not 100% correct.
@@ -1268,12 +1229,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             bstr::BStr::new(url_path_decoded)
                         ),
                     );
-                    return Ok(
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err,
-                        ),
-                    );
+                    return Ok(JSPromise::rejected_promise(global_this, err).to_js());
                 }
             }
 
@@ -1382,12 +1338,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 jsc::ErrorCode::INVALID_ARG_VALUE,
                 format_args!("protocol must be http:, https: or s3:"),
             );
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    err,
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
         }
     }
 
@@ -1399,12 +1350,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             jsc::ErrorCode::INVALID_ARG_VALUE,
             format_args!("fetch() request with GET/HEAD method cannot have body."),
         );
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
+        return Ok(JSPromise::rejected_promise(global_this, err).to_js());
     }
 
     // Fetch spec step 11: reject synchronously for a pre-aborted signal. Runs
@@ -1419,12 +1365,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 }
             }
             body.detach();
-            return Ok(
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    reason,
-                ),
-            );
+            return Ok(JSPromise::rejected_promise(global_this, reason).to_js());
         }
     }
 
@@ -1462,11 +1403,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 old.detach();
                 break 'prepare_body;
             }
-            let rejected_value =
-                JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                    global_this,
-                    global_this.create_error_instance(format_args!("Failed to start s3 stream")),
-                );
+            let rejected_value = JSPromise::rejected_promise(
+                global_this,
+                global_this.create_error_instance(format_args!("Failed to start s3 stream")),
+            )
+            .to_js();
             // HTTPRequestBody has no Drop impl, so a bare `drop(body)` would
             // leak the S3 Blob.Store ref.
             body.detach();
@@ -1498,11 +1439,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             let opened_fd = match opened_fd_res {
                 Err(err) => {
                     let err_js = err.to_js(global_this);
-                    let rejected_value =
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err_js,
-                        );
+                    let rejected_value = JSPromise::rejected_promise(global_this, err_js).to_js();
                     return Ok(rejected_value);
                 }
                 Ok(fd) => fd,
@@ -1594,10 +1531,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             match res {
                 Err(err) => {
                     let rejected_value =
-                        JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                            global_this,
-                            err.to_js(global_this),
-                        );
+                        JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js();
                     body.detach();
                     return Ok(rejected_value);
                 }
@@ -1686,14 +1620,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // `defer body.ReadableStream.deinit()` → Drop on `body` scope exit.
 
             if method != Method::PUT && method != Method::POST {
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        global_this.create_error_instance(format_args!(
-                            "Only POST and PUT do support body when using S3"
-                        )),
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(
+                    global_this,
+                    global_this.create_error_instance(format_args!(
+                        "Only POST and PUT do support body when using S3"
+                    )),
+                )
+                .to_js());
             }
             let promise = jsc::JSPromiseStrong::init(global_this);
             let promise_value = promise.value();
@@ -1767,12 +1700,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         ) {
             Ok(r) => r,
             Err(sign_err) => {
-                return Ok(
-                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                        global_this,
-                        s3::get_js_sign_error(sign_err.into(), global_this),
-                    ),
-                );
+                return Ok(JSPromise::rejected_promise(
+                    global_this,
+                    s3::get_js_sign_error(sign_err.into(), global_this),
+                )
+                .to_js());
             }
         };
         // `defer result.deinit()` → Drop.

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -887,7 +887,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                         format_args!("fetch() proxy URL is invalid"),
                                     );
                                     return Ok(
-                                        JSPromise::rejected_promise(global_this, err).to_js(),
+                                        JSPromise::rejected_promise(global_this, err).to_js()
                                     );
                                 }
                                 let mut buffer: Vec<u8> =

--- a/test/js/bun/http/bun-serve-fetch-invalid-args.test.ts
+++ b/test/js/bun/http/bun-serve-fetch-invalid-args.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("server.fetch should reject invalid argument types without crashing", async () => {
   using server = Bun.serve({
@@ -15,4 +16,127 @@ test("server.fetch should reject invalid argument types without crashing", async
   await expect(server.fetch(true)).rejects.toThrow("fetch() expects a string, but received Boolean");
   // @ts-expect-error
   await expect(server.fetch(1)).rejects.toThrow("fetch() expects a string, but received Number");
+});
+
+test("server.fetch rejects with the value thrown by the fetch handler", async () => {
+  const error = Object.assign(new Error("handler threw"), { code: "E_HANDLER" });
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      throw error;
+    },
+  });
+  await expect(server.fetch("/")).rejects.toBe(error);
+
+  using serverThrowingString = Bun.serve({
+    port: 0,
+    fetch() {
+      throw "not an error";
+    },
+  });
+  await expect(serverThrowingString.fetch("/")).rejects.toBe("not an error");
+});
+
+test("server.fetch rejects with an Error returned by the fetch handler", async () => {
+  const error = new RangeError("handler returned an error");
+  using server = Bun.serve({
+    port: 0,
+    fetch: (() => error) as any,
+  });
+  await expect(server.fetch("/")).rejects.toBe(error);
+});
+
+test("server.fetch rejects instead of throwing when the body cannot be converted", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("Hello World!");
+    },
+  });
+  const error = new Error("body getter threw");
+  const body: unknown[] = [];
+  Object.defineProperty(body, 0, {
+    get() {
+      throw error;
+    },
+  });
+  await expect(server.fetch("/", { body: body as any })).rejects.toBe(error);
+});
+
+// server.fetch() returns an already-rejected promise for all of these. Like any
+// other rejected promise, it has to be reported when nothing handles it.
+describe.concurrent("server.fetch early rejections are tracked", () => {
+  const respond = `fetch() { return new Response("Hello World!"); }`;
+
+  async function runChild(body: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", body],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.each([
+    ["no arguments", respond, `server.fetch()`, "fetch() expects a string but received no arguments"],
+    ["a blank URL", respond, `server.fetch("")`, "fetch() URL must not be a blank string"],
+    ["a non-string argument", respond, `server.fetch(1)`, "fetch() expects a string, but received Number"],
+    [
+      "a server without a fetch handler",
+      `routes: { "/": () => new Response("Hello World!") }`,
+      `server.fetch("/")`,
+      "fetch() requires the server to have a fetch handler",
+    ],
+    [
+      "a fetch handler that throws",
+      `fetch() { throw new Error("handler threw"); }`,
+      `server.fetch("/")`,
+      "handler threw",
+    ],
+    [
+      "a fetch handler that returns an Error",
+      `fetch() { return new RangeError("handler returned an error"); }`,
+      `server.fetch("/")`,
+      "handler returned an error",
+    ],
+    ["a fetch handler that returns undefined", `fetch() {}`, `server.fetch("/")`, "fetch() returned an empty value"],
+    [
+      "a body that cannot be converted",
+      respond,
+      `const body = []; Object.defineProperty(body, 0, { get() { throw new Error("body getter threw"); } }); server.fetch("/", { body })`,
+      "body getter threw",
+    ],
+  ])("%s is reported as an unhandled rejection", async (_, serveOptions, call, expected) => {
+    const { stderr, exitCode } = await runChild(`
+      using server = Bun.serve({ port: 0, ${serveOptions} });
+      ${call};
+    `);
+    expect(stderr).toContain(expected);
+    expect(exitCode).toBe(1);
+  });
+
+  test("the returned promise is the one passed to 'unhandledRejection'", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+      process.on("unhandledRejection", (reason, promise) => {
+        console.log(reason.message, promise === p);
+      });
+      using server = Bun.serve({ port: 0, fetch() { throw new Error("handler threw"); } });
+      const p = server.fetch("/");
+    `);
+    expect(stdout).toBe("handler threw true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a handled rejection is not reported", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+      using server = Bun.serve({ port: 0, ${respond} });
+      server.fetch().catch(e => console.log("caught:", e.message));
+    `);
+    expect(stdout).toBe("caught: fetch() expects a string but received no arguments.\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -234,8 +234,11 @@ test("missing file throws the expected error", async () => {
         proxy: "http://localhost:3000",
       });
       expect(Bun.peek.status(resp)).toBe("rejected");
-      expect(async () => await resp).toThrow("no such file or directory");
+      expect(resp).rejects.toThrow("no such file or directory");
     }
   });
+  // The rejection tracker keeps each promise alive until the end of the tick
+  // (a microtask is not enough), so yield one before forcing the collection.
+  await Bun.sleep(0);
   Bun.gc(true);
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1161,3 +1161,95 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     expect(f.name).toBe(filePath);
   });
 });
+
+// These writes fail before any I/O is scheduled, so the write returns a promise
+// that is already rejected. Those rejections must carry the error itself and be
+// reported the same way as the ones produced later by the async path.
+(isWindows ? describe : describe.concurrent)("Bun.write early rejections are tracked", () => {
+  // The endpoint is never contacted: the options are validated first.
+  const s3Options = {
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    bucket: "my_bucket",
+    endpoint: "http://127.0.0.1:1",
+  };
+  const invalidS3Options = { storageClass: "INVALID_VALUE" };
+  const invalidS3Message = "storageClass must be one of";
+
+  async function runChild(body) {
+    using dir = tempDir("bun-write-early-reject", { "file.txt": "x" });
+    const prelude = `
+      const fs = require("fs");
+      const dir = ${JSON.stringify(String(dir))};
+      const file = ${JSON.stringify(join(String(dir), "file.txt"))};
+      const s3file = new Bun.S3Client(${JSON.stringify(s3Options)}).file("key");
+      const invalidS3Options = ${JSON.stringify(invalidS3Options)};
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", prelude + body],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it.each([
+    ["a string written to a directory", `Bun.write(dir, "x")`, "EISDIR"],
+    ["a TypedArray written to a directory", `Bun.write(dir, new Uint8Array(4))`, "EISDIR"],
+    // Truncating a directory fails with EINVAL on Windows and EISDIR elsewhere.
+    ["an empty Blob written to a directory", `Bun.write(dir, new Blob([]))`, isWindows ? "EINVAL" : "EISDIR"],
+    // Windows reports these two as "UV_EBADF" (errno -4083), which the substring check also accepts.
+    ["a string written to a read-only file descriptor", `Bun.write(Bun.file(fs.openSync(file, "r")), "x")`, "EBADF"],
+    [
+      "a TypedArray written to a read-only file descriptor",
+      `Bun.write(Bun.file(fs.openSync(file, "r")), new Uint8Array(4))`,
+      "EBADF",
+    ],
+    ["BunFile.write() on a directory", `Bun.file(dir).write("x")`, "EISDIR"],
+    ["an S3 write with invalid options", `s3file.write("x", invalidS3Options)`, invalidS3Message],
+    [
+      "an S3 write of an empty Blob with invalid options",
+      `s3file.write(new Blob([]), invalidS3Options)`,
+      invalidS3Message,
+    ],
+  ])("%s is reported as an unhandled rejection", async (_, expression, expected) => {
+    const { stderr, exitCode } = await runChild(`${expression};`);
+    expect(stderr).toContain(expected);
+    expect(exitCode).toBe(1);
+  });
+
+  it.each([
+    ["a string", () => "x"],
+    ["an empty Blob", () => new Blob([])],
+  ])("an S3 write of %s with invalid options rejects with the validation error itself", async (_, data) => {
+    const promise = new Bun.S3Client(s3Options).file("key").write(data(), invalidS3Options);
+    await expect(promise).rejects.toBeInstanceOf(TypeError);
+    await expect(promise).rejects.toMatchObject({
+      code: "ERR_INVALID_ARG_TYPE",
+      message: expect.stringContaining(invalidS3Message),
+    });
+  });
+
+  it("the returned promise is the one passed to 'unhandledRejection'", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+      process.on("unhandledRejection", (reason, promise) => {
+        console.log(reason.code, promise === p);
+      });
+      const p = Bun.write(dir, "x");
+    `);
+    expect(stdout).toBe("EISDIR true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it("a handled rejection is not reported", async () => {
+    const { stdout, stderr, exitCode } = await runChild(`
+      Bun.write(dir, "x").catch(e => console.log("caught", e.code));
+    `);
+    expect(stdout).toBe("caught EISDIR\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -283,3 +283,47 @@ describe.concurrent("tsconfig paths wildcard with overlapping prefix/suffix", ()
     await run("xy*xy", "xy");
   });
 });
+
+// Bun.resolve() resolves synchronously and returns an already-settled promise.
+// A rejected one has to be reported like any other unhandled rejection.
+describe.concurrent("Bun.resolve() rejections are tracked", () => {
+  async function run(body: string) {
+    using dir = tempDir("bun-resolve-unhandled", {});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const dir = ${JSON.stringify(String(dir))};\n${body}`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("an unhandled rejection is reported", async () => {
+    const { stdout, stderr, exitCode } = await run(`Bun.resolve("./does-not-exist", dir);`);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Cannot find module './does-not-exist'");
+    expect(exitCode).toBe(1);
+  });
+
+  it("the returned promise is the one passed to 'unhandledRejection'", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      process.on("unhandledRejection", (reason, promise) => {
+        console.log(reason.code, promise === p);
+      });
+      const p = Bun.resolve("./does-not-exist", dir);
+    `);
+    expect(stdout).toBe("ERR_MODULE_NOT_FOUND true\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it("a handled rejection is not reported", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      Bun.resolve("./does-not-exist", dir).catch(e => console.log("caught", e.code));
+    `);
+    expect(stdout).toBe("caught ERR_MODULE_NOT_FOUND\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -749,3 +749,90 @@ test("my-test", () => {
     });
   }
 });
+
+// Native APIs that fail before scheduling any work return a promise that is
+// already rejected. A test that drops one of those on the floor has to fail,
+// exactly like it does for `Promise.reject()` in the same position.
+test("a test that leaves a natively pre-rejected promise unhandled fails", () => {
+  const cases: [name: string, setup: string, promise: string, message: string][] = [
+    [
+      "fetch with an already aborted signal",
+      ``,
+      `fetch("http://127.0.0.1:1/", { signal: AbortSignal.abort() })`,
+      "The operation was aborted",
+    ],
+    [
+      "fetch GET with a body",
+      ``,
+      `fetch("http://127.0.0.1:1/", { method: "GET", body: "x" })`,
+      "fetch() request with GET/HEAD method cannot have body",
+    ],
+    [
+      "fetch with a used Request body",
+      `const r = new Request("http://127.0.0.1:1/", { method: "POST", body: "x" }); await r.text();`,
+      `fetch(r)`,
+      "Request body already used",
+    ],
+    ["fetch with an invalid url", ``, `fetch("http://[bad")`, "fetch() URL is invalid"],
+    ["Bun.write to a directory", ``, `Bun.write(dir, "x")`, "EISDIR"],
+    [
+      "Bun.write of a used Response",
+      `const r = new Response("x"); await r.text();`,
+      `Bun.write(join(dir, "out.txt"), r)`,
+      "Body already used",
+    ],
+    ["BunFile.write on a directory", ``, `Bun.file(dir).write("x")`, "EISDIR"],
+    [
+      "Bun.resolve of a missing package",
+      ``,
+      `Bun.resolve("no-such-pkg-zz", dir)`,
+      "Cannot find package 'no-such-pkg-zz'",
+    ],
+    [
+      "S3 write with an invalid option",
+      `const s3 = new Bun.S3Client({ accessKeyId: "a", secretAccessKey: "b", bucket: "bk", endpoint: "http://127.0.0.1:1" });`,
+      `s3.file("k").write("d", { acl: "bogus" })`,
+      "acl must be one of",
+    ],
+    [
+      "server.fetch without arguments",
+      `using server = Bun.serve({ port: 0, fetch: () => new Response("x") });`,
+      `server.fetch()`,
+      "fetch() expects a string but received no arguments",
+    ],
+  ];
+  // The test bodies never attach a handler. They only keep the test alive until
+  // the promise has settled (immediately, everywhere but the Windows write
+  // path), so the rejection cannot land after the runner moved on.
+  const code = [
+    `import { test } from "bun:test";`,
+    `import { join } from "node:path";`,
+    `const dir = import.meta.dir;`,
+    `async function settled(promise) { while (Bun.peek.status(promise) === "pending") await Bun.sleep(1); }`,
+    ...cases.map(
+      ([name, setup, promise]) => `test(${JSON.stringify(name)}, async () => { ${setup} await settled(${promise}); });`,
+    ),
+  ].join("\n");
+
+  using test_dir = tempDir("unhandled-native-rejection", {
+    "native.test.ts": code,
+    "package.json": "{}",
+  });
+
+  const { stderr, exitCode } = spawnSync({
+    cmd: [bunExe(), "test", "./native.test.ts"],
+    cwd: String(test_dir),
+    stdout: "ignore",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const output = stderr.toString();
+
+  for (const [name, , , message] of cases) {
+    expect(output).toContain(message);
+    expect(output).toContain(`(fail) ${name}`);
+  }
+  expect(output).toContain("\n 0 pass");
+  expect(output).toContain(`\n ${cases.length} fail`);
+  expect(exitCode).toBe(1);
+});

--- a/test/js/web/fetch/fetch-args.test.ts
+++ b/test/js/web/fetch/fetch-args.test.ts
@@ -1,5 +1,7 @@
 import { TCPSocketListener } from "bun";
 import { afterAll, beforeAll, describe, expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 let server;
 let requestCount = 0;
@@ -136,6 +138,130 @@ describe("fetch() rejects instead of throwing synchronously when option conversi
         } as any),
       `${name}-BOOM`,
     );
+  });
+});
+
+// Every early exit in fetch() (bad arguments, unsupported scheme, unresolvable
+// blob:, pre-aborted signal, unreadable Bun.file() body, ...) returns an already
+// rejected promise. Those promises used to be created without notifying the VM,
+// so when nothing handled them the process printed nothing and exited 0.
+describe.concurrent("fetch() early rejections are reported when unhandled", () => {
+  async function runUnhandled(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const cases: [name: string, code: string, expectedStderr: string][] = [
+    ["no arguments", `fetch()`, "fetch() expects a string but received no arguments"],
+    ["blank url", `fetch("")`, "fetch() URL must not be a blank string"],
+    ["invalid url", `fetch("not a url")`, "fetch() URL is invalid"],
+    ["unsupported protocol", `fetch("gopher://example.com/")`, "protocol must be http:, https: or s3:"],
+    [
+      "revoked blob: url",
+      `const url = URL.createObjectURL(new Blob(["x"])); URL.revokeObjectURL(url); fetch(url);`,
+      "Failed to resolve blob:",
+    ],
+    ["data: url without a comma", `fetch("data:text/plain")`, "failed to fetch the data URL"],
+    ["data: url with invalid base64", `fetch("data:text/plain;base64,@@@")`, "failed to fetch the data URL"],
+    ["url toString() throws", `fetch({ toString() { throw new Error("UBOOM"); } })`, "UBOOM"],
+    [
+      "GET with a body",
+      `fetch("http://127.0.0.1:1/", { body: "x" })`,
+      "fetch() request with GET/HEAD method cannot have body",
+    ],
+    [
+      "proxy combined with unix",
+      `fetch("http://127.0.0.1:1/", { proxy: "http://127.0.0.1:1/", unix: "/tmp/fetch-args.sock" })`,
+      "fetch() cannot use a proxy with a unix socket",
+    ],
+    ["invalid proxy url", `fetch("http://127.0.0.1:1/", { proxy: "not a url" })`, "fetch() proxy URL is invalid"],
+    [
+      "invalid proxy.url",
+      `fetch("http://127.0.0.1:1/", { proxy: { url: "not a url" } })`,
+      "fetch() proxy URL is invalid",
+    ],
+    [
+      "init.signal is not an AbortSignal",
+      `fetch("http://127.0.0.1:1/", { signal: 1 })`,
+      "signal is not of type AbortSignal",
+    ],
+    [
+      "input.signal is not an AbortSignal",
+      `fetch({ url: "http://127.0.0.1:1/", signal: 1 })`,
+      "signal is not of type AbortSignal",
+    ],
+    [
+      "already aborted signal",
+      `fetch("http://127.0.0.1:1/", { signal: AbortSignal.abort() })`,
+      "The operation was aborted",
+    ],
+    [
+      "s3: request signing fails",
+      `fetch("s3://bucket/key", { method: "PATCH", s3: { accessKeyId: "a", secretAccessKey: "b" } })`,
+      "Method must be GET, PUT, DELETE or HEAD when using s3:// protocol",
+    ],
+    [
+      "s3: ReadableStream body with a non-upload method",
+      `fetch("s3://bucket/key", { method: "DELETE", body: new ReadableStream() })`,
+      "Only POST and PUT do support body when using S3",
+    ],
+  ];
+
+  test.each(cases)("%s", async (_name, code, expectedStderr) => {
+    const { stderr, exitCode } = await runUnhandled(code);
+    expect(stderr).toContain(expectedStderr);
+    expect(exitCode).toBe(1);
+  });
+
+  test("Bun.file() body that does not exist", async () => {
+    using dir = tempDir("fetch-unhandled-body", {});
+    const missing = JSON.stringify(join(String(dir), "missing.bin"));
+    const { stderr, exitCode } = await runUnhandled(
+      `fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(${missing}) })`,
+    );
+    expect(stderr).toContain("ENOENT");
+    expect(exitCode).toBe(1);
+  });
+
+  test("Bun.file() body that is a directory", async () => {
+    using dir = tempDir("fetch-unhandled-body", {});
+    const directory = JSON.stringify(String(dir));
+    const { stderr, exitCode } = await runUnhandled(
+      `fetch("http://127.0.0.1:1/", { method: "POST", body: Bun.file(${directory}) })`,
+    );
+    expect(stderr).toContain("EISDIR");
+    expect(exitCode).toBe(1);
+  });
+
+  test("the rejection is delivered to process.on('unhandledRejection')", async () => {
+    const { stdout, stderr, exitCode } = await runUnhandled(`
+      process.on("unhandledRejection", (reason, promise) => {
+        console.log(promise === returned, reason.code, reason.message);
+      });
+      const returned = fetch("gopher://example.com/");
+    `);
+    expect(stdout).toBe("true ERR_INVALID_ARG_VALUE protocol must be http:, https: or s3:\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  // Before the rejection was registered, handling it still reached the tracker's
+  // "handled" side, which emitted a spurious rejectionHandled event.
+  test("a rejection that is handled is not reported", async () => {
+    const { stdout, stderr, exitCode } = await runUnhandled(`
+      process.on("unhandledRejection", () => console.log("unhandledRejection fired"));
+      process.on("rejectionHandled", () => console.log("rejectionHandled fired"));
+      fetch("gopher://example.com/").catch(err => console.log("caught:", err.message));
+    `);
+    expect(stdout).toBe("caught: protocol must be http:, https: or s3:\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem
- Native APIs that fail before they schedule any work return an already rejected promise: `fetch()` argument errors and pre-aborted signals, the `Bun.write()` / `BunFile.write()` fast paths, `server.fetch()`, `Bun.resolve()`, S3 option validation. That promise came from `JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm` (`JSC__JSPromise__rejectedPromiseValue` in `src/jsc/bindings/bindings.cpp`), which sets the rejected flag and the result slot directly and never calls `promiseRejectionTracker`.
- An unhandled one was invisible. No `unhandledRejection` event, `bun -e 'fetch("http://[bad")'` exits 0, and in `bun test` a test that drops the promise passes while `Promise.reject()` in the same position fails it (10 pass, 0 fail for the file in the new test).
- Six of the sites rejected with the `JSC::Exception` cell from `take_exception()`, so `.catch()` got a value with no `message` and no `code` (S3 `acl` / `storageClass` validation, `Bun.resolve()`, a throwing `server.fetch()` handler). `server.fetch()` with a body that cannot be converted threw synchronously instead of rejecting.

### Fix
- Build all 51 sites with `JSPromise::rejected_promise(global, err).to_js()`. It goes through `JSC::JSPromise::rejectedPromise` and the tracker, like `Promise.reject()`. The helper and `JSC__JSPromise__rejectedPromiseValue` are deleted so the pattern cannot come back.
- The caught-exception sites use the new `JSPromise::rejected_promise_with_caught_exception(global, err)`: `create()` plus the existing `reject(global, Err(err))`, which takes the exception off the VM, rejects with the thrown value, and propagates a termination instead of recording it.
- Supersedes #37434 and #37474, which were this change split in two and now conflict with main. Their tests are carried over unchanged.
- Verified: `test/js/bun/test/test-test.test.ts` ("natively pre-rejected"), `test/js/web/fetch/fetch-args.test.ts`, `test/js/bun/http/bun-serve-fetch-invalid-args.test.ts`, `test/js/bun/io/bun-write.test.js`, `test/js/bun/resolve/resolve-error.test.ts`. On 1.4.2 they fail 1, 21, 10, 11 and 2 tests.

### Background
- JSC reports rejections through `globalObjectMethodTable()->promiseRejectionTracker`, which `JSPromise::rejectPromise` calls when the promise is not marked handled. Bun queues the promise there and, once the microtask queue drains, reports the ones still unhandled: the `unhandledRejection` event, exit code 1, or a failed test in `bun test`.
- A handler attached before that checkpoint (`await`, `.catch()`, `expect(p).rejects`) marks the promise handled, so code that handles these rejections sees no change. The async paths of the same calls already behaved this way.
- #18549 renamed the helper to `dangerously...WithoutNotifyingVM` and deprecated it in favor of `rejectedPromise`. The remaining callers were never converted.

<details><summary>Notes</summary>

- `JSC::JSPromise::reject(VM&, JSValue)` asserts the reason is not a `JSC::Exception`. That is why the `take_exception()` sites could not be converted one-to-one and go through `rejected_promise_with_caught_exception` (or `to_error()`, which unwraps an `Exception` to its value) instead.
- `JSPromise::wrap_value` (used by `formData()`) had the same helper on its error branch and now uses `rejected_promise` too.
- `fetch-file-upload.test.ts` "missing file throws the expected error" creates 1000 rejected `fetch()` promises and asserted on each with `expect(async () => await resp).toThrow()`. With the promises registered, the first `toThrow()` reported the other 999 as unhandled, as it would for plain `Promise.reject()`. It now uses `expect(resp).rejects.toThrow()` and yields one event loop turn before the final `Bun.gc(true)`, because the tracker keeps the promises alive until the end of the tick.
- Native consumers of these promises were checked: they return the value to JS, resolve another promise with it (`Image.rs`), or unwrap it with `PromiseUnwrapMode::MarkHandled` (`blob/write_file.rs`, `pipe_readable_stream_to_blob`), so none of them produces a spurious report.
- `subprocess.exited` read after a `waitpid` failure and `text()`/`json()` on an already failed native stream were converted as well. The first now matches the promise created while the process was still running; the second is not observable because the C++ fast path chains a reaction onto it.

</details>
