### PR TITLE
install: re-resolve a root dependency edited to name a different package under a range the old version fits

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1574,8 +1574,7 @@ impl Diff {
                 }
             }
 
-            // Changed literal: keep the locked resolution while it is still the package the edge names and
-            // still satisfies the new range (npm's sticky rule), unless this row is being updated.
+            // Changed literal: keep the locked package while it still matches the new spec (npm's sticky rule), unless this row is being updated.
             let is_explicit_update_target = matches!(update_requests, Some(updates)
             if updates.is_empty()
                 || (named_update_here

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1589,7 +1589,8 @@ impl Diff {
                     if (from_res_id as usize) < from_lockfile.packages.len() {
                         let from_pkg_resolution =
                             from_lockfile.packages.items_resolution()[from_res_id as usize];
-                        let from_pkg_name = from_lockfile.packages.items_name()[from_res_id as usize];
+                        let from_pkg_name =
+                            from_lockfile.packages.items_name()[from_res_id as usize];
                         let to_dep = &to_deps!()[cur_to_i];
                         if to_dep.version.tag == dependency::version::Tag::Npm
                             && from_pkg_resolution.tag == ResolutionTag::Npm

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1574,7 +1574,8 @@ impl Diff {
                 }
             }
 
-            // Changed literal: keep the locked resolution while it still satisfies the new range (npm's sticky rule), unless this row is being updated.
+            // Changed literal: keep the locked resolution while it is still the package the edge names and
+            // still satisfies the new range (npm's sticky rule), unless this row is being updated.
             let is_explicit_update_target = matches!(update_requests, Some(updates)
             if updates.is_empty()
                 || (named_update_here
@@ -1588,9 +1589,15 @@ impl Diff {
                     if (from_res_id as usize) < from_lockfile.packages.len() {
                         let from_pkg_resolution =
                             from_lockfile.packages.items_resolution()[from_res_id as usize];
+                        let from_pkg_name = from_lockfile.packages.items_name()[from_res_id as usize];
                         let to_dep = &to_deps!()[cur_to_i];
                         if to_dep.version.tag == dependency::version::Tag::Npm
                             && from_pkg_resolution.tag == ResolutionTag::Npm
+                            && to_dep.version.npm().name.eql(
+                                from_pkg_name,
+                                to_lockfile.buffers.string_bytes.as_slice(),
+                                from_lockfile.buffers.string_bytes.as_slice(),
+                            )
                             && to_dep.version.npm().version.satisfies(
                                 from_pkg_resolution.npm().version,
                                 to_lockfile.buffers.string_bytes.as_slice(),

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -870,3 +870,30 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
     await expectInSync(dir);
   });
 });
+
+// The locked version (no-deps@1.1.0) satisfies the new range in every row, so only the package name tells the edit apart.
+describe.concurrent("pointing a dependency at a different package re-resolves it", () => {
+  test.each([
+    { key: "aliased", before: "npm:no-deps@^1.0.0", after: "npm:a-dep@^1.0.0" },
+    { key: "a-dep", before: "npm:no-deps@^1.0.0", after: "^1.0.1" },
+    { key: "no-deps", before: "^1.0.0", after: "npm:a-dep@^1.0.2" },
+  ])('"$key": "$before" -> "$after"', async ({ key, before, after }) => {
+    const dir = await setup({ "package.json": root({ dependencies: { [key]: before } }) });
+    expect(await installed(dir, key)).toMatchObject({ name: "no-deps", version: "1.1.0" });
+
+    await writePkg(dir, root({ dependencies: { [key]: after } }));
+    const frozen = await tryRun(dir, "", "install", "--frozen-lockfile");
+    expect(frozen.stderr).toContain("error: lockfile had changes, but lockfile is frozen");
+    expect(frozen.exitCode).toBe(1);
+    expect(await installed(dir, key)).toMatchObject({ name: "no-deps", version: "1.1.0" });
+
+    await runBunInstall(envFor(dir), dir);
+    expect(await installed(dir, key)).toMatchObject({ name: "a-dep", version: "1.0.10" });
+    const { workspaces, packages } = await lock(dir);
+    expect(workspaces[""].dependencies).toStrictEqual({ [key]: after });
+    expect(Object.fromEntries(Object.entries(packages).map(([path, entry]) => [path, (entry as string[])[0]]))).toStrictEqual(
+      { [key]: "a-dep@1.0.10" },
+    );
+    await expectInSync(dir, [""], { reinstall: true });
+  });
+});

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -891,9 +891,9 @@ describe.concurrent("pointing a dependency at a different package re-resolves it
     expect(await installed(dir, key)).toMatchObject({ name: "a-dep", version: "1.0.10" });
     const { workspaces, packages } = await lock(dir);
     expect(workspaces[""].dependencies).toStrictEqual({ [key]: after });
-    expect(Object.fromEntries(Object.entries(packages).map(([path, entry]) => [path, (entry as string[])[0]]))).toStrictEqual(
-      { [key]: "a-dep@1.0.10" },
-    );
+    expect(
+      Object.fromEntries(Object.entries(packages).map(([path, entry]) => [path, (entry as string[])[0]])),
+    ).toStrictEqual({ [key]: "a-dep@1.0.10" });
     await expectInSync(dir, [""], { reinstall: true });
   });
 });


### PR DESCRIPTION
### Problem
- Regression from 1.3.14. With a `bun.lock` present, editing a root dependency so that it names a different package but the locked version still fits the new range is ignored: `"ali": "npm:left-pad@^1.0.0"` -> `"ali": "npm:is-odd@^1.0.0"` (also un-aliasing to `"ali": "^1.0.0"`, or `"left-pad": "^1.0.0"` -> `"left-pad": "npm:is-odd@^1.0.0"`). `bun install` prints `(no changes)`, keeps `left-pad` in `node_modules/ali`, and writes a `bun.lock` whose `workspaces` entry says `npm:is-odd@^1.0.0` while its `packages` entry still says `left-pad@1.1.0`. `bun install --frozen-lockfile` / `bun ci` exit 0.
- Cause: the sticky rule in `Diff::generate` (`src/install/lockfile/Package.rs:1577`). When a root dependency's literal changed, it keeps the locked resolution if the locked version satisfies the new range. It compared only the version, never the package name, so `left-pad@1.1.0` satisfied `npm:is-odd@^1.0.0`. 1.3.14 had no sticky rule and re-resolved every changed literal.

### Fix
- The sticky rule now also requires the locked package's name to equal the name the edited dependency resolves from the registry (`version.npm().name`: the `npm:` target for an alias, the key otherwise). A mismatch leaves the edge unmapped, so it is resolved again like any other changed dependency, and the frozen check sees a different package set.
- Widening or narrowing a range on the same package keeps the locked version as before (covered by the existing `bun-update.test.ts` and `bun-update-lockfile-sync.test.ts` rows).
- Verified: `test/cli/install/bun-update-lockfile-sync.test.ts`, new block `pointing a dependency at a different package re-resolves it` (alias -> alias, alias -> plain, plain -> alias; each asserts `--frozen-lockfile` fails before the install and passes after). Fails 3/3 on 1.4.3-canary, passes with this change. Also ran the whole file, `bun-update.test.ts`, `bun-lock.test.ts` and `bun-install-registry.test.ts`.

### Background
- `Diff::generate` compares the root package loaded from the lockfile with a fresh parse of `package.json`. For each dependency present in both it either maps the new edge onto the old resolution (`id_mapping`) or leaves it unmapped, which makes the installer resolve it from the manifest.
- The sticky rule exists so that `"foo": "1.0.0"` -> `"foo": "^1.0.0"` does not move `foo` on a plain `bun install` (npm behaves the same). It only applies to root edges with an npm resolution.
- Lockfile packages are stored under their registry name (`left-pad`), the alias (`ali`) only exists on the dependency edge and as the `node_modules` path, so the package name is the ground truth for "is this still the same package".

<details><summary>Notes</summary>

- A `bun.lock` already written in the inconsistent state by 1.4.0 to 1.4.3 (workspaces entry retargeted, packages entry not) is not repaired by this change: its `workspaces` entry matches `package.json`, so the differ sees no edit. `bun update <alias>` or deleting `bun.lock` fixes such a lockfile, same as today. Rejecting an `npm:` alias edge bound to a package of another name in the `bun.lock` loader would repair it automatically; left out to keep this change to the regression.
- #33632 makes `--frozen-lockfile` fail on any manifest literal drift, which would also catch the frozen half of this, but not the plain `bun install` keeping the old package.
- The two `bun-install-registry.test.ts` failures seen locally on Windows (`npm manifest cache entries are only reused for the package name they were saved for`, `manifest conditional requests > a changed etag ...`) are about the manifest disk cache, delete the lockfile before reinstalling, and do not reach `Diff::generate`.

</details>
