### PR TITLE
yaml: escape non-printable characters and use explicit entries for keys over 1024 characters in stringify

### DIFF
--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -518,8 +518,7 @@ impl Stringifier {
                     }
                     first = false;
 
-                    self.append_string(&prop_name);
-                    self.builder.append_latin1(b": ");
+                    self.append_key(&prop_name);
 
                     self.stringify(global, value)?;
                 }
@@ -539,8 +538,7 @@ impl Stringifier {
                     }
                     first = false;
 
-                    self.append_string(&prop_name);
-                    self.builder.append_latin1(b": ");
+                    self.append_key(&prop_name);
 
                     self.indent += 1;
 
@@ -595,54 +593,18 @@ impl Stringifier {
         for i in 0..str.length() {
             let c = str.char_at(i);
 
-            match c {
-                0x00 => self.builder.append_latin1(b"\\0"),
-                0x01 => self.builder.append_latin1(b"\\x01"),
-                0x02 => self.builder.append_latin1(b"\\x02"),
-                0x03 => self.builder.append_latin1(b"\\x03"),
-                0x04 => self.builder.append_latin1(b"\\x04"),
-                0x05 => self.builder.append_latin1(b"\\x05"),
-                0x06 => self.builder.append_latin1(b"\\x06"),
-                0x07 => self.builder.append_latin1(b"\\a"), // bell
-                0x08 => self.builder.append_latin1(b"\\b"), // backspace
-                0x09 => self.builder.append_latin1(b"\\t"), // tab
-                0x0a => self.builder.append_latin1(b"\\n"), // line feed
-                0x0b => self.builder.append_latin1(b"\\v"), // vertical tab
-                0x0c => self.builder.append_latin1(b"\\f"), // form feed
-                0x0d => self.builder.append_latin1(b"\\r"), // carriage return
-                0x0e => self.builder.append_latin1(b"\\x0e"),
-                0x0f => self.builder.append_latin1(b"\\x0f"),
-                0x10 => self.builder.append_latin1(b"\\x10"),
-                0x11 => self.builder.append_latin1(b"\\x11"),
-                0x12 => self.builder.append_latin1(b"\\x12"),
-                0x13 => self.builder.append_latin1(b"\\x13"),
-                0x14 => self.builder.append_latin1(b"\\x14"),
-                0x15 => self.builder.append_latin1(b"\\x15"),
-                0x16 => self.builder.append_latin1(b"\\x16"),
-                0x17 => self.builder.append_latin1(b"\\x17"),
-                0x18 => self.builder.append_latin1(b"\\x18"),
-                0x19 => self.builder.append_latin1(b"\\x19"),
-                0x1a => self.builder.append_latin1(b"\\x1a"),
-                0x1b => self.builder.append_latin1(b"\\e"), // escape
-                0x1c => self.builder.append_latin1(b"\\x1c"),
-                0x1d => self.builder.append_latin1(b"\\x1d"),
-                0x1e => self.builder.append_latin1(b"\\x1e"),
-                0x1f => self.builder.append_latin1(b"\\x1f"),
-                0x22 => self.builder.append_latin1(b"\\\""), // "
-                0x5c => self.builder.append_latin1(b"\\\\"), // \
-                0x7f => self.builder.append_latin1(b"\\x7f"), // delete
-                0x85 => self.builder.append_latin1(b"\\N"),  // next line
-                0xa0 => self.builder.append_latin1(b"\\_"),  // non-breaking space
-                0x2028 => self.builder.append_latin1(b"\\L"), // line separator
-                0x2029 => self.builder.append_latin1(b"\\P"), // paragraph separator
-
-                0x20..=0x21
-                | 0x23..=0x5b
-                | 0x5d..=0x7e
-                | 0x80..=0x84
-                | 0x86..=0x9f
-                | 0xa1..=0x2027
-                | 0x202a..=u16::MAX => self.builder.append_uchar(c),
+            match Escape::of(c) {
+                None => self.builder.append_uchar(c),
+                Some(Escape::Short(e)) => self.builder.append_latin1(&[b'\\', e]),
+                Some(Escape::Hex2) => {
+                    let [hi, lo] = bun_core::fmt::hex_byte_lower(c as u8);
+                    self.builder.append_latin1(&[b'\\', b'x', hi, lo]);
+                }
+                Some(Escape::Hex4) => {
+                    let [h1, h2] = bun_core::fmt::hex_byte_lower((c >> 8) as u8);
+                    let [h3, h4] = bun_core::fmt::hex_byte_lower(c as u8);
+                    self.builder.append_latin1(&[b'\\', b'u', h1, h2, h3, h4]);
+                }
             }
         }
 
@@ -656,6 +618,101 @@ impl Stringifier {
         }
         self.builder.append_string(str);
     }
+
+    /// Writes `key: `. A key that is too long to be implicit is written as an
+    /// explicit entry instead: `? key`, then `: ` on the next line (block) or
+    /// right after the key (flow).
+    fn append_key(&mut self, key: &BunString) {
+        let quoted = string_needs_quotes(key);
+        let explicit = key_needs_explicit_entry(key, quoted);
+
+        if explicit {
+            self.builder.append_latin1(b"? ");
+        }
+        if quoted {
+            self.append_double_quoted_string(key);
+        } else {
+            self.builder.append_string(key);
+        }
+        if explicit && !matches!(self.space, Space::Minified) {
+            self.newline();
+        }
+        self.builder.append_latin1(b": ");
+    }
+}
+
+/// An escape sequence in a double-quoted scalar (YAML 1.2 §5.7).
+#[derive(Clone, Copy)]
+enum Escape {
+    /// `\` and one more character: `\0`, `\n`, `\"`, `\N`, ...
+    Short(u8),
+    /// `\xHH`
+    Hex2,
+    /// `\uHHHH`
+    Hex4,
+}
+
+impl Escape {
+    /// The escape for the UTF-16 code unit `c`, or `None` when `c` is written
+    /// as is. Output may only contain printable characters (§5.1 `c-printable`,
+    /// and `nb-char` also keeps a BOM out of content), so every other one is
+    /// escaped. NEL, NBSP, LS and PS are printable but keep their short escapes
+    /// for YAML 1.1 readers.
+    fn of(c: u16) -> Option<Escape> {
+        Some(match c {
+            0x00 => Escape::Short(b'0'),
+            0x07 => Escape::Short(b'a'),
+            0x08 => Escape::Short(b'b'),
+            0x09 => Escape::Short(b't'),
+            0x0a => Escape::Short(b'n'),
+            0x0b => Escape::Short(b'v'),
+            0x0c => Escape::Short(b'f'),
+            0x0d => Escape::Short(b'r'),
+            0x1b => Escape::Short(b'e'),
+            0x22 => Escape::Short(b'"'),
+            0x5c => Escape::Short(b'\\'),
+            0x85 => Escape::Short(b'N'),
+            0xa0 => Escape::Short(b'_'),
+            0x2028 => Escape::Short(b'L'),
+            0x2029 => Escape::Short(b'P'),
+            0x01..=0x06 | 0x0e..=0x1a | 0x1c..=0x1f | 0x7f..=0x84 | 0x86..=0x9f => Escape::Hex2,
+            0xfeff | 0xfffe | 0xffff => Escape::Hex4,
+            _ => return None,
+        })
+    }
+
+    /// Length of the escape sequence in characters.
+    fn len(self) -> usize {
+        match self {
+            Escape::Short(_) => 2,
+            Escape::Hex2 => 4,
+            Escape::Hex4 => 6,
+        }
+    }
+}
+
+/// YAML 1.2 §7.4.2 limits an implicit key to 1024 characters so that a parser
+/// can find the `:` with bounded lookahead. libyaml and PyYAML reject a longer
+/// one, in block and in flow mappings.
+fn key_needs_explicit_entry(key: &BunString, quoted: bool) -> bool {
+    const MAX_IMPLICIT_KEY_LEN: usize = 1024;
+
+    // The longest escape writes one code unit as six characters (`\uHHHH`).
+    if key.length() <= (MAX_IMPLICIT_KEY_LEN - 2) / 6 {
+        return false;
+    }
+
+    let written_len = if quoted {
+        let mut len: usize = 2;
+        for i in 0..key.length() {
+            len += Escape::of(key.char_at(i)).map_or(1, Escape::len);
+        }
+        len
+    } else {
+        key.length()
+    };
+
+    written_len > MAX_IMPLICIT_KEY_LEN
 }
 
 /// Does this (unwrapped) object property value need a newline? True for arrays and objects.
@@ -870,13 +927,15 @@ fn string_needs_quotes(str: &BunString) -> bool {
                 i += 1;
             }
 
+            // not printable, or only representable with an escape (see `Escape::of`)
             0x00..=0x1f
             | 0x22
-            | 0x7f
-            | 0x85
-            | 0xa0
+            | 0x7f..=0xa0
             | 0x2028
-            | 0x2029 => return true,
+            | 0x2029
+            | 0xfeff
+            | 0xfffe
+            | 0xffff => return true,
 
             _ => {
                 i += 1;

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -619,9 +619,7 @@ impl Stringifier {
         self.builder.append_string(str);
     }
 
-    /// Writes `key: `. A key that is too long to be implicit is written as an
-    /// explicit entry instead: `? key`, then `: ` on the next line (block) or
-    /// right after the key (flow).
+    /// Writes `key: `, or an explicit `? key` / `: ` entry when the key is too long to be implicit.
     fn append_key(&mut self, key: &BunString) {
         let quoted = string_needs_quotes(key);
         let explicit = key_needs_explicit_entry(key, quoted);
@@ -653,11 +651,7 @@ enum Escape {
 }
 
 impl Escape {
-    /// The escape for the UTF-16 code unit `c`, or `None` when `c` is written
-    /// as is. Output may only contain printable characters (§5.1 `c-printable`,
-    /// and `nb-char` also keeps a BOM out of content), so every other one is
-    /// escaped. NEL, NBSP, LS and PS are printable but keep their short escapes
-    /// for YAML 1.1 readers.
+    /// The escape for `c`, or `None` to write it as is. Covers all YAML may not hold raw (§5.1).
     fn of(c: u16) -> Option<Escape> {
         Some(match c {
             0x00 => Escape::Short(b'0'),
@@ -691,9 +685,7 @@ impl Escape {
     }
 }
 
-/// YAML 1.2 §7.4.2 limits an implicit key to 1024 characters so that a parser
-/// can find the `:` with bounded lookahead. libyaml and PyYAML apply the limit
-/// inside flow mappings too, so a longer key is rejected in either style.
+/// An implicit key is at most 1024 characters (YAML 1.2 §7.4.2; libyaml applies it in flow too).
 fn key_needs_explicit_entry(key: &BunString, quoted: bool) -> bool {
     const MAX_IMPLICIT_KEY_LEN: usize = 1024;
 

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -692,8 +692,8 @@ impl Escape {
 }
 
 /// YAML 1.2 §7.4.2 limits an implicit key to 1024 characters so that a parser
-/// can find the `:` with bounded lookahead. libyaml and PyYAML reject a longer
-/// one, in block and in flow mappings.
+/// can find the `:` with bounded lookahead. libyaml and PyYAML apply the limit
+/// inside flow mappings too, so a longer key is rejected in either style.
 fn key_needs_explicit_entry(key: &BunString, quoted: bool) -> bool {
     const MAX_IMPLICIT_KEY_LEN: usize = 1024;
 
@@ -927,7 +927,7 @@ fn string_needs_quotes(str: &BunString) -> bool {
                 i += 1;
             }
 
-            // not printable, or only representable with an escape (see `Escape::of`)
+            // written with an escape (see `Escape::of`), which only a quoted scalar has
             0x00..=0x1f
             | 0x22
             | 0x7f..=0xa0

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2939,7 +2939,7 @@ config:
         // (#x9 | #xA | #xD | [#x20-#x7E] | #x85 | [#xA0-#xD7FF] | [#xE000-#xFFFD]
         // | [#x10000-#x10FFFF]); anything else must be an escape sequence in a
         // double-quoted scalar. [27] nb-char also keeps a BOM out of content.
-        // libyaml and PyYAML reject the raw characters.
+        // libyaml and PyYAML reject the raw C1 controls, U+FFFE and U+FFFF.
         const cases: [string, string][] = [
           ["\u0080", '"\\x80"'],
           ["\u0084", '"\\x84"'],

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2934,6 +2934,52 @@ config:
         expect(YAML.parse(YAML.stringify("a\u2028b\u2029c"))).toBe("a\u2028b\u2029c");
       });
 
+      test("escapes C1 controls, U+FEFF, U+FFFE and U+FFFF", () => {
+        // YAML 1.2 §5.1: output may only contain c-printable characters
+        // (#x9 | #xA | #xD | [#x20-#x7E] | #x85 | [#xA0-#xD7FF] | [#xE000-#xFFFD]
+        // | [#x10000-#x10FFFF]); anything else must be an escape sequence in a
+        // double-quoted scalar. [27] nb-char also keeps a BOM out of content.
+        // libyaml and PyYAML reject the raw characters.
+        const cases: [string, string][] = [
+          ["\u0080", '"\\x80"'],
+          ["\u0084", '"\\x84"'],
+          ["\u0085", '"\\N"'],
+          ["\u0086", '"\\x86"'],
+          ["\u009f", '"\\x9f"'],
+          ["\u00a0", '"\\_"'],
+          ["\ufeff", '"\\ufeff"'],
+          ["\ufffe", '"\\ufffe"'],
+          ["\uffff", '"\\uffff"'],
+          ["a\u0080b", '"a\\x80b"'],
+          ["a\u009fb", '"a\\x9fb"'],
+          ["a\ufeffb", '"a\\ufeffb"'],
+          ["a\ufffeb", '"a\\ufffeb"'],
+          ["a\uffffb", '"a\\uffffb"'],
+          // neighbours stay printable and unquoted
+          ["a\u00a1b", "a\u00a1b"],
+          ["a\ue000b", "a\ue000b"],
+          ["a\ufffdb", "a\ufffdb"],
+        ];
+        for (const [input, expected] of cases) {
+          expect(YAML.stringify(input)).toBe(expected);
+          expect(YAML.parse(expected)).toBe(input);
+        }
+
+        expect(YAML.stringify({ "a\u0080b": "c\uffffd" }, null, 2)).toBe('"a\\x80b": "c\\uffffd"');
+        expect(YAML.stringify({ "a\u0080b": "c\uffffd" })).toBe('{"a\\x80b": "c\\uffffd"}');
+        expect(YAML.parse(YAML.stringify({ "a\u0080b": ["c\uffffd", "\u009f"] }))).toEqual({
+          "a\u0080b": ["c\uffffd", "\u009f"],
+        });
+
+        let c1 = "";
+        for (let cp = 0x80; cp <= 0x9f; cp++) c1 += String.fromCharCode(cp);
+        expect(YAML.stringify(c1)).toBe(
+          '"\\x80\\x81\\x82\\x83\\x84\\N\\x86\\x87\\x88\\x89\\x8a\\x8b\\x8c\\x8d\\x8e\\x8f' +
+            '\\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\\x98\\x99\\x9a\\x9b\\x9c\\x9d\\x9e\\x9f"',
+        );
+        expect(YAML.parse(YAML.stringify(c1))).toBe(c1);
+      });
+
       test("round-trips every non-surrogate BMP code point", () => {
         let all = "";
         for (let cp = 0; cp <= 0xffff; cp++) {
@@ -3849,6 +3895,77 @@ config:
         expect(parsed["key: value"]).toBe("colon space key");
         expect(parsed["[array]"]).toBe("bracket key");
         expect(parsed["{object}"]).toBe("brace key");
+      });
+
+      test("writes a key longer than 1024 characters as an explicit `?` entry", () => {
+        // YAML 1.2 [154]/[155]: an implicit key is at most 1024 characters, so
+        // that a parser can find the `:` with bounded lookahead. libyaml and
+        // PyYAML reject a longer one in block and in flow mappings. An explicit
+        // `? key` entry has no length limit.
+        const fits = Buffer.alloc(1024, "k").toString();
+        const long = Buffer.alloc(1025, "k").toString();
+
+        expect(YAML.stringify({ [fits]: 1 }, null, 2)).toBe(`${fits}: 1`);
+        expect(YAML.stringify({ [fits]: 1 })).toBe(`{${fits}: 1}`);
+        expect(YAML.stringify({ [long]: 1 }, null, 2)).toBe(`? ${long}\n: 1`);
+        expect(YAML.stringify({ [long]: 1 })).toBe(`{? ${long}: 1}`);
+
+        // The limit applies to the key as written, quotes and escapes included.
+        const quotedFits = " " + Buffer.alloc(1021, "k").toString(); // `" kkk..."` is 1024 long
+        const quotedLong = " " + Buffer.alloc(1022, "k").toString(); // 1025
+        expect(YAML.stringify({ [quotedFits]: 1 }, null, 2)).toBe(`"${quotedFits}": 1`);
+        expect(YAML.stringify({ [quotedFits]: 1 })).toBe(`{"${quotedFits}": 1}`);
+        expect(YAML.stringify({ [quotedLong]: 1 }, null, 2)).toBe(`? "${quotedLong}"\n: 1`);
+        expect(YAML.stringify({ [quotedLong]: 1 })).toBe(`{? "${quotedLong}": 1}`);
+
+        const hexFits = Buffer.alloc(255, 1).toString("latin1"); // 255 `\x01` + 2 quotes = 1022
+        const hexLong = Buffer.alloc(256, 1).toString("latin1"); // 1026
+        expect(YAML.stringify({ [hexFits]: 1 }, null, 2)).toBe(`"${"\\x01".repeat(255)}": 1`);
+        expect(YAML.stringify({ [hexLong]: 1 }, null, 2)).toBe(`? "${"\\x01".repeat(256)}"\n: 1`);
+
+        const uFits = "\ufffe".repeat(170); // 170 `\ufffe` + 2 quotes = 1022
+        const uLong = "\ufffe".repeat(171); // 1028
+        expect(YAML.stringify({ [uFits]: 1 }, null, 2)).toBe(`"${"\\ufffe".repeat(170)}": 1`);
+        expect(YAML.stringify({ [uLong]: 1 }, null, 2)).toBe(`? "${"\\ufffe".repeat(171)}"\n: 1`);
+
+        // Nested and with collection values: the `:` is written at the
+        // indentation of its `?`.
+        const obj = { a: 0, [long]: { b: [1, 2] }, c: [{ [long]: 3, d: 4 }], [quotedLong]: [] };
+        expect(
+          YAML.stringify(obj, null, 2)
+            .split("\n")
+            .map(line => line.trimEnd()),
+        ).toEqual([
+          "a: 0",
+          `? ${long}`,
+          ":",
+          "  b:",
+          "    - 1",
+          "    - 2",
+          "c:",
+          `  - ? ${long}`,
+          "    : 3",
+          "    d: 4",
+          `? "${quotedLong}"`,
+          ":",
+          "  []",
+        ]);
+        expect(YAML.stringify(obj)).toBe(`{a: 0,? ${long}: {b: [1,2]},c: [{? ${long}: 3,d: 4}],? "${quotedLong}": []}`);
+
+        for (const value of [
+          { [fits]: 1 },
+          { [long]: 1 },
+          { [quotedFits]: 1 },
+          { [quotedLong]: 1 },
+          { [hexFits]: 1 },
+          { [hexLong]: 1 },
+          { [uFits]: 1 },
+          { [uLong]: 1 },
+          obj,
+        ]) {
+          expect(YAML.parse(YAML.stringify(value))).toEqual(value);
+          expect(YAML.parse(YAML.stringify(value, null, 2))).toEqual(value);
+        }
       });
 
       test("handles arrays with objects containing undefined/symbol", () => {


### PR DESCRIPTION
### Problem
- `Bun.YAML.stringify` writes the C1 controls (U+0080 to U+009F except NEL), U+FEFF, U+FFFE and U+FFFF as is, and does not quote a string made only of them. YAML 1.2 §5.1 allows only printable characters in a document. PyYAML and libyaml stop with `unacceptable character #x0080: special characters are not allowed`.
- It writes a key longer than 1024 characters as an implicit `key: value` entry. YAML 1.2 §7.4.2 caps an implicit key at 1024 characters. libyaml and PyYAML stop with `mapping values are not allowed here`, eemeli/yaml with `The : indicator must be at most 1024 chars after the start of an implicit block mapping key`.
- Cause: the escape table in `append_double_quoted_string` and the classifier `string_needs_quotes` (`src/runtime/api/YAMLObject.rs`) have no entry for these code units, and key emission has no length check. `YAML.parse` reads the output back, so the round-trip tests did not catch it.

### Fix
- One table, `Escape::of`, decides how each UTF-16 code unit is written in a double-quoted scalar. New entries: `\xHH` for U+0080 to U+009F, `\uHHHH` for U+FEFF, U+FFFE and U+FFFF. `string_needs_quotes` forces quotes for them.
- `append_key` measures the key as written (quotes and escapes, from the same table). Above 1024 characters it writes an explicit entry: `? key`, then `: value` on the next line in block style, `{? key: value}` in flow style. `YAML.parse` already reads both, so the round trip holds. js-yaml makes the same two choices.
- Verified: `test/js/bun/yaml/yaml.test.ts` (two new tests, both fail on 1.4.3), the rest of `test/js/bun/yaml/`. PyYAML, libyaml, js-yaml and eemeli/yaml load the new block and flow output equal to the JSON of the same value.
- Self-reviewed: no correctness concerns raised; 3 comment-precision nits (U+FEFF is in fact accepted raw by libyaml, the flow-mapping limit comes from libyaml rather than the spec grammar, one imprecise quoting comment), all 3 fixed.

### Background
- YAML has escape sequences only inside double-quoted scalars. A plain scalar is verbatim, so a character that needs an escape also forces the quoted style.
- `key: value` is an implicit key: a parser learns that it read a key only when it reaches the `:`. The spec bounds that lookahead at 1024 characters and one line. An explicit entry marks the key up front with `?` and has no limit.
- Lone surrogates have the same raw pass-through problem. #40042 covers them, so they are out of scope here.

<details><summary>Notes</summary>

Repro on bun 1.4.3 (PyYAML 6.0.2 with libyaml):

```js
const Y = Bun.YAML, fs = require("fs");
fs.writeFileSync("a.yaml", Y.stringify({ v: "a\^@b", w: "\uFFFE" }, null, 2));
fs.writeFileSync("b.yaml", Y.stringify({ ["k".repeat(1025)]: 1 }, null, 2));
fs.writeFileSync("c.yaml", Y.stringify({ ["k".repeat(1025)]: 1 }));
// python3 -c 'import yaml; yaml.safe_load(open("a.yaml"))'
//   yaml.reader.ReaderError: unacceptable character #x0080: special characters are not allowed
// b.yaml: yaml.scanner.ScannerError: mapping values are not allowed here (line 1, column 1026)
// c.yaml: expected ',' or '}', but got ':' (line 1, column 1027)
```

Cross-parser check on this branch: a value holding every non-surrogate BMP code point, 1025-character plain and quoted keys at the root, inside an array item and with collection values, written with `space = 2` and minified. PyYAML `SafeLoader`, PyYAML `CSafeLoader` (libyaml), js-yaml 4 `load` and eemeli/yaml 2 `parse(..., { strict: true })` all return a value equal to `JSON.parse(JSON.stringify(value))`, and so does `Bun.YAML.parse`.

Boundary: PyYAML and libyaml drop a possible simple key once the `:` is more than 1024 characters past the key start, so a written key of exactly 1024 characters is still implicit (`"k" * 1024: 1` loads, 1025 does not). The written length is counted in UTF-16 code units because eemeli/yaml measures the limit on the JavaScript string: a block key of 512 U+1F600 (1024 units) loads there, 513 does not. PyYAML and libyaml count code points (1024 of U+1F600 load, 1025 do not), so the code-unit count is the one every parser accepts; it only moves a key of more than 512 supplementary-plane characters to the explicit form.

U+FEFF: `c-printable` includes it, but `nb-char ::= c-printable - b-char - c-byte-order-mark` keeps it out of plain scalars, and §5.2 says a BOM inside a quoted scalar "should be escaped on output". js-yaml escapes it too.

Reference emitters: js-yaml writes `\x80`, `\uFFFE`, `\uFEFF` and switches to `? ` when the dumped key is longer than 1024. eemeli/yaml switches to `? ` as well (it writes C1 raw). The escapes here use lowercase hex like the existing `\x01` and `\x7f`.

Flow style: the spec grammar puts the 1024 limit on block implicit keys and on single pairs in flow sequences, not on flow mapping entries, but libyaml and PyYAML apply it everywhere, so the minified output uses `{? key: value}` too. All four parsers above accept that form.

Not touched: a sequence of mappings written with an indentation width other than 2 (`YAML.stringify([{ a: 1, b: 2 }], null, 4)` gives `- a: 1\n    b: 2`) is rejected by every parser including `Bun.YAML.parse`. That is a separate, pre-existing layout bug and not part of this change. `Bun.TOML.stringify` with lone-surrogate keys (same report) is also separate.

Suites run locally with the debug build: `test/js/bun/yaml/yaml.test.ts`, `yaml-test-suite.test.ts`, `yaml-block-scalar-matrix.test.ts`.
</details>


