### PR TITLE
install: never drop BUN_CONFIG_REGISTRY / NPM_CONFIG_REGISTRY silently

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -1,6 +1,6 @@
 use crate::bun_schema::api as Api;
 use bun_core::ZStr;
-use bun_core::{Output, env_var};
+use bun_core::{Output, env_var, strings};
 
 use super::Subcommand;
 use super::command_line_arguments::{self, CommandLineArguments};
@@ -625,9 +625,12 @@ impl Options {
 
             for registry_key in REGISTRY_KEYS {
                 if let Some(registry_) = env.get(registry_key) {
-                    if !registry_.is_empty()
-                        && (registry_.starts_with(b"https://") || registry_.starts_with(b"http://"))
-                    {
+                    // Any non-empty value is the registry, as it is for `registry=`
+                    // in .npmrc and `install.registry` in bunfig.toml. A value whose
+                    // scheme is not http(s) fails loudly at request time instead of
+                    // falling through to the next layer's registry.
+                    let registry_ = strings::trim(registry_, b" \t\r\n");
+                    if !registry_.is_empty() {
                         let mut api_registry = Api::NpmRegistry::from_url(registry_);
                         // Credentials in the URL win, as they do for `registry=` in .npmrc.
                         if !api_registry.has_credentials() {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -626,9 +626,9 @@ impl Options {
             for registry_key in REGISTRY_KEYS {
                 if let Some(registry_) = env.get(registry_key) {
                     // Any non-empty value is the registry, as it is for `registry=`
-                    // in .npmrc and `install.registry` in bunfig.toml. A value whose
-                    // scheme is not http(s) fails loudly at request time instead of
-                    // falling through to the next layer's registry.
+                    // in .npmrc and `install.registry` in bunfig.toml, so an unusable
+                    // value surfaces as a request error instead of a silent fall
+                    // through to the next layer's registry.
                     let registry_ = strings::trim(registry_, b" \t\r\n");
                     if !registry_.is_empty() {
                         let mut api_registry = Api::NpmRegistry::from_url(registry_);

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9717,6 +9717,83 @@ describe("registry/token env var priority", () => {
 
     expect(hits).toEqual({ preferred: 1, other: 0 });
   });
+
+  // The registry from the environment is used whatever the case of its scheme,
+  // like `registry=` in .npmrc. It must never be dropped in favor of a lower
+  // layer (here the bunfig registry, otherwise the default public registry).
+  test.each(["HTTP://", "Http://", " http://"])("BUN_CONFIG_REGISTRY=%shost/ is used", async scheme => {
+    const hits = { fromEnv: 0, fromBunfig: 0 };
+    await using fromEnv = Bun.serve({
+      port: 0,
+      fetch() {
+        hits.fromEnv++;
+        return new Response("not found", { status: 404 });
+      },
+    });
+    await using fromBunfig = Bun.serve({
+      port: 0,
+      fetch() {
+        hits.fromBunfig++;
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    await Promise.all([
+      write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({ install: { cache: false, registry: `http://localhost:${fromBunfig.port}/` } }),
+      ),
+      write(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } })),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...env, BUN_CONFIG_REGISTRY: `${scheme}localhost:${fromEnv.port}/` },
+    });
+    const [err, exitCode] = await Promise.all([stderr.text(), exited, stdout.text()]);
+
+    expect(hits).toEqual({ fromEnv: 1, fromBunfig: 0 });
+    expect(err).toContain(`GET http://localhost:${fromEnv.port}/no-deps - 404`);
+    expect(exitCode).toBe(1);
+  });
+
+  // A registry whose scheme is not http(s) is an error, as it is in bunfig.toml
+  // and .npmrc. It must not silently fall through to another registry.
+  test("BUN_CONFIG_REGISTRY with an unsupported scheme fails instead of falling through", async () => {
+    let hits = 0;
+    await using fromBunfig = Bun.serve({
+      port: 0,
+      fetch() {
+        hits++;
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    await Promise.all([
+      write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({ install: { cache: false, registry: `http://localhost:${fromBunfig.port}/` } }),
+      ),
+      write(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } })),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...env, BUN_CONFIG_REGISTRY: `htp://localhost:${fromBunfig.port}/` },
+    });
+    const [err, exitCode] = await Promise.all([stderr.text(), exited, stdout.text()]);
+
+    expect(hits).toBe(0);
+    expect(err).toContain("Registry URL must be http:// or https://");
+    expect(err).toContain(`Received: "htp://localhost:${fromBunfig.port}/no-deps"`);
+    expect(exitCode).toBe(1);
+  });
 });
 
 test("npm manifest cache entries with invalid package version records are treated as invalid", async () => {


### PR DESCRIPTION
### Problem
- `BUN_CONFIG_REGISTRY=HTTP://127.0.0.2:4873/ bun install` (or `NPM_CONFIG_REGISTRY`, or `bun publish`) silently ignores the value and uses the next layer's registry, which with no bunfig or `.npmrc` is `registry.npmjs.org`. The same happens for a typo like `htp://...` and for a whitespace-padded value. No diagnostic names the env value, so an env-configured private registry is bypassed and dependencies resolve from (or a package is published to) the public registry.
- The same strings in `bunfig.toml` `[install] registry` or `.npmrc` `registry=` are either honored (the scheme is case-insensitive) or fail with `Registry URL must be http:// or https://` and exit 1.
- Cause: `src/install/PackageManager/PackageManagerOptions.rs:628` applied the env registry only when the value started with byte-lowercase `https://` or `http://`, and skipped it otherwise.

### Fix
- Treat any non-empty (trimmed) env value as the registry, as `registry=` in `.npmrc` already is. It then takes the same path as the other sources: `Scope::set_url` WHATWG-normalizes an uppercase scheme, and an unsupported scheme reaches the existing check in `NetworkTask.rs:523` and errors with the value in the message.
- An empty value still falls through to the next key (`BUN_CONFIG_REGISTRY`, then `NPM_CONFIG_REGISTRY`, then `npm_config_registry`), as the existing tests document.
- Verified: `test/cli/install/bun-install-registry.test.ts` ("registry/token env var priority": four new cases, all fail on stock bun). Also ran `config-precedence.test.ts`, `npmrc.test.ts`, `bun-publish.test.ts`, `bun-pm-diff.test.ts`, `bun-audit.test.ts`.

### Background
- The default registry is resolved in layers: the built-in default, then `bunfig.toml` / `.npmrc`, then the `*_CONFIG_REGISTRY` environment variables, then `--registry`. Each layer replaces the scope URL of the previous one.
- The scheme check that prints `Registry URL must be http:// or https://` runs per request on the joined manifest URL, after WHATWG normalization. That is why `HTTP://` from bunfig already worked.

<details><summary>Notes</summary>

Before / after, with a loopback registry stub on 127.0.0.1:4873 and a package.json that depends on one package:

```
BUN_CONFIG_REGISTRY=http://127.0.0.1:4873/   before: GET /pkg at the stub                  after: same
BUN_CONFIG_REGISTRY=HTTP://127.0.0.1:4873/   before: GET https://registry.npmjs.org/pkg    after: GET /pkg at the stub
BUN_CONFIG_REGISTRY=htp://127.0.0.1:4873/    before: GET https://registry.npmjs.org/pkg    after: error: Registry URL must be http:// or https:// / Received: "htp://127.0.0.1:4873/pkg", exit 1
BUN_CONFIG_REGISTRY=R.TEST:4873              before: GET https://registry.npmjs.org/pkg    after: error: Failed to join registry "r.test:4873" and package "pkg" URLs, exit 1
```

`bun install --registry=HTTP://...` still errors up front (`CommandLineArguments.rs:1666`). That check is explicit and loud, so it is left alone here.

Because the env value now goes through `Scope::from_api` like a bunfig value, the `$VAR` indirection that bunfig and `.npmrc` registry values support (`registry = "$MY_REGISTRY"`) applies to it too.

Reported via an internal URL-consumer differential run.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->