### PR TITLE
ipc: report an undecodable message instead of closing the channel silently

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -313,7 +313,7 @@ childProc.disconnect();
 
 ### IPC between Bun & Node.js
 
-To use IPC between a `bun` process and a Node.js process, set `serialization: "json"` in `Bun.spawn`. This is because Node.js and Bun use different JavaScript engines with different object serialization formats.
+To use IPC between a `bun` process and a Node.js process, set `serialization: "json"` in `Bun.spawn`. This is because Node.js and Bun use different JavaScript engines with different object serialization formats. If the formats do not match, the Bun process reports the first message it cannot decode as an uncaught exception and closes the channel.
 
 ```js bun-node-ipc.js icon="file-code"
 if (typeof Bun !== "undefined") {

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -982,6 +982,29 @@ impl SendQueueOwner {
             SendQueueOwner::Instance(_) => JSValue::ZERO,
         }
     }
+
+    /// Names the process at the other end of the channel in error messages.
+    fn peer(self) -> PeerName {
+        match self {
+            // SAFETY: an attached owner is live (it holds a ref on the SendQueue).
+            SendQueueOwner::Subprocess(p) => PeerName::Subprocess(unsafe { p.as_ref() }.pid()),
+            SendQueueOwner::Instance(_) => PeerName::Parent,
+        }
+    }
+}
+
+enum PeerName {
+    Subprocess(i32),
+    Parent,
+}
+
+impl core::fmt::Display for PeerName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            PeerName::Subprocess(pid) => write!(f, "The subprocess (pid {pid})"),
+            PeerName::Parent => f.write_str("The parent process"),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -2253,18 +2276,43 @@ fn finish_decode(send_queue: &SendQueue, step: &DecodeStep) {
             Output::print_errorln("IPC message is too long.");
             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
         }
-        // Materializing the message (structured-clone deserialize, buffer
-        // restore) threw: that is this message's delivery failing, folded like
-        // a throwing listener, and the channel is closed as for any undecodable
-        // input.
+        // Undecodable input is reported as the receiving process's uncaught
+        // exception, like a throwing listener, and closes the channel. `Js`:
+        // materializing the message (structured-clone deserialize, buffer
+        // restore) threw; the pending exception is consumed before anything
+        // else runs. `InvalidFormat`: the bytes are not a message in this
+        // channel's format at all (a peer that speaks another serialization,
+        // or garbage); nothing is pending, so the channel is closed first and
+        // a handler already sees it disconnected.
         DecodeStep::Fail(IPCDecodeError::Js(err)) => {
             crate::dispatch::fold(Err(*err));
             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
         }
-        DecodeStep::Fail(_) => {
+        DecodeStep::Fail(IPCDecodeError::InvalidFormat) => {
+            send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
+            report_undecodable_message(send_queue);
+        }
+        DecodeStep::Fail(IPCDecodeError::Stopped | IPCDecodeError::NotEnoughBytes) => {
             send_queue.close_socket(CloseReason::Failure, CloseFrom::User);
         }
     }
+}
+
+fn report_undecodable_message(send_queue: &SendQueue) {
+    let Some(owner) = send_queue.owner_ref() else {
+        return;
+    };
+    let global = send_queue.get_global_this();
+    let peer = owner.peer();
+    let err = match send_queue.mode {
+        Mode::Advanced => global.create_error_instance(format_args!(
+            "{peer} sent an IPC message that is not in Bun's \"advanced\" serialization format, so Bun closed the IPC channel. \"advanced\" serialization only works between two Bun processes. For IPC between Bun and Node.js, use serialization: \"json\"."
+        )),
+        Mode::Json => global.create_error_instance(format_args!(
+            "{peer} sent an IPC message that is not valid JSON, so Bun closed the IPC channel."
+        )),
+    };
+    crate::dispatch::fold(Err(global.throw_value(err)));
 }
 
 fn decode_next_json(incoming: &JsCell<IncomingBuffer>, global: &JSGlobalObject) -> DecodeStep {

--- a/test/js/bun/spawn/spawn.ipc.bun-node.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.bun-node.test.ts
@@ -19,6 +19,40 @@ p I am your father
   expect(await new Response(child.stderr).text()).toEqual("");
 });
 
+test.skipIf(!nodeExe())(
+  'a node child under the default serialization is reported, with the "json" remedy',
+  async () => {
+    // Bun.spawn({ ipc }) defaults to serialization: "advanced", which only Bun
+    // speaks. A Node.js child answers in v8's framing; the parent cannot decode it
+    // and must fail loudly instead of leaving the user with a channel that never
+    // delivers anything.
+    const parentSource = `
+    const child = Bun.spawn({
+      cmd: [process.env.NODE_BIN, "-e", 'process.send({ hello: "from node" }, () => process.disconnect())'],
+      stdio: ["ignore", "inherit", "inherit"],
+      ipc(message) { console.log("UNEXPECTED_IPC_MESSAGE", message); },
+    });
+    await child.exited;
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parentSource],
+      env: { ...bunEnv, NODE_BIN: nodeExe()! },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // No uncaughtException handler: the parent exits 1 at the report.
+    expect(stdout).toBe("");
+    expect(normalizeBunSnapshot(stderr)).toContain(
+      `sent an IPC message that is not in Bun's "advanced" serialization format, so Bun closed the IPC channel. "advanced" serialization only works between two Bun processes. For IPC between Bun and Node.js, use serialization: "json".`,
+    );
+    expect(exitCode).toBe(1);
+  },
+);
+
 test.skipIf(isWindows || !nodeExe())(
   "receives a net.Socket handle from a node child and releases its descriptor",
   async () => {

--- a/test/js/bun/spawn/spawn.ipc.node-bun.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.node-bun.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunExe } from "harness";
+import { bunEnv, bunExe, nodeExe } from "harness";
 import path from "path";
 
 test("ipc with json serialization still works when bun is not the parent and the child", async () => {
@@ -19,3 +19,45 @@ p I am your father
 `,
   );
 });
+
+test.skipIf(!nodeExe())(
+  'a bun child of a node parent using serialization: "advanced" reports the mismatch',
+  async () => {
+    // Node's "advanced" serialization is v8's wire format, which Bun cannot decode.
+    // The child must report the first such message instead of dropping the channel
+    // silently.
+    const parentSource = `
+    const { spawn } = require("node:child_process");
+    const child = spawn(process.argv[1], ["-e", 'process.on("message", msg => console.log("UNEXPECTED_IPC_MESSAGE", msg));'], {
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      serialization: "advanced",
+    });
+    let stdout = "", stderr = "";
+    child.stdout.setEncoding("utf8").on("data", chunk => (stdout += chunk));
+    child.stderr.setEncoding("utf8").on("data", chunk => (stderr += chunk));
+    child.on("close", (exitCode, signalCode) => {
+      console.log(JSON.stringify({ stdout, stderr, exitCode, signalCode }));
+    });
+    child.send({ hello: "from node" });
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [nodeExe()!, "-e", parentSource, bunExe()],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const child = JSON.parse(stdout);
+    // No uncaughtException handler in the child: it exits 1 at the report.
+    expect(child.stdout).toBe("");
+    expect(child.stderr).toContain(
+      `The parent process sent an IPC message that is not in Bun's "advanced" serialization format, so Bun closed the IPC channel. "advanced" serialization only works between two Bun processes. For IPC between Bun and Node.js, use serialization: "json".`,
+    );
+    expect({ exitCode: child.exitCode, signalCode: child.signalCode }).toEqual({ exitCode: 1, signalCode: null });
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -1,7 +1,26 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, gcTick, isWindows } from "harness";
+import { closeSync, writeSync } from "node:fs";
 import path from "path";
+
+// The uncaught exception a receiver reports for bytes that are not a message in
+// the channel's serialization format. The channel is closed before the report.
+const undecodableMessageError = {
+  advancedFromSubprocess:
+    `The subprocess (pid <pid>) sent an IPC message that is not in Bun's "advanced" serialization format, so Bun closed the IPC channel. ` +
+    `"advanced" serialization only works between two Bun processes. For IPC between Bun and Node.js, use serialization: "json".`,
+  advancedFromParent:
+    `The parent process sent an IPC message that is not in Bun's "advanced" serialization format, so Bun closed the IPC channel. ` +
+    `"advanced" serialization only works between two Bun processes. For IPC between Bun and Node.js, use serialization: "json".`,
+  jsonFromSubprocess: `The subprocess (pid <pid>) sent an IPC message that is not valid JSON, so Bun closed the IPC channel.`,
+};
+
+// What a Node.js process whose channel uses serialization: "advanced" writes for
+// send({ hello: "from node" }): a 4-byte big-endian length, then the v8.serialize()
+// payload (0xff 0x0f is the v8 wire-format version header). See writeChannelMessage in
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/child_process/serialization.js#L109-L124
+const nodeAdvancedFrame = Buffer.from("00000017ff0f6f220568656c6c6f220966726f6d206e6f64657b01", "hex");
 
 describe.each(["advanced", "json"])("ipc mode %s", mode => {
   it("the subprocess should be defined and the child should send", done => {
@@ -126,8 +145,8 @@ describe("ipc mode json", () => {
   it.skipIf(isWindows)("closes the channel on a line that holds only the internal tag byte", async () => {
     // An internal JSON message is "\\x02" + json + "\\n". A line of just the tag
     // byte strips to an empty payload. The receiver must treat it like an empty
-    // line (invalid, close the channel) instead of building an external string
-    // over a zero-length slice.
+    // line (invalid: report it and close the channel) instead of building an
+    // external string over a zero-length slice.
     //
     // The receiver runs in its own subprocess so a crash shows up as a failing
     // assertion here rather than taking out the test runner.
@@ -141,6 +160,9 @@ describe("ipc mode json", () => {
         serialization: "json",
         ipc(msg) { console.error("UNEXPECTED_IPC_MESSAGE", msg); },
       });
+      process.on("uncaughtException", err => {
+        console.log("UNCAUGHT", child.connected, err.message.replaceAll(String(child.pid), "<pid>"));
+      });
       console.log("CHILD_EXIT", await child.exited);
     `;
 
@@ -153,7 +175,10 @@ describe("ipc mode json", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout.trim()).toBe("CHILD_EXIT 42");
+    expect(stdout.trim().split("\n")).toEqual([
+      `UNCAUGHT false ${undecodableMessageError.jsonFromSubprocess}`,
+      "CHILD_EXIT 42",
+    ]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
@@ -201,16 +226,29 @@ describe("ipc mode advanced", () => {
     expect(received.filter(message => Array.isArray(message))).toHaveLength(0);
   });
 
-  it("a message_len that overflows header_length + message_len does not crash the receiver", async () => {
-    // The advanced IPC framing is [u8 type][u32-le length][payload]. Decoding previously
-    // checked `data.len < header_length + message_len`, which is u32 arithmetic: a child
-    // sending length 0xFFFFFFFB makes the sum wrap to 0, the guard passes, and the receiver
-    // slices `data[5..0]` (length ~SIZE_MAX) straight into the deserializer.
-    //
-    // Run the receiver in its own subprocess so a crash is observed as a failing
-    // assertion here rather than taking out the test runner.
-    // prettier-ignore
-    const parent = `
+  // The raw-frame tests below inject bytes with fs.writeSync(3). On Windows the
+  // channel is a libuv IPC pipe with its own framing under ours, so a raw write
+  // never reaches the decoder; the node-peer tests in spawn.ipc.bun-node.test.ts
+  // and spawn.ipc.node-bun.test.ts cover the undecodable-message report there.
+  it.skipIf(isWindows)(
+    "a message_len that overflows header_length + message_len does not crash the receiver",
+    async () => {
+      // The advanced IPC framing is [u8 type][u32-le length][payload]. Decoding previously
+      // checked `data.len < header_length + message_len`, which is u32 arithmetic: a child
+      // sending length 0xFFFFFFFB makes the sum wrap to 0, the guard passes, and the receiver
+      // slices `data[5..0]` (length ~SIZE_MAX) straight into the deserializer.
+      //
+      // Run the receiver in its own subprocess so a crash is observed as a failing
+      // assertion here rather than taking out the test runner.
+      // prettier-ignore
+      const parent = `
+      // The child exits right after writing, so its exit and the report can
+      // land in either order; print at parent exit, when both have happened.
+      const lines = [];
+      process.on("uncaughtException", err => {
+        lines.push("UNCAUGHT " + err.message.replaceAll(String(child.pid), "<pid>"));
+      });
+      process.on("exit", () => console.log([...lines, "PARENT_EXIT"].join("\\n")));
       const child = Bun.spawn({
         cmd: [
           process.execPath, "-e",
@@ -223,22 +261,25 @@ describe("ipc mode advanced", () => {
         ipc(msg) { console.error("UNEXPECTED_IPC_MESSAGE", msg); },
       });
       await child.exited;
-      console.log("PARENT_OK");
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", parent],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", parent],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout.trim()).toBe("PARENT_OK");
-    expect(stderr).not.toContain("UNEXPECTED_IPC_MESSAGE");
-    expect(exitCode).toBe(0);
-  });
+      expect(stdout.trim().split("\n")).toEqual([
+        `UNCAUGHT ${undecodableMessageError.advancedFromSubprocess}`,
+        "PARENT_EXIT",
+      ]);
+      expect(stderr).not.toContain("UNEXPECTED_IPC_MESSAGE");
+      expect(exitCode).toBe(0);
+    },
+  );
 
   it.skipIf(isWindows)("rejects a Buffer envelope whose buffer list holds a non-Uint8Array view", async () => {
     // Frame type 4 carries a [message, buffers] envelope and the receiver puts
@@ -305,6 +346,9 @@ describe("ipc mode advanced", () => {
         serialization: "advanced",
         ipc(msg) { console.error("UNEXPECTED_IPC_MESSAGE", msg); },
       });
+      process.on("uncaughtException", err => {
+        console.log("UNCAUGHT", err.message.replaceAll(String(child.pid), "<pid>"));
+      });
       console.log("CHILD_EXIT", await child.exited);
     `;
 
@@ -317,11 +361,82 @@ describe("ipc mode advanced", () => {
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(stdout.trim()).toBe("CHILD_EXIT 42");
+      expect(stdout.trim().split("\n")).toEqual([
+        `UNCAUGHT ${undecodableMessageError.advancedFromSubprocess}`,
+        "CHILD_EXIT 42",
+      ]);
       expect(stderr).not.toContain("UNEXPECTED_IPC_MESSAGE");
       expect(exitCode).toBe(0);
     },
   );
+
+  it.skipIf(isWindows)("reports a subprocess that does not speak the advanced format", async () => {
+    // A Node.js child answers a Bun.spawn({ ipc }) parent in v8's framing, which
+    // no Bun receiver can decode. The parent must say so (naming the remedy)
+    // instead of dropping the channel silently. The child here is Bun writing the
+    // exact bytes Node writes, so the test does not need a node binary.
+    const parent = `
+      const child = Bun.spawn({
+        cmd: [
+          process.execPath, "-e",
+          'process.on("disconnect", () => process.exit(42)); require("fs").writeSync(3, Buffer.from("${nodeAdvancedFrame.toString("hex")}", "hex"));',
+        ],
+        stdio: ["ignore", "inherit", "inherit"],
+        // no serialization option: "advanced", as in a bare Bun.spawn({ ipc }).
+        ipc(msg) { console.error("UNEXPECTED_IPC_MESSAGE", msg); },
+      });
+      process.on("uncaughtException", err => {
+        console.log("UNCAUGHT", child.connected, err.message.replaceAll(String(child.pid), "<pid>"));
+      });
+      console.log("CHILD_EXIT", await child.exited);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parent],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim().split("\n")).toEqual([
+      `UNCAUGHT false ${undecodableMessageError.advancedFromSubprocess}`,
+      "CHILD_EXIT 42",
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(isWindows)("a child reports a parent that does not speak the advanced format", async () => {
+    // The reverse pairing: a Node.js parent that spawned Bun with
+    // serialization: "advanced". The test plays the parent by holding the other
+    // end of the child's NODE_CHANNEL_FD and writing Node's bytes into it.
+    await using child = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.on("uncaughtException", err => console.log("UNCAUGHT", process.connected, err.message));
+          process.on("disconnect", () => process.exit(42));
+          process.on("message", msg => console.log("UNEXPECTED_IPC_MESSAGE", msg));
+        `,
+      ],
+      env: { ...bunEnv, NODE_CHANNEL_FD: "3", NODE_CHANNEL_SERIALIZATION_MODE: "advanced" },
+      stdio: ["ignore", "pipe", "pipe", "pipe"],
+    });
+    // Reading .stdio[3] hands the descriptor to us; we close it.
+    const fd = child.stdio[3] as number;
+    try {
+      writeSync(fd, nodeAdvancedFrame);
+      const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+      expect(stdout.trim().split("\n")).toEqual([`UNCAUGHT false ${undecodableMessageError.advancedFromParent}`]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(42);
+    } finally {
+      closeSync(fd);
+    }
+  });
 });
 
 // getIPCInstance error path: on Windows, windowsConfigureClient can open the


### PR DESCRIPTION
### Problem
- `Bun.spawn(["node", ...], { ipc })` defaults to `serialization: "advanced"`, which only Bun speaks. The Node child answers in V8's framing, the parent cannot decode it, and the channel dies with no output. Any bytes that are not a frame in the channel's format do the same, in both directions and in `"json"` mode.
- Cause: `finish_decode` in `src/runtime/ipc.rs` closed the socket on `IPCDecodeError::InvalidFormat` and reported nothing. The arm next to it (a well-formed frame whose payload fails to deserialize) already raises an uncaught exception.

### Fix
- `InvalidFormat` now closes the channel, then reports an uncaught exception in the receiving process. The message names the peer and, in `"advanced"` mode, the remedy: `For IPC between Bun and Node.js, use serialization: "json".`
- Correct because the channel was already dead here. The receiver now hears why, on the path a throwing `ipc` listener takes. Node also throws on undecodable input. Self-reviewed: 7 concerns probed, none survived.
- Verified: `test/js/bun/spawn/spawn.ipc.test.ts` (Node's exact bytes injected in each direction, three raw-frame tests now assert the report) plus real-Node pairings in `spawn.ipc.bun-node.test.ts` and `spawn.ipc.node-bun.test.ts`. They fail on stock bun and pass with the fix, on Linux and Windows.

### Background
- `"advanced"` frames are `[u8 type][u32 LE length][JSC structured-clone payload]`. Node's are `[u32 BE length][v8.serialize() payload]`, so the first byte is `0x00` and matches no frame type.
- `node:child_process` in Bun defaults to `"json"`, which both runtimes share. `Bun.spawn` defaults to `"advanced"`. The docs say to pass `"json"` for a Node child.

<details><summary>Notes</summary>

- With no `uncaughtException` handler the receiver prints the error and exits 1. With one, the program continues and `connected` is already `false` inside the handler.
- `"json"` mode still closes the channel on a malformed line (Node keeps it open and throws `SyntaxError`). Only the silence changes. The OOM arm (`IPC message is too long.`) and the `Stopped` arm (VM shutting down) are unchanged.
- The deserialize arm still reports before it closes, because its exception is already pending and has to be consumed first. `InvalidFormat` has nothing pending, so it closes first.
- On Windows the channel is a libuv IPC pipe with libuv's own framing under Bun's. The existing tests that inject raw bytes with `fs.writeSync(3)` never reached the decoder there (a probe on a Windows build shows the parent sees only EOF). The one such test that was not Windows-skipped passed only because it asserted nothing about delivery. It is now skipped with the reason, and the Node-peer tests cover the report on Windows (they pass on a Windows build).
- Other suites run: `child_process_ipc.test.js`, `child_process_ipc_large_disconnect.test.js`, `bun-ipc-inherit.test.ts`, 19 `test-child-process-*` and 7 `test-cluster-*` Node tests.
- The report's repro after the fix:
  ```
  $ bun adv.js
  error: The subprocess (pid 24849) sent an IPC message that is not in Bun's "advanced" serialization format, so Bun closed the IPC channel. "advanced" serialization only works between two Bun processes. For IPC between Bun and Node.js, use serialization: "json".
  parent got []
  ```
- #32980 (closed) went the other way and taught Bun V8's wire format. This PR does not change what either mode can carry.

</details>

