### PR TITLE
completions: fix first-argument paths, widen `can_be_run_by_bun()`

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -14,6 +14,19 @@ _file_arguments() {
     $reset
 }
 
+# The `compgen -X` exclusion pattern for the files bun can run, built from the
+# extensions bun itself reports (".ts" per line) with the leading dots stripped.
+# Empty when bun reports none, which excludes nothing.
+_bun_runnable_filter() {
+    local extensions
+    extensions="$(SHELL=bash bun getcompletes e)"
+    extensions="${extensions//./}"
+    extensions="${extensions//$'\n'/|}"
+    if [[ -n "${extensions}" ]]; then
+        echo "!(*.@(${extensions})?($|))"
+    fi
+}
+
 _long_short_completion() {
     local wordlist="${1}";
     local short_options="${2}"
@@ -201,7 +214,7 @@ _bun_completions() {
             COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") );
             return;;
         run)
-            _file_arguments "!(*.@(js|ts|jsx|tsx|mjs|cjs)?($|))";
+            _file_arguments "$(_bun_runnable_filter)";
             COMPREPLY+=( $(compgen -W "--version --cwd --help --silent -v -h" -- "${cur_word}" ) );
             _read_scripts_in_package_json;
             return;;

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -28,8 +28,12 @@ function __history_completions
 	history --prefix (commandline) | string replace -r \^$tokens[1]\\s\* "" | string replace -r \^$tokens[2]\\s\* "" | string split ' '
 end
 
-function __fish__get_bun_bun_js_files
-	string split ' ' (bun getcompletes j)
+function __fish__get_bun_runnable_files
+	# `bun getcompletes e` reports the extensions bun can run, dot included, which
+	# is the form __fish_complete_suffix takes its non-switch arguments in. It
+	# completes real paths, ordering suffix matches ahead of directories and the
+	# rest rather than hiding either.
+	__fish_complete_suffix --description "Bun.js" (string split ' ' (bun getcompletes e))
 end
 
 set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
@@ -65,8 +69,8 @@ function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without
         for bin in $bins
             echo "$bin"\t"package bin"
         end
-        for file in (__fish__get_bun_bun_js_files)
-            echo "$file"\t"Bun.js"
+        for file in (__fish__get_bun_runnable_files)
+            echo $file
         end
     end
 end

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -868,8 +868,15 @@ _bun() {
         local -a scripts_list
         IFS=$'\n' scripts_list=($(SHELL=zsh bun getcompletes i))
         scripts="scripts:scripts:compadd -a scripts_list"
-        local -a files_list
-        IFS=$'\n' files_list=($(SHELL=zsh bun getcompletes j))
+        # Extensions bun can run, as bun itself reports them (".ts"); zsh wants
+        # them bare inside the alternation, so strip the leading dot.
+        local -a extensions
+        IFS=$'\n' extensions=($(SHELL=zsh bun getcompletes e))
+        extensions=(${extensions#.})
+        local files="files:file:_files"
+        if (( $#extensions )); then
+            files+=" -g '*.(${(j:|:)extensions})'"
+        fi
 
         main_commands=(
             'run\:"Run JavaScript with Bun, a package.json script, or a bin" '
@@ -894,7 +901,7 @@ _bun() {
             'help\:"Show all supported flags and commands" '
         )
         main_commands=($main_commands)
-        _alternative "$scripts" "args:command:(($main_commands))" "files:files:compadd -a files_list"
+        _alternative "$scripts" "args:command:(($main_commands))" "$files"
 
         ;;
     args)

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -137,10 +137,19 @@ impl Loader {
         matches!(self, Loader::Jsx | Loader::Js | Loader::Ts | Loader::Tsx)
     }
 
+    /// Whether `bun <file>` executes a file with this loader. `Md` renders the
+    /// file and exits; `Html` boots as an HTML entry point.
     pub fn can_be_run_by_bun(self) -> bool {
         matches!(
             self,
-            Loader::Jsx | Loader::Js | Loader::Ts | Loader::Tsx | Loader::Wasm | Loader::Bunsh
+            Loader::Jsx
+                | Loader::Js
+                | Loader::Ts
+                | Loader::Tsx
+                | Loader::Wasm
+                | Loader::Bunsh
+                | Loader::Md
+                | Loader::Html
         )
     }
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -581,7 +581,6 @@ pub fn get_loader_and_virtual_source<'a>(
     })
 }
 
-#[cfg(test)]
 const DEFAULT_LOADERS_POSIX: &[(&[u8], Loader)] = &[
     (b".jsx", Loader::Jsx),
     (b".json", Loader::Json),
@@ -608,8 +607,11 @@ const DEFAULT_LOADERS_POSIX: &[(&[u8], Loader)] = &[
     (b".markdown", Loader::Md),
 ];
 
-#[cfg(all(windows, test))]
+#[cfg(windows)]
 const DEFAULT_LOADERS_WIN32_EXTRA: &[(&[u8], Loader)] = &[(b".sh", Loader::Bunsh)];
+
+#[cfg(not(windows))]
+const DEFAULT_LOADERS_WIN32_EXTRA: &[(&[u8], Loader)] = &[];
 
 /// File-extension → default [`Loader`] map.
 ///
@@ -682,6 +684,16 @@ impl DefaultLoaders {
     #[inline]
     pub fn contains_key(&self, ext: &[u8]) -> bool {
         self.get(ext).is_some()
+    }
+
+    /// Every extension → loader pair, for callers that enumerate rather than
+    /// look up. The length-gated `get` above cannot be iterated, so this walks
+    /// the canonical tables the `default_loaders_match_table` test checks it
+    /// against.
+    pub fn entries(&self) -> impl Iterator<Item = &'static (&'static [u8], Loader)> {
+        DEFAULT_LOADERS_POSIX
+            .iter()
+            .chain(DEFAULT_LOADERS_WIN32_EXTRA)
     }
 }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1702,6 +1702,9 @@ pub mod command {
                 RunCommand::completions::<{ Filter::AllPlusBunJs }>(ctx, None, REJECT_LIST)?;
         } else if filter[0] == b"j" {
             completions = RunCommand::completions::<{ Filter::BunJs }>(ctx, None, REJECT_LIST)?;
+        } else if filter[0] == b"e" {
+            completions =
+                RunCommand::completions::<{ Filter::RunnableExtensions }>(ctx, None, REJECT_LIST)?;
         } else if filter[0] == b"z" {
             completions = RunCommand::completions::<{ Filter::ScriptAndDescriptions }>(
                 ctx,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -784,6 +784,32 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             .copied()
     }
 
+    /// The loader an extension resolves to once configuration is taken into
+    /// account: a `--loader` flag or bunfig `[loader]` entry wins over the
+    /// built-in default, so an override can make an extension unrunnable as
+    /// well as runnable. `None` when neither map knows the extension.
+    fn configured_loader(loaders: &bun_ast::LoaderHashTable, ext: &[u8]) -> Option<Loader> {
+        loaders
+            .get(ext)
+            .copied()
+            .or_else(|| bun_bundler::options::DEFAULT_LOADERS.get(ext).copied())
+    }
+
+    /// The same question as [`RunCommand::configured_loader`], answered before a
+    /// `Transpiler` exists: the `--loader` / bunfig entries are still the parsed
+    /// parallel arrays on the context rather than a built map.
+    fn context_loader_for(ctx: &ContextData, target: &[u8]) -> Option<Loader> {
+        let ext = paths::extension(target);
+        if let Some(map) = ctx.args.loaders.as_ref() {
+            if let Some(i) = map.extensions.iter().position(|e| &**e == ext) {
+                return Some(<Loader as bun_options_types::LoaderExt>::from_api(
+                    map.loaders[i],
+                ));
+            }
+        }
+        Self::default_loader_for(target)
+    }
+
     /// Shared ctx→transpiler/resolver option projection used by [`boot`] and
     /// [`boot_standalone`].
     fn wire_transpiler_from_ctx(b: &mut Transpiler<'_>, ctx: &mut ContextData) {
@@ -1684,8 +1710,12 @@ impl RunCommand {
     /// Duplicate `path` to a process-lifetime buffer, boot the VM, and on
     /// failure print the formatted error + `exit(1)`.
     fn boot_and_handle_error(ctx: &mut ContextData, path: &[u8], loader: Option<Loader>) -> bool {
+        // An explicit path reaches here with no loader, so the extension decides —
+        // and it has to decide the way the rest of the run path does, or a bunfig
+        // `[loader]` entry mapping `.md` elsewhere would still render as Markdown,
+        // and an extension mapped *to* `md` would not render at all.
         if matches!(
-            loader.or_else(|| Self::default_loader_for(path)),
+            loader.or_else(|| Self::context_loader_for(ctx, path)),
             Some(Loader::Md)
         ) {
             Self::render_markdown_file_and_exit(path);
@@ -2310,7 +2340,7 @@ impl RunCommand {
             skip_script_check = true;
         } else if cfg.allow_fast_run_for_extensions {
             if let Some(l) = Self::default_loader_for(target_name) {
-                if l.can_be_run_by_bun() || l == Loader::Md {
+                if l.can_be_run_by_bun() {
                     try_fast_run = true;
                 }
             }
@@ -2539,14 +2569,9 @@ impl RunCommand {
             Ok(mut resolved) => {
                 let path = resolved.path().expect("resolved primary path");
                 let ext = path.name().ext;
-                let loader: Loader = this_transpiler
-                    .options
-                    .loaders
-                    .get(ext)
-                    .copied()
-                    .or_else(|| bun_bundler::options::DEFAULT_LOADERS.get(ext).copied())
+                let loader: Loader = Self::configured_loader(&this_transpiler.options.loaders, ext)
                     .unwrap_or(Loader::Tsx);
-                if loader.can_be_run_by_bun() || loader == Loader::Html || loader == Loader::Md {
+                if loader.can_be_run_by_bun() {
                     bun_core::scoped_log!(RUN_LOG, "Resolved to: `{}`", bstr::BStr::new(path.text));
                     // borrowck — `boot_and_handle_error` takes
                     // `&mut ctx`; copy `path.text` out of the resolver borrow.
@@ -3065,6 +3090,7 @@ pub enum Filter {
     AllPlusBunJs,
     ScriptExclude,
     ScriptAndDescriptions,
+    RunnableExtensions,
 }
 
 type DoneChannel =
@@ -3629,6 +3655,36 @@ impl RunCommand {
             }
         }
 
+        if FILTER == Filter::RunnableExtensions {
+            // Candidates are every extension either map names; `configured_loader`
+            // then resolves each one the way the run path would, so a configured
+            // loader can add an extension or take a default one away.
+            let mut candidates: Vec<&[u8]> = this_transpiler
+                .options
+                .loaders
+                .keys()
+                .iter()
+                .map(|ext| &**ext)
+                .collect();
+            candidates.extend(
+                bun_bundler::options::DEFAULT_LOADERS
+                    .entries()
+                    .map(|(ext, _)| *ext),
+            );
+            let extensions: Vec<Box<[u8]>> = candidates
+                .iter()
+                .filter(|ext| {
+                    Self::configured_loader(&this_transpiler.options.loaders, ext)
+                        .is_some_and(Loader::can_be_run_by_bun)
+                })
+                .map(|ext| Box::from(*ext))
+                .collect();
+            results.ensure_unused_capacity(extensions.len())?;
+            for ext in extensions {
+                let _ = results.get_or_put(ext)?;
+            }
+        }
+
         if FILTER == Filter::AllPlusBunJs || FILTER == Filter::BunJs {
             if let Some(dir_info) = this_transpiler
                 .resolver
@@ -3651,10 +3707,11 @@ impl RunCommand {
                         let value = unsafe { &**entry.1 };
                         let name = value.base();
                         if name[0] != b'.'
-                            && this_transpiler
-                                .options
-                                .loader(paths::extension(name))
-                                .can_be_run_by_bun()
+                            && Self::configured_loader(
+                                &this_transpiler.options.loaders,
+                                paths::extension(name),
+                            )
+                            .is_some_and(Loader::can_be_run_by_bun)
                             && !strings::contains(name, b".config")
                             && !strings::contains(name, b".d.ts")
                             && !strings::contains(name, b".d.mts")

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -241,6 +241,69 @@ describe("bun", () => {
         expect(exitCode).toBe(0);
       }
     });
+
+    const getcompletes = (filter: string, dir: string) => {
+      const { stdout, stderr, exitCode } = spawnSync({
+        cmd: [bunExe(), "getcompletes", filter],
+        env: bunEnv,
+        cwd: dir,
+      });
+      // stderr holds the reason when the subprocess fails, so assert it first: the
+      // failure then reads as the message instead of as a bare exit code.
+      if (exitCode !== 0) expect(stderr.toString()).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout.toString().split("\n").filter(Boolean);
+    };
+
+    test("getcompletes e reports the extensions bun can run", () => {
+      using dir = tempDir("getcompletes-extensions", {});
+      const extensions = getcompletes("e", String(dir));
+
+      expect(extensions).toContain(".js");
+      expect(extensions).toContain(".mjs");
+      expect(extensions).toContain(".ts");
+      expect(extensions).toContain(".tsx");
+      expect(extensions).toContain(".wasm");
+      // `bun x.md` renders the file, `bun x.html` boots an HTML entry point
+      expect(extensions).toContain(".md");
+      expect(extensions).toContain(".html");
+
+      // loaders bun has, but not for entry points
+      expect(extensions).not.toContain(".json");
+      expect(extensions).not.toContain(".css");
+      expect(extensions).not.toContain(".txt");
+      expect(extensions).not.toContain(".toml");
+    });
+
+    test("getcompletes e follows a configured loader in both directions", () => {
+      using dir = tempDir("getcompletes-extensions-bunfig", {
+        "bunfig.toml": '[loader]\n".bagel" = "tsx"\n".ts" = "text"\n',
+      });
+      const extensions = getcompletes("e", String(dir));
+
+      expect(extensions).toContain(".bagel");
+      expect(extensions).not.toContain(".ts");
+      // untouched by the config
+      expect(extensions).toContain(".js");
+    });
+
+    test("getcompletes j lists every runnable file, not only JavaScript and TypeScript", () => {
+      using dir = tempDir("getcompletes-runnable-files", {
+        "app.ts": "",
+        "readme.md": "# hi",
+        "index.html": "<!doctype html>",
+        "data.json": "{}",
+        "style.css": "",
+      });
+      const files = getcompletes("j", String(dir));
+
+      expect(files).toContain("app.ts");
+      expect(files).toContain("readme.md");
+      expect(files).toContain("index.html");
+
+      expect(files).not.toContain("data.json");
+      expect(files).not.toContain("style.css");
+    });
   });
   // On Windows `bun completions` installs bunx as a hardlink (or a .cmd shim) instead of a symlink.
   describe.skipIf(isWindows)("completions", () => {

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -401,4 +401,36 @@ describe("bun <file.md>", () => {
       expect(secondExit).toBe(0);
     },
   );
+
+  // Which extensions render is a loader question, so a bunfig `[loader]` entry
+  // answers it in both directions — including for an explicit path, which
+  // reaches the run path carrying no loader of its own.
+  test("follows a configured loader rather than the extension's default", async () => {
+    using dir = tempDir("md-entry-loader-", {
+      "bunfig.toml": ["[loader]", '".bagel" = "md"', '".md" = "text"'].join("\n"),
+      "doc.bagel": "# Heading\n",
+      "doc.md": "# Heading\n",
+    });
+    const run = async (entry: string) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), entry],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // Only read on the way to a failure, so the ASAN warnings that keep `runMd`
+      // from asserting stderr at all are harmless here: they appear alongside the
+      // real reason instead of on their own.
+      if (exitCode !== 0) expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout;
+    };
+
+    // rendered markdown underlines a heading
+    expect(await run("./doc.bagel")).toContain("===");
+    // mapped away from `md`, the same heading is not rendered
+    expect(await run("./doc.md")).not.toContain("===");
+  });
 });


### PR DESCRIPTION
`bun <TAB>` cannot complete a path today:

```
bun s<TAB>          # src/ exists — no match
bun src/<TAB>       # no match
bun ./app.ts        # bun runs it; ./ap<TAB> completes nothing
```

The zsh completion feeds `compadd -a` a flat list of bare filenames from `bun getcompletes j`, which carries no path information and never offers a directory to descend into. Path completion has to be the shell's job — it knows the user's matchers, ignore rules and expansions.

Everything else follows from that, because a shell doing its own file completion still needs the one thing only bun knows: which extensions it can run. `bun getcompletes e` reports them, resolved as the run path resolves an entry point, so `--loader` and bunfig `[loader]` entries count.

Collecting that set showed it wasn't one. `can_be_run_by_bun()` listed six loaders while two callers hand-patched it and disagreed — the resolve gate added `Html` and `Md`, the fast-run gate only `Md` — so `bun x.md` worked while nothing would ever complete it. `Md` and `Html` moved into the predicate, the patches went away, and the two-tier configured/default lookup became one shared helper.

`j` stays and is fixed: completion files already on disk, or shipped by a distribution, still call it, and they should agree with the binary next to them.

**Please read this as a sketch rather than finished work.** None of the Rust has been compiled — there was no toolchain available where it was written. The zsh side was exercised through a pty against a real directory with `getcompletes e` shimmed, and the shell files parse, but fish was never run and the Rust is reasoned from the sources alone. The shape and the reasoning should be sound; the details want a build and a review.
