### PR TITLE
node:os: return aarch64 from os.machine() on Linux arm64

### DIFF
--- a/src/js/node/os.ts
+++ b/src/js/node/os.ts
@@ -131,11 +131,9 @@ function bound(binding) {
     userInfo: binding.userInfo,
     version: binding.version,
     machine: function () {
-      // TODO: linux arm64 should also return "aarch64" (Node/uname compat) —
-      // separate PR to avoid behavior change in the Android port.
       // FreeBSD: uname -m returns MACHINE ("arm64"/"amd64"), not MACHINE_ARCH.
       return process.arch === "arm64"
-        ? process.platform === "android"
+        ? process.platform === "linux" || process.platform === "android"
           ? "aarch64"
           : "arm64"
         : process.arch === "x64"

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -202,21 +202,15 @@ it("networkInterfaces IPv6 loopback", () => {
 });
 
 it("machine", () => {
-  const possibleValues = [
-    "arm",
-    "arm64",
-    "aarch64",
-    "mips",
-    "mips64",
-    "ppc64",
-    "ppc64le",
-    "s390",
-    "s390x",
-    "i386",
-    "i686",
-    "x86_64",
-  ];
-  expect(possibleValues.includes(os.machine())).toBe(true);
+  const expected =
+    process.arch === "arm64"
+      ? process.platform === "linux" || process.platform === "android"
+        ? "aarch64"
+        : "arm64"
+      : process.platform === "freebsd"
+        ? "amd64"
+        : "x86_64";
+  expect(os.machine()).toBe(expected);
 });
 
 it("EOL", () => {


### PR DESCRIPTION
### What does this PR do?

Fix `os.machine()` on Linux arm64 to return `"aarch64"`.

Node documents `os.machine()` as returning the machine type from `uname(3)` on POSIX systems. On Linux arm64, `uname -m` returns `aarch64`, but Bun currently returns `arm64`.

This keeps the existing behavior for other platforms:

- Android arm64: `aarch64`
- Linux arm64: `aarch64`
- macOS arm64: `arm64`
- FreeBSD arm64: `arm64`
- FreeBSD x64: `amd64`

### How did you verify your code works?

- `npx --yes prettier@3.6.2 --check src/js/node/os.ts test/js/node/os/os.test.js`
- `npx --yes oxlint@1.70.0 --config=oxlint.json src/js/node/os.ts test/js/node/os/os.test.js`


