### PR TITLE
install: dedupe a file: folder listed in both dependencies and devDependencies

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1800,7 +1800,7 @@ impl<'a> PackageInstall<'a> {
                                 }
 
                                 let _ = sys::unlinkat(destination_dir, entry.path);
-                                sys::symlinkat(entry.basename, destination_dir.fd(), entry.path)?;
+                                sys::symlinkat(target, destination_dir.fd(), entry.path)?;
                             }
                         }
                         _ => {}

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -823,9 +823,7 @@ impl Tree {
                         tree_id = tree.parent;
                     }
 
-                    // `next_id` is its own hoist root: the folder package is placed in this
-                    // node, unless the same name is already placed here (the same `file:`
-                    // folder in two dependency groups), which dedupes like any other package.
+                    // Its own hoist root: stays in this node, dedupes against a same-name sibling.
                     break 'hoisted Tree::hoist_dependency::<true, METHOD>(
                         next_id,
                         next_id,

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -822,10 +822,18 @@ impl Tree {
                         }
                         tree_id = tree.parent;
                     }
-                    break 'hoisted HoistDependencyResult::Placement(Placement {
-                        id: next_id,
-                        bundled: false,
-                    });
+
+                    // `next_id` is its own hoist root: the folder package is placed in this
+                    // node, unless the same name is already placed here (the same `file:`
+                    // folder in two dependency groups), which dedupes like any other package.
+                    break 'hoisted Tree::hoist_dependency::<true, METHOD>(
+                        next_id,
+                        next_id,
+                        pkg_id,
+                        dep_id,
+                        resolution_list,
+                        builder,
+                    );
                 }
 
                 Tree::hoist_dependency::<true, METHOD>(

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { readlinkSync } from "fs";
+import { readlinkSync, realpathSync } from "fs";
 import { access, copyFile, cp, exists, open, rm, writeFile } from "fs/promises";
 import {
   bunExe,
@@ -1824,5 +1824,104 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
     ({ err } = await install(String(dir), "--frozen-lockfile"));
     expect(err).not.toContain("Ignoring lockfile");
     expect(await file(lockfilePath).text()).toBe(lockfile);
+  });
+});
+
+describe.concurrent("a file: folder listed in both dependencies and devDependencies", () => {
+  async function install(cwd: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // the duplicate dependency warning is expected, an error is not
+    expect({ args, err, code }).toEqual({ args, err: expect.not.stringContaining("error:"), code: 0 });
+    return { out, err };
+  }
+
+  // every key of the "packages" object (only package entries have an array value)
+  const packageKeys = (lockfile: string) => lockfile.match(/^ {4}"[^"]*": \[/gm);
+
+  it.each(["hoisted", "isolated"] as const)(
+    "writes one packages entry and --frozen-lockfile accepts it (%s linker)",
+    async linker => {
+      using dir = tempDir("dup-folder-dep-", {
+        "vendor/a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+        "package.json": JSON.stringify({
+          name: "app",
+          dependencies: { a: "file:./vendor/a" },
+          devDependencies: { a: "file:./vendor/a" },
+        }),
+        "bunfig.toml": Bun.TOML.stringify({ install: { linker } }),
+      });
+      const lockfilePath = join(String(dir), "bun.lock");
+
+      let { err } = await install(String(dir));
+      expect(err).toContain("Saved lockfile");
+      const lockfile = await file(lockfilePath).text();
+      // one key, not two: a duplicate object key is rejected by bun's own lockfile parser
+      expect(packageKeys(lockfile)).toEqual(['    "a": [']);
+
+      ({ err } = await install(String(dir), "--frozen-lockfile"));
+      expect(err).not.toContain("Ignoring lockfile");
+      expect(await file(lockfilePath).text()).toBe(lockfile);
+    },
+  );
+
+  it("keeps one entry when the two groups point at different folders", async () => {
+    using dir = tempDir("dup-folder-dep-", {
+      "v1/a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+      "v2/a/package.json": JSON.stringify({ name: "a", version: "2.0.0" }),
+      "package.json": JSON.stringify({
+        name: "app",
+        dependencies: { a: "file:./v1/a" },
+        devDependencies: { a: "file:./v2/a" },
+      }),
+    });
+    const lockfilePath = join(String(dir), "bun.lock");
+
+    await install(String(dir));
+    const lockfile = await file(lockfilePath).text();
+    expect(packageKeys(lockfile)).toEqual(['    "a": [']);
+
+    const { err } = await install(String(dir), "--frozen-lockfile");
+    expect(err).not.toContain("Ignoring lockfile");
+    expect(await file(lockfilePath).text()).toBe(lockfile);
+  });
+
+  // A folder outside the project installs through per-file symlinks. Installing it
+  // twice into the same node_modules folder made the second pass hit EEXIST, and the
+  // EEXIST fallback linked each file to its own basename: `package.json -> package.json`.
+  it.skipIf(isWindows)("a folder outside the project does not become self-referencing symlinks", async () => {
+    using dir = tempDir("dup-folder-dep-", {
+      "a/package.json": JSON.stringify({ name: "a", version: "1.0.0", main: "index.js" }),
+      "a/index.js": `module.exports = "a from outside the project";`,
+      "app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: { a: "file:../a" },
+        devDependencies: { a: "file:../a" },
+      }),
+      "app/bunfig.toml": Bun.TOML.stringify({ install: { linker: "hoisted" } }),
+    });
+    // the symlinks bun writes are absolute real paths (the tmpdir may sit behind a symlink)
+    const root = realpathSync(String(dir));
+    const appDir = join(root, "app");
+
+    await install(appDir);
+    expect(packageKeys(await file(join(appDir, "bun.lock")).text())).toEqual(['    "a": [']);
+    expect(readlinkSync(join(appDir, "node_modules", "a", "package.json"))).toBe(join(root, "a", "package.json"));
+
+    await using proc = spawn({
+      cmd: [bunExe(), "-p", `require("a")`],
+      cwd: appDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: out.trim(), err, code }).toEqual({ out: "a from outside the project", err: "", code: 0 });
   });
 });


### PR DESCRIPTION
### Problem
- The same `file:` folder in `dependencies` and `devDependencies` writes a `bun.lock` with the key `"a"` twice under `"packages"`. bun's parser rejects that (`error: Duplicate package path`), so every later `--frozen-lockfile` install fails.
- `Tree::process_subtree` (`src/install/lockfile/Tree.rs:792`) places Folder resolutions without calling `hoist_dependency`, where a name already placed in the same node dedupes. #36303 fixed this for every other resolution type.
- The duplicate entry also installs the package twice. For a folder outside the project (`file:../a`, per-file symlinks) the second pass hits `EEXIST`, and the fallback at `src/install/PackageInstall.rs:1803` links each file to its own basename (`package.json -> package.json`): `ELOOP` on `require`.

### Fix
- Call `hoist_dependency` for folder packages with the node as its own hoist root. They dedupe within the node and still never hoist: with `hoist_root_id == self_id` the parent walk is skipped and the result is the `Placement` from before.
- On `EEXIST`, retry `symlinkat` with the target, as the Windows branch already does.
- Verified: `test/cli/install/bun-lock.test.ts` (4 new tests, all fail on 1.4.3), plus the `bun-install`, `isolated-install`, `bun-workspaces`, `hoist` and `bun-link` suites.
- Self-reviewed: 4 questions checked (see Notes), no changes.

### Background
- The tree builder places each dependency into a `Tree` node, one per `node_modules` folder. `hoist_dependency` scans a node for the name: the same package dedupes, a different one stays lower, no match tries the parent.
- `file:` folders never hoist, so the Folder branch skipped `hoist_dependency`, and the same-node scan with it. Each `(node, name)` pair is one `"packages"` key.

<details><summary>Notes</summary>

- Reported by an install fuzzer on 1.4.0, re-observed on 1.4.2 with the `ELOOP` symptom. A plain `bun install` on the broken lockfile prints `Ignoring lockfile` and re-resolves every time. #33156 carried the same `Tree.rs` change in July and dropped it in a later rework, so nothing open covered it.
- The `EEXIST` pass happens on a fresh install because `skip_delete` is set when `node_modules` did not exist, so the second install of the same package does not remove the first one's files. The fallback passed `entry.basename` as the symlink target since the original Zig source. It is only reachable when the destination already holds the file, which the dedupe fix makes rare, but the retry was wrong on its own. Checked separately: with only the `PackageInstall.rs` hunk the lockfile still has two keys and the symlinks come out correct.
- Review questions checked: (1) with `hoist_root_id == self_id` the call cannot climb to the parent, so folder packages are placed exactly where they were before; (2) while a package's own dependencies are being placed, its node only holds that package's earlier dependencies, so the scan can only return `Hoisted` (same package, or same name in another group of the same package), `ResolveReplace`/`Rebind` (an optional peer of the same name placed first), or `Placement`, and `process_subtree` already handles each of these for non-folder packages; (3) when the two groups point at different folders the `devDependencies` entry wins, in the lockfile and on disk, which is what already happens for two local tarballs under one name (the `input_dep_range` path from #36303); (4) `target` is still valid at the retry, nothing writes its buffer in between.
- Also ran the folder and `file:` tests of `bun-install-registry`.
- The symlink test is skipped on Windows, where a folder outside the project installs through a different code path.
- Separate issue seen while testing, not addressed here: a `file:..` dependency on an ancestor directory makes the symlink installer mirror the project (and the destination it is writing) into `node_modules/<name>` recursively.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->