### PR TITLE
upgrade: unpack and run the new binary through the staging directory fd

### DIFF
--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -756,8 +756,7 @@ impl UpgradeCommand {
                 };
             let save_dir: sys::Dir = save_dir_it;
 
-            // `mkdirat` made it 0700 and ours; anything else was renamed over
-            // the name by another user of $TMPDIR before the open.
+            // `mkdirat` made it ours and 0700; anything else was swapped in by another $TMPDIR user.
             #[cfg(unix)]
             {
                 let staging = match sys::fstat(save_dir.fd()) {
@@ -789,8 +788,7 @@ impl UpgradeCommand {
                 }
             }
 
-            // The children below inherit this cwd. Never hand them the path:
-            // another user of $TMPDIR can rename a different directory onto it.
+            // The children inherit this cwd; a path would re-resolve to whatever now sits at the name.
             if let Err(err) = sys::fchdir(save_dir.fd()) {
                 let _ = save_dir_.delete_tree(&version_name);
                 Output::err_generic(

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -756,11 +756,8 @@ impl UpgradeCommand {
                 };
             let save_dir: sys::Dir = save_dir_it;
 
-            // The staging directory lives in $TMPDIR, which another user may own.
-            // `mkdirat` above gave it our uid and mode 0700, so a different owner
-            // or any group/other write bit means this is not the directory we
-            // created: someone renamed theirs over it, and they can write the
-            // files that get unpacked and executed below.
+            // `mkdirat` made it 0700 and ours; anything else was renamed over
+            // the name by another user of $TMPDIR before the open.
             #[cfg(unix)]
             {
                 let staging = match sys::fstat(save_dir.fd()) {
@@ -779,8 +776,7 @@ impl UpgradeCommand {
                 let ours = (staging.st_mode & libc::S_IFMT) == libc::S_IFDIR
                     && staging.st_uid == euid
                     && (staging.st_mode & (libc::S_IWGRP | libc::S_IWOTH)) == 0;
-                // The directory at this name belongs to someone else, so leave
-                // it alone instead of deleting it.
+                // Not ours, so not ours to delete either.
                 if !ours {
                     Output::err_generic(
                         "Refusing to unpack the upgrade: another user can write to the staging directory {} in {}.\n\nSet $TMPDIR to a directory that only you can write to, then run `bun upgrade` again.",
@@ -793,11 +789,8 @@ impl UpgradeCommand {
                 }
             }
 
-            // Enter the staging directory through its file descriptor, and give
-            // the child processes below no cwd of their own so they inherit it.
-            // A path resolved again after this point can name a different
-            // directory: whoever may rename entries in $TMPDIR can swap the
-            // staging directory for one they control.
+            // The children below inherit this cwd. Never hand them the path:
+            // another user of $TMPDIR can rename a different directory onto it.
             if let Err(err) = sys::fchdir(save_dir.fd()) {
                 let _ = save_dir_.delete_tree(&version_name);
                 Output::err_generic(
@@ -918,9 +911,7 @@ impl UpgradeCommand {
                 }
                 #[cfg(windows)]
                 {
-                    // Run a powershell script to unzip the file
-                    // Both paths are relative to the inherited cwd, which is the
-                    // staging directory this process entered by file descriptor.
+                    // Run a powershell script to unzip the file into the inherited cwd.
                     let mut unzip_script = Vec::new();
                     write!(
                         &mut unzip_script,

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -743,36 +743,69 @@ impl UpgradeCommand {
                 );
                 Global::exit(1);
             }
-            let save_dir_it = match save_dir_.open_at(&version_name) {
-                Ok(d) => d,
-                Err(err) => {
-                    Output::err_generic(
-                        "Failed to open temporary directory: {}",
-                        (bstr::BStr::new(err.name()),),
-                    );
-                    Global::exit(1);
-                }
-            };
+            let save_dir_it =
+                match save_dir_.open_at_with(&version_name, sys::O::NOFOLLOW | sys::O::CLOEXEC) {
+                    Ok(d) => d,
+                    Err(err) => {
+                        Output::err_generic(
+                            "Failed to open temporary directory: {}",
+                            (bstr::BStr::new(err.name()),),
+                        );
+                        Global::exit(1);
+                    }
+                };
             let save_dir: sys::Dir = save_dir_it;
 
-            // Reshaped for borrowck — use a stack-local PathBuffer instead of thread_local
-            let mut tmpdir_path_buf = bun_paths::path_buffer_pool::get();
-            let tmpdir_path = match sys::get_fd_path(save_dir.fd(), &mut tmpdir_path_buf) {
-                Ok(p) => p,
-                Err(err) => {
+            // The staging directory lives in $TMPDIR, which another user may own.
+            // `mkdirat` above gave it our uid and mode 0700, so a different owner
+            // or any group/other write bit means this is not the directory we
+            // created: someone renamed theirs over it, and they can write the
+            // files that get unpacked and executed below.
+            #[cfg(unix)]
+            {
+                let staging = match sys::fstat(save_dir.fd()) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        let _ = save_dir_.delete_tree(&version_name);
+                        Output::err_generic(
+                            "Failed to stat temporary directory: {}",
+                            (bstr::BStr::new(err.name()),),
+                        );
+                        Global::exit(1);
+                    }
+                };
+                // SAFETY: `geteuid` takes no arguments and cannot fail.
+                let euid = unsafe { libc::geteuid() };
+                let ours = (staging.st_mode & libc::S_IFMT) == libc::S_IFDIR
+                    && staging.st_uid == euid
+                    && (staging.st_mode & (libc::S_IWGRP | libc::S_IWOTH)) == 0;
+                // The directory at this name belongs to someone else, so leave
+                // it alone instead of deleting it.
+                if !ours {
                     Output::err_generic(
-                        "Failed to read temporary directory: {}",
-                        (bstr::BStr::new(err.name()),),
+                        "Refusing to unpack the upgrade: another user can write to the staging directory {} in {}.\n\nSet $TMPDIR to a directory that only you can write to, then run `bun upgrade` again.",
+                        (
+                            bstr::BStr::new(&version_name),
+                            bstr::BStr::new(fs::RealFS::tmpdir_path()),
+                        ),
                     );
                     Global::exit(1);
                 }
-            };
+            }
 
-            let tmpdir_path_len = tmpdir_path.len();
-            tmpdir_path_buf[tmpdir_path_len] = 0;
-            // SAFETY: buf[tmpdir_path_len] == 0 written above
-            let tmpdir_z = ZStr::from_buf(&tmpdir_path_buf[..], tmpdir_path_len);
-            let _ = sys::chdir(tmpdir_z);
+            // Enter the staging directory through its file descriptor, and give
+            // the child processes below no cwd of their own so they inherit it.
+            // A path resolved again after this point can name a different
+            // directory: whoever may rename entries in $TMPDIR can swap the
+            // staging directory for one they control.
+            if let Err(err) = sys::fchdir(save_dir.fd()) {
+                let _ = save_dir_.delete_tree(&version_name);
+                Output::err_generic(
+                    "Failed to enter temporary directory: {}",
+                    (bstr::BStr::new(err.name()),),
+                );
+                Global::exit(1);
+            }
 
             // SAFETY: literal ends with NUL.
             let tmpname: &ZStr = ZStr::from_static(b"bun.zip\0");
@@ -840,7 +873,6 @@ impl UpgradeCommand {
                     let unzip_result = match spawn_sync::spawn(&spawn_sync::Options {
                         argv: build_argv(&unzip_argv),
                         envp: None,
-                        cwd: Box::<[u8]>::from(&tmpdir_path_buf[..tmpdir_path_len]),
                         stdin: spawn_sync::SyncStdio::Inherit,
                         stdout: spawn_sync::SyncStdio::Inherit,
                         stderr: spawn_sync::SyncStdio::Inherit,
@@ -887,12 +919,13 @@ impl UpgradeCommand {
                 #[cfg(windows)]
                 {
                     // Run a powershell script to unzip the file
+                    // Both paths are relative to the inherited cwd, which is the
+                    // staging directory this process entered by file descriptor.
                     let mut unzip_script = Vec::new();
                     write!(
                         &mut unzip_script,
-                        "$global:ProgressPreference='SilentlyContinue';Expand-Archive -Path \"{}\" \"{}\" -Force",
+                        "$global:ProgressPreference='SilentlyContinue';Expand-Archive -Path \"{}\" \".\" -Force",
                         bun_fmt::escape_powershell(bstr::BStr::new(tmpname.as_bytes())),
-                        bun_fmt::escape_powershell(bstr::BStr::new(&tmpdir_path_buf[..tmpdir_path_len])),
                     )
                     .expect("oom");
 
@@ -943,7 +976,6 @@ impl UpgradeCommand {
                     let spawn_res = spawn_sync::spawn(&spawn_sync::Options {
                         argv: build_argv(&unzip_argv),
                         envp: None,
-                        cwd: Box::<[u8]>::from(&tmpdir_path_buf[..tmpdir_path_len]),
                         stderr: spawn_sync::SyncStdio::Inherit,
                         stdout: spawn_sync::SyncStdio::Inherit,
                         stdin: spawn_sync::SyncStdio::Inherit,
@@ -988,7 +1020,6 @@ impl UpgradeCommand {
                     let spawned = spawn_sync::spawn(&spawn_sync::Options {
                         argv: build_argv(&verify_argv),
                         envp: None,
-                        cwd: Box::<[u8]>::from(&tmpdir_path_buf[..tmpdir_path_len]),
                         stdout: spawn_sync::SyncStdio::Buffer,
                         stderr: spawn_sync::SyncStdio::Ignore,
                         stdin: spawn_sync::SyncStdio::Ignore,

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -391,37 +391,39 @@ it("verifies the downloaded release archive against the digest reported by the r
   expect(matched.exitCode).toBe(1);
 });
 
-it.skipIf(isWindows)("runs the unpacked release from the staging directory it created, not from a re-resolved path", async () => {
-  const folder = releaseFolderName();
-  // The version each binary reports. Both differ from the served tag, so the
-  // upgrade stops at the version check: it neither replaces this build nor
-  // runs `bun completions`.
-  const unpackedVersion = "6.6.6";
-  const lookAlikeVersion = "7.7.7";
+it.skipIf(isWindows)(
+  "runs the unpacked release from the staging directory it created, not from a re-resolved path",
+  async () => {
+    const folder = releaseFolderName();
+    // The version each binary reports. Both differ from the served tag, so the
+    // upgrade stops at the version check: it neither replaces this build nor
+    // runs `bun completions`.
+    const unpackedVersion = "6.6.6";
+    const lookAlikeVersion = "7.7.7";
 
-  // $TMPDIR for the upgrade. Another user of this directory may rename the
-  // entries in it, so the path of the staging directory is not stable.
-  using tmpRoot = tempDir("bun-upgrade-hostile-tmpdir", {});
-  const tmpRootPath = String(tmpRoot);
-  const ranMarker = join(tmpRootPath, "look-alike-ran.txt");
+    // $TMPDIR for the upgrade. Another user of this directory may rename the
+    // entries in it, so the path of the staging directory is not stable.
+    using tmpRoot = tempDir("bun-upgrade-hostile-tmpdir", {});
+    const tmpRootPath = String(tmpRoot);
+    const ranMarker = join(tmpRootPath, "look-alike-ran.txt");
 
-  // A look-alike staging directory, ready to be renamed into place.
-  await mkdir(join(tmpRootPath, "look-alike", folder), { recursive: true });
-  await writeFile(
-    join(tmpRootPath, "look-alike", folder, "bun"),
-    `#!/bin/sh\nprintf 'ran\\n' > '${ranMarker}'\nprintf '%s\\n' '${lookAlikeVersion}'\n`,
-    { mode: 0o755 },
-  );
+    // A look-alike staging directory, ready to be renamed into place.
+    await mkdir(join(tmpRootPath, "look-alike", folder), { recursive: true });
+    await writeFile(
+      join(tmpRootPath, "look-alike", folder, "bun"),
+      `#!/bin/sh\nprintf 'ran\\n' > '${ranMarker}'\nprintf '%s\\n' '${lookAlikeVersion}'\n`,
+      { mode: 0o755 },
+    );
 
-  // `bun upgrade` looks up `unzip` in PATH and runs it in the staging
-  // directory. This stand-in writes what the real unzip would produce, then
-  // renames the staging directory away and puts the look-alike at the path
-  // that bun created.
-  const binDir = join(tmpRootPath, "bin");
-  await mkdir(binDir, { recursive: true });
-  await writeFile(
-    join(binDir, "unzip"),
-    `#!/bin/sh
+    // `bun upgrade` looks up `unzip` in PATH and runs it in the staging
+    // directory. This stand-in writes what the real unzip would produce, then
+    // renames the staging directory away and puts the look-alike at the path
+    // that bun created.
+    const binDir = join(tmpRootPath, "bin");
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      join(binDir, "unzip"),
+      `#!/bin/sh
 set -e
 staging=$(pwd -P)
 parent=$(dirname "$staging")
@@ -434,31 +436,32 @@ chmod 755 '${folder}/bun'
 mv "$staging" "$parent/renamed-away"
 mv "$parent/look-alike" "$staging"
 `,
-    { mode: 0o755 },
-  );
+      { mode: 0o755 },
+    );
 
-  using server = startReleaseServer({ tagName: "bun-v9.9.9" });
+    using server = startReleaseServer({ tagName: "bun-v9.9.9" });
 
-  await using proc = Bun.spawn({
-    // --stable forces the GitHub-release code path even on a canary build.
-    cmd: [bunExe(), "upgrade", "--stable"],
-    cwd: tmpdirSync(),
-    stdout: null,
-    stdin: "pipe",
-    stderr: "pipe",
-    env: {
-      ...server.env,
-      BUN_TMPDIR: tmpRootPath,
-      PATH: `${binDir}:${server.env.PATH}`,
-    },
-  });
+    await using proc = Bun.spawn({
+      // --stable forces the GitHub-release code path even on a canary build.
+      cmd: [bunExe(), "upgrade", "--stable"],
+      cwd: tmpdirSync(),
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...server.env,
+        BUN_TMPDIR: tmpRootPath,
+        PATH: `${binDir}:${server.env.PATH}`,
+      },
+    });
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  // bun must verify the binary it unpacked itself. The look-alike binary at
-  // the old path belongs to whoever renamed the directory.
-  expect(existsSync(ranMarker)).toBe(false);
-  // The reported version keeps the trailing newline the binary printed.
-  expect(stderr).toMatch(new RegExp(`The downloaded version of Bun \\(${unpackedVersion}\\s*\\) doesn't match`));
-  expect(exitCode).toBe(1);
-});
+    // bun must verify the binary it unpacked itself. The look-alike binary at
+    // the old path belongs to whoever renamed the directory.
+    expect(existsSync(ranMarker)).toBe(false);
+    // The reported version keeps the trailing newline the binary printed.
+    expect(stderr).toMatch(new RegExp(`The downloaded version of Bun \\(${unpackedVersion}\\s*\\) doesn't match`));
+    expect(exitCode).toBe(1);
+  },
+);

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -3,7 +3,7 @@ import { upgrade_test_helpers } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { bunExe, bunEnv as env, isMusl, isWindows, tempDir, tls, tmpdirSync } from "harness";
 import { existsSync, statSync } from "node:fs";
-import { copyFile, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import { basename, join } from "path";
 const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
 
@@ -98,15 +98,21 @@ function makeZipStored(entryName: string, data: Buffer, unixMode: number): Buffe
   return buf;
 }
 
+// The directory name inside the release archive for the current target. It is
+// also the directory `bun upgrade` runs the downloaded binary from.
+function releaseFolderName(): string {
+  const os = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux";
+  const arch = process.arch === "arm64" ? "aarch64" : "x64";
+  const abi = isMusl ? "-musl" : "";
+  return `bun-${os}-${arch}${abi}`;
+}
+
 // Write a release zip for the current target that, once unpacked, yields an
 // executable at the path `bun upgrade` verifies. On POSIX a shell script is
 // enough because `unzip` preserves the mode bits; on Windows the verify step
 // spawns `bun.exe` directly, so the archive has to carry a real PE image.
 async function writeFakeReleaseZip(outPath: string, version: string): Promise<void> {
-  const os = process.platform === "win32" ? "windows" : process.platform === "darwin" ? "darwin" : "linux";
-  const arch = process.arch === "arm64" ? "aarch64" : "x64";
-  const abi = isMusl ? "-musl" : "";
-  const folder = `bun-${os}-${arch}${abi}`;
+  const folder = releaseFolderName();
   if (isWindows) {
     const exe = Buffer.from(await Bun.file(bunExe()).arrayBuffer());
     await writeFile(outPath, makeZipStored(`${folder}/bun.exe`, exe, 0o755));
@@ -383,4 +389,76 @@ it("verifies the downloaded release archive against the digest reported by the r
   expect(matched.stderr).toContain("9.9.8");
   expect(matched.stderr).not.toContain("did not match the checksum reported by the GitHub API for this release");
   expect(matched.exitCode).toBe(1);
+});
+
+it.skipIf(isWindows)("runs the unpacked release from the staging directory it created, not from a re-resolved path", async () => {
+  const folder = releaseFolderName();
+  // The version each binary reports. Both differ from the served tag, so the
+  // upgrade stops at the version check: it neither replaces this build nor
+  // runs `bun completions`.
+  const unpackedVersion = "6.6.6";
+  const lookAlikeVersion = "7.7.7";
+
+  // $TMPDIR for the upgrade. Another user of this directory may rename the
+  // entries in it, so the path of the staging directory is not stable.
+  using tmpRoot = tempDir("bun-upgrade-hostile-tmpdir", {});
+  const tmpRootPath = String(tmpRoot);
+  const ranMarker = join(tmpRootPath, "look-alike-ran.txt");
+
+  // A look-alike staging directory, ready to be renamed into place.
+  await mkdir(join(tmpRootPath, "look-alike", folder), { recursive: true });
+  await writeFile(
+    join(tmpRootPath, "look-alike", folder, "bun"),
+    `#!/bin/sh\nprintf 'ran\\n' > '${ranMarker}'\nprintf '%s\\n' '${lookAlikeVersion}'\n`,
+    { mode: 0o755 },
+  );
+
+  // `bun upgrade` looks up `unzip` in PATH and runs it in the staging
+  // directory. This stand-in writes what the real unzip would produce, then
+  // renames the staging directory away and puts the look-alike at the path
+  // that bun created.
+  const binDir = join(tmpRootPath, "bin");
+  await mkdir(binDir, { recursive: true });
+  await writeFile(
+    join(binDir, "unzip"),
+    `#!/bin/sh
+set -e
+staging=$(pwd -P)
+parent=$(dirname "$staging")
+mkdir -p '${folder}'
+cat > '${folder}/bun' <<'SCRIPT'
+#!/bin/sh
+printf '%s\\n' '${unpackedVersion}'
+SCRIPT
+chmod 755 '${folder}/bun'
+mv "$staging" "$parent/renamed-away"
+mv "$parent/look-alike" "$staging"
+`,
+    { mode: 0o755 },
+  );
+
+  using server = startReleaseServer({ tagName: "bun-v9.9.9" });
+
+  await using proc = Bun.spawn({
+    // --stable forces the GitHub-release code path even on a canary build.
+    cmd: [bunExe(), "upgrade", "--stable"],
+    cwd: tmpdirSync(),
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...server.env,
+      BUN_TMPDIR: tmpRootPath,
+      PATH: `${binDir}:${server.env.PATH}`,
+    },
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // bun must verify the binary it unpacked itself. The look-alike binary at
+  // the old path belongs to whoever renamed the directory.
+  expect(existsSync(ranMarker)).toBe(false);
+  // The reported version keeps the trailing newline the binary printed.
+  expect(stderr).toMatch(new RegExp(`The downloaded version of Bun \\(${unpackedVersion}\\s*\\) doesn't match`));
+  expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
### Problem

- `bun upgrade` creates its staging directory in `$TMPDIR` with `mkdirat(tmpdir_fd, "<version>", 0700)` and opens it, but then hands both child processes the absolute path `$TMPDIR/<version>` as their working directory (`upgrade_command.rs:775` plus the three `spawn_sync::Options { cwd: .. }` sites). Nothing checks who owns `$TMPDIR`.
- A user who may rename entries in `$TMPDIR` (its owner, or any user when it is `0777` without the sticky bit) replaces the fresh directory with a look-alike between the create and the spawn. `unzip` then runs in their directory, and the verify step runs their `bun-<target>/bun`. The upgrading user is often root.
- `$TMPDIR` and `BUN_TMPDIR` come from the environment, so a shared CI scratch directory, `su` without `-`, or `sudo` with `env_keep` is enough to point the upgrade at a directory somebody else owns.

### Fix

- The command enters the staging directory with `fchdir` on the descriptor it opened, and the children get no `cwd` of their own, so they inherit it. No path is resolved a second time. An empty `cwd` adds no `chdir` file action on posix and passes `NULL` to libuv on Windows, which is how a child inherits the parent working directory.
- On unix the command stops unless the opened directory is a directory owned by the effective uid with no group or other write bit. `mkdirat` gives it our uid and mode `0700`, so anything else means the name now points somewhere else. This covers a rename that lands before the open, where the descriptor itself would be the attacker's directory.
- The open adds `O_NOFOLLOW | O_CLOEXEC`: a symlink at that name is an error instead of a target, and the descriptor no longer leaks into the children.
- Verified: `test/cli/install/bun-upgrade.test.ts` (9 pass on linux x64 debug, 8 pass and 1 posix-only skip on Windows x64 debug). The new test fails on released bun 1.4.2 and on canary 1.4.3.

### Background

- `bun upgrade` downloads the release archive into a fresh directory in `$TMPDIR`, runs `unzip` there, runs the unpacked binary once (`--version`, or `--revision` for canary) to verify it, and renames it over the running executable.
- A path is resolved again on every use. A descriptor names the directory itself. A rename changes what a path resolves to, and changes nothing about a descriptor that is already open. That difference is the whole fix.
- `mkdirat` and `openat` were already relative to the `$TMPDIR` descriptor. The two `posix_spawn` calls were the only steps that went back to a path, and they are the two steps that execute code.

<details><summary>Notes</summary>

How the test reproduces it without a race: `bun upgrade` looks up `unzip` in `PATH` and runs it in the staging directory. The test puts a stand-in `unzip` first on `PATH`. It writes what the real `unzip` would produce, then renames the staging directory away and renames a look-alike into its place. The look-alike reports a different version string and writes a marker file. With released bun the marker appears, which means bun executed a binary the test never staged. With this change the marker does not appear and the reported version is the one from the directory bun unpacked.

Both binaries report a version that differs from the served release tag, so the upgrade stops at the version check. It neither replaces the test runner's build nor runs `bun completions`, and the test needs no copy of the 700 MB debug binary.

The ownership check has no test. The window it closes is between `mkdirat` and the open, and a test cannot land a rename in that window deterministically, nor create a directory owned by a second uid without one. The check is cheap (one `fstat` on a descriptor that is already open) and it fails closed.

Residual behaviour, unchanged by this PR: on an error path the command still calls `delete_tree("<version>")` on the `$TMPDIR` descriptor, so after a swap it deletes whatever now sits at that name. `delete_tree` opens every level with `O_NOFOLLOW`, so it cannot be walked out of the directory it is given. The cleanup is skipped in the new ownership-failure branch, because that directory belongs to someone else.

Windows keeps the same shape. `sys::fchdir` resolves the handle with `GetFinalPathNameByHandle` and calls `SetCurrentDirectoryW`, which is what the old code did inline, except the result is now checked. The `Expand-Archive` destination becomes `"."`, relative to the inherited working directory, instead of the absolute path. The ownership check is unix-only, since ownership there is an ACL question and not a uid comparison.

The `fstat`, `fchdir` and ownership failures print an error and exit 1 instead of being ignored. The old `chdir` result was discarded (`let _ =`), which was harmless only because every child carried the absolute path.
</details>
