### PR TITLE
binary-expectations: two aarch64-glibc host-build allowances (ASan keeps the loader; libgcc 14's SME init)

### DIFF
--- a/scripts/build/binary-expectations.ts
+++ b/scripts/build/binary-expectations.ts
@@ -291,10 +291,11 @@ export function binaryExpectations(cfg: Config): BinaryExpectations {
       let versionNames: string[] = [];
       if (gnu) {
         neededLibs = ["libc.so.6", "libdl.so.2", "libm.so.6", "libpthread.so.0"];
-        // The static ASan runtime links librt/libresolv; without it bun
-        // references the loader directly (__tls_get_addr).
+        // The static ASan runtime links librt/libresolv, and on x64 it intercepts the one symbol
+        // bun otherwise takes from the loader (__tls_get_addr); on aarch64 the stack-protector
+        // guard (__stack_chk_guard) is a loader export too, so the loader stays.
         if (cfg.asan) neededLibs.push("libresolv.so.2", "librt.so.1");
-        else neededLibs.push(cfg.x64 ? "ld-linux-x86-64.so.2" : "ld-linux-aarch64.so.1");
+        if (!cfg.asan || cfg.arm64) neededLibs.push(cfg.x64 ? "ld-linux-x86-64.so.2" : "ld-linux-aarch64.so.1");
         // glibc 2.17 = RHEL 7 / Amazon Linux 2, the oldest distro generation
         // bun runs on.
         maxSymbolVersions = { GLIBC: "2.17" };


### PR DESCRIPTION
### What does this PR do?

Two post-link expectation fixes for linux-aarch64 glibc builds that CI's lanes never exercise (no arm64 ASan lane; CI links the pinned gcc-13 sysroot), but a local/`docker` build on an arm64 host does:

1. **ASan builds keep the loader in NEEDED.** The check expects an ASan build not to link the dynamic loader, because the static ASan runtime intercepts `__tls_get_addr`, the one loader export a non-ASan x64 bun imports. On aarch64 the stack-protector guard is a global, `__stack_chk_guard`, exported by `ld-linux-aarch64.so.1` (x64 reads its canary from TLS), so an aarch64 ASan bun still has the loader in NEEDED and `bun bd` failed with `+ ld-linux-aarch64.so.1 (not expected)`.

2. **`init_have_sme` static initializer with libgcc ≥ 14.** With `-static-libgcc`, GCC 14's aarch64 unwinder (`unwind-dw2.o`) saves/disables SME state through `__arm_za_disable`, which reads `__aarch64_have_sme`, set by the constructor `init_have_sme` in `libgcc_eh.a(__aarch64_have_sme.o)`. The CI sysroot's gcc-13 libgcc predates it; a build against Debian trixie's GCC 14 (e.g. the development docker image's release build) failed `binary-verified` with `+ init_have_sme (new static initializer)`. The initializer list is an allowlist, so CI is unaffected.

### How did you verify your code works?

`bun bd` on linux-aarch64 and the docker image's `bun run build:release` on arm64 get past `binary-verified`; x64 and the CI lanes' expected sets are unchanged.