### PR TITLE
bundler: keep the CommonJS wrapper when a module touches exports.__proto__

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -462,7 +462,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if p.should_unwrap_common_js_to_esm() {
                         if !p.is_control_flow_dead && id.ref_.eql(p.exports_ref) {
                             if !p.commonjs_named_exports_deoptimized {
-                                if identifier_opts.is_delete_target() {
+                                // `exports.__proto__` is the prototype of `module.exports`, not an export.
+                                if identifier_opts.is_delete_target() || name == b"__proto__" {
                                     p.deoptimize_common_js_named_exports();
                                     return None;
                                 }
@@ -673,7 +674,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if p.should_unwrap_common_js_to_esm() {
                             if !p.is_control_flow_dead {
                                 if !p.commonjs_named_exports_deoptimized {
-                                    if identifier_opts.is_delete_target() {
+                                    if identifier_opts.is_delete_target() || name == b"__proto__" {
                                         p.deoptimize_common_js_named_exports();
                                         return None;
                                     }

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -2280,6 +2280,43 @@ describe("bundler", () => {
       stdout: "1 2 false",
     },
   });
+  // `exports.__proto__` is the prototype of `module.exports`, not an export
+  // named "__proto__". A lifted binding plus a namespace getter cannot stand in
+  // for it, so these files keep their `__commonJS` wrapper.
+  itBundled("cjs2esm/ExportsProtoMemberKeepsWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        import dot, * as dotNs from "./dot.cjs";
+        import bracket from "./bracket.cjs";
+        import viaModule from "./module.cjs";
+        import read, { c } from "./read.cjs";
+        const describe = m => [Object.keys(m), Object.hasOwn(m, "__proto__"), m.inherited, Object.getPrototypeOf(m).inherited];
+        console.log(JSON.stringify([describe(dot), describe(bracket), describe(viaModule), dotNs.a, dotNs.default === dot, read.isObjectPrototype, c]));
+      `,
+      "/dot.cjs": /* js */ `
+        exports.__proto__ = { inherited: 1 };
+        exports.a = 1;
+      `,
+      "/bracket.cjs": /* js */ `
+        exports.b = 2;
+        exports["__proto__"] = { inherited: 2 };
+      `,
+      "/module.cjs": /* js */ `
+        module.exports.c = 3;
+        module.exports.__proto__ = { inherited: 3 };
+      `,
+      "/read.cjs": /* js */ `
+        exports.c = 4;
+        exports.isObjectPrototype = exports.__proto__ === Object.prototype;
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/dot.cjs", "/bracket.cjs", "/module.cjs", "/read.cjs"],
+    },
+    run: {
+      stdout: JSON.stringify([[["a"], false, 1, 1], [["b"], false, 2, 2], [["c"], false, 3, 3], 1, true, true, 4]),
+    },
+  });
   // Module code makes a top-level function declaration lexical, so a `var`
   // with the same name is a SyntaxError there. A function body allows it, so
   // these files keep their `__commonJS` wrapper. In sloppy mode the bundler


### PR DESCRIPTION
### Problem
- `bun build` unwraps a CommonJS module to ESM bindings when an ES module imports it and the module only writes `exports.<name>`. `exports.__proto__ = v` was treated as an export named `__proto__`: it became `var $__proto__ = v` plus a getter in `__exportCjs(exports_lib, { __proto__: () => $__proto__ }, ...)`. In node that statement sets the prototype of `module.exports`. So `import lib from "./lib.cjs"; lib.inherited` is `undefined` in the bundle and `1` in node and in `bun run`.
- The cause is `maybe_rewrite_property_access` (`src/js_parser/fold.rs:462` for `exports.x`, `:673` for `module.exports.x`). It lifts every member name into a `CommonJSExportIdentifier`, `__proto__` included.

### Fix
- A read or write of `exports.__proto__` or `module.exports.__proto__` (dot or bracket form) deoptimizes the named-export unwrapping, the same way `delete exports.x` already does. The module keeps its `__commonJS` wrapper and the statement runs as written.
- Correct because the wrapper is the baseline CommonJS path: `module.exports` is a real object, so the `Object.prototype.__proto__` accessor behaves exactly as in node. esbuild never unwraps and matches node here too.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (`cjs2esm/ExportsProtoMemberKeepsWrapper`, fails on 1.4.3-canary with 3 of 4 files lifted). Also ran all of `bundler_cjs2esm`, `bundler_edgecase`, `bundler_minify`, `esbuild/default`, `esbuild/importstar`.

### Background
- "Unwrapping" (`ExportsKind::EsmWithDynamicFallbackFromCjs`) turns `exports.a = 1` into `var $a = 1; export { $a as a }` so a CommonJS module imported from ESM can be tree-shaken and bound statically. Any use of `exports` that is not a plain member pattern sets `commonjs_named_exports_deoptimized` and the module falls back to the `__commonJS` wrapper.
- `__proto__` on an ordinary object is the `Object.prototype` accessor: assignment calls `[[SetPrototypeOf]]`, a read returns the prototype. Neither creates or reads an own property, so no lifted binding can model it.
- This is the CommonJS face of the `__proto__` export-name family. #40812 covers the ESM faces (the `__export` key and the shorthand property); this change does not depend on it.

<details><summary>Notes</summary>

Repro on 1.4.3-canary (d316760e8):

```js
// lib.cjs
exports.__proto__ = { inherited: 1 };
exports.a = 1;
// main.mjs
import lib from "./lib.cjs";
console.log(Object.keys(lib), lib.inherited);
// node main.mjs / bun main.mjs:      [ 'a' ] 1
// bun build main.mjs | node:          [ 'a' ] undefined   (every target, --minify, --splitting)
// bun build --format=cjs:             [ 'a' ] 1           (no unwrapping there)
```

A `require()` consumer was already correct because a required module is never unwrapped. A module that only reads `exports.__proto__` was already deoptimized by the "export that is never assigned" rule; the test includes that form so all four stay covered.

</details>
