### PR TITLE
shell: forward SIGTERM and SIGHUP from the bun shell runner to its commands

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -352,6 +352,18 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 }
             };
 
+            if let Some(sig) = crate::shell::forward_signals::ended_script(code) {
+                if !silent {
+                    pretty_errorln!(
+                        "<r><red>error<r><d>:<r> script <b>\"{}\"<r> was terminated by signal {}<r>",
+                        bstr::BStr::new(name),
+                        bun_sys::SignalCode(sig as u8).fmt(Output::enable_ansi_colors_stderr()),
+                    );
+                    Output::flush();
+                }
+                Global::raise_ignoring_panic_handler(sig);
+            }
+
             if code > 0 {
                 if code != 2 && !silent {
                     pretty_errorln!(

--- a/src/runtime/shell/forward_signals.rs
+++ b/src/runtime/shell/forward_signals.rs
@@ -1,15 +1,8 @@
-//! SIGTERM / SIGHUP for a process acting as the shell of a script (`bun run
-//! --shell=bun`, `bun exec`, `bun x.sh`). A supervisor (`kill`, `docker stop`,
-//! systemd) signals the runner's pid alone, so the commands it is running
-//! never see the signal. The handler records it and wakes the mini event loop.
-//! The interpreter then forwards it to every live subprocess, waits for them,
-//! and runs no further command (`Interpreter::interrupted`). That is what the
-//! system-shell path of `bun run` gives: its `sh -c` execs a single command,
-//! so the signal lands on the command itself. With no subprocess alive the
-//! handler lets the signal end the process, as it did before the hook.
-//!
-//! Ctrl+C stays with `bun_spawn::ctrl_c`: the terminal delivers it to the
-//! whole process group, so nothing needs forwarding there.
+//! SIGTERM / SIGHUP sent to the pid of a bun-shell script runner (`bun run
+//! --shell=bun`, `bun exec`, `bun x.sh`): recorded here, forwarded to the live
+//! subprocesses by the interpreter between ticks, which then waits for them and
+//! starts no further command. SIGINT is `bun_spawn::ctrl_c`'s (the terminal
+//! signals the whole process group, so there is nothing to forward).
 
 use core::sync::atomic::{AtomicPtr, AtomicU8, Ordering};
 
@@ -25,12 +18,10 @@ static LOOP: AtomicPtr<bun_uws::Loop> = AtomicPtr::new(core::ptr::null_mut());
 #[cfg(unix)]
 const SIGNALS: [i32; 2] = [libc::SIGTERM, libc::SIGHUP];
 
-/// Bit `i` is set when `SIGNALS[i]` was hooked. An inherited `SIG_IGN`
-/// (`nohup`) is left alone: the children inherit it too.
+/// Bit `i`: `SIGNALS[i]` is hooked. A signal inherited as `SIG_IGN` (`nohup`) is not.
 #[cfg(unix)]
 static HOOKED: AtomicU8 = AtomicU8::new(0);
-/// The disposition each hooked signal had before [`install`]. `uninstall` puts
-/// it back (the TTY exit handler from `bun_initialize_process`, usually).
+/// Dispositions replaced by [`install`] and restored by [`uninstall`].
 #[cfg(unix)]
 static PREVIOUS: bun_core::RacyCell<core::mem::MaybeUninit<[libc::sigaction; 2]>> =
     bun_core::RacyCell::new(core::mem::MaybeUninit::uninit());
@@ -38,14 +29,11 @@ static PREVIOUS: bun_core::RacyCell<core::mem::MaybeUninit<[libc::sigaction; 2]>
 #[cfg(unix)]
 extern "C" fn handler(sig: core::ffi::c_int) {
     if bun_spawn::ctrl_c::Child::alive() == 0 {
-        // No subprocess to forward to: a builtin is running, or nothing is.
-        // End the way the signal would have without the hook. A builtin can
-        // hold the main thread for a long time (`yes > /dev/null` never
-        // returns to the event loop), so this cannot wait for a tick.
-        // SAFETY: SIG_DFL is a valid disposition. The handler runs with `sig`
-        // blocked, so unblock it for the raise to be fatal before we return.
-        // If the raise returns, the process is PID 1 of a pid namespace and
-        // the kernel discarded the signal; exit with its status instead.
+        // Nothing to forward to (a builtin runs, or nothing): die from `sig`
+        // now. A builtin may never yield to the loop (`yes > /dev/null`).
+        // SAFETY: SIG_DFL is a valid disposition; `sig` is blocked while the
+        // handler runs, so unblock it for the raise to be fatal here. `raise`
+        // only returns for PID 1 of a pid namespace (signal discarded).
         unsafe {
             let mut action: libc::sigaction = bun_core::ffi::zeroed();
             action.sa_sigaction = libc::SIG_DFL;
@@ -75,8 +63,7 @@ extern "C" fn handler(sig: core::ffi::c_int) {
     unsafe { *errno_ptr = saved };
 }
 
-/// `loop_` is the uws loop the interpreter ticks. No `SA_RESETHAND`: a repeat
-/// delivery is forwarded again, for a command that ignored the first one.
+/// `loop_` is the uws loop to wake. No `SA_RESETHAND`: a repeated signal is forwarded again.
 pub(crate) fn install(loop_: *mut bun_uws::Loop) {
     PENDING.store(0, Ordering::Release);
     RECEIVED.store(0, Ordering::Release);

--- a/src/runtime/shell/forward_signals.rs
+++ b/src/runtime/shell/forward_signals.rs
@@ -1,0 +1,143 @@
+//! SIGTERM / SIGHUP for a process acting as the shell of a script (`bun run
+//! --shell=bun`, `bun exec`, `bun x.sh`). A supervisor (`kill`, `docker stop`,
+//! systemd) signals the runner's pid alone, so the commands it is running
+//! never see the signal. The handler records it and wakes the mini event loop.
+//! The interpreter then forwards it to every live subprocess, waits for them,
+//! and runs no further command (`Interpreter::interrupted`). That is what the
+//! system-shell path of `bun run` gives: its `sh -c` execs a single command,
+//! so the signal lands on the command itself. With no subprocess alive the
+//! handler lets the signal end the process, as it did before the hook.
+//!
+//! Ctrl+C stays with `bun_spawn::ctrl_c`: the terminal delivers it to the
+//! whole process group, so nothing needs forwarding there.
+
+use core::sync::atomic::{AtomicPtr, AtomicU8, Ordering};
+
+use bun_core::SignalCode;
+
+/// A signal that arrived and is not forwarded yet. 0 while none.
+static PENDING: AtomicU8 = AtomicU8::new(0);
+/// The first signal that arrived. 0 while none. Decides the exit status.
+static RECEIVED: AtomicU8 = AtomicU8::new(0);
+/// Set by [`install`], cleared by [`uninstall`]. The uws loop is thread-lifetime.
+static LOOP: AtomicPtr<bun_uws::Loop> = AtomicPtr::new(core::ptr::null_mut());
+
+#[cfg(unix)]
+const SIGNALS: [i32; 2] = [libc::SIGTERM, libc::SIGHUP];
+
+/// Bit `i` is set when `SIGNALS[i]` was hooked. An inherited `SIG_IGN`
+/// (`nohup`) is left alone: the children inherit it too.
+#[cfg(unix)]
+static HOOKED: AtomicU8 = AtomicU8::new(0);
+/// The disposition each hooked signal had before [`install`]. `uninstall` puts
+/// it back (the TTY exit handler from `bun_initialize_process`, usually).
+#[cfg(unix)]
+static PREVIOUS: bun_core::RacyCell<core::mem::MaybeUninit<[libc::sigaction; 2]>> =
+    bun_core::RacyCell::new(core::mem::MaybeUninit::uninit());
+
+#[cfg(unix)]
+extern "C" fn handler(sig: core::ffi::c_int) {
+    if bun_spawn::ctrl_c::Child::alive() == 0 {
+        // No subprocess to forward to: a builtin is running, or nothing is.
+        // End the way the signal would have without the hook. A builtin can
+        // hold the main thread for a long time (`yes > /dev/null` never
+        // returns to the event loop), so this cannot wait for a tick.
+        // SAFETY: SIG_DFL is a valid disposition. The handler runs with `sig`
+        // blocked, so unblock it for the raise to be fatal before we return.
+        // If the raise returns, the process is PID 1 of a pid namespace and
+        // the kernel discarded the signal; exit with its status instead.
+        unsafe {
+            let mut action: libc::sigaction = bun_core::ffi::zeroed();
+            action.sa_sigaction = libc::SIG_DFL;
+            libc::sigaction(sig, &raw const action, core::ptr::null_mut());
+            let mut set: libc::sigset_t = bun_core::ffi::zeroed();
+            libc::sigemptyset(&raw mut set);
+            libc::sigaddset(&raw mut set, sig);
+            libc::pthread_sigmask(libc::SIG_UNBLOCK, &raw const set, core::ptr::null_mut());
+            libc::raise(sig);
+            libc::_exit(128 + sig);
+        }
+    }
+    // The wakeup write may set errno; the interrupted code must not see that.
+    let errno_ptr = bun_core::ffi::errno_ptr();
+    // SAFETY: thread-local errno slot, valid for the calling thread.
+    let saved = unsafe { *errno_ptr };
+    let sig = sig as u8;
+    let _ = RECEIVED.compare_exchange(0, sig, Ordering::AcqRel, Ordering::Acquire);
+    PENDING.store(sig, Ordering::Release);
+    let loop_ = LOOP.load(Ordering::Acquire);
+    if !loop_.is_null() {
+        // SAFETY: the loop is thread-lifetime and `us_wakeup_loop` is the
+        // thread-safe entry point (an eventfd write, no lock).
+        unsafe { bun_uws::us_wakeup_loop(loop_) };
+    }
+    // SAFETY: same slot.
+    unsafe { *errno_ptr = saved };
+}
+
+/// `loop_` is the uws loop the interpreter ticks. No `SA_RESETHAND`: a repeat
+/// delivery is forwarded again, for a command that ignored the first one.
+pub(crate) fn install(loop_: *mut bun_uws::Loop) {
+    PENDING.store(0, Ordering::Release);
+    RECEIVED.store(0, Ordering::Release);
+    LOOP.store(loop_, Ordering::Release);
+    #[cfg(unix)]
+    // SAFETY: zeroed sigaction + a handler fn is a valid disposition;
+    // `sigemptyset` and `sigaction` are FFI calls over valid pointers.
+    // `PREVIOUS` is written on this thread only, while no hook is active.
+    unsafe {
+        let mut action: libc::sigaction = bun_core::ffi::zeroed();
+        action.sa_sigaction = handler as *const () as usize;
+        libc::sigemptyset(&raw mut action.sa_mask);
+        action.sa_flags = libc::SA_RESTART;
+        let previous = (*PREVIOUS.get()).as_mut_ptr().cast::<libc::sigaction>();
+        let mut hooked: u8 = 0;
+        for (i, sig) in SIGNALS.into_iter().enumerate() {
+            let slot = previous.add(i);
+            libc::sigaction(sig, core::ptr::null(), slot);
+            if (*slot).sa_sigaction != libc::SIG_IGN {
+                libc::sigaction(sig, &raw const action, core::ptr::null_mut());
+                hooked |= 1 << i;
+            }
+        }
+        HOOKED.store(hooked, Ordering::Release);
+    }
+}
+
+/// Puts back the disposition each hooked signal had before [`install`].
+pub(crate) fn uninstall() {
+    LOOP.store(core::ptr::null_mut(), Ordering::Release);
+    #[cfg(unix)]
+    {
+        let hooked = HOOKED.swap(0, Ordering::AcqRel);
+        // SAFETY: `install` filled `PREVIOUS[i]` for every bit set in `hooked`.
+        unsafe {
+            let previous = (*PREVIOUS.get()).as_ptr().cast::<libc::sigaction>();
+            for (i, sig) in SIGNALS.into_iter().enumerate() {
+                if hooked & (1 << i) != 0 {
+                    libc::sigaction(sig, previous.add(i), core::ptr::null_mut());
+                }
+            }
+        }
+    }
+}
+
+/// The signal that arrived since the last call, if any.
+pub(crate) fn take_pending() -> Option<SignalCode> {
+    SignalCode::from_raw(PENDING.swap(0, Ordering::AcqRel))
+}
+
+/// The first signal that arrived during the run, if any.
+pub(crate) fn received() -> Option<SignalCode> {
+    SignalCode::from_raw(RECEIVED.load(Ordering::Acquire))
+}
+
+/// The signal the script was ended by: one arrived and was forwarded, and the
+/// script's exit code is the one a shell reports for a command that signal
+/// killed. A command that handled the signal and exited on its own terms
+/// keeps its exit code.
+pub(crate) fn ended_script(exit_code: crate::shell::interpreter::ExitCode) -> Option<SignalCode> {
+    let sig = received()?;
+    let signal_exit_code = bun_sys::SignalCode(sig as u8).to_exit_code()?;
+    (exit_code == u16::from(signal_exit_code)).then_some(sig)
+}

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -733,6 +733,8 @@ impl Interpreter {
 
         // ── run ────────────────────────────────────────────────────────────
         interp.exit_code.set(Some(1));
+        // Armed before `run()`: it spawns the first command before it returns.
+        crate::shell::forward_signals::install(mini.loop_ptr());
         if let Err(e) = interp.run() {
             let name = e.name();
             interp.deinit_from_exec();
@@ -748,7 +750,6 @@ impl Interpreter {
         // The closure captures a raw pointer so borrowck doesn't see an
         // overlap with `tick`'s `&mut self` on `mini`.
         let interp_ptr: *const Interpreter = &raw const *interp;
-        crate::shell::forward_signals::install(mini.loop_ptr());
         mini.tick(core::ptr::null_mut(), |_ctx| {
             // SAFETY: `interp` lives in this stack frame for the whole tick
             // loop; `flags` is `Cell<InterpreterFlags>` (interior-mutable), so

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -47,6 +47,7 @@ use crate::shell::states::pipeline::Pipeline;
 use crate::shell::states::script::Script;
 use crate::shell::states::stmt::Stmt;
 use crate::shell::states::subshell::Subshell;
+use crate::shell::subproc::ShellSubprocess;
 use crate::shell::yield_::Yield;
 use crate::shell::{ShellErr, ast};
 
@@ -747,12 +748,20 @@ impl Interpreter {
         // The closure captures a raw pointer so borrowck doesn't see an
         // overlap with `tick`'s `&mut self` on `mini`.
         let interp_ptr: *const Interpreter = &raw const *interp;
+        crate::shell::forward_signals::install(mini.loop_ptr());
         mini.tick(core::ptr::null_mut(), |_ctx| {
             // SAFETY: `interp` lives in this stack frame for the whole tick
             // loop; `flags` is `Cell<InterpreterFlags>` (interior-mutable), so
             // the read is sound even while tasks `tick` drains mutate it.
-            unsafe { (*interp_ptr).flags.get().done() }
+            // `forward_signal` runs between ticks, so no task holds a borrow of
+            // the node arena.
+            let interp = unsafe { &*interp_ptr };
+            if let Some(sig) = crate::shell::forward_signals::take_pending() {
+                interp.forward_signal(sig);
+            }
+            interp.flags.get().done()
         });
+        crate::shell::forward_signals::uninstall();
 
         let code = interp.exit_code.get().expect("exit_code set by finish()");
         interp.deinit_from_exec();
@@ -925,10 +934,40 @@ impl Interpreter {
         }
     }
 
+    /// Send `sig` to every subprocess that is still running (see
+    /// `forward_signals`). Every command the script runs, pipeline members and
+    /// command substitutions included, is a `Cmd` node in the arena. Call
+    /// between ticks only: no callback holds a borrow of a subprocess then.
+    pub(crate) fn forward_signal(&self, sig: bun_core::SignalCode) {
+        let Some(sig) = sig.platform_number() else {
+            return;
+        };
+        for node in self.nodes.get() {
+            let Node::Cmd(cmd) = node else { continue };
+            let crate::shell::states::cmd::Exec::Subproc(sub) = &cmd.exec else {
+                continue;
+            };
+            if sub.child.is_null() {
+                continue;
+            }
+            // SAFETY: `child` is the live `heap::alloc` subprocess owned by
+            // this `Cmd` until `Cmd::deinit` frees it (it is also the
+            // `Process`'s exit-callback context). Between ticks no callback
+            // holds a borrow of it.
+            let child: &mut ShellSubprocess = unsafe { &mut *sub.child };
+            if child.process.is_some() {
+                let _ = child.try_kill(sig);
+            }
+        }
+    }
+
     /// For sequencing states' `child_done`: an interrupted pipeline member stops
-    /// where it is instead of running its next command.
+    /// where it is instead of running its next command. After a termination
+    /// signal (see `forward_signals`) every sequence stops, so the script ends
+    /// with the commands that received it.
     pub(crate) fn interrupted(&self, id: NodeId) -> bool {
         self.node(id).base().is_some_and(|b| b.interrupted)
+            || crate::shell::forward_signals::received().is_some()
     }
 
     /// Some ancestor is a member of a multi-command pipeline.

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -32,6 +32,8 @@ pub mod util;
 
 #[path = "Builtin.rs"]
 pub mod builtin;
+#[path = "forward_signals.rs"]
+pub(crate) mod forward_signals;
 #[path = "interpreter.rs"]
 pub mod interpreter;
 #[path = "IO.rs"]

--- a/src/runtime/shell/states/Binary.rs
+++ b/src/runtime/shell/states/Binary.rs
@@ -78,9 +78,10 @@ impl Binary {
     ) -> Yield {
         interp.deinit_node(child);
         {
+            let interrupted = interp.interrupted(this);
             let me = interp.as_binary_mut(this);
             me.currently_executing = None;
-            if me.left.is_none() && !me.base.interrupted {
+            if me.left.is_none() && !interrupted {
                 me.left = Some(exit_code);
             } else {
                 me.right = Some(exit_code);

--- a/test/cli/run/run-shell.test.ts
+++ b/test/cli/run/run-shell.test.ts
@@ -80,3 +80,127 @@ test.skipIf(isWindows)(
     expect(exitCode).toBe(0);
   },
 );
+
+// A signal sent to the runner's pid alone (kill, docker stop, systemd), not to
+// the process group. proc.kill() is TerminateProcess on Windows and reaches no
+// handler, so this is POSIX only. Sequential: each case starts two debug
+// builds of bun, and several at once overrun the per-test budget under ASAN.
+describe.skipIf(isWindows)("signal to the bun shell runner", () => {
+  // Prints its pid, then waits. With a signal name as its argument it handles
+  // that signal and exits 7. SIGUSR1 ends it with 0.
+  const fixture = `
+    const sig = process.argv[2];
+    if (sig) process.on(sig, () => { console.log("got " + sig); process.exit(7); });
+    process.on("SIGUSR1", () => process.exit(0));
+    console.log("ready " + process.pid);
+    setTimeout(() => {}, 30_000);
+  `;
+
+  function project(prefix: string, script: string) {
+    return tempDir(prefix, {
+      "child.js": fixture,
+      "package.json": JSON.stringify({ name: "p", scripts: { wait: script } }),
+    });
+  }
+
+  async function runAndSignal(cmd: string[], cwd: string, signal: "SIGTERM" | "SIGHUP", endChild = false) {
+    await using proc = Bun.spawn({
+      cmd,
+      cwd,
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const ready = Promise.withResolvers<number>();
+    let stdout = "";
+    const stdoutDone = (async () => {
+      for await (const chunk of proc.stdout) {
+        stdout += new TextDecoder().decode(chunk);
+        const m = stdout.match(/ready (\d+)/);
+        if (m) ready.resolve(Number(m[1]));
+      }
+      ready.reject(new Error(`stdout ended before the child was ready:\n${stdout}`));
+    })();
+    const childPid = await ready.promise;
+    proc.kill(signal);
+    if (endChild) process.kill(childPid, "SIGUSR1");
+    const exitCode = await proc.exited;
+    // The runner waited for the child, so the child is gone once the runner is.
+    // An orphan still holds the stdio pipes open, so check (and end it) before
+    // reading them to the end.
+    let childAlive = true;
+    try {
+      process.kill(childPid, 0);
+      process.kill(childPid, "SIGKILL");
+    } catch {
+      childAlive = false;
+    }
+    const [, stderr] = await Promise.all([stdoutDone, proc.stderr.text()]);
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode, childAlive };
+  }
+
+  test("bun run --shell=bun forwards SIGTERM to the command and dies from it", async () => {
+    using dir = project("run-shell-sigterm", `${bunExe()} child.js`);
+    const r = await runAndSignal([bunExe(), "run", "--shell=bun", "wait"], String(dir), "SIGTERM");
+    expect(r.childAlive).toBe(false);
+    expect(r.stderr).toContain('script "wait" was terminated by signal SIGTERM');
+    expect(r.signalCode).toBe("SIGTERM");
+  });
+
+  test("bun exec forwards SIGHUP to the command and exits 129", async () => {
+    using dir = project("run-shell-exec-sighup", "");
+    const r = await runAndSignal([bunExe(), "exec", `${bunExe()} child.js`], String(dir), "SIGHUP");
+    expect(r.childAlive).toBe(false);
+    expect(r.exitCode).toBe(129);
+  });
+
+  test("a command that handles the forwarded SIGTERM keeps its own exit code", async () => {
+    using dir = project("run-shell-sigterm-handled", `${bunExe()} child.js SIGTERM`);
+    const r = await runAndSignal([bunExe(), "run", "--shell=bun", "wait"], String(dir), "SIGTERM");
+    expect(r.childAlive).toBe(false);
+    expect(r.stdout).toContain("got SIGTERM");
+    expect(r.stderr).toContain('script "wait" exited with code 7');
+    expect(r.exitCode).toBe(7);
+  });
+
+  test("the script stops at the command that received the signal", async () => {
+    using dir = project("run-shell-sigterm-sequence", `${bunExe()} child.js; echo after`);
+    const r = await runAndSignal([bunExe(), "run", "--shell=bun", "wait"], String(dir), "SIGTERM");
+    expect(r.childAlive).toBe(false);
+    expect(r.stdout).not.toContain("after");
+    expect(r.signalCode).toBe("SIGTERM");
+  });
+
+  test("a script with no subprocess to forward to dies from the signal at once", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "exec", "echo ready; yes > /dev/null"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const reader = proc.stdout.getReader();
+    let stdout = "";
+    while (!stdout.includes("ready")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      stdout += new TextDecoder().decode(value);
+    }
+    expect(stdout).toContain("ready");
+    proc.kill("SIGTERM");
+    await proc.exited;
+    expect(proc.signalCode).toBe("SIGTERM");
+  });
+
+  test("a SIGTERM the runner inherited as ignored stays ignored", async () => {
+    using dir = project("run-shell-sigterm-ignored", `${bunExe()} child.js`);
+    const r = await runAndSignal(
+      ["sh", "-c", 'trap "" TERM; exec "$0" run --shell=bun wait', bunExe()],
+      String(dir),
+      "SIGTERM",
+      true,
+    );
+    expect(r.childAlive).toBe(false);
+    expect(r.stderr).toBe(`$ ${bunExe()} child.js\n`);
+    expect(r.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- SIGTERM or SIGHUP to the pid of `bun run --shell=bun <script>`, `bun exec '<cmd>'` or `bun x.sh` kills bun at once (exit 143, no message) and leaves the running command reparented to init. `docker stop` and `kill` orphan the script. The system-shell path forwards the signal and waits (`Bun__registerSignalsForForwarding`, `c-bindings.cpp:1091`).
- Cause: the Bun-shell runner (`Interpreter::init_and_run_impl`) only installs the Ctrl+C deferral (`src/spawn/ctrl_c.rs`). SIGTERM and SIGHUP stay `SIG_DFL`. As container PID 1 the kernel drops them and the runner never stops.

### Fix
- New `src/runtime/shell/forward_signals.rs` hooks both signals around the tick loop (an inherited `SIG_IGN` is left alone). The handler records the signal and wakes the loop. Between ticks `Interpreter::forward_signal` sends it to every live subprocess and keeps waiting.
- The script runs no further command after the signal (`Interpreter::interrupted`). With no subprocess alive (a builtin, or nothing) the handler re-raises with `SIG_DFL` at once, `_exit(128 + n)` if PID 1 drops it.
- `bun run` then matches the system-shell path: exit code `128 + signal` prints `script "x" was terminated by signal SIGTERM` and re-raises. A command that handles the signal keeps its exit code.
- Verified: `test/cli/run/run-shell.test.ts` (6 new tests, 4 fail on 1.4.3 with the child alive), shell and `bun run` suites, `cargo check` for linux, darwin, windows. Self-reviewed: 2 concerns, both addressed (Notes).

### Background
- With `--shell=bun`, bunfig `[run] shell = "bun"`, or on Windows by default, `bun run` interprets scripts in-process on `MiniEventLoop`, a JS-free usockets loop. Each external command is a `Cmd` node owning a `ShellSubprocess`.
- The loop's poll retries on EINTR, so a signal alone never returns control. `us_wakeup_loop` (eventfd write, mach message on macOS) takes no lock, so it is signal-safe.
- `sh -c <one command>` execs the command, so the system-shell path's signal lands on the command itself. SIGINT stays unforwarded: the terminal sends it to the whole group (`ctrl_c.rs`), whose `Child::alive()` counter the handler reads.

<details><summary>Notes</summary>

Reproduction (bun 1.4.3):

```sh
printf '{"name":"p","scripts":{"srv":"sleep 30"}}' > package.json
bun run --shell=bun srv & sleep 1; kill -TERM $!; wait $!; echo rc=$?; pgrep -a sleep
# rc=143, "sleep 30" still running, ppid 1
bun exec 'sleep 30' & sleep 1; kill -TERM $!; wait $!; pgrep -a sleep
# same
```

With this branch (debug build):

- `bun run --shell=bun srv`, SIGTERM: prints `error: script "srv" was terminated by signal SIGTERM (Polite quit request)`, dies by SIGTERM (rc 143), `sleep` gone. SIGHUP: rc 129, same message with SIGHUP.
- `bun exec 'sleep 30'` and `bun s.sh` (`sleep 30`): rc 143, `sleep` gone.
- `sleep 30 | sleep 30`: both members receive the signal.
- `sleep 30; echo after`, `sleep 30 && echo after`, `sleep 30 || echo after`: stop at `sleep`, `after` is not printed, rc 143.
- A script whose command handles SIGTERM and exits 7: `bun run` reports `exited with code 7`, rc 7.
- A command that ignores SIGTERM keeps running after the first signal and the runner stays with it. A second signal is forwarded again (no `SA_RESETHAND`). The system-shell path behaves the same way.
- `bun exec 'echo ready; yes > /dev/null'` (builtin only, never yields to the event loop): SIGTERM ends it at once, death by signal.
- `sh -c 'trap "" TERM; exec bun run --shell=bun wait'`: SIGTERM stays ignored by the runner and the child, the script completes, rc 0.

Review follow-ups: `install` now runs before `interp.run()`, which spawns the first command before it returns, so no window is left where a child exists and the handler is not armed. Background jobs (`&`) are rejected by the parser today, so the `ctrl_c::Child` foreground count is the full set of subprocesses that can exist.

Self-review concerns and what changed:

1. A builtin-only phase (or the gap between two commands) would have swallowed the signal until the script ended on its own. The handler now re-raises at once when `ctrl_c::Child::alive() == 0`. A builtin can hold the main thread without returning to the event loop (`yes > /dev/null`), so this cannot wait for a tick.
2. `a; b` would have continued to `b` after `a` died from the forwarded signal. `Interpreter::interrupted` now stops every sequencing state (`Script`, `Stmt`, `Binary`, `If`) once a signal was received.

The handler saves and restores `errno` around the wakeup write. `PREVIOUS` dispositions live in a `RacyCell<MaybeUninit<[sigaction; 2]>>`, written on the CLI thread before the hook and read after the unhook.

PID 1: installing a handler is what makes the kernel deliver SIGTERM to init at all, so the runner now reacts there too. The final re-raise of `bun run` goes through `Global::raise_ignoring_panic_handler`; #38877 turns a dropped re-raise into `_exit(128 + signo)` inside that function. The handler's own no-subprocess path already has the fallback. Not run here: `unshare --pid` is not permitted in the development container.

Windows: `install` and `uninstall` only record the loop pointer. Console control events keep going through `bun_spawn::ctrl_c`. The new tests are skipped there (`proc.kill()` is `TerminateProcess`).

Related, not overlapping: #41478 does the same for `--filter` / `--parallel` (a different runner), #38877 covers the PID 1 exit status of the re-raise.

Suites run against the debug build: `test/cli/run/run-shell.test.ts` (9 pass, 3 runs), `test/js/bun/shell/exec.test.ts`, `bunshell.test.ts`, `bunshell-file.test.ts`, `test/cli/run/run_command.test.ts`, `test/cli/run/shell-keepalive.test.ts`. `test/js/bun/shell/shell-hang.test.ts` (700 ms budgets) and four `--bun` cases of `test/regression/issue/ctrl-c.test.ts` time out in this container on main as well, against the ASAN debug build. Neither touches this path.
</details>

