### PR TITLE
minify: do not fold new Array(x, ...spread) into an array literal

### DIFF
--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -243,7 +243,16 @@ impl KnownGlobal {
                     // > 1
                     _ => {
                         // new Array(1, 2, 3) -> [1, 2, 3]
-                        // But NOT new Array(3) which creates an array with 3 empty slots
+                        // But NOT new Array(3) which creates an array with 3 empty slots,
+                        // and `new Array(5, ...rest)` is `new Array(5)` when `rest` is empty.
+                        if e
+                            .args
+                            .slice()
+                            .iter()
+                            .any(|arg| matches!(arg.data, js_ast::ExprData::ESpread(_)))
+                        {
+                            return Some(Self::call_from_new(e, loc));
+                        }
                         Some(js_ast::Expr::init(
                             E::Array {
                                 items: bun_alloc::AstAlloc::take(&mut e.args),

--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -245,8 +245,7 @@ impl KnownGlobal {
                         // new Array(1, 2, 3) -> [1, 2, 3]
                         // But NOT new Array(3) which creates an array with 3 empty slots,
                         // and `new Array(5, ...rest)` is `new Array(5)` when `rest` is empty.
-                        if e
-                            .args
+                        if e.args
                             .slice()
                             .iter()
                             .any(|arg| matches!(arg.data, js_ast::ExprData::ESpread(_)))

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -56,7 +56,8 @@ bun_core::declare_scope!(cache, visible);
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
-const EXPECTED_VERSION: u32 = 28;
+/// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
+const EXPECTED_VERSION: u32 = 29;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1197,6 +1197,8 @@ describe("bundler", () => {
         capture(new Array());
         capture(new Array(3));
         capture(new Array(1, 2, 3));
+        capture(new Array(...unknownValue));
+        capture(new Array(5, ...unknownValue));
         
         // Test Array with non-numeric single arguments (should convert to literal)
         capture(new Array("string"));
@@ -1237,6 +1239,8 @@ describe("bundler", () => {
   2,
   3
 ]`, // new Array(1, 2, 3) -> [1, 2, 3]
+      "Array(...unknownValue)", // a spread may leave a single number behind, which is a length
+      "Array(5, ...unknownValue)",
       `[
   "string"
 ]`, // new Array("string") -> ["string"]
@@ -1329,6 +1333,12 @@ describe("bundler", () => {
         const a3 = new Array(n);
         const a4 = Array(n);
         capture(a3.length === a4.length && a3.length === 3 && a3[0] === undefined);
+
+        // A spread can leave a single number behind at runtime, and then it is a length
+        const none = [];
+        const a5 = new Array(5, ...none);
+        capture(a5.length === 5);
+        capture(0 in a5 === false);
         
         // Test Object semantics
         const o1 = new Object();
@@ -1357,6 +1367,8 @@ describe("bundler", () => {
       "0 in sparse === !1",
       'JSON.stringify(sparse) === "[null,null,null,null,null]"',
       "a3.length === a4.length && a3.length === 3 && a3[0] === void 0",
+      "a5.length === 5",
+      "0 in a5 === !1",
       "typeof o1 === typeof o2",
       "o1.constructor === o2.constructor",
       "typeof f1 === typeof f2",
@@ -1367,7 +1379,7 @@ describe("bundler", () => {
     minifySyntax: true,
     target: "bun",
     run: {
-      stdout: "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue",
+      stdout: "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue",
     },
   });
 


### PR DESCRIPTION
### Problem
- With `minify_syntax`, `new Array(5, ...rest)` becomes `[5, ...rest]`. When `rest` is empty the original means `new Array(5)`, five holes, and the fold is `[5]`. For `const none = []; const a = new Array(5, ...none); console.log(a.length, 0 in a)` Node prints `5 false`. Bun 1.4.3 prints `1 true` under `bun run` and in `bun build --minify-syntax` output.
- The cause is the more-than-one-argument branch of `KnownGlobal::minify_global_constructor` (`src/ast/known_global.rs:244`). It folds the arguments into a literal without checking for a spread, so the argument count can differ at runtime.

### Fix
- If any argument is a spread, emit `Array(5, ...rest)` instead of a literal. This is the `call_from_new` form the single-argument branch already uses when the argument may be a number.
- Correct because `Array` called as a function behaves like `new Array` (ECMA-262 23.1.1). Only the literal fold was unsound.
- `EXPECTED_VERSION` in `RuntimeTranspilerCache.rs` moves to 29: the runtime transpiler enables `minify_syntax`, so its cached output changes.
- Verified: `test/bundler/bundler_minify.test.ts` (one case captures the output, one runs it, both fail on 1.4.3). Also `bundler_npm.test.ts` and `minify-new-array-with-if.test.ts`.

### Background
- `minify_global_constructor` is the byte-saving rewrite from #22493: `new Object()` to `{}`, `new Array(1, 2)` to `[1, 2]`, and `new` dropped from constructors that behave the same when called.
- `new Array(n)` with one number makes a sparse array of length `n`. Any other argument list makes an array of the arguments. A spread hides which case applies until runtime.
- This hunk comes from #37388, closed in favour of #41580. It is independent of the stack-frame change there.

<details><summary>Notes</summary>

- `new Array(...xs)` alone was already safe: it is the single-argument branch and stays a call.
- #41580 and #41159 also bump the transpiler cache version. Whichever lands second bumps again.
- #41580 gates `minify_global_constructor` on `bundle`, which hides this under `bun run` but not in `bun build --minify` output. This PR fixes the fold itself, so it is needed either way.
</details>
