### PR TITLE
bun test --isolate: make a finished file's jest timer controls inert

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1353,6 +1353,17 @@ impl JSGlobalObject {
         Zig__GlobalObject__createForTestIsolation(old_global, console)
     }
 
+    /// The realm's `ScriptExecutionContext` went through `prepareForDestruction()`:
+    /// a `bun test --isolate` global whose file finished (from the start of
+    /// [`VirtualMachine::swap_global_for_test_isolation`] on), or any global once
+    /// VM teardown began. JS the realm leaked (a threadpool job's `.then`, an
+    /// event handler) still runs and still reaches host functions; the ones that
+    /// drive state outside the realm check this to stay inert. `false` for a
+    /// global that is not a `Zig::GlobalObject`.
+    pub fn is_context_stopped(&self) -> bool {
+        Zig__GlobalObject__isContextStopped(self)
+    }
+
     pub fn to_type_error(&self, code: JscError, args: Arguments<'_>) -> JSValue {
         code.fmt(self, args)
     }
@@ -1590,6 +1601,7 @@ unsafe extern "C" {
         old_global: &JSGlobalObject,
         console: *mut c_void,
     ) -> *mut JSGlobalObject;
+    safe fn Zig__GlobalObject__isContextStopped(this: &JSGlobalObject) -> bool;
 }
 
 impl ScriptExecutionContextIdentifier {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5185,7 +5185,9 @@ impl VirtualMachine {
         // graph) for an hour. Every TimeoutObject / ImmediateObject /
         // AbortSignal timeout in the heap belongs to the outgoing file (the
         // new global doesn't exist yet), so drop them eagerly, same as
-        // `global_exit()`. Runs no user JS.
+        // `global_exit()`. Runs no user JS. So does a `jest.useFakeTimers()`
+        // the file left on: the hook puts the thread back on the real clock
+        // here, after the last drain above ran the outgoing realm's JS.
         //
         // The hook also runs `StatWatcherScheduler::shutdown_for_exit` first:
         // it drains the (already-closed — the caller ran

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4380,6 +4380,17 @@ extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::Glo
     globalObject->scriptExecutionContext()->prepareForDestruction();
 }
 
+// The realm's context went through prepareForDestruction(): a `bun test --isolate` global retired by
+// the function above, or any global once VM teardown began. Script the realm leaked can still run.
+extern "C" bool Zig__GlobalObject__isContextStopped(JSC::JSGlobalObject* lexicalGlobalObject)
+{
+    auto* globalObject = dynamicDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    if (!globalObject)
+        return false;
+    auto* context = globalObject->scriptExecutionContext();
+    return !context || context->activeDOMObjectsAreStopped();
+}
+
 extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1735,11 +1735,12 @@ fn stop_dns_for_vm_teardown() -> SweepResult {
 /// prepareForDestruction discards the pre-exit queues.)
 pub(crate) fn stop_active_handles_for_test_isolation(vm: &mut VirtualMachine) {
     let _ = vm.event_loop_mut().drain_microtasks();
-    let _ = stop_active_handles(vm, StopReason::TestIsolation);
+    let _ = stop_active_handles(StopReason::TestIsolation);
 }
 
-pub(crate) fn stop_active_handles_for_vm_teardown(vm: &mut VirtualMachine) -> SweepResult {
-    stop_active_handles(vm, StopReason::VmTeardown)
+/// `_vm`: the caller holds this thread's VM exclusively, on the JS thread.
+pub(crate) fn stop_active_handles_for_vm_teardown(_vm: &mut VirtualMachine) -> SweepResult {
+    stop_active_handles(StopReason::VmTeardown)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1749,7 +1750,7 @@ enum StopReason {
     TestIsolation,
 }
 
-fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResult {
+fn stop_active_handles(reason: StopReason) -> SweepResult {
     let state = runtime_state();
     if state.is_null() {
         return SweepResult::Idle;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1621,9 +1621,10 @@ fn cron_clear_all_reload(vm: &mut VirtualMachine) {
 
 /// `RuntimeHooks::cancel_all_timers` — cancel every `TimeoutObject` /
 /// `ImmediateObject` still linked in the current thread's timer heap so the
-/// in-heap `+1` ref and the JS pin drop before the GC sweep / `~VM`.
-/// `timer::All` lives in `bun_runtime`; callers (`global_exit`,
-/// `WebWorker::shutdown`) are in `bun_jsc`, hence the hook.
+/// in-heap `+1` ref and the JS pin drop before the GC sweep / `~VM`, and put
+/// the thread back on the real clock.
+/// `timer::All` lives in `bun_runtime`; callers (VM teardown, the `--isolate`
+/// swap) are in `bun_jsc`, hence the hook.
 ///
 /// # Safety
 /// `vm` is the live per-thread VM; `runtime_state()` must still be installed.
@@ -1632,6 +1633,23 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
     let state = runtime_state();
     if state.is_null() {
         return;
+    }
+    // Fake-timer activation lives in the per-thread `timer::All`, not the JS
+    // global, so under `--isolate` it belongs to the outgoing file exactly like
+    // the timers below: left on, it would route every later file's `setTimeout`
+    // into the never-driven fake heap. The swap calls this hook after the last
+    // point where the outgoing realm's JS runs as the live realm; anything that
+    // realm runs later is inert (`FakeTimers.rs` `called_from_retired_realm`).
+    // The fake heap itself stays populated for `cancel_all_timeout_objects`,
+    // which walks both heaps.
+    // SAFETY: `state` is the live boxed per-thread `RuntimeState`; `vm` per fn
+    // contract; `reset_for_isolation` touches only `fake_timers.active`, the
+    // `CURRENT_TIME` static and VM fields.
+    unsafe {
+        let fake_timers = &mut *ptr::addr_of_mut!((*state).timer.fake_timers);
+        if fake_timers.is_active() {
+            fake_timers.reset_for_isolation((*vm).global());
+        }
     }
     // Drain the `fs.watchFile` scheduler queue while the timer heap and JSC
     // are both still live. Each queued `StatWatcher` holds a `RefPtr` back to
@@ -1737,26 +1755,12 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
         return SweepResult::Idle;
     }
     let mut result = SweepResult::Idle;
-    // Fake-timer state lives in the per-thread `timer::All`, not the JS
-    // global, so a file that leaves it active routes every later file's
-    // `setTimeout` into the never-driven fake heap. Leave the heap itself
-    // intact: `swap_global_for_test_isolation` runs `cancel_all_timeout_objects`
-    // next, which walks both heaps and releases `TimeoutObject` pins and
-    // discards `AbortSignalTimeout` timers at a point where no user JS can
-    // touch the outgoing signals.
     {
         let all = timer_all();
-        // SAFETY: `state` is non-null so `timer_all()` is non-null; single
-        // JS thread, no re-entry while we hold the field borrow.
-        if !all.is_null() && unsafe { (*all).fake_timers.is_active() } {
-            let global = vm.global();
-            // SAFETY: as above; only touches `fake_timers.active` and the
-            // `CURRENT_TIME` static.
-            unsafe { (*all).fake_timers.reset_for_isolation(global) };
-        }
         if !all.is_null() {
-            // SAFETY: as above; `disable` borrows only `event_loop_delay` and
-            // reaches the heap through `timer_all()` (disjoint-field access).
+            // SAFETY: `state` is non-null so `timer_all()` is live; single JS
+            // thread; `disable` borrows only `event_loop_delay` and reaches the
+            // heap through `timer_all()` (disjoint-field access).
             unsafe { (*all).event_loop_delay.disable() };
         }
     }

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -103,6 +103,9 @@ impl CurrentTime {
 /// and `performance.timeOrigin` go back to real as well.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__FakeTimers__setSystemTime(global: &JSGlobalObject, ms: f64) {
+    if called_from_retired_realm(global) {
+        return;
+    }
     let Some(current) = CURRENT_TIME.get_timespec_now() else {
         return;
     };
@@ -187,10 +190,10 @@ impl FakeTimers {
     }
 
     /// Restore real timers without draining the fake heap. Used by the
-    /// `--isolate` file boundary so `swap_global_for_test_isolation`'s
-    /// `cancel_all_timeout_objects` (which runs after the outgoing global's
-    /// JS has stopped) can walk the still-populated fake heap and release
-    /// `TimeoutObject` pins and discard `AbortSignalTimeout` timers.
+    /// `cancel_all_timers` hook (the `--isolate` swap, VM teardown) right
+    /// before `cancel_all_timeout_objects`, which walks the still-populated
+    /// fake heap itself to release `TimeoutObject` pins and discard
+    /// `AbortSignalTimeout` timers once the outgoing global's JS has stopped.
     pub(crate) fn reset_for_isolation(&mut self, global: &JSGlobalObject) {
         CURRENT_TIME.clear(global);
         self.active = false;
@@ -316,6 +319,15 @@ impl FakeTimers {
 // JS Functions
 // ===
 
+/// Under `--isolate` a file's `jest`/`vi` object outlives the file: JS it
+/// leaked (a threadpool job's `.then`) still runs in the retired realm while a
+/// later file owns the thread. The fake clock is per thread, not per realm, so
+/// from a retired realm every control below is inert: it neither installs,
+/// drives, reads, nor removes the clock of the file that is running now.
+fn called_from_retired_realm(global: &JSGlobalObject) -> bool {
+    global.is_context_stopped()
+}
+
 fn error_unless_fake_timers(global: &JSGlobalObject) -> JsResult<()> {
     // SAFETY: per-thread `timer::All`, live for the VM lifetime.
     if unsafe { (*timer_all()).fake_timers.is_active() } {
@@ -352,6 +364,9 @@ fn set_fake_timer_marker(global: &JSGlobalObject, enabled: bool) -> JsResult<()>
 
 #[bun_jsc::host_fn]
 fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(frame.this());
+    }
     // SAFETY: FFI call into C++ JSMock
     let mut js_now = JSMock__getCurrentUnixTimeMs();
 
@@ -396,6 +411,9 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
 
 #[bun_jsc::host_fn]
 fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(frame.this());
+    }
     // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
     let cleared = unsafe { (*timer_all()).fake_timers.deactivate(global) };
     cleared.release(global.bun_vm_ptr());
@@ -408,6 +426,9 @@ fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
 
 #[bun_jsc::host_fn]
 fn advance_timers_to_next_timer(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(frame.this());
+    }
     error_unless_fake_timers(global)?;
 
     FakeTimers::execute_next(global)?;
@@ -417,6 +438,9 @@ fn advance_timers_to_next_timer(global: &JSGlobalObject, frame: &CallFrame) -> J
 
 #[bun_jsc::host_fn]
 fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(frame.this());
+    }
     error_unless_fake_timers(global)?;
 
     let arg = frame.arguments_as_array::<1>()[0];
@@ -453,6 +477,9 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
 
 #[bun_jsc::host_fn]
 fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(frame.this());
+    }
     error_unless_fake_timers(global)?;
 
     FakeTimers::execute_only_pending_timers(global)?;
@@ -462,6 +489,9 @@ fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 
 #[bun_jsc::host_fn]
 fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(frame.this());
+    }
     error_unless_fake_timers(global)?;
 
     FakeTimers::execute_all_timers(global)?;
@@ -471,6 +501,9 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
 
 #[bun_jsc::host_fn]
 fn get_timer_count(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(JSValue::js_number(0.0));
+    }
     error_unless_fake_timers(global)?;
 
     // SAFETY: per-thread `timer::All`, live for the VM lifetime.
@@ -481,6 +514,9 @@ fn get_timer_count(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSVa
 
 #[bun_jsc::host_fn]
 fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(frame.this());
+    }
     error_unless_fake_timers(global)?;
 
     // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
@@ -491,7 +527,10 @@ fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
 }
 
 #[bun_jsc::host_fn]
-fn is_fake_timers(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+fn is_fake_timers(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    if called_from_retired_realm(global) {
+        return Ok(JSValue::FALSE);
+    }
     // SAFETY: per-thread `timer::All`, live for the VM lifetime.
     let is_active = unsafe { (*timer_all()).fake_timers.is_active() };
 

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -519,6 +519,101 @@ describe.concurrent("bun test --isolate", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("with --isolate, jest timer controls called by a finished file's leaked continuation are inert", async () => {
+    // The boundary reset above covers fake timers a file left on. This covers
+    // the file reaching back afterwards: a threadpool job it leaked completes
+    // while the next file runs, and its `.then` (running in the retired
+    // global) calls jest.useFakeTimers() / useRealTimers() / runAllTimers().
+    // The fake clock is per thread, so those calls used to install, drain or
+    // remove the clock of the file that is running now. The two files
+    // handshake through marker files so the calls land at known points, not
+    // after a sleep.
+    const fixtures = {
+      "a-finished.test.ts": `
+        import { expect, jest, test } from "bun:test";
+        import { existsSync, writeFileSync } from "node:fs";
+        import { join } from "node:path";
+
+        const marker = (name: string) => join(import.meta.dir, name);
+        const hop = (until: string, then: () => unknown): unknown =>
+          Bun.password.hash("pw", { algorithm: "bcrypt", cost: 4 }).then(() =>
+            existsSync(marker(until)) ? then() : hop(until, then),
+          );
+
+        test("leaks a threadpool chain that calls jest timer controls once the next file runs", () => {
+          hop("b-on-real-timers", () => {
+            jest.useFakeTimers();
+            jest.setSystemTime(0);
+            writeFileSync(marker("a-installed-fake-timers"), "");
+            return hop("b-on-fake-timers", () => {
+              jest.advanceTimersByTime(1000);
+              jest.runAllTimers();
+              jest.clearAllTimers();
+              jest.useRealTimers();
+              writeFileSync(marker("a-removed-fake-timers"), String(jest.isFakeTimers()) + " " + jest.getTimerCount());
+            });
+          });
+          expect(1).toBe(1);
+        });
+      `,
+      "b-live.test.ts": `
+        import { expect, jest, test } from "bun:test";
+        import { existsSync, readFileSync, writeFileSync } from "node:fs";
+        import { join } from "node:path";
+
+        const marker = (name: string) => join(import.meta.dir, name);
+        // setImmediate never goes through the fake clock, so this turns the
+        // event loop (landing the finished file's continuations) either way.
+        const until = async (name: string) => {
+          while (!existsSync(marker(name))) await new Promise(resolve => setImmediate(resolve));
+        };
+
+        test("the finished file's calls do not reach this file's clock", async () => {
+          writeFileSync(marker("b-on-real-timers"), "");
+          await until("a-installed-fake-timers");
+          expect(jest.isFakeTimers()).toBe(false);
+          expect(performance.now()).toBeGreaterThan(0);
+          expect(await new Promise(resolve => setTimeout(() => resolve("fired"), 1))).toBe("fired");
+
+          jest.useFakeTimers();
+          let calls = 0;
+          setTimeout(() => calls++, 1000);
+          writeFileSync(marker("b-on-fake-timers"), "");
+          await until("a-removed-fake-timers");
+          expect(readFileSync(marker("a-removed-fake-timers"), "utf8")).toBe("false 0");
+          expect(jest.isFakeTimers()).toBe(true);
+          expect(jest.getTimerCount()).toBe(1);
+          expect(calls).toBe(0);
+          jest.runAllTimers();
+          expect(calls).toBe(1);
+          jest.useRealTimers();
+        });
+      `,
+    };
+    const files = ["./a-finished.test.ts", "./b-live.test.ts"];
+
+    using isolated = tempDir("isolate-retired-fake-timers", fixtures);
+    const serial = await runTests(String(isolated), ["--isolate"], files);
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("2 pass");
+    expect(normalizeBunSnapshot(serial.stderr, isolated)).toContain("0 fail");
+    expect(serial.exitCode).toBe(0);
+
+    // One worker takes both files (scale-up gated), so the finished file's
+    // chain keeps running inside the --parallel worker that runs the next one.
+    using parallel = tempDir("isolate-retired-fake-timers-parallel", fixtures);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=2", ...files],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "60000" },
+      cwd: String(parallel),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("2 pass");
+    expect(normalizeBunSnapshot(stderr, parallel)).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
   test("with --isolate, a leaked monitorEventLoopDelay() is disabled before next file", async () => {
     // The monitor is per thread while its histogram belongs to the file's
     // global. A file that enables it and never disables it used to leave the


### PR DESCRIPTION
### Problem
- Under `--isolate` / `--parallel`, a continuation that a finished file leaked (a threadpool job's `.then`) runs in its retired global while the next file runs. `jest.useFakeTimers()` from there put the thread on fake timers: the running file's real `setTimeout` never fired and it `timed out after 5000ms`.
- Cause: `FakeTimers.active` and the fake clock live in the per-thread `timer::All` (`src/runtime/test_runner/timers/FakeTimers.rs`), and the host functions never checked which realm called them. #36385 resets the flag at the file boundary only.

### Fix
- Every fake-timer control, and the Rust half of `setSystemTime`, does nothing when its realm's `ScriptExecutionContext` is stopped (`JSGlobalObject::is_context_stopped`). The swap stops the outgoing context first, so live, ShadowRealm and worker globals are not affected.
- The boundary reset moves from `stop_active_handles` into the `cancel_all_timers` hook, which the swap runs after the last point where the outgoing realm's JS runs as the live realm. No window is left.
- Inert, not throwing: a throw would become an unhandled rejection charged to the running file. Jest behaves the same way.
- Verified: `test/cli/test/isolation.test.ts` (new case fails on 1.4.3-canary, all 34 pass with the fix), plus the fake-timers, cron and jsonwebtoken suites.

### Background
- `--isolate` gives each file a fresh `Zig::GlobalObject` on the same `JSC::VM` and thread. The old global is not destroyed, so its functions stay callable.
- `ScriptExecutionContext::prepareForDestruction()` is WebCore's "this realm is going away" step. `ActiveDOMCallback::canInvokeCallback()` reads the same flag.
- `cancel_all_timers` is the hook that drops the outgoing timers at the swap and at VM teardown.

<details><summary>Notes</summary>

- Reported as fuzz-ledger #31291. Repro from the report: `a.test.ts` leaks `Bun.password.hash(argon2id, timeCost 12).then(() => jest.useFakeTimers())`, `b.test.ts` awaits `Bun.sleep(1500)` then a real 300 ms `setTimeout`. B times out on 1.4.2 and 1.4.3-canary in `--isolate`, `--parallel` and plain mode.
- `useRealTimers()` / `runAllTimers()` / `clearAllTimers()` from the retired realm had the mirror effect: they drained or removed the running file's fake heap. The same check covers them, and `getTimerCount()` / `isFakeTimers()` read `0` / `false` there. `Zig__GlobalObject__isContextStopped` is the new C++ getter behind `is_context_stopped`.
- The new test does not sleep. The two fixture files handshake through marker files: A's leaked bcrypt chain acts only once B writes that it is running, and B turns the event loop with `setImmediate` (never routed through the fake clock) until A writes that it acted. Phase 1 checks that A's `useFakeTimers()` + `setSystemTime(0)` leave B on real timers (`isFakeTimers() === false`, `performance.now() > 0`, a 1 ms timer fires). Phase 2 has B turn fake timers on itself and checks that A's `advanceTimersByTime` / `runAllTimers` / `clearAllTimers` / `useRealTimers` leave B's fake heap alone and that A's reads return `false` / `0`. The `--parallel=2` run pins both files to one worker with `BUN_TEST_PARALLEL_SCALE_MS`, like the neighbouring cases.
- Why the reset moved: `stop_active_handles` runs before the swap. After it, the outgoing realm's JS still runs as the live realm in socket close handlers and in the swap's two microtask drains, so an activation there used to survive into the next file. `cancel_all_timers` runs after those and before the new global exists. At VM teardown the same hook runs and the reset is harmless there.
- Plain `bun test` (no `--isolate`) shares one global and one `jest` object across files, so a late call there cannot be told apart from the running file's own. That mode is what #36398 (boundary reset in `TestCommand::run`) is about. This PR does not change it.
- `stop_active_handles` lost its `vm` parameter because the reset was its only use.
- A retired realm's `setTimeout` still lands in the live heaps (and, when the live file has fake timers on, in its fake heap). That is the un-cancelled-continuation problem in general, not specific to fake timers, and is left for a separate change.

</details>
