### PR TITLE
bundler: size each chunk's renamer name table from the chunk, not the whole bundle

### DIFF
--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -299,7 +299,12 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
         return Ok(ChunkRenamer::Minify(minify_renamer));
     }
 
-    let mut r = NumberRenamer::init(make_symbols_view(symbols), &reserved_names)?;
+    let symbols_view = make_symbols_view(symbols);
+    let symbols_in_chunk: usize = files_in_order
+        .iter()
+        .map(|&i| symbols_view.symbols_for_source[i as usize].len())
+        .sum();
+    let mut r = NumberRenamer::init(symbols_view, &reserved_names, symbols_in_chunk)?;
     // Bindings that cross chunks carry one bundle-wide name
     // (`assign_cross_chunk_names`); everything else is numbered around them.
     if let Content::Javascript(js) = &chunk.content {

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -812,25 +812,27 @@ impl NameScopes for NumberRenamer {
 }
 
 impl NumberRenamer {
+    /// `symbols_in_chunk`: how many symbols the chunk's files declare, to size
+    /// the name table. `symbols` spans the whole bundle and every chunk's
+    /// renamer is alive at once, so sizing from it costs a bundle-sized table
+    /// per chunk.
     pub fn init(
         symbols: symbol::Map,
         root_names: &StringHashMap<u32>,
+        symbols_in_chunk: usize,
     ) -> Result<Box<NumberRenamer>, bun_alloc::AllocError> {
         let len = symbols.symbols_for_source.len();
         let names: Box<[Vec<NameStr>]> = core::iter::repeat_with(Vec::<NameStr>::default)
             .take(len)
             .collect();
-        let symbol_count: usize = symbols.symbols_for_source.iter().map(|s| s.len()).sum();
+        let capacity = root_names.len() + symbols_in_chunk / 4;
 
         let mut r = Box::new(NumberRenamer {
             symbols: ManuallyDrop::new(symbols),
             names,
             arena: Bump::new(),
-            ids: NameIds::with_capacity_and_hasher(
-                root_names.len() + symbol_count / 4,
-                Default::default(),
-            ),
-            slots: Vec::with_capacity(root_names.len() + symbol_count / 4),
+            ids: NameIds::with_capacity_and_hasher(capacity, Default::default()),
+            slots: Vec::with_capacity(capacity),
         });
         // `root_names` owns its keys and is dropped by the caller; copy them.
         for (key, &count) in root_names.iter() {


### PR DESCRIPTION
### What does this PR do?

`NumberRenamer::init` (#41286) pre-sizes its root name table — the `ids` hash map and the `slots` vec — to `root_names.len() + symbol_count / 4`, where `symbol_count` is summed over `symbols.symbols_for_source`, i.e. **every symbol in the bundle**. That is fine for a single chunk, but with `--splitting` `generateChunksInParallel` builds a renamer for every chunk up front and each one stays alive in `chunk.renamer` until its chunk has been printed. So a build with N JS chunks reserves N bundle-sized tables at once.

On a large app that splits into ~800 chunks (~1M symbols), each chunk reserved a ~4.4 MB hashbrown table plus a ~3 MB `Vec<NameSlot>` and used a few hundred entries of it:

| | peak RSS (Linux, 4 cores) |
|---|---|
| before #41286 (`858f4e7`) | 6.2 GB |
| `main` | 7.7 GB |
| this PR | 6.2 GB |

Linux only pays for the pages that get touched (the control-byte `memset` plus scattered inserts, ~2 MB per chunk). On Windows mimalloc commits the whole block when it is allocated, so the same build carried several GB of extra commit charge and, on a machine with a small commit limit, `bun build` aborted with `memory allocation of 4456464 bytes failed` — 4,456,464 bytes being exactly this table (262,144 × 16-byte `(StoreStr, u32)` buckets + control bytes).

The fix sizes the table from the symbols of the files in the chunk (`files_in_order`), which is what the chunk's renamer can actually add. A non-splitting build has one chunk containing every file, so it reserves exactly what it did before and the #41286 benchmarks are unaffected.

### How did you verify your code works?

Measured the build above with release builds of `858f4e7`, `main` and this branch, pinned to 4 cores, two runs each (numbers in the table; run-to-run spread ±0.1 GB). Page-fault profiles of `main` attribute the extra faults to `renamer::intern_into` and hashbrown's control-byte `memset` under `NumberRenamer::init`; both disappear with this change. Output is byte-identical (capacity is only a hint; `intern` grows the table on demand).