### PR TITLE
install: pick up trustedDependencies added to a workspace member's package.json on a repeat install

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1488,8 +1488,7 @@ impl Diff {
         )) as u32;
         if is_root {
             summary.remove = removed_names.len() as u32;
-            // The set is the union over the root and every workspace, so compare it once the
-            // loop above has parsed the workspaces into `to_lockfile`.
+            // After the loop: it adds each workspace's `trustedDependencies` to `to_lockfile`.
             Self::trusted_dependencies(&mut summary, from_lockfile, to_lockfile)?;
         }
 
@@ -1558,27 +1557,14 @@ impl Diff {
         from_lockfile: &mut Lockfile,
         to_lockfile: &Lockfile,
     ) -> crate::Result<()> {
-        // situations:
-        // 1 - Both old lockfile and new lockfile use default trusted dependencies, no diffs
-        // 2 - Both exist, only diffs are from additions and removals
-        //
-        // 3 - Old lockfile has trusted dependencies, new lockfile does not. Added are dependencies
-        //     from default list that didn't exist previously. We need to be careful not to add these
-        //     to the new lockfile. Removed are dependencies from old list that
-        //     don't exist in the default list.
-        //
-        // 4 - Old lockfile used the default list, new lockfile has trusted dependencies. Added
-        //     are dependencies are all from the new lockfile. Removed is empty because the default
-        //     list isn't appended to the lockfile.
-
-        // 1
+        // Both the old and the new lockfile use the default list: no diffs.
         if from_lockfile.trusted_dependencies.is_none()
             && to_lockfile.trusted_dependencies.is_none()
         {
             return Ok(());
         }
 
-        // 2
+        // Both have a list: the diffs are its additions and removals.
         if let (Some(from_trusted_dependencies), Some(to_trusted_dependencies)) = (
             from_lockfile.trusted_dependencies.as_mut(),
             to_lockfile.trusted_dependencies.as_ref(),
@@ -1624,7 +1610,7 @@ impl Diff {
             return Ok(());
         }
 
-        // 3
+        // Back to the default list: its entries are newly trusted but not written to the lockfile.
         if let (Some(from_trusted_dependencies), None) = (
             from_lockfile.trusted_dependencies.as_ref(),
             to_lockfile.trusted_dependencies.as_ref(),
@@ -1632,8 +1618,6 @@ impl Diff {
             // added
             for entry in default_trusted_dependencies::entries() {
                 if !from_trusted_dependencies.contains(&(entry.hash as TruncatedPackageNameHash)) {
-                    // although this is a new trusted dependency, it is from the default
-                    // list so it shouldn't be added to the lockfile
                     summary.added_trusted_dependencies.put(
                         entry.hash as TruncatedPackageNameHash,
                         AddedTrustedDependency {
@@ -1644,7 +1628,7 @@ impl Diff {
                 }
             }
 
-            // removed
+            // removed: the old entries that are not on the default list
             for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
                 if !default_trusted_dependencies::has_with_hash(u64::from(from_trusted)) {
                     summary
@@ -1656,13 +1640,11 @@ impl Diff {
             return Ok(());
         }
 
-        // 4
+        // First explicit list: every entry is added, also one that is on the default list.
         if let (None, Some(to_trusted_dependencies)) = (
             from_lockfile.trusted_dependencies.as_ref(),
             to_lockfile.trusted_dependencies.as_ref(),
         ) {
-            // add all to trusted dependencies, even if they exist in default because they weren't in the
-            // lockfile originally
             for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
                 summary.added_trusted_dependencies.put(
                     to_trusted,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1182,136 +1182,6 @@ impl Diff {
             }
         }
 
-        'trusted_dependencies: {
-            // trusted dependency diff
-            //
-            // situations:
-            // 1 - Both old lockfile and new lockfile use default trusted dependencies, no diffs
-            // 2 - Both exist, only diffs are from additions and removals
-            //
-            // 3 - Old lockfile has trusted dependencies, new lockfile does not. Added are dependencies
-            //     from default list that didn't exist previously. We need to be careful not to add these
-            //     to the new lockfile. Removed are dependencies from old list that
-            //     don't exist in the default list.
-            //
-            // 4 - Old lockfile used the default list, new lockfile has trusted dependencies. Added
-            //     are dependencies are all from the new lockfile. Removed is empty because the default
-            //     list isn't appended to the lockfile.
-
-            // 1
-            if from_lockfile.trusted_dependencies.is_none()
-                && to_lockfile.trusted_dependencies.is_none()
-            {
-                break 'trusted_dependencies;
-            }
-
-            // 2
-            if let (Some(from_trusted_dependencies), Some(to_trusted_dependencies)) = (
-                from_lockfile.trusted_dependencies.as_mut(),
-                to_lockfile.trusted_dependencies.as_ref(),
-            ) {
-                // added
-                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
-                    // Empty name = legacy bun.lockb hash-only sentinel.
-                    let already_trusted = from_trusted_dependencies
-                        .get_mut(&to_trusted)
-                        .is_some_and(|from_name| {
-                            if from_name.is_empty() && !to_name.is_empty() {
-                                from_name.clone_from(to_name);
-                            }
-                            from_name.is_empty() || to_name.is_empty() || **from_name == **to_name
-                        });
-                    if !already_trusted {
-                        summary.added_trusted_dependencies.put(
-                            to_trusted,
-                            AddedTrustedDependency {
-                                add_to_lockfile: true,
-                                name: to_name.clone(),
-                            },
-                        )?;
-                    }
-                }
-
-                // removed
-                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    let still_trusted =
-                        to_trusted_dependencies
-                            .get(&from_trusted)
-                            .is_some_and(|to_name| {
-                                from_name.is_empty()
-                                    || to_name.is_empty()
-                                    || **to_name == **from_name
-                            });
-                    if !still_trusted {
-                        summary
-                            .removed_trusted_dependencies
-                            .put(from_trusted, from_name.clone())?;
-                    }
-                }
-
-                break 'trusted_dependencies;
-            }
-
-            // 3
-            if let (Some(from_trusted_dependencies), None) = (
-                from_lockfile.trusted_dependencies.as_ref(),
-                to_lockfile.trusted_dependencies.as_ref(),
-            ) {
-                // added
-                for entry in default_trusted_dependencies::entries() {
-                    if !from_trusted_dependencies
-                        .contains(&(entry.hash as TruncatedPackageNameHash))
-                    {
-                        // although this is a new trusted dependency, it is from the default
-                        // list so it shouldn't be added to the lockfile
-                        summary.added_trusted_dependencies.put(
-                            entry.hash as TruncatedPackageNameHash,
-                            AddedTrustedDependency {
-                                add_to_lockfile: false,
-                                name: Box::from(entry.key),
-                            },
-                        )?;
-                    }
-                }
-
-                // removed
-                for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
-                    if !default_trusted_dependencies::has_with_hash(u64::from(from_trusted)) {
-                        summary
-                            .removed_trusted_dependencies
-                            .put(from_trusted, from_name.clone())?;
-                    }
-                }
-
-                break 'trusted_dependencies;
-            }
-
-            // 4
-            if let (None, Some(to_trusted_dependencies)) = (
-                from_lockfile.trusted_dependencies.as_ref(),
-                to_lockfile.trusted_dependencies.as_ref(),
-            ) {
-                // add all to trusted dependencies, even if they exist in default because they weren't in the
-                // lockfile originally
-                for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
-                    summary.added_trusted_dependencies.put(
-                        to_trusted,
-                        AddedTrustedDependency {
-                            add_to_lockfile: true,
-                            name: to_name.clone(),
-                        },
-                    )?;
-                }
-
-                {
-                    // removed
-                    // none
-                }
-
-                break 'trusted_dependencies;
-            }
-        }
-
         summary.patched_dependencies_changed = 'patched_dependencies_changed: {
             if from_lockfile.patched_dependencies.count()
                 != to_lockfile.patched_dependencies.count()
@@ -1618,6 +1488,9 @@ impl Diff {
         )) as u32;
         if is_root {
             summary.remove = removed_names.len() as u32;
+            // The set is the union over the root and every workspace, so compare it once the
+            // loop above has parsed the workspaces into `to_lockfile`.
+            Self::trusted_dependencies(&mut summary, from_lockfile, to_lockfile)?;
         }
 
         if !missing_workspaces.is_empty() {
@@ -1678,6 +1551,132 @@ impl Diff {
         }
 
         Ok(summary)
+    }
+
+    fn trusted_dependencies(
+        summary: &mut DiffSummary,
+        from_lockfile: &mut Lockfile,
+        to_lockfile: &Lockfile,
+    ) -> crate::Result<()> {
+        // situations:
+        // 1 - Both old lockfile and new lockfile use default trusted dependencies, no diffs
+        // 2 - Both exist, only diffs are from additions and removals
+        //
+        // 3 - Old lockfile has trusted dependencies, new lockfile does not. Added are dependencies
+        //     from default list that didn't exist previously. We need to be careful not to add these
+        //     to the new lockfile. Removed are dependencies from old list that
+        //     don't exist in the default list.
+        //
+        // 4 - Old lockfile used the default list, new lockfile has trusted dependencies. Added
+        //     are dependencies are all from the new lockfile. Removed is empty because the default
+        //     list isn't appended to the lockfile.
+
+        // 1
+        if from_lockfile.trusted_dependencies.is_none()
+            && to_lockfile.trusted_dependencies.is_none()
+        {
+            return Ok(());
+        }
+
+        // 2
+        if let (Some(from_trusted_dependencies), Some(to_trusted_dependencies)) = (
+            from_lockfile.trusted_dependencies.as_mut(),
+            to_lockfile.trusted_dependencies.as_ref(),
+        ) {
+            // added
+            for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
+                // Empty name = legacy bun.lockb hash-only sentinel.
+                let already_trusted =
+                    from_trusted_dependencies
+                        .get_mut(&to_trusted)
+                        .is_some_and(|from_name| {
+                            if from_name.is_empty() && !to_name.is_empty() {
+                                from_name.clone_from(to_name);
+                            }
+                            from_name.is_empty() || to_name.is_empty() || **from_name == **to_name
+                        });
+                if !already_trusted {
+                    summary.added_trusted_dependencies.put(
+                        to_trusted,
+                        AddedTrustedDependency {
+                            add_to_lockfile: true,
+                            name: to_name.clone(),
+                        },
+                    )?;
+                }
+            }
+
+            // removed
+            for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
+                let still_trusted =
+                    to_trusted_dependencies
+                        .get(&from_trusted)
+                        .is_some_and(|to_name| {
+                            from_name.is_empty() || to_name.is_empty() || **to_name == **from_name
+                        });
+                if !still_trusted {
+                    summary
+                        .removed_trusted_dependencies
+                        .put(from_trusted, from_name.clone())?;
+                }
+            }
+
+            return Ok(());
+        }
+
+        // 3
+        if let (Some(from_trusted_dependencies), None) = (
+            from_lockfile.trusted_dependencies.as_ref(),
+            to_lockfile.trusted_dependencies.as_ref(),
+        ) {
+            // added
+            for entry in default_trusted_dependencies::entries() {
+                if !from_trusted_dependencies.contains(&(entry.hash as TruncatedPackageNameHash)) {
+                    // although this is a new trusted dependency, it is from the default
+                    // list so it shouldn't be added to the lockfile
+                    summary.added_trusted_dependencies.put(
+                        entry.hash as TruncatedPackageNameHash,
+                        AddedTrustedDependency {
+                            add_to_lockfile: false,
+                            name: Box::from(entry.key),
+                        },
+                    )?;
+                }
+            }
+
+            // removed
+            for (&from_trusted, from_name) in from_trusted_dependencies.iter() {
+                if !default_trusted_dependencies::has_with_hash(u64::from(from_trusted)) {
+                    summary
+                        .removed_trusted_dependencies
+                        .put(from_trusted, from_name.clone())?;
+                }
+            }
+
+            return Ok(());
+        }
+
+        // 4
+        if let (None, Some(to_trusted_dependencies)) = (
+            from_lockfile.trusted_dependencies.as_ref(),
+            to_lockfile.trusted_dependencies.as_ref(),
+        ) {
+            // add all to trusted dependencies, even if they exist in default because they weren't in the
+            // lockfile originally
+            for (&to_trusted, to_name) in to_trusted_dependencies.iter() {
+                summary.added_trusted_dependencies.put(
+                    to_trusted,
+                    AddedTrustedDependency {
+                        add_to_lockfile: true,
+                        name: to_name.clone(),
+                    },
+                )?;
+            }
+
+            // removed: none
+        }
+
+        Ok(())
     }
 }
 

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -259,6 +259,80 @@ test.concurrent(
   },
 );
 
+test.concurrent(
+  "trustedDependencies added to a workspace member's package.json on a later install runs the scripts and is saved",
+  async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+
+    await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", workspaces: ["packages/*"] }));
+    const memberDir = join(packageDir, "packages", "pkg1");
+    await mkdir(memberDir, { recursive: true });
+    const memberJson = { name: "pkg1", version: "1.0.0", dependencies: { "all-lifecycle-scripts": "1.0.0" } };
+    await writeFile(join(memberDir, "package.json"), JSON.stringify(memberJson));
+
+    async function install() {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lockfile = await file(join(packageDir, "bun.lock")).text();
+      return { out, err, exitCode, lockfile };
+    }
+
+    const depDir = join(packageDir, "node_modules", "all-lifecycle-scripts");
+    async function scriptsThatRan() {
+      const names = ["preinstall", "install", "postinstall"];
+      const ran = await Promise.all(names.map(name => exists(join(depDir, `${name}.txt`))));
+      return names.filter((_, i) => ran[i]);
+    }
+
+    // The member's dependency is installed with its scripts blocked.
+    let result = await install();
+    expect(result.err).toContain("Saved lockfile");
+    expect(result.err).not.toContain("error:");
+    expect(result.out).toContain("Blocked 3 postinstalls. Run `bun pm untrusted` for details.");
+    expect(result.lockfile).not.toContain("trustedDependencies");
+    expect(await scriptsThatRan()).toEqual([]);
+    expect(result.exitCode).toBe(0);
+
+    // Trusting it in the member's package.json runs the scripts on the next install and records the entry in bun.lock.
+    await writeFile(
+      join(memberDir, "package.json"),
+      JSON.stringify({ ...memberJson, trustedDependencies: ["all-lifecycle-scripts"] }),
+    );
+    result = await install();
+    expect(result.err).toContain("Saved lockfile");
+    expect(result.err).not.toContain("error:");
+    expect(result.out).not.toContain("Blocked");
+    expect(result.out).toContain("Checked 2 installs across 3 packages (no changes)");
+    expect(result.lockfile).toContain(`"trustedDependencies": [\n    "all-lifecycle-scripts",\n  ],`);
+    expect(await scriptsThatRan()).toEqual(["preinstall", "install", "postinstall"]);
+    expect(await file(join(depDir, "postinstall.txt")).text()).toBe("postinstall!");
+    expect(result.exitCode).toBe(0);
+
+    // With nothing changed the lockfile is up to date.
+    result = await install();
+    expect(result.err).not.toContain("Saved lockfile");
+    expect(result.err).not.toContain("error:");
+    expect(result.out).toContain("Checked 2 installs across 3 packages (no changes)");
+    expect(result.exitCode).toBe(0);
+
+    // Removing the entry from the member's package.json removes it from bun.lock.
+    await writeFile(join(memberDir, "package.json"), JSON.stringify(memberJson));
+    result = await install();
+    expect(result.err).toContain("Saved lockfile");
+    expect(result.err).not.toContain("error:");
+    expect(result.lockfile).not.toContain("trustedDependencies");
+    expect(result.exitCode).toBe(0);
+  },
+);
+
 test.concurrent("node-gyp shim directory added to lifecycle script PATH gets a randomized name", async () => {
   using ctx = await setupTest();
   const { packageDir, packageJson, env } = ctx;

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -316,11 +316,13 @@ test.concurrent(
     expect(await file(join(depDir, "postinstall.txt")).text()).toBe("postinstall!");
     expect(result.exitCode).toBe(0);
 
-    // With nothing changed the lockfile is up to date.
+    // With nothing changed the lockfile is up to date and the scripts do not run again
+    // (the fixture rewrites the file with "postinstall exists!" on a second run).
     result = await install();
     expect(result.err).not.toContain("Saved lockfile");
     expect(result.err).not.toContain("error:");
     expect(result.out).toContain("Checked 2 installs across 3 packages (no changes)");
+    expect(await file(join(depDir, "postinstall.txt")).text()).toBe("postinstall!");
     expect(result.exitCode).toBe(0);
 
     // Removing the entry from the member's package.json removes it from bun.lock.
@@ -329,6 +331,7 @@ test.concurrent(
     expect(result.err).toContain("Saved lockfile");
     expect(result.err).not.toContain("error:");
     expect(result.lockfile).not.toContain("trustedDependencies");
+    expect(await file(join(depDir, "postinstall.txt")).text()).toBe("postinstall!");
     expect(result.exitCode).toBe(0);
   },
 );


### PR DESCRIPTION
### Problem
- In a workspace, `bun install` ignores a `trustedDependencies` entry added to a member's `package.json` after the first install. The blocked script never runs, `bun.lock` gets no `"trustedDependencies"`, the output says `(no changes)`. The same entry in the root `package.json` works.
- Cause: `Diff::generate_inner` (`src/install/lockfile/Package.rs`) compared the `trusted_dependencies` sets before the loop that parses each member into `to_lockfile`, so the member entries were missing. The per-member recursive call compared again, but only its `changes_dependencies()` / `changes_resolutions()` are read.

### Fix
- Move the comparison, unchanged, into `Diff::trusted_dependencies` and call it once, at the root, after the loop.
- Correct because the only consumers, `has_diffs()` in `install_with_manager.rs` (copies the new set, re-saves) and `summary.added_trusted_dependencies` in `PackageInstaller.rs` (runs the scripts of an installed package), read the root summary. It also stops reporting a member entry already in `bun.lock` as removed on every install.
- Verified: new test in `test/cli/install/bun-install-lifecycle-scripts.test.ts` (stock bun fails at the second install). Also ran the whole file, `bun-workspaces`, `bun-lock`, `frozen-lockfile-pruned`, `bun-install-registry`.
- Self-reviewed: 1 concern raised, 1 addressed (the test also pins that the scripts do not run again later).

### Background
- `Diff::generate` compares the root package loaded from `bun.lock` with a fresh parse of `package.json`. Its `DiffSummary` decides whether the install re-resolves and re-saves. Its loop parses each member's `package.json` into the new lockfile.
- `trustedDependencies` from the root and from every member land in one set, `Lockfile::trusted_dependencies`.
- The hoisted installer runs the scripts of an already installed package only when `summary.added_trusted_dependencies` names it.

<details><summary>Notes</summary>

- Repro (hoisted linker): root `package.json` with `workspaces: ["packages/*"]`, `packages/member/package.json` depending on a package with a `postinstall`. `bun install` blocks the script. Add `"trustedDependencies": ["<pkg>"]` to the member's `package.json`, run `bun install` again. Before: `Checked 2 installs across 3 packages (no changes)`, no `Saved lockfile`, script not run. After: `Saved lockfile`, `bun.lock` records the entry, the script runs. Removing the entry again drops it from `bun.lock` (that direction already worked, by way of the spurious "removed" report described above).
- Review probes, all confirmed with no change needed: the extracted body is the removed block token for token (`break 'label` to `return Ok(())`); nothing between the old and the new position reads the trusted sets; the only readers (`PackageInstaller.rs:2251`, `has_diffs()` at `install_with_manager.rs:237`) see the root summary; members that the loop does not parse (`bun update` targets, new members, a changed root entry, a member missing on disk) were compared against a root-only set before too, so no case gets worse; the legacy `bun.lockb` sentinel-name fill in case 2 ends up with the same set; `prune.rs` / `audit fix` read only `changes_dependencies()`.
- A fresh install (no `bun.lock`) always honored the member entry, because the member is parsed through the folder resolver into the same lockfile before anything is installed.
- Isolated linker: `bun.lock` now records the member entry on the repeat install, the same as it does for a root entry. Running the newly trusted scripts of an already installed package on a repeat install is a separate gap in the isolated installer (it affects the root `package.json` case too) and is not touched here.
- `bun update` / `bun add` are unaffected: rows that are update targets `continue` before the member parse, exactly as before, and `has_diffs()` is already true for them.
- The nested calls no longer run the comparison. Their result was never read. The other `Diff::generate` caller (`prune.rs`) reads only `changes_dependencies()`.
- #33632 (open) moves this comparison after the member parse as one part of a larger `--frozen-lockfile` change. This PR is only the member `trustedDependencies` fix and does not depend on it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->