### PR TITLE
printer: print ill-formed UTF-8 in 8-bit strings as U+FFFD instead of NUL

### DIFF
--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1833,7 +1833,7 @@ pub mod printer {
 
     const MALFORMED: i32 = -1;
 
-    /// Same algorithm as `bun_js_printer::write_pre_quoted_string`, except malformed UTF-8 becomes U+FFFD.
+    /// Same algorithm as `bun_js_printer::write_pre_quoted_string`.
     /// PERF: (quote_char, ascii_only, json, encoding) are runtime params —
     /// profile if it shows up on a hot path.
     pub fn write_pre_quoted_string<W: PrinterWriter + ?Sized>(

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1031,11 +1031,16 @@ where
     write_pre_quoted_string_inner::<W, ENCODING>(text_in, writer, QUOTE_CHAR, ASCII_ONLY, JSON)
 }
 
+const MALFORMED: i32 = -1;
+
 /// `quote_char` / `ascii_only` / `json` are runtime args (were `const`): the
 /// branches on them are cheap and well-predicted, and collapsing the
 /// monomorphizations keeps the hot transpile pages dense (see the facade above).
 /// `ENCODING` stays `const` — it changes the code-unit indexing structure of the
 /// loop, so a per-encoding copy is genuinely different code.
+///
+/// In the UTF-8 instance, malformed bytes (a stray continuation byte, an
+/// invalid lead, or a truncated sequence) become U+FFFD, one byte at a time.
 #[inline(never)]
 pub fn write_pre_quoted_string_inner<W, const ENCODING: Encoding>(
     text_in: &[u8],
@@ -1083,14 +1088,23 @@ where
         let clamped_width = (width as usize).min(n.saturating_sub(i));
         let c: i32 = match ENCODING {
             Encoding::Utf8 => {
-                let bytes: [u8; 4] = match clamped_width {
-                    1 => [text[i], 0, 0, 0],
-                    2 => [text[i], text[i + 1], 0, 0],
-                    3 => [text[i], text[i + 1], text[i + 2], 0],
-                    4 => [text[i], text[i + 1], text[i + 2], text[i + 3]],
-                    _ => unreachable!(),
-                };
-                strings::decode_wtf8_rune_t::<i32>(bytes, width, 0)
+                if width == 1 {
+                    // width 1 with a byte >= 0x80 is a stray continuation byte or an invalid lead.
+                    if text[i] >= 0x80 {
+                        MALFORMED
+                    } else {
+                        text[i] as i32
+                    }
+                } else {
+                    let bytes: [u8; 4] = match clamped_width {
+                        1 => [text[i], 0, 0, 0],
+                        2 => [text[i], text[i + 1], 0, 0],
+                        3 => [text[i], text[i + 1], text[i + 2], 0],
+                        4 => [text[i], text[i + 1], text[i + 2], text[i + 3]],
+                        _ => unreachable!(),
+                    };
+                    strings::decode_wtf8_rune_t::<i32>(bytes, width, MALFORMED)
+                }
             }
             Encoding::Ascii => {
                 debug_assert!(text[i] <= 0x7F);
@@ -1104,6 +1118,17 @@ where
                 code_unit_at!(i)
             }
         };
+
+        if c == MALFORMED {
+            if ascii_only {
+                writer.write_all(&bmp_escape(0xFFFD))?;
+            } else {
+                writer.write_all("\u{FFFD}".as_bytes())?;
+            }
+            // One byte, not `width`, so the bytes after a truncated sequence survive.
+            i += 1;
+            continue;
+        }
 
         if can_print_without_escape(c, ascii_only) {
             match ENCODING {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1038,9 +1038,6 @@ const MALFORMED: i32 = -1;
 /// monomorphizations keeps the hot transpile pages dense (see the facade above).
 /// `ENCODING` stays `const` — it changes the code-unit indexing structure of the
 /// loop, so a per-encoding copy is genuinely different code.
-///
-/// In the UTF-8 instance, malformed bytes (a stray continuation byte, an
-/// invalid lead, or a truncated sequence) become U+FFFD, one byte at a time.
 #[inline(never)]
 pub fn write_pre_quoted_string_inner<W, const ENCODING: Encoding>(
     text_in: &[u8],

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -432,6 +432,43 @@ describe("bundler", async () => {
     },
   });
 
+  // A byte that is not valid UTF-8 in a text import or in a string of a data
+  // file prints as U+FFFD. The bytes around it are kept and the output stays
+  // valid UTF-8. "bun" prints the literal with ASCII escapes, "browser" writes
+  // the characters as UTF-8.
+  {
+    // "A" E9 "B" C3 "Z" 80 FF "[" C3 A9, E2 82 AC, F0 9F 98 80 "]" E2
+    // E9 and C3 start a sequence that the next byte does not continue, 80 is a
+    // continuation byte on its own, FF is never valid, the bracket holds valid
+    // 2, 3 and 4 byte sequences, and the E2 at the end is cut off by the end
+    // of the file.
+    const body = Buffer.from("41e942c35a80ff5bc3a9e282acf09f98805d", "hex");
+    const text = Buffer.concat([body, Buffer.from([0xe2])]);
+    const json = Buffer.concat([Buffer.from('{"key":"'), body, Buffer.from('"}')]);
+    const expected = "41 fffd 42 fffd 5a fffd fffd 5b e9 20ac 1f600 5d";
+    for (const target of ["bun", "browser"] as const) {
+      itBundled(`${target}/loader-ill-formed-utf8`, {
+        target,
+        files: {
+          "/entry.ts": /* js */ `
+            import text from "./chars.txt" with { type: "text" };
+            import json from "./chars.json";
+            const codePoints = (s) => [...s].map(c => c.codePointAt(0).toString(16)).join(" ");
+            console.log(codePoints(text));
+            console.log(codePoints(json.key));
+          `,
+          "/chars.txt": text,
+          "/chars.json": json,
+        },
+        onAfterBundle(api) {
+          const output = fs.readFileSync(api.outfile);
+          expect(() => new TextDecoder("utf-8", { fatal: true }).decode(output)).not.toThrow();
+        },
+        run: { stdout: `${expected} fffd\n${expected}` },
+      });
+    }
+  }
+
   const loaders: Loader[] = ["wasm", "json", "file" /* "napi" */, "text"];
   const exts = ["wasm", "json", "lmao" /*  ".node" */, "txt"];
   for (let i = 0; i < loaders.length; i++) {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -463,6 +463,7 @@ describe("bundler", async () => {
         onAfterBundle(api) {
           const output = fs.readFileSync(api.outfile);
           expect(() => new TextDecoder("utf-8", { fatal: true }).decode(output)).not.toThrow();
+          expect(output.includes(target === "bun" ? "\\uFFFD" : "\uFFFD")).toBe(true);
         },
         run: { stdout: `${expected} fffd\n${expected}` },
       });

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -441,7 +441,9 @@ describe("bundler", async () => {
     // E9 and C3 start a sequence that the next byte does not continue, 80 is a
     // continuation byte on its own, FF is never valid, the bracket holds valid
     // 2, 3 and 4 byte sequences, and the E2 at the end is cut off by the end
-    // of the file.
+    // of the file. Every bad sequence here breaks at its second byte, so one
+    // U+FFFD per bad byte (the printer) and one per maximal subpart
+    // (TextDecoder) give the same string.
     const body = Buffer.from("41e942c35a80ff5bc3a9e282acf09f98805d", "hex");
     const text = Buffer.concat([body, Buffer.from([0xe2])]);
     const json = Buffer.concat([Buffer.from('{"key":"'), body, Buffer.from('"}')]);

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -297,7 +297,10 @@ test("yaml", async () => {
 test("ill-formed UTF-8", async () => {
   // {"key":"A E9 B C3 Z 80 FF [é€😀]"}: E9 and C3 start a sequence that the
   // next byte does not continue, 80 is a continuation byte on its own, FF is
-  // never valid, and the bracket holds valid 2, 3 and 4 byte sequences.
+  // never valid, and the bracket holds valid 2, 3 and 4 byte sequences. Every
+  // bad sequence breaks at its second byte, so one U+FFFD per bad byte (the
+  // printer) and one per maximal subpart (TextDecoder, the runtime JSON
+  // loader) give the same string and all import paths agree.
   const code = Buffer.concat([
     Buffer.from('{"key":"'),
     Buffer.from("41e942c35a80ff5bc3a9e282acf09f98805d", "hex"),

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -99,10 +99,7 @@ type Tests = Record<
 const default_tests = Object.fromEntries(
   loaders.map(loader => [loader, { loader, filename: "no_extension" }]),
 ) as Tests;
-async function compileAndTest(
-  code: string | Buffer,
-  tests: Tests = default_tests,
-): Promise<Record<string, unknown>> {
+async function compileAndTest(code: string | Buffer, tests: Tests = default_tests): Promise<Record<string, unknown>> {
   const [v1, v2, v3] = await Promise.all([
     compileAndTest_inner(code, tests, testBunRun),
     compileAndTest_inner(code, tests, testBunRunAwaitImport),

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -99,7 +99,10 @@ type Tests = Record<
 const default_tests = Object.fromEntries(
   loaders.map(loader => [loader, { loader, filename: "no_extension" }]),
 ) as Tests;
-async function compileAndTest(code: string, tests: Tests = default_tests): Promise<Record<string, unknown>> {
+async function compileAndTest(
+  code: string | Buffer,
+  tests: Tests = default_tests,
+): Promise<Record<string, unknown>> {
   const [v1, v2, v3] = await Promise.all([
     compileAndTest_inner(code, tests, testBunRun),
     compileAndTest_inner(code, tests, testBunRunAwaitImport),
@@ -114,7 +117,7 @@ async function compileAndTest(code: string, tests: Tests = default_tests): Promi
   return v1;
 }
 async function compileAndTest_inner(
-  code: string,
+  code: string | Buffer,
   tests: Tests,
   cb: (dir: string, loader: string | null, filename: string) => Promise<unknown>,
 ): Promise<Record<string, unknown>> {
@@ -131,7 +134,7 @@ async function compileAndTest_inner(
   );
   let res: Record<string, unknown> = Object.fromEntries(results);
   if (Object.hasOwn(res, "text")) {
-    expect(res.text).toEqual({ default: code });
+    expect(res.text).toEqual({ default: typeof code === "string" ? code : code.toString("utf8") });
     delete res.text;
   }
   if (Object.hasOwn(res, "yaml")) {
@@ -290,6 +293,24 @@ test("yaml", async () => {
   },
 }
 `);
+});
+
+// A byte that is not valid UTF-8 becomes U+FFFD and the bytes around it are
+// kept, both in a text import and in a string value of a data file.
+test("ill-formed UTF-8", async () => {
+  // {"key":"A E9 B C3 Z 80 FF [é€😀]"}: E9 and C3 start a sequence that the
+  // next byte does not continue, 80 is a continuation byte on its own, FF is
+  // never valid, and the bracket holds valid 2, 3 and 4 byte sequences.
+  const code = Buffer.concat([
+    Buffer.from('{"key":"'),
+    Buffer.from("41e942c35a80ff5bc3a9e282acf09f98805d", "hex"),
+    Buffer.from('"}'),
+  ]);
+  const key = "A\uFFFDB\uFFFDZ\uFFFD\uFFFD[\u00E9\u20AC\u{1F600}]";
+  expect(await compileAndTest(code)).toEqual({
+    "js,jsx,ts,tsx,toml": "error",
+    "json,jsonc,yaml": { default: { key }, key },
+  });
 });
 
 test("tsconfig.json is assumed jsonc", async () => {


### PR DESCRIPTION
### Problem
- A byte that is not valid UTF-8 in a text import, or in a string of a `.json`, `.jsonc` or `.yaml` file under `bun build`, prints as `\x00` and the bytes after it are lost: the file `A E9 B` imports as `"A\x00"`. A stray `80..BF` or `F8..FF` byte becomes U+0080..U+00FF, and `--target=browser` writes it raw, so the bundle is not valid UTF-8.
- Cause: the UTF-8 arm of `write_pre_quoted_string_inner` (`src/js_printer/lib.rs:1093`) decodes a bad sequence with `decode_wtf8_rune_t(.., 0)`, prints the 0, and skips the width the lead byte implies. #40718 fixed only the `bun_core` copy of this loop.

### Fix
- Same treatment as the `bun_core` copy: a failed decode, or a width-1 byte `>= 0x80`, is malformed. It prints as U+FFFD (`\uFFFD` when `ascii_only`) and the loop continues at the next byte.
- WTF-8 surrogates (`ED A0 80`) still decode, so `"\ud800"` in a JSON file still prints as `\uD800`. Valid input takes the same branches as before.
- Verified: new cases in `test/bundler/bundler_loader.test.ts` and `test/js/bun/import-attributes/import-attributes.test.ts`, both fail on 1.4.3. More suites in Notes.
- Self-reviewed: 2 concerns raised, 1 addressed (the tests now say why their byte sequences make every decoder agree). Not taken: the title says "8-bit strings" while raw template literals keep their own path, which is out of scope here.

### Background
- The text and data-file loaders wrap file bytes in an `E::String` node, and the printer turns it back into a JS string literal. Its 8-bit payload is WTF-8 by contract (UTF-8 plus 3-byte lone surrogates), but file bytes reach it unvalidated.
- Related: #35306 (closed for this one) used the strict WHATWG decoder here, which also turns WTF-8 surrogates into U+FFFD. #38253 decodes text and md files at the loader and does not reach JSON or YAML strings. #31998 folds both copies of this loop into one.

<details><summary>Notes</summary>

- One U+FFFD per undecodable byte, as in `bun_core::printer::write_pre_quoted_string`, `strings::write_wtf8_as_utf16le`, `CodepointIterator::next` and esbuild. `TextDecoder` emits one U+FFFD per maximal subpart, so `E2 82 41` gives two U+FFFD here and one there. The tests use sequences where both agree. #38253 gives text and md imports the exact `TextDecoder` result on top of this.
- `wtf8_byte_sequence_length_with_invalid` returns the sequence length for a lead byte and 1 for a byte that cannot start one, so the loop can always advance.
- Before and after, with `printf 'A\xe9B' > t2.txt; printf '{"k":"A\xe9B"}' > j2.json; printf 'hi \xe9\xff w' > t.txt`:

  ```
  bun 1.4.3:
    bun build ./t2.txt     var t2_default = "A\x00";
    bun build ./j2.json    var k = "A\x00";
    import t.txt + j2.json at runtime: ["hi \^@w","A�B"]
  this PR:
    bun build ./t2.txt     var t2_default = "A�B";   (EF BF BD in the output)
    bun build ./j2.json    var k = "A�B";
    runtime:               ["hi �� w","A�B"]
  ```

- Runtime imports of JSON files were already correct (they do not print through this path). Text imports at runtime and every loader under `bun build` were not.
- The other callers of this function (`quote_for_json`, `write_json_string` for console, dev server and snapshot output) get the same change: no NUL and no raw invalid byte in their output.
- Also ran: `bundler_string`, `transpiler`, `text-loader`, `yaml`, `md-edge-cases`, `internal-sourcemap-roundtrip`, `snapshot`, `metafile`.

</details>

