### PR TITLE
fetch, Request, WebSocket: reject hosts with an invalid punycode label, like new URL

### DIFF
--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -648,7 +648,10 @@ extern "C" BunString URL__getHrefJoin(const BunString* baseStr, const BunString*
 {
     auto base = baseStr->toWTFString();
     auto relative = relativeStr->toWTFString();
-    auto url = WTF::URL(WTF::URL(base), relative);
+    auto baseURL = WTF::URL(base);
+    if (!baseURL.isValid() || !Bun::hasValidParsedHost(baseURL, base))
+        return { BunStringTag::Dead };
+    auto url = WTF::URL(baseURL, relative);
     if (!url.isValid() || url.isEmpty() || !Bun::hasValidParsedHost(url, relative))
         return { BunStringTag::Dead };
 

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -12,6 +12,7 @@
 #include "wtf/SIMDUTF.h"
 #include "JSDOMURL.h"
 #include "DOMURL.h"
+#include "NodeURLHelpers.h"
 #include "ZigGlobalObject.h"
 #include "IDLTypes.h"
 #include "MimallocWTFMalloc.h"
@@ -600,7 +601,7 @@ extern "C" WTF::URL* URL__fromJS(EncodedJSValue encodedValue, JSC::JSGlobalObjec
     }
 
     auto url = WTF::URL(str);
-    if (!url.isValid() || url.isNull())
+    if (!url.isValid() || url.isNull() || !Bun::hasValidParsedHost(url, str))
         return nullptr;
 
     return new WTF::URL(WTF::move(url));
@@ -617,7 +618,7 @@ extern "C" BunString URL__getHrefFromJS(EncodedJSValue encodedValue, JSC::JSGlob
     }
 
     auto url = WTF::URL(str);
-    if (!url.isValid() || url.isEmpty())
+    if (!url.isValid() || url.isEmpty() || !Bun::hasValidParsedHost(url, str))
         return { BunStringTag::Dead };
 
     return Bun::toStringRef(url.string());
@@ -627,7 +628,7 @@ extern "C" BunString URL__getHref(const BunString* input)
 {
     auto&& str = input->toWTFString();
     auto url = WTF::URL(str);
-    if (!url.isValid() || url.isEmpty())
+    if (!url.isValid() || url.isEmpty() || !Bun::hasValidParsedHost(url, str))
         return { BunStringTag::Dead };
 
     return Bun::toStringRef(url.string());
@@ -648,7 +649,7 @@ extern "C" BunString URL__getHrefJoin(const BunString* baseStr, const BunString*
     auto base = baseStr->toWTFString();
     auto relative = relativeStr->toWTFString();
     auto url = WTF::URL(WTF::URL(base), relative);
-    if (!url.isValid() || url.isEmpty())
+    if (!url.isValid() || url.isEmpty() || !Bun::hasValidParsedHost(url, relative))
         return { BunStringTag::Dead };
 
     return Bun::toStringRef(url.string());
@@ -666,7 +667,7 @@ extern "C" WTF::URL* URL__fromString(const BunString* input)
 {
     auto&& str = input->toWTFString();
     auto url = WTF::URL(str);
-    if (!url.isValid())
+    if (!url.isValid() || !Bun::hasValidParsedHost(url, str))
         return nullptr;
 
     return new WTF::URL(WTF::move(url));

--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -28,57 +28,8 @@
 
 #include "NodeURLHelpers.h"
 #include "URLSearchParams.h"
-#include <wtf/text/StringCommon.h>
 
 namespace WebCore {
-
-// The WHATWG parser (WebKit) fast-paths all-ASCII hosts without validating
-// xn-- labels; Node's ada rejects invalid punycode in special-scheme hosts.
-// `input` is the string the host was parsed from (a base URL's host was checked when the base was parsed).
-template<typename CharacterType>
-static bool containsXNDashDash(std::span<const CharacterType> host)
-{
-    // "--" is rare in hosts; look for it and check the two characters before it. Special-scheme hosts are lowercase here.
-    for (size_t i = WTF::find(host, '-'); i != notFound && i + 1 < host.size(); i = WTF::find(host, '-', i + 1)) {
-        if (host[i + 1] == '-' && i >= 2 && host[i - 2] == 'x' && host[i - 1] == 'n')
-            return true;
-    }
-    return false;
-}
-
-static bool hasValidParsedHost(const URL& url, const String& input)
-{
-    auto host = url.host();
-    if (host.length() < 4 || !(host.is8Bit() ? containsXNDashDash(host.span8()) : containsXNDashDash(host.span16())))
-        return true;
-    // Non-special schemes have opaque hosts and skip IDNA entirely.
-    if (!url.hasSpecialScheme())
-        return true;
-    // An xn-- label that ICU produced from a Unicode host is valid by construction; only one that was literally in the
-    // input needs checking. If this input supplied the host, it did so from its authority: after the scheme and any
-    // slashes, up to the next slash, '?' or '#'. Tabs and newlines are removed anywhere and percent-encoding is decoded
-    // in hosts, so either could hide a literal label.
-    StringView view(input);
-    if (view.find([](char16_t character) { return character == '\t' || character == '\n' || character == '\r'; }) != notFound)
-        return Bun::hasValidPunycodeHost(host);
-    unsigned start = 0;
-    while (start < view.length() && view[start] <= ' ')
-        ++start;
-    if (start < view.length() && isASCIIAlpha(view[start])) {
-        unsigned schemeEnd = start + 1;
-        while (schemeEnd < view.length() && (isASCIIAlphanumeric(view[schemeEnd]) || view[schemeEnd] == '+' || view[schemeEnd] == '-' || view[schemeEnd] == '.'))
-            ++schemeEnd;
-        if (schemeEnd < view.length() && view[schemeEnd] == ':')
-            start = schemeEnd + 1;
-    }
-    while (start < view.length() && (view[start] == '/' || view[start] == '\\'))
-        ++start;
-    auto authority = view.substring(start);
-    authority = authority.left(std::min<size_t>(authority.find([](char16_t character) { return character == '/' || character == '\\' || character == '?' || character == '#'; }), authority.length()));
-    if (authority.find('%') == notFound && !authority.containsIgnoringASCIICase("xn--"_s))
-        return true;
-    return Bun::hasValidPunycodeHost(host);
-}
 
 inline DOMURL::DOMURL(URL&& completeURL)
     : m_url(WTF::move(completeURL))
@@ -94,7 +45,7 @@ inline DOMURL::DOMURL(URL&& completeURL)
 ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url)
 {
     URL completeURL { url };
-    if (!completeURL.isValid() || !hasValidParsedHost(completeURL, url))
+    if (!completeURL.isValid() || !Bun::hasValidParsedHost(completeURL, url))
         return Exception { InvalidURLError, url };
     return adoptRef(*new DOMURL(WTF::move(completeURL)));
 }
@@ -103,7 +54,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base, cons
 {
     ASSERT(base.isValid() || base.isNull());
     URL completeURL { base, url };
-    if (!completeURL.isValid() || !hasValidParsedHost(completeURL, url))
+    if (!completeURL.isValid() || !Bun::hasValidParsedHost(completeURL, url))
         return Exception { InvalidURLError, url, baseInput };
     return adoptRef(*new DOMURL(WTF::move(completeURL)));
 }
@@ -114,7 +65,7 @@ static URL parseBase(const String& base, DOMURL::BaseURLCache* cache)
     if (cache && cache->input == base) [[likely]]
         return cache->url;
     URL baseURL { base };
-    if (!baseURL.isValid() || !hasValidParsedHost(baseURL, base))
+    if (!baseURL.isValid() || !Bun::hasValidParsedHost(baseURL, base))
         return {};
     if (cache) {
         cache->input = base;
@@ -139,7 +90,7 @@ static URL parseInternal(const String& url, const String& base, DOMURL::BaseURLC
     if (!base.isNull() && !baseURL.isValid())
         return {};
     URL result { baseURL, url };
-    if (result.isValid() && !hasValidParsedHost(result, url))
+    if (result.isValid() && !Bun::hasValidParsedHost(result, url))
         return {};
     return result;
 }
@@ -160,7 +111,7 @@ bool DOMURL::canParse(const String& url, const String& base, BaseURLCache* cache
 ExceptionOr<void> DOMURL::setHref(const String& url)
 {
     URL completeURL { URL {}, url };
-    if (!completeURL.isValid() || !hasValidParsedHost(completeURL, url))
+    if (!completeURL.isValid() || !Bun::hasValidParsedHost(completeURL, url))
         return Exception { InvalidURLError, url };
     m_url = WTF::move(completeURL);
     m_searchParamsDirty = false;

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -3,6 +3,7 @@
 #include "ErrorCode.h"
 #include "wtf/URL.h"
 #include "wtf/URLParser.h"
+#include <wtf/text/StringCommon.h>
 #include <unicode/uidna.h>
 
 namespace Bun {
@@ -113,6 +114,51 @@ bool hasValidPunycodeHost(WTF::StringView host)
             return verdict == ASCIIHostPunycodeVerdict::Valid;
     }
     return !icuToASCII(host.toString(), IDNAMode::Default).isNull();
+}
+
+template<typename CharacterType>
+static bool containsXNDashDash(std::span<const CharacterType> host)
+{
+    // "--" is rare in hosts; look for it and check the two characters before it. Special-scheme hosts are lowercase here.
+    for (size_t i = WTF::find(host, '-'); i != notFound && i + 1 < host.size(); i = WTF::find(host, '-', i + 1)) {
+        if (host[i + 1] == '-' && i >= 2 && host[i - 2] == 'x' && host[i - 1] == 'n')
+            return true;
+    }
+    return false;
+}
+
+bool hasValidParsedHost(const WTF::URL& url, const WTF::String& input)
+{
+    auto host = url.host();
+    if (host.length() < 4 || !(host.is8Bit() ? containsXNDashDash(host.span8()) : containsXNDashDash(host.span16())))
+        return true;
+    // Non-special schemes have opaque hosts and skip IDNA entirely.
+    if (!url.hasSpecialScheme())
+        return true;
+    // An xn-- label that ICU produced from a Unicode host is valid by construction; only one that was literally in the
+    // input needs checking. If this input supplied the host, it did so from its authority: after the scheme and any
+    // slashes, up to the next slash, '?' or '#'. Tabs and newlines are removed anywhere and percent-encoding is decoded
+    // in hosts, so either could hide a literal label.
+    StringView view(input);
+    if (view.find([](char16_t character) { return character == '\t' || character == '\n' || character == '\r'; }) != notFound)
+        return hasValidPunycodeHost(host);
+    unsigned start = 0;
+    while (start < view.length() && view[start] <= ' ')
+        ++start;
+    if (start < view.length() && isASCIIAlpha(view[start])) {
+        unsigned schemeEnd = start + 1;
+        while (schemeEnd < view.length() && (isASCIIAlphanumeric(view[schemeEnd]) || view[schemeEnd] == '+' || view[schemeEnd] == '-' || view[schemeEnd] == '.'))
+            ++schemeEnd;
+        if (schemeEnd < view.length() && view[schemeEnd] == ':')
+            start = schemeEnd + 1;
+    }
+    while (start < view.length() && (view[start] == '/' || view[start] == '\\'))
+        ++start;
+    auto authority = view.substring(start);
+    authority = authority.left(std::min<size_t>(authority.find([](char16_t character) { return character == '/' || character == '\\' || character == '?' || character == '#'; }), authority.length()));
+    if (authority.find('%') == notFound && !authority.containsIgnoringASCIICase("xn--"_s))
+        return true;
+    return hasValidPunycodeHost(host);
 }
 
 // Mirrors Node's url.domainToASCII/domainToUnicode, which run the input

--- a/src/jsc/bindings/NodeURLHelpers.h
+++ b/src/jsc/bindings/NodeURLHelpers.h
@@ -11,4 +11,11 @@ namespace Bun {
 // True when every xn-- label in `host` is valid UTS #46 punycode.
 bool hasValidPunycodeHost(WTF::StringView host);
 
+// The WHATWG parser (WebKit) fast-paths all-ASCII hosts without validating
+// xn-- labels; Node's ada rejects invalid punycode in special-scheme hosts.
+// `input` is the string `url` was parsed from (a base URL's host was checked
+// when the base was parsed). Every URL intake that must agree with `new URL`
+// (fetch, Request, WebSocket) calls this after `isValid()`.
+bool hasValidParsedHost(const WTF::URL& url, const WTF::String& input);
+
 } // namespace Bun

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -35,6 +35,7 @@
 #include "headers.h"
 #include "blob.h"
 #include "BunString.h"
+#include "NodeURLHelpers.h"
 #include "ZigGeneratedClasses.h"
 #include "CloseEvent.h"
 #include <wtf/text/Base64.h>
@@ -215,7 +216,7 @@ static ExceptionOr<std::optional<ProxyConfig>> setupProxy(const String& proxyUrl
         return { std::nullopt };
 
     URL url { proxyUrl };
-    if (!url.isValid())
+    if (!url.isValid() || !Bun::hasValidParsedHost(url, proxyUrl))
         return Exception { SyntaxError, makeString("Invalid proxy URL: "_s, proxyUrl) };
 
     // Only HTTP CONNECT proxies are supported. Reject socks5://, ftp://, etc. up front
@@ -417,7 +418,7 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
 
     ASSERT(scriptExecutionContext());
 
-    if (!m_url.isValid()) {
+    if (!m_url.isValid() || !Bun::hasValidParsedHost(m_url, url)) {
         // context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, );
         m_state = CLOSED;
         return Exception { SyntaxError, makeString("Invalid url for WebSocket "_s, m_url.stringCenterEllipsizedToLength()) };

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -67,6 +67,26 @@ it("new Request(invalid url) throws", () => {
   expect(() => new Request("!")).toThrow();
 });
 
+it("fetch and Request reject a host with an invalid punycode label, like new URL", async () => {
+  // `URL.canParse` is the validity gate apps use before fetch. A host whose
+  // xn-- label is not valid punycode fails that gate, so fetch and Request
+  // must not resolve and connect to it.
+  for (const host of ["xn--a.localhost", "xn--.localhost", "a.xn--0ug.localhost"]) {
+    const href = `http://${host}/x`;
+    expect(URL.canParse(href)).toBe(false);
+    expect(() => new Request(href)).toThrow(TypeError);
+    const rejection = await fetch(href).then(
+      () => "resolved",
+      e => e,
+    );
+    expect(rejection).toBeInstanceOf(TypeError);
+    expect(rejection.code).toBe("ERR_INVALID_URL");
+  }
+  // A valid punycode label still parses and is accepted.
+  expect(URL.canParse("http://xn--bcher-kva.localhost/")).toBe(true);
+  expect(new Request("http://xn--bcher-kva.localhost/").url).toBe("http://xn--bcher-kva.localhost/");
+});
+
 describe("fetch data urls", () => {
   it("basic", async () => {
     var url =

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -9,6 +9,14 @@ const TEST_WEBSOCKET_HOST = process.env.TEST_WEBSOCKET_HOST || "wss://ws.postman
 const COMMON_CERT = { ...tls };
 
 describe.concurrent("WebSocket", () => {
+  it("rejects a host with an invalid punycode label, like new URL", () => {
+    for (const host of ["xn--a.localhost", "xn--.localhost", "a.xn--0ug.localhost"]) {
+      const href = `ws://${host}/`;
+      expect(URL.canParse(href)).toBe(false);
+      expect(() => new WebSocket(href)).toThrow(SyntaxError);
+    }
+  });
+
   it("should connect", async () => {
     using server = Bun.serve({
       port: 0,
@@ -725,14 +733,6 @@ describe.concurrent("websocket in subprocess", () => {
     });
 
     expect(await subprocess.exited).toBe(1);
-  });
-
-  it("rejects a host with an invalid punycode label, like new URL", () => {
-    for (const host of ["xn--a.localhost", "xn--.localhost", "a.xn--0ug.localhost"]) {
-      const href = `ws://${host}/`;
-      expect(URL.canParse(href)).toBe(false);
-      expect(() => new WebSocket(href)).toThrow(SyntaxError);
-    }
   });
 
   it("should exit after timeout", async () => {

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -727,6 +727,14 @@ describe.concurrent("websocket in subprocess", () => {
     expect(await subprocess.exited).toBe(1);
   });
 
+  it("rejects a host with an invalid punycode label, like new URL", () => {
+    for (const host of ["xn--a.localhost", "xn--.localhost", "a.xn--0ug.localhost"]) {
+      const href = `ws://${host}/`;
+      expect(URL.canParse(href)).toBe(false);
+      expect(() => new WebSocket(href)).toThrow(SyntaxError);
+    }
+  });
+
   it("should exit after timeout", async () => {
     let messageReceived = false;
     let start = 0;


### PR DESCRIPTION
### Problem
- `new URL("http://xn--a.localhost/")` throws `ERR_INVALID_URL` and `URL.canParse` returns `false`, but `fetch()`, `new Request()` and `new WebSocket()` accept the same string, resolve the name and send the request. 1.3.14 rejected in all four, and so does Node. `URL.canParse(x)` / `try { new URL(x) }` is the validity gate apps use before handing `x` to fetch. Here the gate says invalid and fetch goes out anyway.
- Cause: WebKit's parser fast-paths ASCII hosts without validating `xn--` labels, so `DOMURL::create` runs an extra check, `hasValidParsedHost`, after the parse (`src/jsc/bindings/DOMURL.cpp`). The other URL intakes (`URL__getHref`, `URL__getHrefFromJS`, `URL__fromString`, `URL__fromJS`, `URL__getHrefJoin` in `BunString.cpp`, `WebSocket::connect` and its proxy URL) only checked `WTF::URL::isValid()`.

### Fix
- Move `hasValidParsedHost` (body unchanged) next to `hasValidPunycodeHost` in `NodeURL.cpp`, declare it in `NodeURLHelpers.h`, and call it after `isValid()` in every intake listed above. `URL__getHrefJoin` checks its base the way `DOMURL`'s `parseBase` does, then the joined URL against the relative input.
- Correct because every string-to-URL entry point now applies the same predicate `new URL` applies, so a string is fetchable exactly when it is parseable. The check returns early unless the host contains `xn--`, so the common path costs one scan of the host.
- Verified: `test/js/web/fetch/fetch.test.ts` ("fetch and Request reject a host with an invalid punycode label") and `test/js/web/websocket/websocket.test.js` ("rejects a host with an invalid punycode label"), both fail on stock bun. Also ran `url.test.ts`, `url-wpt-constructor.test.ts`, `url-domain-ascii-unicode.test.js`, `request.test.ts`, and the rest of `fetch.test.ts` and `websocket.test.js`.
- Self-reviewed: 2 concerns raised (join did not check the base host, test placement), both addressed.

### Background
- An `xn--` label is the ASCII (punycode) form of an internationalized domain label. UTS 46 says a label that starts with `xn--` but does not decode to valid Unicode is an error, and the WHATWG host parser fails on it for special schemes (http, https, ws, wss, ftp, file).
- `hasValidPunycodeHost` is the decoder-backed check (a cheap ASCII pre-check, then ICU). `hasValidParsedHost` wraps it with the conditions under which a literal `xn--` label in the input could have reached the host, so hosts that ICU itself produced from Unicode input are not checked again.
- `URL__getHref` is what `bun_url::href_from_string` and `ZigURL::from_string` call, so the same check now also covers `Response.redirect`, redirect `Location` handling in the HTTP client, the `fetch` proxy option and the S3 endpoint parse.

<details><summary>Notes</summary>

Repro (any `*.localhost` name resolves to loopback, no DNS needed):

```js
for (const host of ["xn--a.localhost", "xn--.localhost", "a.xn--0ug.localhost"]) {
  const s = `http://${host}:${port}/x`;
  URL.canParse(s);        // false
  new Request(s).url;     // before: the URL. after: throws TypeError ERR_INVALID_URL
  await fetch(s);         // before: connects, server sees Host: xn--a.localhost. after: rejects ERR_INVALID_URL
  new WebSocket(`ws://${host}:${port}/`); // before: upgrades. after: SyntaxError "Invalid url for WebSocket"
}
```

A valid label (`xn--bcher-kva.localhost`) is accepted by all of them before and after.

A redirect whose `Location` has an invalid punycode host now fails the fetch with the existing `RedirectURLInvalid` error instead of connecting, which is what Node does.

Reported via an internal URL-consumer differential run (fetch / Request / WebSocket / node:http vs `new URL` over ~3k strings).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/websocket/websocket.test.js, test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->