### PR TITLE
fetch: never send the URL fragment in the request-target

### DIFF
--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -759,6 +759,13 @@ impl<'a> URL<'a> {
             url.pathname = b"/";
         }
 
+        const SLASH_SLASH: u16 = u16::from_le_bytes(*b"//");
+        while url.pathname.len() > 1
+            && u16::from_le_bytes([url.pathname[0], url.pathname[1]]) == SLASH_SLASH
+        {
+            url.pathname = &url.pathname[1..];
+        }
+
         url.origin = strings::trim(url.origin, b"/ ?#");
         url
     }
@@ -1796,21 +1803,6 @@ mod tests {
         assert_eq!(url.path, b"/path");
         assert_eq!(url.search, b"?q=1");
         assert_eq!(url.hash, b"#frag?x=2");
-    }
-
-    #[test]
-    fn leading_empty_path_segments_are_kept() {
-        let url = URL::parse(b"http://localhost:3000//admin");
-        assert_eq!(url.hostname, b"localhost");
-        assert_eq!(url.port, b"3000");
-        assert_eq!(url.pathname, b"//admin");
-
-        let url = URL::parse(b"http://localhost:3000///t?a=1");
-        assert_eq!(url.pathname, b"///t?a=1");
-        assert_eq!(url.search, b"?a=1");
-
-        let url = URL::parse(b"http://localhost:3000/a//b");
-        assert_eq!(url.pathname, b"/a//b");
     }
 
     #[test]

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -703,7 +703,14 @@ impl<'a> URL<'a> {
             url.pathname = url.path;
         }
 
-        if let Some(q) = strings::index_of_char(&base[offset as usize..], b'?') {
+        // The fragment starts at the first `#`, so a `?` after it is part of
+        // the fragment, not the start of the query.
+        let before_hash = match strings::index_of_char(&base[offset as usize..], b'#') {
+            Some(hash) => &base[offset as usize..][..hash as usize],
+            None => &base[offset as usize..],
+        };
+
+        if let Some(q) = strings::index_of_char(before_hash, b'?') {
             offset += q;
             url.path = &base[path_offset as usize..][0..q as usize];
             can_update_path = false;
@@ -750,13 +757,6 @@ impl<'a> URL<'a> {
 
         if url.pathname.is_empty() {
             url.pathname = b"/";
-        }
-
-        const SLASH_SLASH: u16 = u16::from_le_bytes(*b"//");
-        while url.pathname.len() > 1
-            && u16::from_le_bytes([url.pathname[0], url.pathname[1]]) == SLASH_SLASH
-        {
-            url.pathname = &url.pathname[1..];
         }
 
         url.origin = strings::trim(url.origin, b"/ ?#");
@@ -1773,6 +1773,44 @@ mod tests {
             .expect("Vec<u8> writes cannot fail");
         assert_eq!(&*boxed, &*out, "join_alloc and join_write must agree");
         out
+    }
+
+    #[test]
+    fn fragment_is_not_part_of_the_path_or_query() {
+        let url = URL::parse(b"http://localhost:3000/path#frag?x=1");
+        assert_eq!(url.pathname, b"/path");
+        assert_eq!(url.path, b"/path");
+        assert_eq!(url.search, b"");
+        assert_eq!(url.hash, b"#frag?x=1");
+
+        let url = URL::parse(b"http://localhost:3000/cb#access_token=abc&scope=x?y");
+        assert_eq!(url.pathname, b"/cb");
+        assert_eq!(url.hash, b"#access_token=abc&scope=x?y");
+
+        let url = URL::parse(b"http://localhost:3000/#?");
+        assert_eq!(url.pathname, b"/");
+        assert_eq!(url.hash, b"#?");
+
+        let url = URL::parse(b"http://localhost:3000/path?q=1#frag?x=2");
+        assert_eq!(url.pathname, b"/path?q=1");
+        assert_eq!(url.path, b"/path");
+        assert_eq!(url.search, b"?q=1");
+        assert_eq!(url.hash, b"#frag?x=2");
+    }
+
+    #[test]
+    fn leading_empty_path_segments_are_kept() {
+        let url = URL::parse(b"http://localhost:3000//admin");
+        assert_eq!(url.hostname, b"localhost");
+        assert_eq!(url.port, b"3000");
+        assert_eq!(url.pathname, b"//admin");
+
+        let url = URL::parse(b"http://localhost:3000///t?a=1");
+        assert_eq!(url.pathname, b"///t?a=1");
+        assert_eq!(url.search, b"?a=1");
+
+        let url = URL::parse(b"http://localhost:3000/a//b");
+        assert_eq!(url.pathname, b"/a//b");
     }
 
     #[test]

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2923,10 +2923,9 @@ it("rejects a response with an unparseable Content-Length instead of treating it
   expect(await ok.text()).toBe("hello");
 });
 
-it("sends pathname + search as the request-target, never the fragment", async () => {
-  // The request-target is `new URL(s).pathname + search`, byte for byte. A
-  // fragment is never sent, even one that contains `?`, and the leading empty
-  // path segments of `//admin` are kept.
+it("never sends the URL fragment in the request-target", async () => {
+  // The request-target is `new URL(s).pathname + search`. A fragment is never
+  // sent, even one that contains a `?`.
   const targets: string[] = [];
   await using server = net.createServer(socket => {
     socket.once("data", data => {
@@ -2944,10 +2943,7 @@ it("sends pathname + search as the request-target, never the fragment", async ()
     "/cb#access_token=abc&scope=x?y",
     "/p?q=1#frag?x=2",
     "/p#plain",
-    "//admin",
-    "///t",
-    "/.//x",
-    "/a//b",
+    "/a//b?q=1#/c?d",
   ];
   const expected: string[] = [];
   for (const tail of tails) {

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2923,6 +2923,42 @@ it("rejects a response with an unparseable Content-Length instead of treating it
   expect(await ok.text()).toBe("hello");
 });
 
+it("sends pathname + search as the request-target, never the fragment", async () => {
+  // The request-target is `new URL(s).pathname + search`, byte for byte. A
+  // fragment is never sent, even one that contains `?`, and the leading empty
+  // path segments of `//admin` are kept.
+  const targets: string[] = [];
+  await using server = net.createServer(socket => {
+    socket.once("data", data => {
+      targets.push(data.toString("utf8").split("\r\n")[0]);
+      socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+    });
+  });
+  await once(server.listen(0, "localhost"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const tails = [
+    "/p#frag?x=1",
+    "/p#/route?id=7",
+    "/#?",
+    "/cb#access_token=abc&scope=x?y",
+    "/p?q=1#frag?x=2",
+    "/p#plain",
+    "//admin",
+    "///t",
+    "/.//x",
+    "/a//b",
+  ];
+  const expected: string[] = [];
+  for (const tail of tails) {
+    const href = `http://localhost:${port}${tail}`;
+    const url = new URL(href);
+    expected.push(`GET ${url.pathname}${url.search} HTTP/1.1`);
+    await (await fetch(href)).text();
+  }
+  expect(targets).toEqual(expected);
+});
+
 it("combines duplicate response headers per the Fetch spec", async () => {
   // WHATWG Fetch requires repeated header fields to be combined with ", " when
   // read via Headers.get(), except Set-Cookie which is stored as separate


### PR DESCRIPTION
### Problem
- `fetch("http://h/p#frag?x=1")` sends `GET /p#frag?x=1 HTTP/1.1`. The fragment reaches the server whenever it contains a `?`: SPA hash routes like `/#/users?id=1`, OAuth-style fragments, `fetch(location.href)`-shaped code. `#` is not a legal request-target byte, so strict servers answer 400 and lenient ones see a different path or a phantom query. Node, bun's own `node:http` and `WebSocket` send `pathname + search` and nothing else.
- Cause: `URL::parse` in `src/url/lib.rs:706` found the query by scanning for `?` anywhere after the authority, including inside the fragment. The HTTP client writes the resulting `pathname` as the request-target (`src/http/lib.rs:2538`).

### Fix
- Scan for `?` only in the part before the first `#`. A `?` after it stays in `hash`, and `pathname` ends at the `#`.
- Correct because fetch WHATWG-normalizes the href before this parse, so the first `#` is always the fragment delimiter. Inputs with the `?` before the `#`, or with no `#`, parse exactly as before.
- Verified: `test/js/web/fetch/fetch.test.ts` ("never sends the URL fragment in the request-target", 4 of 7 rows fail on stock bun) and a unit test in `src/url/lib.rs`. Also ran `node-http.test.ts`, `npmrc.test.ts`, `serve.test.ts`, `s3.test.ts`, `cookie.test.ts`, `test-21049.test.ts`.

### Background
- bun has two URL parsers. `new URL` and the validity checks use WebKit's WHATWG parser. The HTTP client, the package manager and a few config readers use `bun_url::URL::parse`, a small view-struct parser that slices an already-normalized href into `pathname` (path + query), `search` and `hash`.
- The request-target is the second token of the HTTP request line. RFC 9112 origin-form is `absolute-path [ "?" query ]`. The fragment is client-side only and the Fetch spec never serializes it onto the wire.

<details><summary>Notes</summary>

Wire before/after (the test server records the raw request line):

```
"/p#frag?x=1"                      before: GET /p#frag?x=1                      after: GET /p
"/p#/route?id=7"                   before: GET /p#/route?id=7                   after: GET /p
"/#?"                              before: GET /#?                              after: GET /
"/cb#access_token=abc&scope=x?y"   before: GET /cb#access_token=abc&scope=x?y   after: GET /cb
"/p?q=1#frag?x=2"                  GET /p?q=1   (unchanged: a real query before the #)
"/p#plain"                         GET /p       (unchanged: no ? in the fragment)
"/a//b?q=1#/c?d"                   GET /a//b?q=1 (unchanged)
```

A related finding from the same run is that `fetch("http://h//admin")` sends `GET /admin` (the parser collapses leading empty path segments, `src/url/lib.rs:755`), while WHATWG, Node and `node:http` keep `//admin`. That is deliberately not in this PR: keeping the slashes changes what `` `${server.url}/path` `` puts on the wire (`server.url` ends in `/`, so that is `//path`, which `Bun.serve` routes do not match). 57 call sites in bun's own test suite use that idiom, so it needs its own decision.

Reported via an internal URL-consumer differential run (fetch / Request / WebSocket / node:http vs `new URL` over ~3k strings).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->