### PR TITLE
resolver: skip tsconfig auto-discovery in a world-writable sticky directory

### DIFF
--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -309,6 +309,8 @@ Bun supports import path re-mapping through TypeScript's [`compilerOptions.paths
 }
 ```
 
+Bun looks for `tsconfig.json` and `jsconfig.json` in the directory of each source file and in its parent directories. On POSIX systems it skips a file found in a directory that is world-writable and sticky, such as `/tmp`, `/var/tmp` or `/dev/shm`. Every user can create a file in such a directory, so the file can belong to another user. Pass `--tsconfig-override <path>` to load one anyway.
+
 Bun also supports [Node.js-style subpath imports](https://nodejs.org/api/packages.html#subpath-imports) in `package.json`, where mapped paths must start with `#`. TypeScript and editors resolve these too, and you can use both mechanisms together.
 
 ```json package.json icon="file-json"

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6421,6 +6421,19 @@ impl<'a> Resolver<'a> {
                         }
                     }
                 }
+                if let Some(found) = tsconfig_path {
+                    if is_shared_scratch_dir(path) {
+                        let _ = self.log_mut().add_debug_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "Ignoring {} because its directory is writable by every user on the system. Pass --tsconfig-override to load it anyway.",
+                                bun_core::fmt::quote(found)
+                            ),
+                        );
+                        tsconfig_path = None;
+                    }
+                }
             } else if parent.is_none() {
                 // NOTE: re-borrow as 'static so the `&self.opts` borrow ends before
                 // `self.parse_tsconfig(&mut self, ...)`. `tsconfig_override` is owned by
@@ -6722,6 +6735,35 @@ fn is_dot_slash(path: &[u8]) -> bool {
     #[cfg(windows)]
     {
         path.len() == 2 && path[0] == b'.' && strings::char_is_any_slash(path[1])
+    }
+}
+
+/// True for a directory that is both world-writable and sticky (mode `1777`:
+/// `/tmp`, `/var/tmp`, `/dev/shm`).
+///
+/// Every user on the system can create a file in such a directory, so a file
+/// found there during the upward walk can belong to anyone. The sticky bit is
+/// the boundary that matters: a world-writable directory without it lets the
+/// same attacker rename the project itself, so nothing in the subtree is
+/// trustworthy either way.
+fn is_shared_scratch_dir(path: &[u8]) -> bool {
+    #[cfg(unix)]
+    {
+        const SHARED: libc::mode_t = libc::S_ISVTX | libc::S_IWOTH;
+        let mut buf = bun_paths::path_buffer_pool::get();
+        if path.is_empty() || path.len() >= buf.len() {
+            return false;
+        }
+        buf[..path.len()].copy_from_slice(path);
+        buf[path.len()] = 0;
+        // SAFETY: `buf[path.len()] == 0` written above.
+        let span = bun_core::ZStr::from_buf(&buf[..], path.len());
+        bun_sys::stat(span).is_ok_and(|st| (st.st_mode & SHARED) == SHARED)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        false
     }
 }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6738,14 +6738,10 @@ fn is_dot_slash(path: &[u8]) -> bool {
     }
 }
 
-/// True for an open directory that is both world-writable and sticky (mode
-/// `1777`: `/tmp`, `/var/tmp`, `/dev/shm`), or whose mode cannot be read.
-///
-/// Every user on the system can create a file in such a directory, so a file
-/// found there during the upward walk can belong to anyone. The sticky bit is
-/// the boundary that matters: a world-writable directory without it lets the
-/// same attacker rename the project itself, so nothing in the subtree is
-/// trustworthy either way.
+/// True when every user can create a file in the open directory `dir` (mode
+/// `1777`, world-writable and sticky: `/tmp`, `/var/tmp`, `/dev/shm`), or when
+/// its mode cannot be read. Without the sticky bit any user could also rename
+/// the project below it, so that case gets no check of its own.
 fn is_shared_scratch_dir(dir: FD) -> bool {
     #[cfg(unix)]
     {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6738,10 +6738,7 @@ fn is_dot_slash(path: &[u8]) -> bool {
     }
 }
 
-/// True when every user can create a file in the open directory `dir` (mode
-/// `1777`, world-writable and sticky: `/tmp`, `/var/tmp`, `/dev/shm`), or when
-/// its mode cannot be read. Without the sticky bit any user could also rename
-/// the project below it, so that case gets no check of its own.
+/// Mode `1777` like `/tmp` (any user can create a file in it), or a mode that cannot be read.
 fn is_shared_scratch_dir(dir: FD) -> bool {
     #[cfg(unix)]
     {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6422,7 +6422,7 @@ impl<'a> Resolver<'a> {
                     }
                 }
                 if let Some(found) = tsconfig_path {
-                    if is_shared_scratch_dir(path) {
+                    if is_shared_scratch_dir(fd) {
                         let _ = self.log_mut().add_debug_fmt(
                             None,
                             bun_ast::Loc::EMPTY,
@@ -6738,31 +6738,26 @@ fn is_dot_slash(path: &[u8]) -> bool {
     }
 }
 
-/// True for a directory that is both world-writable and sticky (mode `1777`:
-/// `/tmp`, `/var/tmp`, `/dev/shm`).
+/// True for an open directory that is both world-writable and sticky (mode
+/// `1777`: `/tmp`, `/var/tmp`, `/dev/shm`), or whose mode cannot be read.
 ///
 /// Every user on the system can create a file in such a directory, so a file
 /// found there during the upward walk can belong to anyone. The sticky bit is
 /// the boundary that matters: a world-writable directory without it lets the
 /// same attacker rename the project itself, so nothing in the subtree is
 /// trustworthy either way.
-fn is_shared_scratch_dir(path: &[u8]) -> bool {
+fn is_shared_scratch_dir(dir: FD) -> bool {
     #[cfg(unix)]
     {
         const SHARED: libc::mode_t = libc::S_ISVTX | libc::S_IWOTH;
-        let mut buf = bun_paths::path_buffer_pool::get();
-        if path.is_empty() || path.len() >= buf.len() {
-            return false;
+        if !dir.is_valid() {
+            return true;
         }
-        buf[..path.len()].copy_from_slice(path);
-        buf[path.len()] = 0;
-        // SAFETY: `buf[path.len()] == 0` written above.
-        let span = bun_core::ZStr::from_buf(&buf[..], path.len());
-        bun_sys::stat(span).is_ok_and(|st| (st.st_mode & SHARED) == SHARED)
+        bun_sys::fstat(dir).map_or(true, |st| (st.st_mode & SHARED) == SHARED)
     }
     #[cfg(not(unix))]
     {
-        let _ = path;
+        let _ = dir;
         false
     }
 }

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1766,8 +1766,8 @@ describe("tsconfig paths skip `.d.ts` substitutions", () => {
 describe.skipIf(isWindows)("tsconfig in a world-writable sticky directory", () => {
   // `shared/` stands in for `/tmp`: another user plants the config, the victim's
   // project is a private subdirectory with its own package.json and node_modules.
-  function plantedFixture(configName: "tsconfig.json" | "jsconfig.json", extra: Record<string, string> = {}) {
-    const dir = tempDir("tsconfig-shared-dir", {
+  function plantedFixture(configName: "tsconfig.json" | "jsconfig.json") {
+    return tempDir("tsconfig-shared-dir", {
       [`shared/${configName}`]: JSON.stringify({
         compilerOptions: { paths: { "lib": ["./planted.js"] } },
       }),
@@ -1776,9 +1776,7 @@ describe.skipIf(isWindows)("tsconfig in a world-writable sticky directory", () =
       "shared/proj/node_modules/lib/package.json": JSON.stringify({ name: "lib", version: "1.0.0" }),
       "shared/proj/node_modules/lib/index.js": `module.exports = "GENUINE";`,
       "shared/proj/app.js": `console.log(require("lib"));`,
-      ...extra,
     });
-    return dir;
   }
 
   test.concurrent("a planted tsconfig does not rewrite a bare import at runtime", async () => {
@@ -1853,7 +1851,9 @@ describe.skipIf(isWindows)("tsconfig in a world-writable sticky directory", () =
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    // stderr is drained but not asserted: `--tsconfig-override` prints an
+    // unrelated "directory mismatch" note (#34980).
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout.trim()).toBe("PLANTED");
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1758,6 +1758,107 @@ describe("tsconfig paths skip `.d.ts` substitutions", () => {
   });
 });
 
+// `/tmp`, `/var/tmp` and `/dev/shm` are world-writable and sticky (mode 1777).
+// Every user can create a file in them, so a `tsconfig.json` found there during
+// the upward walk can belong to any user on the system. Because tsconfig `paths`
+// win over the node_modules walk, such a file would rewrite a project's bare
+// imports to code the project never installed. Auto-discovery skips it.
+describe.skipIf(isWindows)("tsconfig in a world-writable sticky directory", () => {
+  // `shared/` stands in for `/tmp`: another user plants the config, the victim's
+  // project is a private subdirectory with its own package.json and node_modules.
+  function plantedFixture(configName: "tsconfig.json" | "jsconfig.json", extra: Record<string, string> = {}) {
+    const dir = tempDir("tsconfig-shared-dir", {
+      [`shared/${configName}`]: JSON.stringify({
+        compilerOptions: { paths: { "lib": ["./planted.js"] } },
+      }),
+      "shared/planted.js": `module.exports = "PLANTED";`,
+      "shared/proj/package.json": JSON.stringify({ name: "proj", dependencies: { lib: "1.0.0" } }),
+      "shared/proj/node_modules/lib/package.json": JSON.stringify({ name: "lib", version: "1.0.0" }),
+      "shared/proj/node_modules/lib/index.js": `module.exports = "GENUINE";`,
+      "shared/proj/app.js": `console.log(require("lib"));`,
+      ...extra,
+    });
+    return dir;
+  }
+
+  test.concurrent("a planted tsconfig does not rewrite a bare import at runtime", async () => {
+    using dir = plantedFixture("tsconfig.json");
+    const shared = join(String(dir), "shared");
+    chmodSync(shared, 0o1777);
+
+    expect(await runWildcardScript(join(shared, "proj"), "app.js")).toEqual({
+      stdout: "GENUINE",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("a planted jsconfig does not rewrite a bare import at runtime", async () => {
+    using dir = plantedFixture("jsconfig.json");
+    const shared = join(String(dir), "shared");
+    chmodSync(shared, 0o1777);
+
+    expect(await runWildcardScript(join(shared, "proj"), "app.js")).toEqual({
+      stdout: "GENUINE",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("a planted tsconfig does not reach the bundle", async () => {
+    using dir = plantedFixture("tsconfig.json");
+    const shared = join(String(dir), "shared");
+    chmodSync(shared, 0o1777);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./app.js", "--target", "node"],
+      env: bunEnv,
+      cwd: join(shared, "proj"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error");
+    expect(stdout).toContain("GENUINE");
+    expect(stdout).not.toContain("PLANTED");
+    expect(exitCode).toBe(0);
+  });
+
+  // The sticky bit is the boundary. A directory that only the owner can write
+  // keeps supplying its tsconfig to every subdirectory, which is what a monorepo
+  // with a root tsconfig above per-package package.json files relies on.
+  test.concurrent("an owner-only ancestor directory still supplies its tsconfig", async () => {
+    using dir = plantedFixture("tsconfig.json");
+    const shared = join(String(dir), "shared");
+    chmodSync(shared, 0o755);
+
+    expect(await runWildcardScript(join(shared, "proj"), "app.js")).toEqual({
+      stdout: "PLANTED",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // `--tsconfig-override` is an explicit choice by the person running bun, so it
+  // is loaded whatever the directory mode is.
+  test.concurrent("--tsconfig-override loads the file anyway", async () => {
+    using dir = plantedFixture("tsconfig.json");
+    const shared = join(String(dir), "shared");
+    chmodSync(shared, 0o1777);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--tsconfig-override", join(shared, "tsconfig.json"), "app.js"],
+      env: bunEnv,
+      cwd: join(shared, "proj"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("PLANTED");
+    expect(exitCode).toBe(0);
+  });
+});
+
 it.skipIf(isWindows)("runs a script from a working directory nested 256 directories deep", async () => {
   using dir = tempDir("resolver-deep-cwd", { ".keep": "" });
   const base = realpathSync(String(dir));


### PR DESCRIPTION
### Problem

- A `tsconfig.json` or `jsconfig.json` that another user plants in `/tmp` rewrites the bare imports of a project that lives in its own private directory under `/tmp`, with its own `package.json` and its own `node_modules`. The attacker's module then runs with the victim's privileges, for example uid 0 for a root cron job that builds in `mktemp -d`. `bun app.js`, `bun run`, `bun test`, `bun -e` and `bun build` are all affected. Node ignores `tsconfig.json`, so `node app.js` loads the installed package.
- `dir_info_uncached` reads `tsconfig.json` in every ancestor directory and inherits it into every directory below it, with no boundary (`src/resolver/resolver.rs`, the `load_tsconfig_json` block and the `enclosing_tsconfig_json` inherit). `load_node_modules` then applies its `paths` and `baseUrl` before the `node_modules` walk, so vendored dependencies give no protection.

### Fix

- Skip auto-discovery of `tsconfig.json` and `jsconfig.json` in a directory that is world-writable and sticky (mode `1777`: `/tmp`, `/var/tmp`, `/dev/shm`). The check is one `fstat` on the directory fd the walk already holds. If the mode cannot be read, the file is skipped too (fail closed). POSIX only. `--tsconfig-override` still loads such a file, because the person who runs bun names it.
- The sticky bit is the boundary. Without it the same user can rename the victim's project directory, so nothing below it is trustworthy either way. With it the victim's own files are safe, but a new file next to them is not. That is the window this closes.
- Self-reviewed: 0 design concerns survived. Bot review raised 3 nits (fail-open on stat error, a stray `SAFETY:` label, an undrained stderr pipe in one test), all 3 addressed.
- Verified: `test/js/bun/resolve/resolve.test.ts` (one new describe, five blocks, three of which fail on stock bun). Also all of `test/js/bun/resolve/`, `test/cli/run/tsconfig-override.test.ts` and `test/bundler/bundler_jsx.test.ts`.

### Background

- Bun applies `compilerOptions.paths` and `baseUrl` when it runs a file, not only when it bundles one. A mapping wins over an installed package.
- The config file is found by a walk up from each source file. The nearest file wins, and it then applies to every directory below it.
- The sticky bit (`S_ISVTX`, the `t` in `drwxrwxrwt`) means only a file's owner can rename or delete that file. It is what makes `/tmp` safe to share.
- Two other shapes were rejected. Stopping the walk at the nearest `package.json` breaks a monorepo that keeps a root `tsconfig.json` above per-package `package.json` files, and neither `tsc` nor esbuild stops there. Requiring the file to be owned by the current user breaks a Docker bind mount, where a root process reads host-uid files.

<details><summary>Notes</summary>

#### Repro, on 1.4.3 and on canary d316760e8

```sh
# attacker (any uid)
echo '{"compilerOptions":{"paths":{"lib":["/tmp/evil/lib.js"]}}}' > /tmp/tsconfig.json
mkdir -p /tmp/evil && echo 'module.exports={evil:true}' > /tmp/evil/lib.js

# victim (root), private project directory, dependency installed locally
D=$(mktemp -d /tmp/build-XXXXXX); chmod 700 $D; cd $D
echo '{"name":"rp","dependencies":{"lib":"1.0.0"}}' > package.json
mkdir -p node_modules/lib
echo '{"name":"lib","version":"1.0.0","main":"index.js"}' > node_modules/lib/package.json
echo 'module.exports="GENUINE"' > node_modules/lib/index.js
echo 'console.log("victim got:", JSON.stringify(require("lib")))' > app.js

bun app.js    # before: victim got: {"evil":true}    after: victim got: "GENUINE"
node app.js   # victim got: "GENUINE"
```

`jsconfig.json` works the same. `bun -e`, `bun test` and `bun build` all took the planted mapping before this change.

#### The `jsxImportSource` leg

The same planted file with `{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"evjsx"}}` made `bun build ./index.tsx` import `/tmp/node_modules/evjsx/jsx-dev-runtime.js`, even though the project had vendored its own `react`. After this change the same build emits `node_modules/react/jsx-dev-runtime.js`. `experimentalDecorators` and `extends` from the planted file are gone for the same reason: the file is never parsed.

#### Out of scope

- An attacker who **owns** a directory in the project's ancestor chain (for example `/tmp/w/a`, with the project at `/tmp/w/a/b/c/proj`) can rename or replace the whole subtree, because write permission on a non-sticky directory is enough to rename its entries. The `tsconfig.json` is not the weakest link there, and no change to the resolver fixes it.
- The upward `node_modules` walk itself is unchanged. Node does the same walk, so an ancestor `node_modules` is ecosystem behaviour, not a bun-specific hole.
- A planted ancestor `package.json` was probed too. Bun does not continue the `imports` walk past the nearest `package.json`, so `require("#x")` from the project fails, as it does on Node. No change needed.

#### Why `fstat` on the directory fd

The walk opens and reads each directory before it looks for `tsconfig.json` in the entries, so the fd is already there. `fstat` on it reads the mode of the exact directory that was enumerated, with no second path lookup and no path buffer. A directory whose entries came from the cache but that can no longer be opened has no valid fd; its config is skipped rather than trusted.

#### Why not a warning on stderr

The skip is recorded with `Log::add_debug_fmt`, the same level the resolver uses when an `extends` target fails to load. A loud warning would print for a case that is, in practice, either an attack or a directory layout nobody relies on, and the resolver already has a history of noisy one-off warnings (#34980).

#### Test environment note

`test/js/bun/resolve/load-same-js-file-a-lot.test.ts` times out in this container on a debug plus ASAN build, with and without this diff. It is already listed in `test/flaky-tests.txt` for the same timeout.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->