### PR TITLE
bundler: join publicPath and output paths with exactly one slash

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -58,8 +58,8 @@ pub use string::{
     StringView, Utf8Bytes, Utf8WithString, WTFStringImpl, WTFStringImplExt, WTFStringImplStruct,
 };
 pub use string::{
-    STRING_ALLOCATION_LIMIT, cheap_prefix_normalizer, escape_reg_exp, identifier, lexer,
-    lexer_tables, parse_double, printer, quote_for_json, string_joiner, write,
+    PrefixedPath, STRING_ALLOCATION_LIMIT, cheap_prefix_normalizer, escape_reg_exp, identifier,
+    lexer, lexer_tables, parse_double, printer, quote_for_json, string_joiner, write,
 };
 pub use string::{StringPointer, Tag, slice_to_nul};
 

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -2021,10 +2021,35 @@ pub use printer::quote_for_json;
 
 pub use crate::ffi::slice_to_nul;
 
+/// The pieces of `prefix + separator + path`; see [`cheap_prefix_normalizer`].
+#[derive(Clone, Copy)]
+pub struct PrefixedPath<'a> {
+    pub prefix: &'a [u8],
+    pub separator: &'static [u8],
+    pub path: &'a [u8],
+}
+
+impl<'a> PrefixedPath<'a> {
+    pub fn parts(&self) -> [&'a [u8]; 3] {
+        [self.prefix, self.separator, self.path]
+    }
+
+    pub fn len(&self) -> usize {
+        self.prefix.len() + self.separator.len() + self.path.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn to_boxed(&self) -> Box<[u8]> {
+        strings::concat(&self.parts())
+    }
+}
+
 /// Joins a public path (`prefix`) with an output-relative path (`suffix`) the
-/// way esbuild's `joinWithPublicPath` does. Returns `[prefix', sep, suffix']`;
-/// concatenate the three parts. A leading `./` on `suffix` is dropped, and
-/// exactly one `/` separates a non-empty `prefix` from `suffix`.
+/// way esbuild's `joinWithPublicPath` does: a leading `./` on `suffix` is
+/// dropped, and exactly one `/` separates a non-empty `prefix` from `suffix`.
 ///
 /// ```text
 /// ["", "./out.js"]                      => "./out.js"
@@ -2033,18 +2058,18 @@ pub use crate::ffi::slice_to_nul;
 /// ["https://example.com", "./out.js"]   => "https://example.com/out.js"
 /// ["/foo/", "bar.js"]                   => "/foo/bar.js"
 /// ```
-pub fn cheap_prefix_normalizer<'a>(prefix: &'a [u8], suffix: &'a [u8]) -> [&'a [u8]; 3] {
+pub fn cheap_prefix_normalizer<'a>(prefix: &'a [u8], suffix: &'a [u8]) -> PrefixedPath<'a> {
     if prefix.is_empty() {
-        let suffix_no_slash = strings::remove_leading_dot_slash(suffix);
-        return [
-            if strings::has_prefix_comptime(suffix_no_slash, b"../") {
+        let path = strings::remove_leading_dot_slash(suffix);
+        return PrefixedPath {
+            prefix: if strings::has_prefix_comptime(path, b"../") {
                 b""
             } else {
                 b"./"
             },
-            b"",
-            suffix_no_slash,
-        ];
+            separator: b"",
+            path,
+        };
     }
 
     let win = crate::Environment::IS_WINDOWS;
@@ -2054,10 +2079,15 @@ pub fn cheap_prefix_normalizer<'a>(prefix: &'a [u8], suffix: &'a [u8]) -> [&'a [
     let prefix_has_sep = prefix.last().is_some_and(|&c| is_sep(c));
     let suffix_has_sep = suffix.first().is_some_and(|&c| is_sep(c));
 
-    match (prefix_has_sep, suffix_has_sep) {
-        (true, true) => [prefix, b"", &suffix[1..]],
-        (false, false) => [prefix, b"/", suffix],
-        _ => [prefix, b"", suffix],
+    let (separator, path): (&'static [u8], &'a [u8]) = match (prefix_has_sep, suffix_has_sep) {
+        (true, true) => (b"", &suffix[1..]),
+        (false, false) => (b"/", suffix),
+        _ => (b"", suffix),
+    };
+    PrefixedPath {
+        prefix,
+        separator,
+        path,
     }
 }
 

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -2021,12 +2021,19 @@ pub use printer::quote_for_json;
 
 pub use crate::ffi::slice_to_nul;
 
-/// Pure path-string helper used by the bundler chunk writer and `css::printer`.
-/// Returns `[prefix', suffix']` such that concatenating them produces a
-/// reasonably-normalized path (collapses `./` leading and avoids `//`).
-/// The two-element-array return shape lets bundler call-sites index it
-/// directly.
-pub fn cheap_prefix_normalizer<'a>(prefix: &'a [u8], suffix: &'a [u8]) -> [&'a [u8]; 2] {
+/// Joins a public path (`prefix`) with an output-relative path (`suffix`) the
+/// way esbuild's `joinWithPublicPath` does. Returns `[prefix', sep, suffix']`;
+/// concatenate the three parts. A leading `./` on `suffix` is dropped, and
+/// exactly one `/` separates a non-empty `prefix` from `suffix`.
+///
+/// ```text
+/// ["", "./out.js"]                      => "./out.js"
+/// ["", "../out.js"]                     => "../out.js"
+/// ["https://example.com/", "/out.js"]   => "https://example.com/out.js"
+/// ["https://example.com", "./out.js"]   => "https://example.com/out.js"
+/// ["/foo/", "bar.js"]                   => "/foo/bar.js"
+/// ```
+pub fn cheap_prefix_normalizer<'a>(prefix: &'a [u8], suffix: &'a [u8]) -> [&'a [u8]; 3] {
     if prefix.is_empty() {
         let suffix_no_slash = strings::remove_leading_dot_slash(suffix);
         return [
@@ -2035,23 +2042,23 @@ pub fn cheap_prefix_normalizer<'a>(prefix: &'a [u8], suffix: &'a [u8]) -> [&'a [
             } else {
                 b"./"
             },
+            b"",
             suffix_no_slash,
         ];
     }
 
-    // ["https://example.com/", "/out.js"]  => "https://example.com/out.js"
-    // ["/foo/", "/bar.js"]                 => "/foo/bar.js"
     let win = crate::Environment::IS_WINDOWS;
-    if strings::ends_with_char(prefix, b'/') || (win && strings::ends_with_char(prefix, b'\\')) {
-        if strings::starts_with_char(suffix, b'/')
-            || (win && strings::starts_with_char(suffix, b'\\'))
-        {
-            return [prefix, &suffix[1..]];
-        }
-        // It gets really complicated if we try to deal with URLs more than this.
-    }
+    let is_sep = |c: u8| c == b'/' || (win && c == b'\\');
 
-    [prefix, strings::remove_leading_dot_slash(suffix)]
+    let suffix = strings::remove_leading_dot_slash(suffix);
+    let prefix_has_sep = prefix.last().is_some_and(|&c| is_sep(c));
+    let suffix_has_sep = suffix.first().is_some_and(|&c| is_sep(c));
+
+    match (prefix_has_sep, suffix_has_sep) {
+        (true, true) => [prefix, b"", &suffix[1..]],
+        (false, false) => [prefix, b"/", suffix],
+        _ => [prefix, b"", suffix],
+    }
 }
 
 // Re-export `wtf::parse_double` at crate root (callers spell it `bun_core::parse_double`).

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -865,7 +865,10 @@ impl IntermediateOutput {
                                     )
                                 },
                             );
-                            count += cheap_normalizer[0].len() + cheap_normalizer[1].len();
+                            count += cheap_normalizer
+                                .iter()
+                                .map(|part| part.len())
+                                .sum::<usize>();
                         }
                         QueryKind::None => {}
                     }
@@ -1064,21 +1067,14 @@ impl IntermediateOutput {
                                 },
                             );
 
-                            if !cheap_normalizer[0].is_empty() {
-                                remain[..cheap_normalizer[0].len()]
-                                    .copy_from_slice(cheap_normalizer[0]);
-                                remain = &mut remain[cheap_normalizer[0].len()..];
-                                if ENABLE_SOURCE_MAP_SHIFTS {
-                                    shift.after.advance(cheap_normalizer[0]);
+                            for part in cheap_normalizer {
+                                if part.is_empty() {
+                                    continue;
                                 }
-                            }
-
-                            if !cheap_normalizer[1].is_empty() {
-                                remain[..cheap_normalizer[1].len()]
-                                    .copy_from_slice(cheap_normalizer[1]);
-                                remain = &mut remain[cheap_normalizer[1].len()..];
+                                remain[..part.len()].copy_from_slice(part);
+                                remain = &mut remain[part.len()..];
                                 if ENABLE_SOURCE_MAP_SHIFTS {
-                                    shift.after.advance(cheap_normalizer[1]);
+                                    shift.after.advance(part);
                                 }
                             }
 

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -865,10 +865,7 @@ impl IntermediateOutput {
                                     )
                                 },
                             );
-                            count += cheap_normalizer
-                                .iter()
-                                .map(|part| part.len())
-                                .sum::<usize>();
+                            count += cheap_normalizer.len();
                         }
                         QueryKind::None => {}
                     }
@@ -1067,7 +1064,7 @@ impl IntermediateOutput {
                                 },
                             );
 
-                            for part in cheap_normalizer {
+                            for part in cheap_normalizer.parts() {
                                 if part.is_empty() {
                                     continue;
                                 }

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -44,7 +44,7 @@ pub use bun_js_printer::MangledProps;
 pub use options_impl::PathTemplate;
 
 pub use HTMLImportManifest::html_import_manifest;
-pub use bun_core::cheap_prefix_normalizer;
+pub use bun_core::{PrefixedPath, cheap_prefix_normalizer};
 pub use bundle_v2::{
     CompileResult, CompileResultForSourceMap, ContentHasher, EventLoop, ImportTracker, PartRange,
     StableRef, WrapKind, generic_path_with_pretty_initialized, target_from_hashbang,

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -555,11 +555,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 } else {
                     c.options.public_path
                 };
-                let normalizer = cheap_prefix_normalizer(public_path, &ch.final_rel_path);
-                let mut resolved: Vec<u8> = Vec::new();
-                resolved.extend_from_slice(normalizer[0]);
-                resolved.extend_from_slice(normalizer[1]);
-                let _ = unique_key_to_path.put(ch.unique_key, resolved.into_boxed_slice()); // OOM-only Result
+                let resolved =
+                    strings::concat(&cheap_prefix_normalizer(public_path, &ch.final_rel_path));
+                let _ = unique_key_to_path.put(ch.unique_key, resolved); // OOM-only Result
             }
         }
 
@@ -743,7 +741,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // file rather than a JS file next to the .map. Point at
                         // the .map path relative to the HTML chunk's directory.
                         let mut relative_platform_buf = path::path_buffer_pool::get();
-                        let [a, b]: [&[u8]; 2] = if !c.options.public_path.is_empty() {
+                        let url_parts: [&[u8]; 3] = if !c.options.public_path.is_empty() {
                             cheap_prefix_normalizer(
                                 c.options.public_path,
                                 &source_map_final_rel_path,
@@ -782,16 +780,14 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                             )
                         };
 
-                        let source_map_start = b"//# sourceMappingURL=";
-                        let total_len =
-                            buffer.len() + source_map_start.len() + a.len() + b.len() + b"\n".len();
-                        let mut buf: Vec<u8> = Vec::with_capacity(total_len);
-                        buf.extend_from_slice(&buffer);
-                        buf.extend_from_slice(source_map_start);
-                        buf.extend_from_slice(a);
-                        buf.extend_from_slice(b);
-                        buf.push(b'\n');
-                        buffer = buf.into_boxed_slice();
+                        buffer = strings::concat(&[
+                            &buffer,
+                            b"//# sourceMappingURL=",
+                            url_parts[0],
+                            url_parts[1],
+                            url_parts[2],
+                            b"\n",
+                        ]);
                     }
 
                     standalone_sourcemaps[ci] = Some(output_source_map);
@@ -993,26 +989,20 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     source_map_final_rel_path.extend_from_slice(b".map");
 
                     if tag == SourceMapOption::Linked {
-                        let [a, b]: [&[u8]; 2] = if public_path.len() > 0 {
+                        let url_parts: [&[u8]; 3] = if public_path.len() > 0 {
                             cheap_prefix_normalizer(public_path, &source_map_final_rel_path)
                         } else {
-                            [b"", path::basename(&source_map_final_rel_path)]
+                            [b"", b"", path::basename(&source_map_final_rel_path)]
                         };
 
-                        let source_map_start = b"//# sourceMappingURL=";
-                        let total_len = code_result.buffer.len()
-                            + source_map_start.len()
-                            + a.len()
-                            + b.len()
-                            + b"\n".len();
-                        let mut buf: Vec<u8> = Vec::with_capacity(total_len);
-                        buf.extend_from_slice(&code_result.buffer);
-                        buf.extend_from_slice(source_map_start);
-                        buf.extend_from_slice(a);
-                        buf.extend_from_slice(b);
-                        buf.push(b'\n');
-
-                        code_result.buffer = buf.into_boxed_slice();
+                        code_result.buffer = strings::concat(&[
+                            &code_result.buffer,
+                            b"//# sourceMappingURL=",
+                            url_parts[0],
+                            url_parts[1],
+                            url_parts[2],
+                            b"\n",
+                        ]);
                     }
 
                     sourcemap_output_file =
@@ -1079,13 +1069,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // with module_info path fixup.
                         // For non-compile builds, use the normal .jsc extension.
                         let source_provider_url = if c.options.compile_mode.is_executable() {
-                            let normalizer =
-                                cheap_prefix_normalizer(public_path, &chunk.final_rel_path);
-                            BunString::create_format(format_args!(
-                                "{}{}",
-                                bstr::BStr::new(normalizer[0]),
-                                bstr::BStr::new(normalizer[1])
-                            ))
+                            BunString::clone_utf8(&strings::concat(&cheap_prefix_normalizer(
+                                public_path,
+                                &chunk.final_rel_path,
+                            )))
                         } else {
                             BunString::create_format(format_args!(
                                 "{}{}",

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -15,10 +15,10 @@ use crate::Chunk;
 use crate::Index;
 use crate::analyze_transpiled_module;
 use crate::analyze_transpiled_module::StringIDExt as _;
-use crate::cheap_prefix_normalizer;
 use crate::chunk::{ReferencePathStyle, SourceMapShiftTracking};
 use crate::options;
 use crate::options::Loader;
+use crate::{PrefixedPath, cheap_prefix_normalizer};
 
 use crate::LinkerContext;
 use crate::linker_context::generate_compile_result_for_css_chunk::generate_compile_result_for_css_chunk;
@@ -555,8 +555,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 } else {
                     c.options.public_path
                 };
-                let resolved =
-                    strings::concat(&cheap_prefix_normalizer(public_path, &ch.final_rel_path));
+                let resolved = cheap_prefix_normalizer(public_path, &ch.final_rel_path).to_boxed();
                 let _ = unique_key_to_path.put(ch.unique_key, resolved); // OOM-only Result
             }
         }
@@ -741,7 +740,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // file rather than a JS file next to the .map. Point at
                         // the .map path relative to the HTML chunk's directory.
                         let mut relative_platform_buf = path::path_buffer_pool::get();
-                        let url_parts: [&[u8]; 3] = if !c.options.public_path.is_empty() {
+                        let url = if !c.options.public_path.is_empty() {
                             cheap_prefix_normalizer(
                                 c.options.public_path,
                                 &source_map_final_rel_path,
@@ -783,9 +782,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         buffer = strings::concat(&[
                             &buffer,
                             b"//# sourceMappingURL=",
-                            url_parts[0],
-                            url_parts[1],
-                            url_parts[2],
+                            url.prefix,
+                            url.separator,
+                            url.path,
                             b"\n",
                         ]);
                     }
@@ -989,18 +988,22 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     source_map_final_rel_path.extend_from_slice(b".map");
 
                     if tag == SourceMapOption::Linked {
-                        let url_parts: [&[u8]; 3] = if public_path.len() > 0 {
+                        let url = if public_path.len() > 0 {
                             cheap_prefix_normalizer(public_path, &source_map_final_rel_path)
                         } else {
-                            [b"", b"", path::basename(&source_map_final_rel_path)]
+                            PrefixedPath {
+                                prefix: b"",
+                                separator: b"",
+                                path: path::basename(&source_map_final_rel_path),
+                            }
                         };
 
                         code_result.buffer = strings::concat(&[
                             &code_result.buffer,
                             b"//# sourceMappingURL=",
-                            url_parts[0],
-                            url_parts[1],
-                            url_parts[2],
+                            url.prefix,
+                            url.separator,
+                            url.path,
                             b"\n",
                         ]);
                     }
@@ -1069,10 +1072,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // with module_info path fixup.
                         // For non-compile builds, use the normal .jsc extension.
                         let source_provider_url = if c.options.compile_mode.is_executable() {
-                            BunString::clone_utf8(&strings::concat(&cheap_prefix_normalizer(
-                                public_path,
-                                &chunk.final_rel_path,
-                            )))
+                            BunString::clone_utf8(
+                                &cheap_prefix_normalizer(public_path, &chunk.final_rel_path)
+                                    .to_boxed(),
+                            )
                         } else {
                             BunString::create_format(format_args!(
                                 "{}{}",

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -302,25 +302,20 @@ pub(crate) fn write_output_files_to_disk(
                 let source_map_final_rel_path = strings::concat(&[&chunk.final_rel_path, b".map"]);
 
                 if tag == SourceMapOption::Linked {
-                    let [a, b] = if !public_path.is_empty() {
+                    let url_parts: [&[u8]; 3] = if !public_path.is_empty() {
                         cheap_prefix_normalizer(public_path, &source_map_final_rel_path)
                     } else {
-                        [b"" as &[u8], paths::basename(&source_map_final_rel_path)]
+                        [b"", b"", paths::basename(&source_map_final_rel_path)]
                     };
 
-                    let source_map_start = b"//# sourceMappingURL=";
-                    let total_len = code_result.buffer.len()
-                        + source_map_start.len()
-                        + a.len()
-                        + b.len()
-                        + b"\n".len();
-                    let mut buf: Vec<u8> = Vec::with_capacity(total_len);
-                    buf.extend_from_slice(&code_result.buffer);
-                    buf.extend_from_slice(source_map_start);
-                    buf.extend_from_slice(a);
-                    buf.extend_from_slice(b);
-                    buf.push(b'\n');
-                    code_result.buffer = buf.into_boxed_slice();
+                    code_result.buffer = strings::concat(&[
+                        &code_result.buffer,
+                        b"//# sourceMappingURL=",
+                        url_parts[0],
+                        url_parts[1],
+                        url_parts[2],
+                        b"\n",
+                    ]);
                 }
 
                 match bun_sys::File::write_file(

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -18,7 +18,7 @@ use crate::output_file::{
     BakeExtra, Index as OutputFileIndex, IndexOptional, Options as OutputFileInit,
     OptionsData as OutputFileData, SavedFile, Value as OutputFileValue,
 };
-use crate::{BundleV2, Chunk, cheap_prefix_normalizer};
+use crate::{BundleV2, Chunk, PrefixedPath, cheap_prefix_normalizer};
 
 use bun_sys::{
     FdDirExt, PathOrFileDescriptor, WriteFileArgs, WriteFileData, WriteFileEncoding,
@@ -302,18 +302,22 @@ pub(crate) fn write_output_files_to_disk(
                 let source_map_final_rel_path = strings::concat(&[&chunk.final_rel_path, b".map"]);
 
                 if tag == SourceMapOption::Linked {
-                    let url_parts: [&[u8]; 3] = if !public_path.is_empty() {
+                    let url = if !public_path.is_empty() {
                         cheap_prefix_normalizer(public_path, &source_map_final_rel_path)
                     } else {
-                        [b"", b"", paths::basename(&source_map_final_rel_path)]
+                        PrefixedPath {
+                            prefix: b"",
+                            separator: b"",
+                            path: paths::basename(&source_map_final_rel_path),
+                        }
                     };
 
                     code_result.buffer = strings::concat(&[
                         &code_result.buffer,
                         b"//# sourceMappingURL=",
-                        url_parts[0],
-                        url_parts[1],
-                        url_parts[2],
+                        url.prefix,
+                        url.separator,
+                        url.path,
                         b"\n",
                     ]);
                 }

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -913,7 +913,78 @@ describe("bundler", () => {
     },
     outdir: "/out",
     publicPath: "/www",
-    run: {},
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatch(/"\/www\/hello-[a-z0-9]+\.file"/);
+    },
+  });
+  // A publicPath without a trailing slash gets exactly one "/" before the
+  // output-relative path in every emitter: cross-chunk imports, HTML tags,
+  // CSS url(), file-loader strings, and sourceMappingURL.
+  itBundled("edgecase/PublicPathWithoutTrailingSlash", {
+    files: {
+      "/src/index.html": /* html */ `
+        <!doctype html>
+        <html>
+          <head>
+            <link rel="stylesheet" href="./styles.css" />
+            <script type="module" src="./app.ts"></script>
+          </head>
+          <body><img src="./logo.svg" /></body>
+        </html>
+      `,
+      "/src/styles.css": /* css */ `body { background: url(./icon.svg); }`,
+      "/src/app.ts": `console.log("app");`,
+      "/src/pages/a/entry.ts": /* ts */ `
+        import { shared } from "../../shared";
+        import logo from "../../logo.svg";
+        console.log(shared(), logo);
+      `,
+      "/src/pages/b/entry.ts": /* ts */ `
+        import { shared } from "../../shared";
+        console.log(shared());
+      `,
+      "/src/shared.ts": `export const shared = () => "shared";`,
+      // at least 128 KB, else the CSS printer inlines it as a data: URL
+      "/src/icon.svg": `<svg id="icon">${Buffer.alloc(128 * 1024, "x")}</svg>`,
+      "/src/logo.svg": `<svg id="logo" />`,
+    },
+    entryPoints: ["/src/index.html", "/src/pages/a/entry.ts", "/src/pages/b/entry.ts"],
+    outputPaths: ["/out/index.html", "/out/pages/a/entry.js", "/out/pages/b/entry.js"],
+    root: "/src",
+    outdir: "/out",
+    splitting: true,
+    sourceMap: "linked",
+    publicPath: "https://cdn.example/app",
+    chunkNaming: "chunk-[hash].[ext]",
+    loader: { ".svg": "file" },
+    onAfterBundle(api) {
+      const prefix = "https://cdn.example/app/";
+      const expectUnderPrefix = (urls: string[]) => {
+        expect(urls).not.toBeEmpty();
+        for (const url of urls) {
+          expect(url).toStartWith(prefix);
+          api.assertFileExists(join("/out", url.slice(prefix.length)));
+        }
+      };
+
+      const entry = api.readFile("/out/pages/a/entry.js");
+      expect(entry).toMatch(/from "https:\/\/cdn\.example\/app\/chunk-[a-z0-9]+\.js"/);
+      expect(entry).toContain(`//# sourceMappingURL=${prefix}pages/a/entry.js.map\n`);
+
+      const jsUrls = readdirSync(api.outdir, { recursive: true })
+        .filter(file => file.endsWith(".js"))
+        .flatMap(file => cdnUrls(api.readFile(join("/out", file))));
+      expectUnderPrefix(jsUrls);
+      expect(jsUrls).toContainEqual(expect.stringMatching(/^https:\/\/cdn\.example\/app\/logo-[a-z0-9]+\.svg$/));
+
+      const htmlUrls = [...api.readFile("/out/index.html").matchAll(/(?:src|href)="([^"]+)"/g)].map(m => m[1]);
+      expectUnderPrefix(htmlUrls);
+      expect(htmlUrls.map(url => url.slice(prefix.length).split(".").pop()).sort()).toEqual(["css", "js", "svg"]);
+
+      const css = readdirSync(api.outdir).find(file => file.endsWith(".css"))!;
+      const cssUrls = [...api.readFile(join("/out", css)).matchAll(/url\("?([^")]+)"?\)/g)].map(m => m[1]);
+      expectUnderPrefix(cssUrls);
+    },
   });
   itBundled("edgecase/PublicPathNestedChunkReferences", {
     files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -918,8 +918,8 @@ describe("bundler", () => {
     },
   });
   // A publicPath without a trailing slash gets exactly one "/" before the
-  // output-relative path in every emitter: cross-chunk imports, HTML tags,
-  // CSS url(), file-loader strings, and sourceMappingURL.
+  // output-relative path in every emitter: static and dynamic cross-chunk
+  // imports, HTML tags, CSS url(), file-loader strings, and sourceMappingURL.
   itBundled("edgecase/PublicPathWithoutTrailingSlash", {
     files: {
       "/src/index.html": /* html */ `
@@ -937,8 +937,10 @@ describe("bundler", () => {
       "/src/pages/a/entry.ts": /* ts */ `
         import { shared } from "../../shared";
         import logo from "../../logo.svg";
+        import("../../lazy").then(m => console.log(m.lazy));
         console.log(shared(), logo);
       `,
+      "/src/lazy.ts": `export const lazy = "lazy";`,
       "/src/pages/b/entry.ts": /* ts */ `
         import { shared } from "../../shared";
         console.log(shared());
@@ -969,6 +971,7 @@ describe("bundler", () => {
 
       const entry = api.readFile("/out/pages/a/entry.js");
       expect(entry).toMatch(/from "https:\/\/cdn\.example\/app\/chunk-[a-z0-9]+\.js"/);
+      expect(entry).toMatch(/import\("https:\/\/cdn\.example\/app\/(pages\/a\/)?[a-z0-9-]+\.js"\)/);
       expect(entry).toContain(`//# sourceMappingURL=${prefix}pages/a/entry.js.map\n`);
 
       const jsUrls = readdirSync(api.outdir, { recursive: true })

--- a/test/bundler/esbuild/loader.test.ts
+++ b/test/bundler/esbuild/loader.test.ts
@@ -352,6 +352,84 @@ describe("bundler", () => {
   //   },
   //   outbase: "/src",
   // });
+  // A publicPath without a trailing slash is joined with exactly one "/",
+  // matching esbuild's joinWithPublicPath.
+  itBundled("loader/FilePublicPathJS", {
+    files: {
+      "/src/entries/entry.js": /* js */ `
+        import x from '../images/image.png'
+        console.log(x)
+      `,
+      "/src/images/image.png": `x`,
+    },
+    root: "/src",
+    outdir: "/out",
+    outputPaths: ["/out/entries/entry.js"],
+    publicPath: "https://example.com",
+    loader: { ".png": "file" },
+    onAfterBundle(api) {
+      api.expectFile("/out/entries/entry.js").toMatch(/"https:\/\/example\.com\/image-[a-z0-9]+\.png"/);
+    },
+  });
+  itBundled("loader/FilePublicPathCSS", {
+    files: {
+      "/src/entries/entry.css": /* css */ `
+        div {
+          background: url(../images/image.png);
+        }
+      `,
+      // at least 128 KB, else the CSS printer inlines it as a data: URL
+      "/src/images/image.png": Buffer.alloc(128 * 1024, "x").toString(),
+    },
+    root: "/src",
+    outdir: "/out",
+    outputPaths: ["/out/entries/entry.css"],
+    publicPath: "https://example.com",
+    loader: { ".png": "file" },
+    onAfterBundle(api) {
+      api.expectFile("/out/entries/entry.css").toMatch(/url\("?https:\/\/example\.com\/image-[a-z0-9]+\.png"?\)/);
+    },
+  });
+  itBundled("loader/FilePublicPathAssetNamesJS", {
+    files: {
+      "/src/entries/entry.js": /* js */ `
+        import x from '../images/image.png'
+        console.log(x)
+      `,
+      "/src/images/image.png": `x`,
+    },
+    root: "/src",
+    outdir: "/out",
+    outputPaths: ["/out/entries/entry.js"],
+    publicPath: "https://example.com",
+    loader: { ".png": "file" },
+    assetNaming: "[dir]/[name]-[hash].[ext]",
+    onAfterBundle(api) {
+      api.expectFile("/out/entries/entry.js").toMatch(/"https:\/\/example\.com\/images\/image-[a-z0-9]+\.png"/);
+    },
+  });
+  itBundled("loader/FilePublicPathAssetNamesCSS", {
+    files: {
+      "/src/entries/entry.css": /* css */ `
+        div {
+          background: url(../images/image.png);
+        }
+      `,
+      // at least 128 KB, else the CSS printer inlines it as a data: URL
+      "/src/images/image.png": Buffer.alloc(128 * 1024, "x").toString(),
+    },
+    root: "/src",
+    outdir: "/out",
+    outputPaths: ["/out/entries/entry.css"],
+    publicPath: "https://example.com",
+    loader: { ".png": "file" },
+    assetNaming: "[dir]/[name]-[hash].[ext]",
+    onAfterBundle(api) {
+      api
+        .expectFile("/out/entries/entry.css")
+        .toMatch(/url\("?https:\/\/example\.com\/images\/image-[a-z0-9]+\.png"?\)/);
+    },
+  });
   return;
   itBundled("loader/FileRelativePathAssetNamesJS", {
     // GENERATED
@@ -398,58 +476,6 @@ describe("bundler", () => {
       "/src/images/image.png": `x`,
     },
     root: "/src",
-    assetNaming: "[dir]/[name]-[hash]",
-  });
-  itBundled("loader/FilePublicPathJS", {
-    // GENERATED
-    files: {
-      "/src/entries/entry.js": /* js */ `
-        import x from '../images/image.png'
-        console.log(x)
-      `,
-      "/src/images/image.png": `x`,
-    },
-    root: "/src",
-    publicPath: "https://example.com",
-  });
-  itBundled("loader/FilePublicPathCSS", {
-    // GENERATED
-    files: {
-      "/src/entries/entry.css": /* css */ `
-        div {
-          background: url(../images/image.png);
-        }
-      `,
-      "/src/images/image.png": `x`,
-    },
-    root: "/src",
-    publicPath: "https://example.com",
-  });
-  itBundled("loader/FilePublicPathAssetNamesJS", {
-    // GENERATED
-    files: {
-      "/src/entries/entry.js": /* js */ `
-        import x from '../images/image.png'
-        console.log(x)
-      `,
-      "/src/images/image.png": `x`,
-    },
-    root: "/src",
-    publicPath: "https://example.com",
-    assetNaming: "[dir]/[name]-[hash]",
-  });
-  itBundled("loader/FilePublicPathAssetNamesCSS", {
-    // GENERATED
-    files: {
-      "/src/entries/entry.css": /* css */ `
-        div {
-          background: url(../images/image.png);
-        }
-      `,
-      "/src/images/image.png": `x`,
-    },
-    root: "/src",
-    publicPath: "https://example.com",
     assetNaming: "[dir]/[name]-[hash]",
   });
   itBundled("loader/FileOneSourceTwoDifferentOutputPathsJS", {


### PR DESCRIPTION
### Problem
- `bun build a.ts --outdir o --public-path https://cdn.test/assets` (no trailing slash) writes `"https://cdn.test/assetslogo-7zjyd5xx.png"`: the prefix and the output path are concatenated with no separator. The same happens in static and dynamic cross-chunk imports, the `__chunks(...)` preload table, HTML `<script src>`/`<link href>`/`<img src>` rewrites, CSS `url()` and `//# sourceMappingURL=`. esbuild writes `https://cdn.test/assets/logo-QH5AQSJV.png`.
- The cause is `cheap_prefix_normalizer` (`src/bun_core/string/mod.rs`). It only handled a prefix that ends with `/`. For any other prefix it returned `[prefix, suffix]` and every caller concatenated the two as is.

### Fix
- `cheap_prefix_normalizer` returns a named `PrefixedPath { prefix, separator, path }`. `separator` is `/` when a non-empty prefix does not end with a slash and the suffix does not start with one, which is what esbuild's `joinWithPublicPath` does. Every caller (the chunk count and write passes in `Chunk.rs`, the `sourceMappingURL` writers, the `--compile --bytecode` module paths) concatenates the three parts. The named struct makes a caller that still expects two parts fail to compile instead of dropping the path.
- A prefix that ends with `/` gives the same bytes as before. That includes the `/$bunfs/root/` prefix of `--compile`, which must stay equal to the keys in the standalone module graph.
- Verified: `test/bundler/bundler_edgecase.test.ts` (`edgecase/PublicPathWithoutTrailingSlash`, `edgecase/AssetPublicPath`) and `test/bundler/esbuild/loader.test.ts` (`loader/FilePublicPath{JS,CSS,AssetNamesJS,AssetNamesCSS}`, now asserting esbuild's expected output). All six fail on 1.4.3. Also ran `bundler_splitting`, `esbuild/splitting`, `bundler_regressions`, `bundler_html`, `bake/dev-and-prod`.
- Self-reviewed: 3 concerns raised, 3 addressed (named return type instead of a wider array, no tracker issue claimed, sibling join helper named below as out of scope).

### Background
- `publicPath` (`--public-path`) is a string that the bundler puts in front of every URL it writes into its output: asset URLs from the `file` loader, `import` specifiers between chunks, the tags injected into an HTML entry point, and linked source map URLs.
- The bundler prints each chunk with fixed-width placeholder keys where those URLs go. `IntermediateOutput::code_with_source_map_shifts` (`src/bundler/Chunk.rs`) later replaces each key with `publicPath + path`. It runs a byte-count pass and then a write pass into one allocation, so both passes call the same helper and must agree on the length.
- `docs/bundler/esbuild.mdx` lists `publicPath` as having no differences from esbuild. There is no tracker issue for this; it was found by comparing output with esbuild 0.28.

<details><summary>Notes</summary>

- Repro on 1.4.3 (`bun-1.4.2` behaves the same):
  ```sh
  printf PNGDATA > logo.png; echo 'import p from "./logo.png"; console.log(p)' > a.ts
  bun build a.ts --outdir o --public-path https://cdn.test/assets && grep -o '"https://[^"]*"' o/a.js
  # "https://cdn.test/assetslogo-7zjyd5xx.png"
  ```
  With `--splitting --sourcemap=linked --public-path /static`: `from "/statice-qz30kz5y.js"`, `import("/staticd-k47thy3c.js")`, `sourceMappingURL=/statice.js.map`. With this change: `/static/e-….js`, `/static/d-….js`, `/static/e.js.map`.
- Other prefixes that reach the same helper and now get a `/`: a bunfig `[serve.static] publicPath` without a trailing slash for `Bun.serve` HTML imports, and the client transpiler of `bun build --app` production builds (`/_bun/client`). Both produced joined-up URLs before.
- Open PRs that touch the same call sites with the old two-part shape (#41793, #34188, #39106) need a rebase onto the struct; the compiler flags every site.
- Not in this PR: `URL::join_normalize` in `src/url/lib.rs` (used for `Bun.FileSystemRouter`'s `assetPrefix`) also places its prefix directly before the directory name. That is a different helper with its own callers and is left for a separate look.
- The four `loader/FilePublicPath*` cases in `esbuild/loader.test.ts` sat below the file's early `return;` with no assertions. They are moved above it, given the `.png: file` loader that the esbuild suite configures globally, and the CSS cases use a 128 KB image so the CSS printer does not inline it as a `data:` URL.
</details>
