### PR TITLE
fetch: reject a non-string unix option instead of dialing the URL host over TCP

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -686,7 +686,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         break 'extract_ssl_config ssl_config;
     };
 
-    // unix: string | undefined
+    // unix: string | undefined. A falsy value means "no unix socket", like
+    // `Bun.connect`. Any other non-string is a TypeError: ignoring it would
+    // send the request to the URL's host over TCP instead.
     unix_socket_path = 'extract_unix_socket_path: {
         let objects_to_try = [
             options_object.unwrap_or_default(),
@@ -696,11 +698,19 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         for obj in objects_to_try {
             if !obj.is_empty() {
                 if let Some(socket_path) = obj.get(global_this, "unix")? {
-                    if socket_path.is_string() && socket_path.get_length(ctx)? > 0 {
-                        break 'extract_unix_socket_path absolute_unix_socket_path(
-                            vm.top_level_dir(),
-                            socket_path.to_bun_string(global_this)?.to_owned_slice(),
-                        );
+                    if socket_path.is_string() {
+                        if socket_path.get_length(ctx)? > 0 {
+                            break 'extract_unix_socket_path absolute_unix_socket_path(
+                                vm.top_level_dir(),
+                                socket_path.to_bun_string(global_this)?.to_owned_slice(),
+                            );
+                        }
+                    } else if socket_path.to_boolean() {
+                        let received =
+                            JSGlobalObject::determine_specific_type(global_this, socket_path)?;
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "fetch: 'unix' must be a string. Received {received}"
+                        )));
                     }
                 }
             }

--- a/test/js/web/fetch/fetch.unix.test.ts
+++ b/test/js/web/fetch/fetch.unix.test.ts
@@ -503,6 +503,55 @@ it.skipIf(isWindows)("unix keep-alive entries are not evicted by TCP pool pressu
   }
 });
 
+it("rejects a non-string unix option instead of dialing the URL host over TCP", async () => {
+  let requests = 0;
+  using tcp = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      requests++;
+      return new Response("via TCP");
+    },
+  });
+  const url = `http://127.0.0.1:${tcp.port}/x`;
+  // Nothing listens here, so a value coerced to this path would fail to
+  // connect rather than answer "via TCP".
+  const sock = join(tmp_dir, "not-listening.sock");
+  const values = {
+    buffer: Buffer.from(sock),
+    uint8array: new TextEncoder().encode(sock),
+    url: Bun.pathToFileURL(sock),
+    object: { toString: () => sock },
+    number: 42,
+    boolean: true,
+    symbol: Symbol("unix"),
+  };
+  const results: Record<string, string> = {};
+  for (const [name, unix] of Object.entries(values)) {
+    results[name] = await fetch(url, { unix: unix as any }).then(
+      res => res.text(),
+      e => `${e.constructor.name} ${e.code}`,
+    );
+  }
+  expect(results).toEqual(
+    Object.fromEntries(Object.keys(values).map(name => [name, "TypeError ERR_INVALID_ARG_TYPE"])),
+  );
+  expect(async () => await fetch(url, { unix: values.buffer as any })).toThrow(
+    "fetch: 'unix' must be a string. Received an instance of Buffer",
+  );
+  expect(requests).toBe(0);
+});
+
+it("treats a falsy unix option as absent", async () => {
+  using tcp = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("via TCP") });
+  const url = `http://127.0.0.1:${tcp.port}/x`;
+  const bodies: string[] = [];
+  for (const unix of ["", null, undefined, false, 0]) {
+    bodies.push(await (await fetch(url, { unix: unix as any })).text());
+  }
+  expect(bodies).toEqual(Array(5).fill("via TCP"));
+});
+
 it("handle redirect to non-unix", async () => {
   startServer({
     async fetch(req) {


### PR DESCRIPTION
### Problem
- `fetch(url, { unix })` ignores `unix` when it is not a JS string. A `Buffer`, `Uint8Array`, `URL`, number, `true`, `Symbol`, or an object with `toString` all send the request to the URL's host over TCP. There is no error and no coercion.
- The cause is the `unix` extraction in `fetch_impl` (`src/runtime/webcore/fetch.rs:690`). It takes the option only when `is_string() && length > 0` and falls through for everything else.

### Fix
- A truthy non-string `unix` now rejects with `TypeError` (`ERR_INVALID_ARG_TYPE`): `fetch: 'unix' must be a string. Received an instance of Buffer`. No request is sent.
- Falsy values (`""`, `null`, `undefined`, `false`, `0`) still mean "no unix socket". This matches `Bun.connect` and `Bun.listen`, whose `unix` member is `String.nullable.loose`: falsy is absent, a truthy non-string throws `SocketOptions.unix must be a string`.
- Correct because the option can no longer change the transport in silence. `fetch_impl` errors become rejected promises through `reject_on_exception`, so `fetch()` still never throws synchronously.
- Verified: `test/js/web/fetch/fetch.unix.test.ts` (two new tests, stock bun fails the first). Also `test/js/web/fetch/fetch-args.test.ts`.

### Background
- `unix` is a Bun extension to `fetch` init. It dials a unix domain socket and sends the request for `url` over it. The docs (`docs/runtime/networking/fetch.mdx`) give its type as `unix: string`.
- `fetch_impl` reads each Bun extension from fetch's init object and, when the first argument is a plain object, from that object. Both paths go through the same extraction block, so both get the new check.
- Node has no `unix` option on `fetch`. Its closest analogue, `net.connect({ path: Buffer })`, throws `ERR_INVALID_ARG_TYPE`.

<details><summary>Notes</summary>

Repro on 1.4.3-canary (`f42e98025`), every non-string row answered by the TCP server:

```js
import os from "node:os"; import path from "node:path";
const sock = path.join(os.tmpdir(), `r-${process.pid}.sock`);
const unixSrv = Bun.serve({ unix: sock, fetch: () => new Response("via UNIX") });
const tcpSrv = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("via TCP") });
const U = `http://127.0.0.1:${tcpSrv.port}/x`;
for (const [k, v] of Object.entries({ string: sock, buffer: Buffer.from(sock), url: new URL("file://" + sock), number: 42, toStringObj: { toString: () => sock }, empty: "", nul: null }))
  console.log(k.padEnd(12), await fetch(U, { unix: v }).then(r => r.text(), e => "REJECT " + e.message));
unixSrv.stop(true); tcpSrv.stop(true);
```

Before: `string -> via UNIX`, every other row `-> via TCP`. After: `buffer`, `url`, `number`, `toStringObj` reject with `ERR_INVALID_ARG_TYPE`. `empty` and `nul` still go to TCP.

Accepting `Buffer`/`URL` like `node:fs` path arguments was considered. `Bun.connect`, `Bun.listen`, and the docs are string-only, so this change keeps `fetch` consistent with them instead of adding a new accepted shape in one place.

No built-in JS module passes `unix` to native `fetch` (`node:http` uses raw sockets for `socketPath`), so nothing internal depends on the old fall-through.

Out of scope here: `new Request(url, { unix })` does not keep the option, so `fetch(request)` goes over TCP. That is a separate design question (store Bun extensions on `Request`, or throw in the constructor).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.unix.test.ts

<!-- robobun:evidence:end -->