### PR TITLE
require(esm): reject top-level await before evaluating, with ERR_REQUIRE_ASYNC_MODULE

### DIFF
--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -163,7 +163,7 @@ const myStuff = require("./my-commonjs.cjs");
 
 ### Top level await
 
-The only exception to this rule is top-level await. You can't `require()` a file that uses top-level await, since the `require()` function is inherently synchronous.
+The only exception to this rule is top-level await. You can't `require()` a file that uses top-level await, or a file that imports one, since the `require()` function is inherently synchronous. Like Node.js, Bun throws an `ERR_REQUIRE_ASYNC_MODULE` error in that case, before it runs any module in that graph.
 
 Fortunately, very few libraries use top-level await, so this is rarely a problem. But if you're using top-level await in your application code, make sure that file isn't `require()`'d from elsewhere in your application. Use `import` or [dynamic `import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) instead.
 

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -229,7 +229,7 @@ declare function $format(): TODO;
 declare function $esmNamespaceForCjs(key: string): any | undefined;
 declare function $esmRegistryDelete(key: string): boolean;
 declare function $esmRegistryEvaluatedKeys(): string[];
-declare function $esmLoadSync(key: string): any;
+declare function $esmLoadSync(key: string, parentFilename?: string): any;
 declare function $get(): TODO;
 declare function $handleEvent(): TODO;
 declare function $headers(): TODO;
@@ -257,7 +257,7 @@ declare function $removeAbortAlgorithmFromSignal(signal: AbortSignal, algorithmI
 declare function $redirect(): TODO;
 declare function $relative(): TODO;
 declare function $require(): TODO;
-declare function $requireESM(path: string): any;
+declare function $requireESM(path: string, parentFilename?: string): any;
 declare const $requireMap: Map<string, JSCommonJSModule>;
 declare const $internalModuleRegistry: InternalFieldObject<any[]>;
 declare function $resolve(name: string, from: string): Promise<string>;

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -107,7 +107,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
   // -1 means we need to lookup the module from the ESM registry.
   if (out === -1) {
     try {
-      out = $requireESM(id);
+      out = $requireESM(id, this.filename);
     } catch (exception) {
       // Since the ESM code is mostly JS, we need to handle exceptions here.
       $requireMap.$delete(id);
@@ -171,22 +171,24 @@ export function internalRequire(id: string, parent: JSCommonJSModule) {
 }
 
 $visibility = "Private";
-export function loadEsmIntoCjs(resolvedSpecifier: string) {
+export function loadEsmIntoCjs(resolvedSpecifier: string, parentFilename?: string) {
   // The JSC module loader pipeline is now pure C++. $esmLoadSync sets a VM
   // flag that makes the loader's internal promise reactions run immediately
   // (instead of queueing microtasks) whenever the upstream promise is already
   // settled. Because Bun resolves and reads source code synchronously, the
-  // entire fetch → parse → link → evaluate chain completes within this call
-  // for any module graph that does not use top-level await.
-  return $esmLoadSync(resolvedSpecifier);
+  // entire fetch → parse → link → evaluate chain completes within this call.
+  // A graph that contains top-level await is rejected with
+  // ERR_REQUIRE_ASYNC_MODULE after it is loaded and before any of it runs;
+  // `parentFilename` only feeds that error's message.
+  return $esmLoadSync(resolvedSpecifier, parentFilename);
 }
 
 $visibility = "Private";
-export function requireESM(this, resolved: string) {
+export function requireESM(this, resolved: string, parentFilename?: string) {
   // `$esmLoadSync` answers from the registry for a record that is already
   // Evaluated, or still Evaluating because this require() sits inside its own
   // evaluation (a require cycle), before it loads anything.
-  const exports = $loadEsmIntoCjs(resolved);
+  const exports = $loadEsmIntoCjs(resolved, parentFilename);
   if (exports === undefined) {
     throw new TypeError(`require() failed to evaluate module "${resolved}". This is an internal consistentency error.`);
   }
@@ -197,7 +199,7 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
   $assert(this);
   let namespace;
   try {
-    namespace = $requireESM(id);
+    namespace = $requireESM(id, this.parent?.filename);
   } catch (exception) {
     // Since the ESM code is mostly JS, we need to handle exceptions here.
     $requireMap.$delete(id);

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -172,14 +172,8 @@ export function internalRequire(id: string, parent: JSCommonJSModule) {
 
 $visibility = "Private";
 export function loadEsmIntoCjs(resolvedSpecifier: string, parentFilename?: string) {
-  // The JSC module loader pipeline is now pure C++. $esmLoadSync sets a VM
-  // flag that makes the loader's internal promise reactions run immediately
-  // (instead of queueing microtasks) whenever the upstream promise is already
-  // settled. Because Bun resolves and reads source code synchronously, the
-  // entire fetch → parse → link → evaluate chain completes within this call.
-  // A graph that contains top-level await is rejected with
-  // ERR_REQUIRE_ASYNC_MODULE after it is loaded and before any of it runs;
-  // `parentFilename` only feeds that error's message.
+  // Runs JSC's loader synchronously (fetch → parse → link → evaluate) in C++. A graph with
+  // top-level await throws ERR_REQUIRE_ASYNC_MODULE before any of it runs.
   return $esmLoadSync(resolvedSpecifier, parentFilename);
 }
 

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -172,8 +172,7 @@ export function internalRequire(id: string, parent: JSCommonJSModule) {
 
 $visibility = "Private";
 export function loadEsmIntoCjs(resolvedSpecifier: string, parentFilename?: string) {
-  // Runs JSC's loader synchronously (fetch → parse → link → evaluate) in C++. A graph with
-  // top-level await throws ERR_REQUIRE_ASYNC_MODULE before any of it runs.
+  // Runs JSC's loader synchronously in C++; a graph with top-level await throws ERR_REQUIRE_ASYNC_MODULE before any of it runs.
   return $esmLoadSync(resolvedSpecifier, parentFilename);
 }
 

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -296,6 +296,7 @@ const errors: ErrorCodeMapping = [
   ["HPE_INVALID_EOF_STATE", Error],
   ["HPE_INVALID_METHOD", Error],
   ["HPE_INTERNAL", Error],
+  ["ERR_REQUIRE_ASYNC_MODULE", Error],
   ["ERR_VM_MODULE_STATUS", Error],
   ["ERR_VM_MODULE_ALREADY_LINKED", Error],
   ["ERR_VM_MODULE_CANNOT_CREATE_CACHED_DATA", Error],

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -738,18 +738,14 @@ static bool isModuleEvaluating(JSC::AbstractModuleRecord* record)
     return cyclic && cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluating;
 }
 
-// Once a cyclic record has left Status::New its LoadRequestedModules has
-// completed, so [[LoadedModules]] names every dependency transitively.
+// Past Status::New, LoadRequestedModules has completed: [[LoadedModules]] is complete, transitively.
 static bool isModuleGraphLoaded(JSC::AbstractModuleRecord* record)
 {
     auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record);
     return cyclic && cyclic->status() != JSC::CyclicModuleRecord::Status::New;
 }
 
-// The first record in `root`'s loaded graph whose own body uses top-level
-// await, or null. This is the static [[HasTLA]] walk Node performs
-// (v8::Module::IsGraphAsync) before it lets require() evaluate an ES module,
-// and again when require() meets a graph that import() already evaluated.
+// Node's check before require(esm) may evaluate (v8::Module::IsGraphAsync): a [[HasTLA]] record anywhere in the loaded graph.
 static JSC::AbstractModuleRecord* findTopLevelAwaitInGraph(JSC::AbstractModuleRecord* root)
 {
     WTF::UncheckedKeyHashSet<JSC::AbstractModuleRecord*> visited;
@@ -839,9 +835,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     auto keyString = keyValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     auto key = JSC::Identifier::fromString(vm, keyString);
-    // The filename of the CommonJS module whose require() this is. Only used
-    // for the "From" line of ERR_REQUIRE_ASYNC_MODULE, as in Node.
-    WTF::String parentFilename;
+    WTF::String parentFilename; // the requiring module, for the error message only
     if (JSValue parentValue = callFrame->argument(1); parentValue.isString()) {
         parentFilename = asString(parentValue)->value(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
@@ -852,9 +846,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     if (auto* entry = loader->registryEntry(key)) {
         entryExistedBefore = true;
         auto* record = entry->record();
-        // Checked before the evaluated / evaluating fast paths: Node rejects
-        // require() of a top-level-await graph even after import() has fully
-        // evaluated it, so the answer does not depend on timing.
+        // First, so that a graph import() has already evaluated is rejected too, as in Node.
         if (isModuleGraphLoaded(record)) {
             if (auto* asyncRecord = findTopLevelAwaitInGraph(record))
                 return throwRequireAsyncModule(globalObject, scope, keyString, parentFilename, asyncRecord);
@@ -864,18 +856,12 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
         }
-        // Any other Evaluating record must not reach loadModule: Link() and
-        // Evaluate() reject that status.
+        // Any other Evaluating record must not reach loadModule: Link() and Evaluate() reject that status.
         if (isModuleEvaluating(record))
             return throwVMTypeError(globalObject, scope, makeString("require() async module \""_s, keyString, "\" is unsupported. use \"await import()\" instead."_s));
     }
 
-    // Load the graph (fetch, parse, LoadRequestedModules) without evaluating
-    // anything, so that top-level await anywhere in it is rejected before a
-    // single module body has run. The loader's internal reactions are diverted
-    // to a private queue and drained inline; Bun fetches synchronously while a
-    // queue is installed, so this completes here unless a fetch is genuinely
-    // asynchronous.
+    // Load the whole graph without evaluating it, so that top-level await is rejected before any module body runs.
     JSPromise* loadPromise;
     {
         JSC::VM::SynchronousModuleQueue queue;
@@ -903,11 +889,8 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     }
     case JSPromise::Status::Pending: {
         loadPromise->markAsHandled();
-        // A fetch in this graph did not complete synchronously: a plugin with
-        // an asynchronous onLoad, or a load that an outer import() still has
-        // in flight. Only drop the entry this call created; one that existed
-        // before belongs to that outer load, and removing it would make the
-        // module evaluate a second time once the outer load completes.
+        // A fetch is genuinely asynchronous (a plugin's async onLoad, or an outer import() still fetching).
+        // Keep an entry that outer load owns, or the module would evaluate twice once that load completes.
         if (!entryExistedBefore) {
             WTF::Locker locker { loader->cellLock() };
             loader->removeEntry(key);
@@ -916,8 +899,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     }
     }
 
-    // Link and evaluate. The graph is loaded and has no top-level await, so
-    // this settles synchronously except for the evaluation-cycle cases below.
+    // Link and evaluate. With the graph loaded and free of top-level await this settles synchronously.
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);
     RETURN_IF_EXCEPTION(scope, {});
 
@@ -932,12 +914,9 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     }
     case JSPromise::Status::Pending: {
         promise->markAsHandled();
-        // The promise stays Pending when this module shares an SCC with an
-        // outer module that is still Evaluating (e.g. ESM entry → CJS shim →
-        // require(esm) → imports something the entry already loaded). For a
-        // record whose status is exactly Evaluating, the body already ran
-        // synchronously; only the status flip waits on the SCC root. Treat
-        // that as success — the namespace is fully populated.
+        // Still Pending: this module shares an SCC with an outer module that is mid-evaluation (ESM entry →
+        // CJS shim → require(esm) → imports something the entry already loaded). Its body already ran; only
+        // the status flip waits on the SCC root, so the namespace is complete.
         if (auto* entry = loader->registryEntry(key)) {
             auto* record = entry->record();
             if (isModuleEvaluatingSync(record))

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -738,6 +738,46 @@ static bool isModuleEvaluating(JSC::AbstractModuleRecord* record)
     return cyclic && cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluating;
 }
 
+// Once a cyclic record has left Status::New its LoadRequestedModules has
+// completed, so [[LoadedModules]] names every dependency transitively.
+static bool isModuleGraphLoaded(JSC::AbstractModuleRecord* record)
+{
+    auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record);
+    return cyclic && cyclic->status() != JSC::CyclicModuleRecord::Status::New;
+}
+
+// The first record in `root`'s loaded graph whose own body uses top-level
+// await, or null. This is the static [[HasTLA]] walk Node performs
+// (v8::Module::IsGraphAsync) before it lets require() evaluate an ES module,
+// and again when require() meets a graph that import() already evaluated.
+static JSC::AbstractModuleRecord* findTopLevelAwaitInGraph(JSC::AbstractModuleRecord* root)
+{
+    WTF::UncheckedKeyHashSet<JSC::AbstractModuleRecord*> visited;
+    WTF::Vector<JSC::AbstractModuleRecord*, 16> stack;
+    visited.add(root);
+    stack.append(root);
+    while (!stack.isEmpty()) {
+        auto* record = stack.takeLast();
+        if (record->hasTLA())
+            return record;
+        for (auto& [key, loaded] : record->loadedModules()) {
+            auto* dependency = loaded.m_module.get();
+            if (dependency && visited.add(dependency).isNewEntry)
+                stack.append(dependency);
+        }
+    }
+    return nullptr;
+}
+
+static JSC::EncodedJSValue throwRequireAsyncModule(Zig::GlobalObject* globalObject, JSC::ThrowScope& scope, const WTF::String& key, const WTF::String& parentFilename, JSC::AbstractModuleRecord* asyncRecord)
+{
+    WTF::String from = parentFilename.isEmpty() ? emptyString() : makeString("\n  From "_s, parentFilename);
+    WTF::String asyncKey = asyncRecord->moduleKey().isSymbol() ? WTF::String() : asyncRecord->moduleKey().string();
+    WTF::String where = asyncKey.isEmpty() || asyncKey == key ? emptyString() : makeString("\n  The top-level await is in "_s, asyncKey);
+    return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_REQUIRE_ASYNC_MODULE,
+        makeString("require() cannot be used on an ESM graph with top-level await. Use import() instead."_s, from, "\n  Requiring "_s, key, where));
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -799,22 +839,85 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     auto keyString = keyValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     auto key = JSC::Identifier::fromString(vm, keyString);
+    // The filename of the CommonJS module whose require() this is. Only used
+    // for the "From" line of ERR_REQUIRE_ASYNC_MODULE, as in Node.
+    WTF::String parentFilename;
+    if (JSValue parentValue = callFrame->argument(1); parentValue.isString()) {
+        parentFilename = asString(parentValue)->value(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
 
     auto* loader = globalObject->moduleLoader();
     bool entryExistedBefore = false;
     if (auto* entry = loader->registryEntry(key)) {
         entryExistedBefore = true;
-        if (isModuleEvaluated(entry->record()) || isModuleEvaluatingSync(entry->record())) {
-            auto* ns = entry->record()->getModuleNamespace(globalObject, false);
+        auto* record = entry->record();
+        // Checked before the evaluated / evaluating fast paths: Node rejects
+        // require() of a top-level-await graph even after import() has fully
+        // evaluated it, so the answer does not depend on timing.
+        if (isModuleGraphLoaded(record)) {
+            if (auto* asyncRecord = findTopLevelAwaitInGraph(record))
+                return throwRequireAsyncModule(globalObject, scope, keyString, parentFilename, asyncRecord);
+        }
+        if (isModuleEvaluated(record) || isModuleEvaluatingSync(record)) {
+            auto* ns = record->getModuleNamespace(globalObject, false);
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(ns);
         }
-        // Any other Evaluating record (one with top-level await) must not
-        // reach loadModuleSync: Link() and Evaluate() reject that status.
-        if (isModuleEvaluating(entry->record()))
+        // Any other Evaluating record must not reach loadModule: Link() and
+        // Evaluate() reject that status.
+        if (isModuleEvaluating(record))
             return throwVMTypeError(globalObject, scope, makeString("require() async module \""_s, keyString, "\" is unsupported. use \"await import()\" instead."_s));
     }
 
+    // Load the graph (fetch, parse, LoadRequestedModules) without evaluating
+    // anything, so that top-level await anywhere in it is rejected before a
+    // single module body has run. The loader's internal reactions are diverted
+    // to a private queue and drained inline; Bun fetches synchronously while a
+    // queue is installed, so this completes here unless a fetch is genuinely
+    // asynchronous.
+    JSPromise* loadPromise;
+    {
+        JSC::VM::SynchronousModuleQueue queue;
+        queue.prev = vm.m_synchronousModuleQueue;
+        vm.m_synchronousModuleQueue = &queue;
+        loadPromise = loader->loadModule(globalObject, key, nullptr, nullptr, {});
+        if (!scope.exception())
+            JSC::JSModuleLoader::drainSynchronousModuleQueue(globalObject);
+        vm.m_synchronousModuleQueue = queue.prev;
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+    switch (loadPromise->status()) {
+    case JSPromise::Status::Fulfilled: {
+        auto* entry = loader->registryEntry(key);
+        if (auto* record = entry ? entry->record() : nullptr) {
+            if (auto* asyncRecord = findTopLevelAwaitInGraph(record))
+                return throwRequireAsyncModule(globalObject, scope, keyString, parentFilename, asyncRecord);
+        }
+        break;
+    }
+    case JSPromise::Status::Rejected: {
+        loadPromise->markAsHandled();
+        scope.throwException(globalObject, loadPromise->result());
+        return {};
+    }
+    case JSPromise::Status::Pending: {
+        loadPromise->markAsHandled();
+        // A fetch in this graph did not complete synchronously: a plugin with
+        // an asynchronous onLoad, or a load that an outer import() still has
+        // in flight. Only drop the entry this call created; one that existed
+        // before belongs to that outer load, and removing it would make the
+        // module evaluate a second time once the outer load completes.
+        if (!entryExistedBefore) {
+            WTF::Locker locker { loader->cellLock() };
+            loader->removeEntry(key);
+        }
+        return throwVMTypeError(globalObject, scope, makeString("require() async module \""_s, keyString, "\" is unsupported. use \"await import()\" instead."_s));
+    }
+    }
+
+    // Link and evaluate. The graph is loaded and has no top-level await, so
+    // this settles synchronously except for the evaluation-cycle cases below.
     JSPromise* promise = loader->loadModuleSync(globalObject, key, nullptr, nullptr);
     RETURN_IF_EXCEPTION(scope, {});
 
@@ -829,30 +932,21 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     }
     case JSPromise::Status::Pending: {
         promise->markAsHandled();
-        // The load promise stays Pending when this module shares an SCC with an
+        // The promise stays Pending when this module shares an SCC with an
         // outer module that is still Evaluating (e.g. ESM entry → CJS shim →
         // require(esm) → imports something the entry already loaded). For a
-        // non-TLA record whose status is exactly Evaluating, the body already
-        // ran synchronously; only the status flip waits on the SCC root. Treat
+        // record whose status is exactly Evaluating, the body already ran
+        // synchronously; only the status flip waits on the SCC root. Treat
         // that as success — the namespace is fully populated.
-        //
-        // Explicitly exclude EvaluatingAsync: a record reaches that state when
-        // it OR any dependency has top-level await, in which case bindings can
-        // still be in TDZ and we must throw the "async module" error instead
-        // of returning a half-initialized namespace.
         if (auto* entry = loader->registryEntry(key)) {
             auto* record = entry->record();
             if (isModuleEvaluatingSync(record))
                 break;
             if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record)) {
-                if (cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluated && !cyclic->hasTLA() && !cyclic->evaluationError())
+                if (cyclic->status() == JSC::CyclicModuleRecord::Status::Evaluated && !cyclic->evaluationError())
                     break;
             }
         }
-        // Only drop the entry we created. If the entry already existed (an
-        // outer import() is mid-load, or the module is EvaluatingAsync from a
-        // prior import), removing it would force a second evaluation and a
-        // second namespace object once that outer load completes.
         if (!entryExistedBefore) {
             WTF::Locker locker { loader->cellLock() };
             loader->removeEntry(key);
@@ -2864,7 +2958,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         { BuiltinName::k_esmNamespaceForCjs, 1, functionEsmNamespaceForCjs },
         { BuiltinName::k_esmRegistryDelete, 1, functionEsmRegistryDelete },
         { BuiltinName::k_esmRegistryEvaluatedKeys, 0, functionEsmRegistryEvaluatedKeys },
-        { BuiltinName::k_esmLoadSync, 1, functionEsmLoadSync },
+        { BuiltinName::k_esmLoadSync, 2, functionEsmLoadSync },
         { BuiltinName::k_makeErrorWithCode, 2, jsFunctionMakeErrorWithCode },
         { BuiltinName::k_toClass, 1, jsFunctionToClass },
         { BuiltinName::k_inherits, 1, jsFunctionInherits },

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -889,8 +889,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     }
     case JSPromise::Status::Pending: {
         loadPromise->markAsHandled();
-        // A fetch is genuinely asynchronous (a plugin's async onLoad, or an outer import() still fetching).
-        // Keep an entry that outer load owns, or the module would evaluate twice once that load completes.
+        // A fetch is genuinely asynchronous (a plugin's async onLoad, or an outer import() that owns the entry is still fetching).
         if (!entryExistedBefore) {
             WTF::Locker locker { loader->cellLock() };
             loader->removeEntry(key);
@@ -914,9 +913,7 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmLoadSync, (JSC::JSGlobalObject * lexicalGlob
     }
     case JSPromise::Status::Pending: {
         promise->markAsHandled();
-        // Still Pending: this module shares an SCC with an outer module that is mid-evaluation (ESM entry →
-        // CJS shim → require(esm) → imports something the entry already loaded). Its body already ran; only
-        // the status flip waits on the SCC root, so the namespace is complete.
+        // Pending here: the module shares an SCC with an outer module that is mid-evaluation. Its body already ran; only the status flip waits on the SCC root.
         if (auto* entry = loader->registryEntry(key)) {
             auto* record = entry->record();
             if (isModuleEvaluatingSync(record))

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -1,13 +1,130 @@
-// $esmLoadSync's Pending fallback used to accept any record at status >=
-// Evaluating with !hasTLA(). hasTLA() only reports the *self* flag, so a
-// module with no TLA whose dependency has TLA (status EvaluatingAsync) was
-// returned with bindings still in TDZ. It must throw "async module" instead.
+// require() of an ES module graph that contains top-level await.
 //
-// Separately, when the Pending path *does* throw, it used to removeEntry()
-// unconditionally. If an outer import() already created the entry, deleting
-// it forces a second evaluation when the outer import settles.
-import { expect, test } from "bun:test";
+// Like Node, Bun rejects it with ERR_REQUIRE_ASYNC_MODULE, decided from the
+// records' [[HasTLA]] flags once the graph is loaded and before any module
+// body in it runs. $esmLoadSync used to load+link+evaluate in one step and
+// infer "async" from a still-pending promise afterwards, so side effects ran
+// before the throw, graphs whose awaits settled on microtasks alone were
+// returned, and a graph that import() had already evaluated was returned too.
+//
+// Separately, when $esmLoadSync does throw for a load it cannot finish
+// synchronously, it must only removeEntry() an entry it created itself. If an
+// outer import() already created the entry, deleting it forces a second
+// evaluation when the outer import settles.
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("require(esm) rejects top-level await before evaluating anything", () => {
+  const fixtures = {
+    "tla-value.mjs": `globalThis.order.push("tla-value"); await 0; export const x = "value";`,
+    "tla-resolved.mjs": `globalThis.order.push("tla-resolved"); await Promise.resolve(); export const x = "resolved";`,
+    "tla-task.mjs": `globalThis.order.push("tla-task"); await new Promise(r => setTimeout(r, 1)); export const x = "task";`,
+    "dep-tla.mjs": `globalThis.order.push("dep-tla"); await 0; export const y = "dep";`,
+    "parent.mjs": `import { y } from "./dep-tla.mjs"; globalThis.order.push("parent"); export const x = "parent:" + y;`,
+    "plain.mjs": `globalThis.order.push("plain"); export const x = "plain";`,
+    "attempt.cjs": `
+      globalThis.order = [];
+      exports.attempt = function attempt(file) {
+        try {
+          return { returned: require(file).x };
+        } catch (e) {
+          return { name: e.name, code: e.code };
+        }
+      };
+    `,
+  };
+  const rejected = { name: "Error", code: "ERR_REQUIRE_ASYNC_MODULE" };
+
+  async function run(dir: string, file: string) {
+    await using proc = Bun.spawn({ cmd: [bunExe(), file], env: bunEnv, cwd: dir, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  test.concurrent("whatever the await shape, and a later import() still evaluates each module once", async () => {
+    using dir = tempDir("require-esm-tla-shapes", {
+      ...fixtures,
+      "main.cjs": `
+        const { attempt } = require("./attempt.cjs");
+        const files = ["./tla-value.mjs", "./tla-resolved.mjs", "./tla-task.mjs", "./parent.mjs", "./plain.mjs"];
+        const required = {};
+        // Twice each: a failed require() must fail the same way when retried.
+        for (const f of files) required[f] = [attempt(f), attempt(f)];
+        const orderAfterRequire = [...globalThis.order];
+        (async () => {
+          const imported = {};
+          for (const f of files) imported[f] = (await import(f)).x;
+          console.log(JSON.stringify({ required, orderAfterRequire, imported, order: globalThis.order }));
+        })();
+      `,
+    });
+    expect(await run(String(dir), "main.cjs")).toEqual({
+      required: {
+        "./tla-value.mjs": [rejected, rejected],
+        "./tla-resolved.mjs": [rejected, rejected],
+        "./tla-task.mjs": [rejected, rejected],
+        "./parent.mjs": [rejected, rejected],
+        "./plain.mjs": [{ returned: "plain" }, { returned: "plain" }],
+      },
+      // No module with top-level await in its graph ran any part of its body.
+      orderAfterRequire: ["plain"],
+      imported: {
+        "./tla-value.mjs": "value",
+        "./tla-resolved.mjs": "resolved",
+        "./tla-task.mjs": "task",
+        "./parent.mjs": "parent:dep",
+        "./plain.mjs": "plain",
+      },
+      order: ["plain", "tla-value", "tla-resolved", "tla-task", "dep-tla", "parent"],
+    });
+  });
+
+  test.concurrent("also when import() already evaluated the graph", async () => {
+    using dir = tempDir("require-esm-tla-cached", {
+      ...fixtures,
+      "main.cjs": `
+        const { attempt } = require("./attempt.cjs");
+        (async () => {
+          const first = await import("./parent.mjs");
+          const required = attempt("./parent.mjs");
+          const requiredDep = attempt("./dep-tla.mjs");
+          const second = await import("./parent.mjs");
+          console.log(JSON.stringify({ required, requiredDep, same: first === second, order: globalThis.order }));
+        })();
+      `,
+    });
+    expect(await run(String(dir), "main.cjs")).toEqual({
+      required: rejected,
+      requiredDep: rejected,
+      same: true,
+      order: ["dep-tla", "parent"],
+    });
+  });
+
+  test.concurrent("with a message that names the requiring module and the one with the await", async () => {
+    using dir = tempDir("require-esm-tla-message", {
+      ...fixtures,
+      "main.cjs": `
+        const { sep } = require("node:path");
+        globalThis.order = [];
+        try {
+          require("./parent.mjs");
+          console.log(JSON.stringify("returned"));
+        } catch (e) {
+          console.log(JSON.stringify(e.message.replaceAll(__dirname, "<dir>").replaceAll(sep, "/")));
+        }
+      `,
+    });
+    expect(await run(String(dir), "main.cjs")).toBe(
+      "require() cannot be used on an ESM graph with top-level await. Use import() instead.\n" +
+        "  From <dir>/main.cjs\n" +
+        "  Requiring <dir>/parent.mjs\n" +
+        "  The top-level await is in <dir>/dep-tla.mjs",
+    );
+  });
+});
 
 test("require(esm) rejects when a transitive dependency has top-level await", async () => {
   using dir = tempDir("require-esm-transitive-tla", {
@@ -28,7 +145,7 @@ test("require(esm) rejects when a transitive dependency has top-level await", as
       try {
         require("./middle.mjs");
       } catch (e) {
-        threw = e instanceof TypeError && String(e.message).includes("async module");
+        threw = e.code === "ERR_REQUIRE_ASYNC_MODULE";
       }
       if (!threw) throw new Error("expected require(transitive-TLA) to throw");
       console.log("ok");

--- a/test/js/bun/resolve/require-esm-transitive-tla.test.ts
+++ b/test/js/bun/resolve/require-esm-transitive-tla.test.ts
@@ -107,22 +107,25 @@ describe("require(esm) rejects top-level await before evaluating anything", () =
     using dir = tempDir("require-esm-tla-message", {
       ...fixtures,
       "main.cjs": `
-        const { sep } = require("node:path");
         globalThis.order = [];
         try {
           require("./parent.mjs");
           console.log(JSON.stringify("returned"));
         } catch (e) {
-          console.log(JSON.stringify(e.message.replaceAll(__dirname, "<dir>").replaceAll(sep, "/")));
+          const message = e.message
+            .replaceAll(__filename, "<main.cjs>")
+            .replaceAll(require.resolve("./parent.mjs"), "<parent.mjs>")
+            .replaceAll(require.resolve("./dep-tla.mjs"), "<dep-tla.mjs>");
+          console.log(JSON.stringify(message.split("\\n")));
         }
       `,
     });
-    expect(await run(String(dir), "main.cjs")).toBe(
-      "require() cannot be used on an ESM graph with top-level await. Use import() instead.\n" +
-        "  From <dir>/main.cjs\n" +
-        "  Requiring <dir>/parent.mjs\n" +
-        "  The top-level await is in <dir>/dep-tla.mjs",
-    );
+    expect(await run(String(dir), "main.cjs")).toEqual([
+      "require() cannot be used on an ESM graph with top-level await. Use import() instead.",
+      "  From <main.cjs>",
+      "  Requiring <parent.mjs>",
+      "  The top-level await is in <dep-tla.mjs>",
+    ]);
   });
 });
 

--- a/test/regression/issue/24387.test.ts
+++ b/test/regression/issue/24387.test.ts
@@ -13,7 +13,7 @@ test("regression: require()ing a module with TLA should error and then wipe the 
 
   expect(await stderr.text()).toBe("");
   expect(await stdout.text()).toMatchInlineSnapshot(`
-    "require() async module "<the module>" is unsupported. use "await import()" instead.
+    "ERR_REQUIRE_ASYNC_MODULE require() cannot be used on an ESM graph with top-level await. Use import() instead.
     Module {
       foo: 67,
     }

--- a/test/regression/issue/24387/entry.js
+++ b/test/regression/issue/24387/entry.js
@@ -5,7 +5,7 @@ let listener;
 try {
   listener = await require(entrypointPath);
 } catch (e) {
-  console.log(e.message.replace(require.resolve(entrypointPath), "<the module>"));
+  console.log(e.code, e.message.split("\n")[0]);
   listener = await import(entrypointPath);
 }
 for (let i = 0; i < 5; i++) if (listener.default) listener = listener.default;


### PR DESCRIPTION
### Problem
- `require()` of an ES module graph with top-level await runs the modules up to the first await, then throws `TypeError: require() async module "<path>" is unsupported. use "await import()" instead.` Node throws `ERR_REQUIRE_ASYNC_MODULE` before anything runs.
- Since #43022 this also happens when the requiring CommonJS file runs inside an ES graph that still loads that module. Before, that shape threw without running it.
- Cause: `functionEsmLoadSync` (`src/jsc/bindings/ZigGlobalObject.cpp`) loads, links and evaluates in one `loadModuleSync()` call. Only a promise still pending afterwards shows top-level await.

### Fix
- Load the graph first (`JSModuleLoader::loadModule` without `ModuleLoadFlag::Evaluate`). Walk the records' `[[HasTLA]]` flags (`findTopLevelAwaitInGraph`). Link and evaluate only if none is set.
- The throw is Node's: an `Error` with code `ERR_REQUIRE_ASYNC_MODULE` and Node's message, plus lines that name the requiring module and the module with the await.
- Correct because the registry entry stays on that throw. A later `import()` evaluates the same record once. A plugin with an asynchronous `onLoad` keeps the old TypeError.
- Verified: `test/js/bun/resolve/require-esm-transitive-tla.test.ts` (4 new tests fail on main) and `test/regression/issue/24387.test.ts`. The notes list the other suites.

### Background
- `functionEsmLoadSync` runs JSC's module loader with a `VM::SynchronousModuleQueue`: promise reactions run inline, so a graph loads without yielding.
- `loadModuleSync` is `loadModule` with the `Evaluate` flag.
- `[[HasTLA]]` is set per record at parse time. Past `Status::New`, `[[LoadedModules]]` lists every dependency. Node runs the same check (`v8::Module::IsGraphAsync`).
- A CommonJS module that an ES graph imports runs while that graph still loads. A module it requires can have a fetch in flight. Since oven-sh/WebKit#662 JSC runs that fetch again synchronously.

<details><summary>Notes</summary>

- Behaviour matrix against Node 26 (`x` = module body ran):

  | case | node | bun before | bun after |
  | --- | --- | --- | --- |
  | `require(tla.mjs)`, `await 0` | ERR_REQUIRE_ASYNC_MODULE | TypeError, x | ERR_REQUIRE_ASYNC_MODULE |
  | `await Promise.resolve()` | ERR_REQUIRE_ASYNC_MODULE | returns namespace, x | ERR_REQUIRE_ASYNC_MODULE |
  | parent without TLA importing a TLA dep | ERR_REQUIRE_ASYNC_MODULE | TypeError, dep x | ERR_REQUIRE_ASYNC_MODULE |
  | `await import(tla)` then `require(tla)` | ERR_REQUIRE_ASYNC_MODULE | returns namespace | ERR_REQUIRE_ASYNC_MODULE |
  | a CommonJS file in a loading ES graph requires a TLA module of that graph | ERR_REQUIRE_ASYNC_MODULE | TypeError, x since #43022 | ERR_REQUIRE_ASYNC_MODULE |
  | failed `require(tla)` then `import(tla)` | evaluates once | entry wiped, evaluates again | evaluates once, same record |
  | `require(esm)` whose body throws, x3, then `import()` | one evaluation, cached error | same | same |
  | `(async () => { await 0 })()` at top level | returns | returns | returns |

- The in-graph shape, as reported after #43022:

  ```js
  // t.mjs
  console.log("t.mjs runs (before its await)"); await 0; console.log("t.mjs after its await"); export const x = 1;
  // ct.cjs
  console.log("ct.cjs start");
  try { require("./t.mjs"); } catch (e) { console.log("require threw " + e.name); }
  console.log("ct.cjs end");
  // entry.mjs
  import "./ct.cjs";
  import "./t.mjs";
  ```

  - Node 26.3, Bun 1.4.2 and main before #43022: `ct.cjs start`, `require threw`, `ct.cjs end`, `t.mjs runs (before its await)`, `t.mjs after its await`.
  - main at b52d513481: `ct.cjs start`, `t.mjs runs (before its await)`, `require threw TypeError`, `ct.cjs end`, `t.mjs after its await`.
  - This branch: Node's order, with `ERR_REQUIRE_ASYNC_MODULE`. 10 of 10 runs each for the files as posted, for a 1.5 MB `ct.cjs`, and for a 1.5 MB `t.mjs`.
  - The mechanism: `ct.cjs` runs when its fetch settles, while the entry of `t.mjs` is still in status `Fetching`. Before oven-sh/WebKit#662 `loadModule` reused the pending fetch promise, so the synchronous load never settled and `require()` threw without running anything. Now JSC fetches synchronously, the load completes, and link and evaluate run as in the standalone case. The same bump is what makes this shape load at all when the module has no top-level await (#33180).
- The walk also runs when the registry already holds a loaded record, so a graph that `import()` already evaluated is rejected too.
- Instead of Node's hint at `--experimental-print-required-tla` (a flag Bun does not have) the message names the module with the await.
- Behaviour changes for code that worked on Bun before (each one is what Node does, and what `docs/runtime/module-resolution.mdx` already said: "You can't `require()` a file that uses top-level await"):
  - A graph whose awaits settle on microtasks alone (`export const x = await Promise.resolve(1)`) was returned by `require()` and now throws.
  - A file whose only top-level `await` sits behind a condition that is false at run time (`if (import.meta.main) { await main(); }`) was returned and now throws, because the check is static. The `import.meta.main` idiom keeps working for the entry point and for `import`; only `require()` of such a file from elsewhere changes.
  - A graph that `import()` already evaluated was returned by a later `require()` and now throws.
- Differences from Node that remain: `if (false) await 0` is accepted by Bun because the transpiler drops the dead branch before the record exists. A module that has both top-level await and a link error (a missing export) reports `ERR_REQUIRE_ASYNC_MODULE` in Bun and the `SyntaxError` in Node, because Node links before its check and this check runs before link.
- Loads that cannot finish synchronously keep the old TypeError and the old entry handling. After #43022 that is a plugin with an asynchronous `onLoad` (checked by hand). A fetch that an `import` already started is no longer such a case.
- Supersedes #33438 and #33891 (mine, closed in favour of this). #35693 (draft, stacked on another branch) contains a similar two-phase load as part of a larger Node `require(esm)` error-contract change that also adds `ERR_REQUIRE_CYCLE_MODULE`; this PR is the top-level-await part alone, on main.
- Inside a `bun build --compile` executable the same path applies: `require()` of an embedded ESM with top-level await now throws the code before running it, and `import()` of it afterwards works (checked by hand).
- Merge with main: `JSModuleLoader::removeEntry` takes the loader's `cellLock` itself since #42002, so the two call sites in `functionEsmLoadSync` no longer lock around it.
- Suites run on Linux x64 (ASAN debug) after the merge: the two files above, `require-esm-evaluating-cycle`, `require-esm-gc-roots`, `require-esm-microtask-order`, `require.test.ts`, `import-meta`, `esModule`, `esModule-annotation`, `dynamic-import-tla-cycle`, `builtin-esm-lazy-exports`, `import-defer`, `concurrent-dynamic-import`, `star-export-namespace`, `run-cjs`, `require-and-import-trailing`, `plugins`, `mock-module`, `node-module-module`, `esm-registry-concurrent-gc`. In `test/cli/run/require-cache.test.ts` the seven RSS leak tests time out on my debug build with and without this change (the CommonJS fixture alone takes 30 s on both). The other tests in that file pass. Windows x64 was checked on the revision before the merge.
- Self-reviewed: 2 concerns raised, 0 needed code changes (both are the intended Node behaviour, listed under "Behaviour changes" above).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 4 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/require-esm-transitive-tla.test.ts "test/regression/issue/24387.test.ts"
bun test v1.4.3 (c6b7fcb5b)

test/regression/issue/24387.test.ts:
10 |   });
11 | 
12 |   const { stdout, stderr } = proc;
13 | 
14 |   expect(await stderr.text()).toBe("");
15 |   expect(await stdout.text()).toMatchInlineSnapshot(`
                                   ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "ERR_REQUIRE_ASYNC_MODULE require() cannot be used on an ESM graph with top-level await. Use import() instead.
+ "undefined require() async module "/workspace/bun/test/regression/issue/24387/p.js" is unsupported. use "await import()" instead.
  Module {
    foo: 67,
  }
  "
  

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/regression/issue/24387.test.ts:15:31)
(fail) regression: require()ing a module with TLA should error and then wipe the module cache, so that importing it again works [398.16ms]

test/js/bun/resolve/require-esm-transitive-tla.test.ts:
93 |           const second = await imp
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (f12cf1c8c)

test/regression/issue/24387.test.ts:
(pass) regression: require()ing a module with TLA should error and then wipe the module cache, so that importing it again works [107.86ms]

test/js/bun/resolve/require-esm-transitive-tla.test.ts:
(pass) require(esm) rejects top-level await before evaluating anything > with a message that names the requiring module and the one with the await [7.81ms]
(pass) require(esm) rejects top-level await before evaluating anything > whatever the await shape, and a later import() still evaluates each module once [12.17ms]
(pass) require(esm) rejects top-level await before evaluating anything > also when import() already evaluated the graph [10.43ms]
(pass) require(esm) rejects top-level await before evaluating anything > also when the ES module graph that imports it is still loading [9.57ms]
(pass) require(esm) rejects when a transitive dependency has top-level await [7.20ms]
(pass) require(esm) failing on TLA does not delete an entry an outer import() owns [30.89ms]

 7 pass
 0 fail
 1 snapshots, 21 expect() calls
Ran 7 tests across 2 files. [235.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/require-esm-transitive-tla.test.ts "test/regression/issue/24387.test.ts"
bun test v1.4.3 (c6b7fcb5b)

test/regression/issue/24387.test.ts:
(pass) regression: require()ing a module with TLA should error and then wipe the module cache, so that importing it again works [388.70ms]

test/js/bun/resolve/require-esm-transitive-tla.test.ts:
(pass) require(esm) rejects top-level await before evaluating anything > also when import() already evaluated the graph [327.74ms]
(pass) require(esm) rejects top-level await before evaluating anything > also when the ES module graph that imports it is still loading [319.20ms]
(pass) require(esm) rejects top-level await before evaluating anything > with a message that names the requiring module and the one with the await [368.76ms]
(pass) require(esm) rejects top-level await before evaluating anything > whatever the await shape, and a later import() still evaluates each module once [448.37ms]
(pass) require(esm) rejects when a transitive dependency has top-level await [286.85ms]
(pass) re
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 660ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/127] gen ErrorCode+*.h
[2/127] gen cpp.rs (cppbind)
[3/127] gen JS modules (bundle-modules)
Preprocess modules (8255ms)
Bundle modules (80ms)
Postprocesss modules (462ms)
Bundle Functions (692ms)
Generate Code (42ms)

[9.55s] Bundled "src/js" for production
  2603 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/11] cargo bun_runtime → libbun_runtime.a
[1m[33mwarning[0m[1m: binary `bun_shim_impl` should have a kebab-case name[0m
   [1m[94m|[0m
[1m[94m 1[0m [1m[94m|[0m /workspace/bun/build/release/rust-target/.../bun_shim_impl
   [1m[94m|[0m                                              [1m[33m^^^^^^^^^^^^^[0m
   [1m[94m|[0m
   [1m[94m= [0m[1mnote[0m: `cargo::non_kebab_case_bins` is set to `warn` by default
[1m[96mhelp[0m: to change the binary name to `bun-shim-impl`, convert `bin.name`
  [1m[94m--> [0msrc/install/windows-shim/Cargo.toml:41:8
   [1m[94m|[0m
[1m[94m41[0m [91m- [0mname = [91m"bun_shim_impl"[0m
[1m[94m41
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/module-resolution.mdx                 |   2 +-
 src/js/builtins.d.ts                               |   4 +-
 src/js/builtins/CommonJS.ts                        |  19 +--
 src/jsc/bindings/ErrorCode.ts                      |   1 +
 src/jsc/bindings/ZigGlobalObject.cpp               | 112 +++++++++++---
 .../bun/resolve/require-esm-transitive-tla.test.ts | 164 +++++++++++++++++++--
 test/regression/issue/24387.test.ts                |   2 +-
 test/regression/issue/24387/entry.js               |   2 +-
 8 files changed, 258 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
docs/runtime/module-resolution.mdx                          1      1     12
src/js/builtins.d.ts                                        0      0     12
src/js/builtins/CommonJS.ts                                 4      4     12
src/jsc/bindings/ErrorCode.ts                               1      1     13
src/jsc/bindings/ZigGlobalObject.cpp                        6      7     14
test/js/bun/resolve/require-esm-transitive-tla.test.ts      2      2     10
test/regression/issue/24387.test.ts                         0      0      8
test/regression/issue/24387/entry.js                        0      0     12
```

</details>

<!-- robobun:evidence:end -->
