### PR TITLE
error printer: attribute the code frame, its caret and the GitHub annotation to the first user frame, not a builtin on top

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5804,10 +5804,8 @@ impl VirtualMachine {
             return;
         }
 
-        // Pick the top-most non-builtin frame for source preview. When every
-        // frame is a builtin, `top` stays 0 and `top_frame_is_builtin` stays
-        // set: frame 0's source is then bun's bundled module text or a JSC
-        // builtin, and nothing below may excerpt it.
+        // Pick the top-most non-builtin frame for source preview. If there is
+        // none, `top_frame_is_builtin` stays set and no source is excerpted.
         let mut top: usize = 0;
         let mut top_frame_is_builtin = false;
         if self.hide_bun_stackframes {
@@ -6898,11 +6896,8 @@ impl VirtualMachine {
     }
 }
 
-/// Whether a stack frame's source URL names one of bun's bundled JS modules
-/// (`node:fs`, `bun:sqlite`, `internal:streams/from`): the names
-/// `src/codegen/bundle-modules.ts` gives the sources in `src/js/`. Such a
-/// frame has no file on disk, and its JSC source is the bundled module text,
-/// so the error printer neither picks it for the code frame nor excerpts it.
+/// Whether a frame's source URL names one of bun's bundled `src/js` modules
+/// (named in `src/codegen/bundle-modules.ts`), whose source is not user code.
 fn is_bun_module_url(url: &bun_core::String) -> bool {
     url.starts_with_ascii(b"bun:")
         || url.starts_with_ascii(b"node:")

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5831,6 +5831,10 @@ impl VirtualMachine {
             enable_source_code_preview.set(false);
         }
 
+        // `collect_source_lines` excerpts frame 0's JSC source: for a bun module, bundled text.
+        let first_frame_is_bun_module =
+            self.hide_bun_stackframes && is_bun_module_url(&frames[0].source_url);
+
         let already_remapped = frames[top].remapped;
         let resolved = {
             let top_source_url = frames[top].source_url.to_utf8();
@@ -5915,7 +5919,9 @@ impl VirtualMachine {
                 original_source.source_code.into_utf8()
             };
 
-            if enable_source_code_preview.get() && !top_frame_is_builtin && code.slice().is_empty()
+            if enable_source_code_preview.get()
+                && !first_frame_is_bun_module
+                && code.slice().is_empty()
             {
                 exception.collect_source_lines(error_instance, global);
             }
@@ -5960,7 +5966,7 @@ impl VirtualMachine {
             if !code.slice().is_empty() {
                 *source_code_slice = Some(code);
             }
-        } else if enable_source_code_preview.get() && !top_frame_is_builtin {
+        } else if enable_source_code_preview.get() && !first_frame_is_bun_module {
             exception.collect_source_lines(error_instance, global);
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5753,9 +5753,6 @@ impl VirtualMachine {
         fn is_hidden_frame(f: &crate::ZigStackFrame) -> bool {
             f.source_url.eq_ascii(b"bun:wrap") || f.function_name.eq_ascii(b"::bunternal::")
         }
-        fn is_unknown_source(url: &bun_core::String) -> bool {
-            url.is_empty() || url.eq_ascii(b"[unknown]") || url.starts_with_ascii(b"[source:")
-        }
 
         let mut frames_len = exception.stack.frames_len as usize;
         // SAFETY: `frames_ptr[..frames_len]` is the caller-owned `Holder`
@@ -5772,7 +5769,7 @@ impl VirtualMachine {
                 }
                 // Workaround for being unable to hide that specific frame
                 // without also hiding the frame before it.
-                if is_unknown_source(&frame.source_url) && is_noisy_builtin(&frame.function_name) {
+                if frame.is_unknown_source() && is_noisy_builtin(&frame.function_name) {
                     start_index = Some(0);
                     break;
                 }
@@ -5784,9 +5781,7 @@ impl VirtualMachine {
                     if is_hidden_frame(frame) {
                         continue;
                     }
-                    if is_unknown_source(&frame.source_url)
-                        && is_noisy_builtin(&frame.function_name)
-                    {
+                    if frame.is_unknown_source() && is_noisy_builtin(&frame.function_name) {
                         continue;
                     }
                     // Swap rather than overwrite: the discarded tail past `j`
@@ -5825,8 +5820,9 @@ impl VirtualMachine {
             enable_source_code_preview.set(false);
         }
 
-        // `collect_source_lines` excerpts `frames[top]`'s JSC source: for a bun module, bundled text.
-        let top_frame_is_bun_module = self.hide_bun_stackframes && frames[top].is_bun_module();
+        // `collect_source_lines` excerpts `frames[top]`'s JSC source: for a builtin, its own or a
+        // bundled module's text. `top` is only a builtin when no frame is the user's.
+        let top_frame_is_builtin_code = self.hide_bun_stackframes && frames[top].is_builtin_code();
 
         let already_remapped = frames[top].remapped;
         let resolved = {
@@ -5913,7 +5909,7 @@ impl VirtualMachine {
             };
 
             if enable_source_code_preview.get()
-                && !top_frame_is_bun_module
+                && !top_frame_is_builtin_code
                 && code.slice().is_empty()
             {
                 exception.collect_source_lines(error_instance, global, top as u8);
@@ -5959,7 +5955,7 @@ impl VirtualMachine {
             if !code.slice().is_empty() {
                 *source_code_slice = Some(code);
             }
-        } else if enable_source_code_preview.get() && !top_frame_is_bun_module {
+        } else if enable_source_code_preview.get() && !top_frame_is_builtin_code {
             // Nothing to remap through (node:vm script, eval, new Function):
             // excerpt the picked frame straight from its JSC source.
             exception.collect_source_lines(error_instance, global, top as u8);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5820,8 +5820,7 @@ impl VirtualMachine {
             enable_source_code_preview.set(false);
         }
 
-        // `collect_source_lines` excerpts `frames[top]`'s JSC source: for a builtin, its own or a
-        // bundled module's text. `top` is only a builtin when no frame is the user's.
+        // True only when no frame is the user's; `frames[top]`'s JSC source is then builtin or bundled text.
         let top_frame_is_builtin_code = self.hide_bun_stackframes && frames[top].is_builtin_code();
 
         let already_remapped = frames[top].remapped;
@@ -5956,8 +5955,7 @@ impl VirtualMachine {
                 *source_code_slice = Some(code);
             }
         } else if enable_source_code_preview.get() && !top_frame_is_builtin_code {
-            // Nothing to remap through (node:vm script, eval, new Function):
-            // excerpt the picked frame straight from its JSC source.
+            // No source map (node:vm script, eval, new Function): excerpt `frames[top]`'s JSC source.
             exception.collect_source_lines(error_instance, global, top as u8);
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5832,6 +5832,14 @@ impl VirtualMachine {
             enable_source_code_preview.set(false);
         }
 
+        // Every frame is one of bun's own modules, so `top` is still frame 0 and
+        // names a builtin. `collect_source_lines` reads that frame's JSC source
+        // provider, which holds the bundled builtin text, so the fallback below
+        // has to skip it the way the `code` fetch already does.
+        let top_frame_is_bun_module = self.hide_bun_stackframes
+            && (frames[top].source_url.starts_with_ascii(b"bun:")
+                || frames[top].source_url.starts_with_ascii(b"node:"));
+
         let already_remapped = frames[top].remapped;
         let resolved = {
             let top_source_url = frames[top].source_url.to_utf8();
@@ -5916,7 +5924,10 @@ impl VirtualMachine {
                 original_source.source_code.into_utf8()
             };
 
-            if enable_source_code_preview.get() && code.slice().is_empty() {
+            if enable_source_code_preview.get()
+                && !top_frame_is_bun_module
+                && code.slice().is_empty()
+            {
                 exception.collect_source_lines(error_instance, global);
             }
 
@@ -5960,7 +5971,7 @@ impl VirtualMachine {
             if !code.slice().is_empty() {
                 *source_code_slice = Some(code);
             }
-        } else if enable_source_code_preview.get() {
+        } else if enable_source_code_preview.get() && !top_frame_is_bun_module {
             exception.collect_source_lines(error_instance, global);
         }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5804,8 +5804,7 @@ impl VirtualMachine {
             return;
         }
 
-        // Pick the top-most non-builtin frame for source preview. If there is
-        // none, `top_frame_is_builtin` stays set and no source is excerpted.
+        // Pick the top-most non-builtin frame for source preview.
         let mut top: usize = 0;
         let mut top_frame_is_builtin = false;
         if self.hide_bun_stackframes {
@@ -6896,8 +6895,7 @@ impl VirtualMachine {
     }
 }
 
-/// Whether a frame's source URL names one of bun's bundled `src/js` modules
-/// (named in `src/codegen/bundle-modules.ts`), whose source is not user code.
+/// Whether `url` names one of bun's bundled `src/js` modules (see `bundle-modules.ts`).
 fn is_bun_module_url(url: &bun_core::String) -> bool {
     url.starts_with_ascii(b"bun:")
         || url.starts_with_ascii(b"node:")

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5809,13 +5809,7 @@ impl VirtualMachine {
         let mut top_frame_is_builtin = false;
         if self.hide_bun_stackframes {
             for (i, frame) in frames.iter().enumerate() {
-                if is_bun_module_url(&frame.source_url)
-                    || frame.source_url.is_empty()
-                    || frame.source_url.eq_ascii(b"native")
-                    || frame.source_url.eq_ascii(b"unknown")
-                    || frame.source_url.eq_ascii(b"[unknown]")
-                    || frame.source_url.starts_with_ascii(b"[source:")
-                {
+                if !frame.has_user_source() {
                     top_frame_is_builtin = true;
                     continue;
                 }
@@ -5831,9 +5825,8 @@ impl VirtualMachine {
             enable_source_code_preview.set(false);
         }
 
-        // `collect_source_lines` excerpts frame 0's JSC source: for a bun module, bundled text.
-        let first_frame_is_bun_module =
-            self.hide_bun_stackframes && is_bun_module_url(&frames[0].source_url);
+        // `collect_source_lines` excerpts `frames[top]`'s JSC source: for a bun module, bundled text.
+        let top_frame_is_bun_module = self.hide_bun_stackframes && frames[top].is_bun_module();
 
         let already_remapped = frames[top].remapped;
         let resolved = {
@@ -5920,10 +5913,10 @@ impl VirtualMachine {
             };
 
             if enable_source_code_preview.get()
-                && !first_frame_is_bun_module
+                && !top_frame_is_bun_module
                 && code.slice().is_empty()
             {
-                exception.collect_source_lines(error_instance, global);
+                exception.collect_source_lines(error_instance, global, top as u8);
             }
 
             // Direct copy; both sides are `bun_core::Ordinal`.
@@ -5966,8 +5959,10 @@ impl VirtualMachine {
             if !code.slice().is_empty() {
                 *source_code_slice = Some(code);
             }
-        } else if enable_source_code_preview.get() && !first_frame_is_bun_module {
-            exception.collect_source_lines(error_instance, global);
+        } else if enable_source_code_preview.get() && !top_frame_is_bun_module {
+            // Nothing to remap through (node:vm script, eval, new Function):
+            // excerpt the picked frame straight from its JSC source.
+            exception.collect_source_lines(error_instance, global, top as u8);
         }
 
         if frames.len() > 1 {
@@ -6307,7 +6302,7 @@ impl VirtualMachine {
                 let mut top_frame: Option<&crate::ZigStackFrame> = frames.first();
                 if self.hide_bun_stackframes {
                     for frame in frames {
-                        if frame.position.is_invalid() || is_bun_module_url(&frame.source_url) {
+                        if frame.position.is_invalid() || !frame.has_user_source() {
                             continue;
                         }
                         top_frame = Some(frame);
@@ -6735,29 +6730,27 @@ impl VirtualMachine {
         let name = &exception.name;
         let message = &exception.message;
         let frames = exception.stack.frames();
-        let top_frame = frames.first();
+        // GitHub only places the annotation on a file in the checkout.
+        let location_frame = frames
+            .iter()
+            .find(|frame| frame.has_user_source() && !frame.position.is_invalid());
         let dir = bun_core::env_var::GITHUB_WORKSPACE::get()
             .unwrap_or_else(|| bun_bundler::bun_fs::FileSystem::instance().top_level_dir);
         bun_core::Output::flush();
 
         let writer = bun_core::Output::error_writer();
 
-        let mut has_location = false;
-        if let Some(frame) = top_frame {
-            if !frame.position.is_invalid() {
-                let source_url = frame.source_url.to_utf8();
-                let file = crate::ZigStackFrame::relative_source_url(dir, source_url.slice());
-                let _ = write!(
-                    writer,
-                    "\n::error file={},line={},col={},title=",
-                    bun_core::fmt::github_action_property(file),
-                    frame.position.line.one_based(),
-                    frame.position.column.one_based(),
-                );
-                has_location = true;
-            }
-        }
-        if !has_location {
+        if let Some(frame) = location_frame {
+            let source_url = frame.source_url.to_utf8();
+            let file = crate::ZigStackFrame::relative_source_url(dir, source_url.slice());
+            let _ = write!(
+                writer,
+                "\n::error file={},line={},col={},title=",
+                bun_core::fmt::github_action_property(file),
+                frame.position.line.one_based(),
+                frame.position.column.one_based(),
+            );
+        } else {
             let _ = writer.write_all(b"\n::error title=");
         }
 
@@ -6801,7 +6794,7 @@ impl VirtualMachine {
             let _ = writer.write_all(b"::");
         }
 
-        if top_frame.is_some() {
+        if !frames.is_empty() {
             // SAFETY: per-thread VM.
             let vm = VirtualMachine::get();
             let origin = if vm.is_from_devserver {
@@ -6900,13 +6893,6 @@ impl VirtualMachine {
     pub(crate) fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
         self.transpiler.resolver.bust_dir_cache(path)
     }
-}
-
-/// Whether `url` names one of bun's bundled `src/js` modules (see `bundle-modules.ts`).
-fn is_bun_module_url(url: &bun_core::String) -> bool {
-    url.starts_with_ascii(b"bun:")
-        || url.starts_with_ascii(b"node:")
-        || url.starts_with_ascii(b"internal:")
 }
 
 fn is_error_like(global_object: &JSGlobalObject, reason: JSValue) -> JsResult<bool> {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5804,13 +5804,15 @@ impl VirtualMachine {
             return;
         }
 
-        // Pick the top-most non-builtin frame for source preview.
+        // Pick the top-most non-builtin frame for source preview. When every
+        // frame is a builtin, `top` stays 0 and `top_frame_is_builtin` stays
+        // set: frame 0's source is then bun's bundled module text or a JSC
+        // builtin, and nothing below may excerpt it.
         let mut top: usize = 0;
         let mut top_frame_is_builtin = false;
         if self.hide_bun_stackframes {
             for (i, frame) in frames.iter().enumerate() {
-                if frame.source_url.starts_with_ascii(b"bun:")
-                    || frame.source_url.starts_with_ascii(b"node:")
+                if is_bun_module_url(&frame.source_url)
                     || frame.source_url.is_empty()
                     || frame.source_url.eq_ascii(b"native")
                     || frame.source_url.eq_ascii(b"unknown")
@@ -5831,14 +5833,6 @@ impl VirtualMachine {
         if frames[top].source_url.eq_ascii(b"[repl]") {
             enable_source_code_preview.set(false);
         }
-
-        // Every frame is one of bun's own modules, so `top` is still frame 0 and
-        // names a builtin. `collect_source_lines` reads that frame's JSC source
-        // provider, which holds the bundled builtin text, so the fallback below
-        // has to skip it the way the `code` fetch already does.
-        let top_frame_is_bun_module = self.hide_bun_stackframes
-            && (frames[top].source_url.starts_with_ascii(b"bun:")
-                || frames[top].source_url.starts_with_ascii(b"node:"));
 
         let already_remapped = frames[top].remapped;
         let resolved = {
@@ -5924,9 +5918,7 @@ impl VirtualMachine {
                 original_source.source_code.into_utf8()
             };
 
-            if enable_source_code_preview.get()
-                && !top_frame_is_bun_module
-                && code.slice().is_empty()
+            if enable_source_code_preview.get() && !top_frame_is_builtin && code.slice().is_empty()
             {
                 exception.collect_source_lines(error_instance, global);
             }
@@ -5971,7 +5963,7 @@ impl VirtualMachine {
             if !code.slice().is_empty() {
                 *source_code_slice = Some(code);
             }
-        } else if enable_source_code_preview.get() && !top_frame_is_bun_module {
+        } else if enable_source_code_preview.get() && !top_frame_is_builtin {
             exception.collect_source_lines(error_instance, global);
         }
 
@@ -6312,10 +6304,7 @@ impl VirtualMachine {
                 let mut top_frame: Option<&crate::ZigStackFrame> = frames.first();
                 if self.hide_bun_stackframes {
                     for frame in frames {
-                        if frame.position.is_invalid()
-                            || frame.source_url.starts_with_ascii(b"bun:")
-                            || frame.source_url.starts_with_ascii(b"node:")
-                        {
+                        if frame.position.is_invalid() || is_bun_module_url(&frame.source_url) {
                             continue;
                         }
                         top_frame = Some(frame);
@@ -6907,6 +6896,17 @@ impl VirtualMachine {
     pub(crate) fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
         self.transpiler.resolver.bust_dir_cache(path)
     }
+}
+
+/// Whether a stack frame's source URL names one of bun's bundled JS modules
+/// (`node:fs`, `bun:sqlite`, `internal:streams/from`): the names
+/// `src/codegen/bundle-modules.ts` gives the sources in `src/js/`. Such a
+/// frame has no file on disk, and its JSC source is the bundled module text,
+/// so the error printer neither picks it for the code frame nor excerpts it.
+fn is_bun_module_url(url: &bun_core::String) -> bool {
+    url.starts_with_ascii(b"bun:")
+        || url.starts_with_ascii(b"node:")
+        || url.starts_with_ascii(b"internal:")
 }
 
 fn is_error_like(global_object: &JSGlobalObject, reason: JSValue) -> JsResult<bool> {

--- a/src/jsc/ZigException.rs
+++ b/src/jsc/ZigException.rs
@@ -11,9 +11,7 @@ use crate::{JSErrorCode, JSGlobalObject, JSRuntimeType, JSValue, ZigStackFrame, 
 
 // SAFETY (safe fn): `JSValue` is a by-value scalar; `JSGlobalObject` is an
 // opaque `UnsafeCell`-backed handle (`&` is ABI-identical to non-null `*mut`);
-// `ZigException` is a `#[repr(C)]` out-param the C++ side fills in-place;
-// `frame_index` is a by-value scalar that C++ bounds-checks against
-// `stack.frames_len`.
+// `ZigException` is a `#[repr(C)]` out-param the C++ side fills in-place.
 unsafe extern "C" {
     pub(crate) safe fn ZigException__collectSourceLines(
         js_value: JSValue,
@@ -52,10 +50,7 @@ pub struct ZigException {
 }
 
 impl ZigException {
-    /// Fills `stack.source_lines_*` with the source around `stack.frames()[frame_index]`,
-    /// read from that frame's JSC source provider. For sources bun transpiled,
-    /// `remap_zig_exception` reads the original file instead; this is the path for
-    /// everything else (`node:vm` scripts, `eval`, `new Function`).
+    /// Fills `stack.source_lines_*` from the JSC source provider of `stack.frames()[frame_index]`.
     pub(crate) fn collect_source_lines(
         &mut self,
         value: JSValue,

--- a/src/jsc/ZigException.rs
+++ b/src/jsc/ZigException.rs
@@ -11,12 +11,15 @@ use crate::{JSErrorCode, JSGlobalObject, JSRuntimeType, JSValue, ZigStackFrame, 
 
 // SAFETY (safe fn): `JSValue` is a by-value scalar; `JSGlobalObject` is an
 // opaque `UnsafeCell`-backed handle (`&` is ABI-identical to non-null `*mut`);
-// `ZigException` is a `#[repr(C)]` out-param the C++ side fills in-place.
+// `ZigException` is a `#[repr(C)]` out-param the C++ side fills in-place;
+// `frame_index` is a by-value scalar that C++ bounds-checks against
+// `stack.frames_len`.
 unsafe extern "C" {
     pub(crate) safe fn ZigException__collectSourceLines(
         js_value: JSValue,
         global: &JSGlobalObject,
         exception: &mut ZigException,
+        frame_index: u8,
     );
 }
 
@@ -49,8 +52,17 @@ pub struct ZigException {
 }
 
 impl ZigException {
-    pub(crate) fn collect_source_lines(&mut self, value: JSValue, global: &JSGlobalObject) {
-        ZigException__collectSourceLines(value, global, self);
+    /// Fills `stack.source_lines_*` with the source around `stack.frames()[frame_index]`,
+    /// read from that frame's JSC source provider. For sources bun transpiled,
+    /// `remap_zig_exception` reads the original file instead; this is the path for
+    /// everything else (`node:vm` scripts, `eval`, `new Function`).
+    pub(crate) fn collect_source_lines(
+        &mut self,
+        value: JSValue,
+        global: &JSGlobalObject,
+        frame_index: u8,
+    ) {
+        ZigException__collectSourceLines(value, global, self, frame_index);
     }
 
     // `ZigException__fromException` is declared in headers.h but has no C++

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -32,6 +32,9 @@ pub struct ZigStackFrame {
     pub jsc_stack_frame_index: i32,
 }
 
+// Mirrors `ZigStackFrame` in headers-handwritten.h.
+bun_core::assert_ffi_layout!(ZigStackFrame, 72, 8);
+
 impl ZigStackFrame {
     pub(crate) fn snapshot(
         &self,

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -23,9 +23,7 @@ pub struct ZigStackFrame {
     /// This informs formatters whether to display as a blob URL or not
     pub remapped: bool,
 
-    /// The frame runs code JSC compiled as a builtin: JSC's own JS builtins and bun's bundled
-    /// `src/js` modules. Only known for frames taken from a JSC stack trace, not for frames
-    /// parsed back out of an `error.stack` string.
+    /// A JSC builtin or one of bun's bundled modules; false for frames parsed out of `error.stack`.
     pub is_builtin: bool,
 
     /// -1 means not set.
@@ -70,9 +68,7 @@ impl ZigStackFrame {
         jsc_stack_frame_index: -1,
     };
 
-    /// Whether the frame runs a JSC builtin or one of bun's bundled modules: `is_builtin` for
-    /// a frame taken from JSC's stack, the module URL (see `bundle-modules.ts`) for a frame
-    /// parsed back out of `error.stack`, which carries nothing else.
+    /// `is_builtin`, or a bundled module's URL for a frame parsed out of `error.stack`.
     pub(crate) fn is_builtin_code(&self) -> bool {
         let url = &self.source_url;
         self.is_builtin
@@ -87,10 +83,7 @@ impl ZigStackFrame {
         url.is_empty() || url.eq_ascii(b"[unknown]") || url.starts_with_ascii(b"[source:")
     }
 
-    /// Whether `source_url` names a source the user can open: not builtin code, and not one of
-    /// the placeholders of a frame without a source (`native` / `unknown` are how a formatted
-    /// `error.stack` spells those). The code frame, its caret and the GitHub Actions
-    /// annotation all use the first frame for which this is true.
+    /// Names a source the user can open; the code frame, caret and GitHub annotation use the first such frame.
     pub(crate) fn has_user_source(&self) -> bool {
         let url = &self.source_url;
         !(self.is_builtin_code()

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -61,6 +61,28 @@ impl ZigStackFrame {
         jsc_stack_frame_index: -1,
     };
 
+    /// Whether `source_url` is one of bun's bundled `src/js` modules (see `bundle-modules.ts`).
+    pub(crate) fn is_bun_module(&self) -> bool {
+        let url = &self.source_url;
+        url.starts_with_ascii(b"bun:")
+            || url.starts_with_ascii(b"node:")
+            || url.starts_with_ascii(b"internal:")
+    }
+
+    /// Whether `source_url` names a source the user can open. False for JSC's JS builtins
+    /// (no URL, or `native` / `unknown` once parsed back out of `error.stack`), for bun's
+    /// own modules, and for sources JSC could not attribute. The code frame, its caret and
+    /// the GitHub Actions annotation all use the first frame for which this is true.
+    pub(crate) fn has_user_source(&self) -> bool {
+        let url = &self.source_url;
+        !(self.is_bun_module()
+            || url.is_empty()
+            || url.eq_ascii(b"native")
+            || url.eq_ascii(b"unknown")
+            || url.eq_ascii(b"[unknown]")
+            || url.starts_with_ascii(b"[source:"))
+    }
+
     /// The frame's source as a report that lists files relative to `dir` (the JUnit
     /// reporter, the GitHub Actions annotation) prints it.
     ///

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -23,6 +23,11 @@ pub struct ZigStackFrame {
     /// This informs formatters whether to display as a blob URL or not
     pub remapped: bool,
 
+    /// The frame runs code JSC compiled as a builtin: JSC's own JS builtins and bun's bundled
+    /// `src/js` modules. Only known for frames taken from a JSC stack trace, not for frames
+    /// parsed back out of an `error.stack` string.
+    pub is_builtin: bool,
+
     /// -1 means not set.
     pub jsc_stack_frame_index: i32,
 }
@@ -58,29 +63,37 @@ impl ZigStackFrame {
         position: ZigStackFramePosition::INVALID,
         is_async: false,
         remapped: false,
+        is_builtin: false,
         jsc_stack_frame_index: -1,
     };
 
-    /// Whether `source_url` is one of bun's bundled `src/js` modules (see `bundle-modules.ts`).
-    pub(crate) fn is_bun_module(&self) -> bool {
+    /// Whether the frame runs a JSC builtin or one of bun's bundled modules: `is_builtin` for
+    /// a frame taken from JSC's stack, the module URL (see `bundle-modules.ts`) for a frame
+    /// parsed back out of `error.stack`, which carries nothing else.
+    pub(crate) fn is_builtin_code(&self) -> bool {
         let url = &self.source_url;
-        url.starts_with_ascii(b"bun:")
+        self.is_builtin
+            || url.starts_with_ascii(b"bun:")
             || url.starts_with_ascii(b"node:")
             || url.starts_with_ascii(b"internal:")
     }
 
-    /// Whether `source_url` names a source the user can open. False for JSC's JS builtins
-    /// (no URL, or `native` / `unknown` once parsed back out of `error.stack`), for bun's
-    /// own modules, and for sources JSC could not attribute. The code frame, its caret and
-    /// the GitHub Actions annotation all use the first frame for which this is true.
+    /// Whether JSC could not attribute the frame to a source at all.
+    pub(crate) fn is_unknown_source(&self) -> bool {
+        let url = &self.source_url;
+        url.is_empty() || url.eq_ascii(b"[unknown]") || url.starts_with_ascii(b"[source:")
+    }
+
+    /// Whether `source_url` names a source the user can open: not builtin code, and not one of
+    /// the placeholders of a frame without a source (`native` / `unknown` are how a formatted
+    /// `error.stack` spells those). The code frame, its caret and the GitHub Actions
+    /// annotation all use the first frame for which this is true.
     pub(crate) fn has_user_source(&self) -> bool {
         let url = &self.source_url;
-        !(self.is_bun_module()
-            || url.is_empty()
+        !(self.is_builtin_code()
+            || self.is_unknown_source()
             || url.eq_ascii(b"native")
-            || url.eq_ascii(b"unknown")
-            || url.eq_ascii(b"[unknown]")
-            || url.starts_with_ascii(b"[source:"))
+            || url.eq_ascii(b"unknown"))
     }
 
     /// The frame's source as a report that lists files relative to `dir` (the JUnit

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -225,7 +225,7 @@ static void populateStackFramePosition(const JSC::StackFrame& stackFrame, BunStr
 }
 
 static void populateStackFrame(JSC::VM& vm, ZigStackTrace& trace, const JSC::StackFrame& stackFrame,
-    ZigStackFrame& frame, bool is_top, JSC::SourceProvider** referenced_source_provider, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety)
+    ZigStackFrame& frame, JSC::SourceProvider** referenced_source_provider, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety)
 {
     if (flags == PopulateStackTraceFlags::OnlyPosition) {
         populateStackFrameMetadata(vm, globalObject, stackFrame, frame, finalizerSafety);
@@ -233,9 +233,9 @@ static void populateStackFrame(JSC::VM& vm, ZigStackTrace& trace, const JSC::Sta
             nullptr,
             0, frame.position, referenced_source_provider, flags);
     } else if (flags == PopulateStackTraceFlags::OnlySourceLines) {
-        populateStackFramePosition(stackFrame, is_top ? trace.source_lines_ptr : nullptr,
-            is_top ? trace.source_lines_numbers : nullptr,
-            is_top ? trace.source_lines_to_collect : 0, frame.position, referenced_source_provider, flags);
+        populateStackFramePosition(stackFrame, trace.source_lines_ptr,
+            trace.source_lines_numbers,
+            trace.source_lines_to_collect, frame.position, referenced_source_provider, flags);
     }
 }
 
@@ -421,7 +421,11 @@ public:
     }
 };
 
-static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& frames, ZigStackTrace& trace, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety = FinalizerSafety::NotInFinalizer)
+// OnlyPosition fills `trace.frames_ptr` from `frames`. OnlySourceLines runs
+// later, after Rust has filtered the frames and picked the one whose source
+// to excerpt (`remap_zig_exception`), and collects the source lines of
+// `trace.frames_ptr[source_lines_frame_index]` only.
+static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& frames, ZigStackTrace& trace, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety = FinalizerSafety::NotInFinalizer, uint8_t source_lines_frame_index = 0)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     if (flags == PopulateStackTraceFlags::OnlyPosition) {
@@ -440,20 +444,21 @@ static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& 
 
             ZigStackFrame& frame = trace.frames_ptr[frame_i];
             frame.jsc_stack_frame_index = static_cast<int32_t>(stack_frame_i);
-            populateStackFrame(vm, trace, frames[stack_frame_i], frame, frame_i == 0, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
+            populateStackFrame(vm, trace, frames[stack_frame_i], frame, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
             RETURN_IF_EXCEPTION(scope, );
             stack_frame_i++;
             frame_i++;
         }
         trace.frames_len = frame_i;
     } else if (flags == PopulateStackTraceFlags::OnlySourceLines) {
-        for (uint8_t i = 0; i < trace.frames_len; i++) {
-            ZigStackFrame& frame = trace.frames_ptr[i];
-            if (frame.jsc_stack_frame_index < 0 || static_cast<size_t>(frame.jsc_stack_frame_index) >= frames.size())
-                continue;
-            populateStackFrame(vm, trace, frames[frame.jsc_stack_frame_index], frame, i == 0, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
-            RETURN_IF_EXCEPTION(scope, );
-        }
+        if (source_lines_frame_index >= trace.frames_len)
+            return;
+        ZigStackFrame& frame = trace.frames_ptr[source_lines_frame_index];
+        // -1 when the frames were parsed out of an `error.stack` string.
+        if (frame.jsc_stack_frame_index < 0 || static_cast<size_t>(frame.jsc_stack_frame_index) >= frames.size())
+            return;
+        populateStackFrame(vm, trace, frames[frame.jsc_stack_frame_index], frame, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
+        RETURN_IF_EXCEPTION(scope, );
     }
 }
 
@@ -873,7 +878,8 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSValue__toZigException(JSC::Enc
     exceptionFromString(*exception, value, global);
 }
 
-extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException, JSC::JSGlobalObject* global, ZigException* exception)
+// `frame_index` indexes `exception->stack.frames_ptr` (after Rust's frame filtering).
+extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException, JSC::JSGlobalObject* global, ZigException* exception, uint8_t frame_index)
 {
     JSC::JSValue value = JSC::JSValue::decode(jsException);
     if (value == JSC::JSValue {}) {
@@ -885,7 +891,7 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
         JSValue unwrapped = jscException->value();
 
         if (jscException->stack().size() > 0) {
-            populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines);
+            populateStackTrace(global->vm(), jscException->stack(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::NotInFinalizer, frame_index);
         }
 
         exceptionFromString(*exception, unwrapped, global);
@@ -894,7 +900,7 @@ extern "C" void ZigException__collectSourceLines(JSC::EncodedJSValue jsException
 
     if (JSC::ErrorInstance* error = dynamicDowncast<JSC::ErrorInstance>(value)) {
         if (error->stackTrace() != nullptr && error->stackTrace()->size() > 0) {
-            populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC);
+            populateStackTrace(global->vm(), *error->stackTrace(), exception->stack, global, PopulateStackTraceFlags::OnlySourceLines, FinalizerSafety::MustNotTriggerGC, frame_index);
         }
         return;
     }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -88,8 +88,7 @@ static void populateStackFrameMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalO
     frame.source_url = Bun::toStringRef(sourceURL);
     auto m_codeBlock = stackFrame.codeBlock();
     if (m_codeBlock) {
-        // Bun's bundled modules are builtin executables too (createBuiltinExecutable), and
-        // functions nested in a builtin inherit the flag.
+        // Also true inside bun's bundled modules (createBuiltinExecutable); nested functions inherit it.
         frame.is_builtin = m_codeBlock->unlinkedCodeBlock()->isBuiltinFunction();
         switch (m_codeBlock->codeType()) {
         case JSC::EvalCode: {
@@ -424,10 +423,7 @@ public:
     }
 };
 
-// OnlyPosition fills `trace.frames_ptr` from `frames`. OnlySourceLines runs
-// later, after Rust has filtered the frames and picked the one whose source
-// to excerpt (`remap_zig_exception`), and collects the source lines of
-// `trace.frames_ptr[source_lines_frame_index]` only.
+// OnlySourceLines runs after Rust picked `trace.frames_ptr[source_lines_frame_index]` (remap_zig_exception).
 static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& frames, ZigStackTrace& trace, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety = FinalizerSafety::NotInFinalizer, uint8_t source_lines_frame_index = 0)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -88,6 +88,9 @@ static void populateStackFrameMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalO
     frame.source_url = Bun::toStringRef(sourceURL);
     auto m_codeBlock = stackFrame.codeBlock();
     if (m_codeBlock) {
+        // Bun's bundled modules are builtin executables too (createBuiltinExecutable), and
+        // functions nested in a builtin inherit the flag.
+        frame.is_builtin = m_codeBlock->unlinkedCodeBlock()->isBuiltinFunction();
         switch (m_codeBlock->codeType()) {
         case JSC::EvalCode: {
             frame.code_type = ZigStackFrameCodeEval;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -249,6 +249,7 @@ typedef struct ZigStackFrame {
     {
     }
 } ZigStackFrame;
+static_assert(sizeof(ZigStackFrame) == 72 && alignof(ZigStackFrame) == 8, "ZigStackFrame layout is mirrored in src/jsc/ZigStackFrame.rs");
 
 typedef struct ZigStackTrace {
     BunString* source_lines_ptr;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -232,8 +232,7 @@ typedef struct ZigStackFrame {
     ZigStackFrameCode code_type;
     bool is_async;
     bool remapped;
-    /// The frame runs code JSC compiled as a builtin: JSC's own JS builtins and bun's bundled
-    /// `src/js` modules. Only known for frames taken from a JSC stack trace.
+    /// A JSC builtin or one of bun's bundled modules; false for frames parsed out of `error.stack`.
     bool is_builtin;
     int32_t jsc_stack_frame_index;
 

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -232,6 +232,9 @@ typedef struct ZigStackFrame {
     ZigStackFrameCode code_type;
     bool is_async;
     bool remapped;
+    /// The frame runs code JSC compiled as a builtin: JSC's own JS builtins and bun's bundled
+    /// `src/js` modules. Only known for frames taken from a JSC stack trace.
+    bool is_builtin;
     int32_t jsc_stack_frame_index;
 
     ZigStackFrame()
@@ -241,6 +244,7 @@ typedef struct ZigStackFrame {
         , code_type {}
         , is_async(false)
         , remapped(false)
+        , is_builtin(false)
         , jsc_stack_frame_index(-1)
     {
     }

--- a/src/runtime/bake/dev_server/error_report_request.rs
+++ b/src/runtime/bake/dev_server/error_report_request.rs
@@ -152,6 +152,7 @@ impl ErrorReportRequest {
                 code_type: ZigStackFrameCode::NONE,
                 is_async: false,
                 remapped: false,
+                is_builtin: false,
                 jsc_stack_frame_index: -1,
             });
         }

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -785,57 +785,66 @@ describe("bun test", () => {
     // (`reduce`), the `native` / `unknown` placeholders such frames turn into
     // once error.stack has been read, or one of bun's own `node:*` modules.
     // The annotation has to point at the first frame below it that is in the
-    // test file. The test callbacks are async so the error reaches the
-    // reporter with its own stack; a synchronous throw is reported with the
-    // frames of the throw site instead, which would not have these on top.
+    // test file, while its body still lists every frame.
     test.each([
       {
         label: "a JS builtin",
         body: `[].reduce((a, b) => a);`,
         callee: "reduce",
+        topFrame: "at reduce (",
         title: "TypeError: reduce of empty array with no initial value",
       },
       {
         label: "a JS builtin after error.stack was read",
         body: `try { [].reduce((a, b) => a); } catch (e) { void e.stack; throw e; }`,
         callee: "reduce",
+        topFrame: "at reduce (",
         title: "TypeError: reduce of empty array with no initial value",
       },
       {
         label: "a node: module",
         body: `new EventEmitter().emit("error");`,
         callee: "emit",
+        topFrame: "at emitError (node:events:",
         title: "error: Unhandled error. (undefined)",
       },
       {
         label: "a node: module after error.stack was read",
         body: `try { new EventEmitter().emit("error"); } catch (e) { void e.stack; throw e; }`,
         callee: "emit",
+        topFrame: "at emitError (node:events:",
         title: "error: Unhandled error. (undefined)",
       },
-    ])("should annotate the first frame in the test file when the top frame is $label", ({ body, callee, title }) => {
-      const lines = [
-        `import { test } from "bun:test";`,
-        `import { EventEmitter } from "node:events";`,
-        `test("fail", async () => {`,
-        `  ${body}`,
-        `});`,
-      ];
-      const line = lines.findIndex(l => l.includes(body)) + 1;
-      const col = lines[line - 1].indexOf(callee) + 1;
-      const stderr = runTest({
-        input: [{ filename: "top-frame-has-no-file.test.ts", contents: lines.join("\n") }],
-        env: {
-          GITHUB_ACTIONS: "true",
-        },
-        expectExitCode: 1,
-      });
-      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
-      expect(annotation).toStartWith("::error file=");
-      expect(annotation!.replace(/^::error file=(?:[^,]*[\\/])?/, "")).toStartWith(
-        `top-frame-has-no-file.test.ts,line=${line},col=${col},title=${title}::`,
-      );
-    });
+    ])(
+      "should annotate the first frame in the test file when the top frame is $label",
+      ({ body, callee, topFrame, title }) => {
+        const lines = [
+          `import { test } from "bun:test";`,
+          `import { EventEmitter } from "node:events";`,
+          `test("fail", async () => {`,
+          `  ${body}`,
+          `});`,
+        ];
+        const line = lines.findIndex(l => l.includes(body)) + 1;
+        const col = lines[line - 1].indexOf(callee) + 1;
+        const stderr = runTest({
+          input: [{ filename: "top-frame-has-no-file.test.ts", contents: lines.join("\n") }],
+          env: {
+            GITHUB_ACTIONS: "true",
+          },
+          expectExitCode: 1,
+        });
+        const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+        expect(annotation).toStartWith("::error file=");
+        expect(annotation!.replace(/^::error file=(?:[^,]*[\\/])?/, "")).toStartWith(
+          `top-frame-has-no-file.test.ts,line=${line},col=${col},title=${title}::`,
+        );
+        // The builtin's frame is listed in the body, above the test file's frame.
+        const builtinFrame = annotation!.indexOf(`%0A      ${topFrame}`);
+        expect(builtinFrame).toBeGreaterThan(0);
+        expect(annotation!.indexOf("top-frame-has-no-file.test.ts:", builtinFrame)).toBeGreaterThan(builtinFrame);
+      },
+    );
     test("should annotate without a location when no frame has a file", () => {
       const stderr = runTest({
         input: `

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -781,6 +781,80 @@ describe("bun test", () => {
       expect(sourceUrl).toStartWith("::error file=webpack%3A//app/./src/x.ts,line=1,col=");
       expect(sourceUrl).toContain("%0A      at fromSourceUrl (webpack://app/./src/x.ts:1:");
     });
+    // The frame on top of these stacks has no file to annotate: a JS builtin
+    // (`reduce`), the `native` / `unknown` placeholders such frames turn into
+    // once error.stack has been read, or one of bun's own `node:*` modules.
+    // The annotation has to point at the first frame below it that is in the
+    // test file. The test callbacks are async so the error reaches the
+    // reporter with its own stack; a synchronous throw is reported with the
+    // frames of the throw site instead, which would not have these on top.
+    test.each([
+      {
+        label: "a JS builtin",
+        body: `[].reduce((a, b) => a);`,
+        callee: "reduce",
+        title: "TypeError: reduce of empty array with no initial value",
+      },
+      {
+        label: "a JS builtin after error.stack was read",
+        body: `try { [].reduce((a, b) => a); } catch (e) { void e.stack; throw e; }`,
+        callee: "reduce",
+        title: "TypeError: reduce of empty array with no initial value",
+      },
+      {
+        label: "a node: module",
+        body: `new EventEmitter().emit("error");`,
+        callee: "emit",
+        title: "error: Unhandled error. (undefined)",
+      },
+      {
+        label: "a node: module after error.stack was read",
+        body: `try { new EventEmitter().emit("error"); } catch (e) { void e.stack; throw e; }`,
+        callee: "emit",
+        title: "error: Unhandled error. (undefined)",
+      },
+    ])("should annotate the first frame in the test file when the top frame is $label", ({ body, callee, title }) => {
+      const lines = [
+        `import { test } from "bun:test";`,
+        `import { EventEmitter } from "node:events";`,
+        `test("fail", async () => {`,
+        `  ${body}`,
+        `});`,
+      ];
+      const line = lines.findIndex(l => l.includes(body)) + 1;
+      const col = lines[line - 1].indexOf(callee) + 1;
+      const stderr = runTest({
+        input: [{ filename: "top-frame-has-no-file.test.ts", contents: lines.join("\n") }],
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+        expectExitCode: 1,
+      });
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toStartWith("::error file=");
+      expect(annotation!.replace(/^::error file=(?:[^,]*[\\/])?/, "")).toStartWith(
+        `top-frame-has-no-file.test.ts,line=${line},col=${col},title=${title}::`,
+      );
+    });
+    test("should annotate without a location when no frame has a file", () => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          test("fail", async () => {
+            const err = new Error("boom");
+            err.stack = "Error: boom\\n    at reduce (native:1:11)";
+            throw err;
+          });
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
+        },
+        expectExitCode: 1,
+      });
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toStartWith("::error title=error: boom::");
+      expect(annotation).toContain("at reduce (");
+    });
   });
   describe(".each", () => {
     test("should run tests with test.each", () => {

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -197,6 +197,8 @@ test.each([
   const lines = Bun.inspect(err).split("\n");
   const header = lines.indexOf("TypeError: reduce of empty array with no initial value");
   expect(header).toBeGreaterThanOrEqual(2);
+  // The builtin's frame is the first one listed, above this file's.
+  expect(lines[header + 1].trim()).toStartWith("at reduce (");
   const [sourceLine, caretLine] = lines.slice(header - 2, header);
   expect(sourceLine).toEndWith("emptyArray.reduce((a, b) => a);");
   expect(caretLine.trim()).toBe("^");

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -175,3 +175,30 @@ test("Async functions frame should be included in stack trace", async () => {
         at async <anonymous> (file:NN:NN)"
   `);
 });
+
+// `reduce` throws from inside JSC's builtin, so the first frame has a
+// line:column inside the builtin's source and no file. The code frame shows
+// this file, so its caret has to be placed by this file's frame as well. Once
+// error.stack has been read, the frames are parsed back out of that string
+// and the builtin frame turns into the `native` placeholder.
+test.each([
+  ["fresh error", false],
+  ["error whose .stack has been read", true],
+])("code frame caret is placed by the first frame with a file, not a builtin frame on top: %s", (_, readStack) => {
+  let err: unknown;
+  try {
+    const emptyArray: number[] = [];
+    emptyArray.reduce((a, b) => a);
+  } catch (e) {
+    err = e;
+  }
+  if (readStack) void (err as Error).stack;
+
+  const lines = Bun.inspect(err).split("\n");
+  const header = lines.indexOf("TypeError: reduce of empty array with no initial value");
+  expect(header).toBeGreaterThanOrEqual(2);
+  const [sourceLine, caretLine] = lines.slice(header - 2, header);
+  expect(sourceLine).toEndWith("emptyArray.reduce((a, b) => a);");
+  expect(caretLine.trim()).toBe("^");
+  expect(caretLine.indexOf("^")).toBe(sourceLine.indexOf("reduce"));
+});

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -457,13 +457,40 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
   });
 });
 
-describe.concurrent("an error a bun builtin created with no user frame below it", () => {
+describe.concurrent("code frame of an error thrown inside a bun builtin module", () => {
+  // Frames in bun's bundled modules (`node:*`, `bun:*`, `internal:*`) have no
+  // file to excerpt: the code frame comes from the first user frame below them,
+  // and when there is none, no code frame is printed at all.
+  const codeFrameLines = text => text.split("\n").filter(line => /^\s*(?:\d+|-) \|/.test(line));
+
+  test("points at the caller when an internal: module throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Readable } = require("node:stream");
+         try {
+           Readable.from(42);
+         } catch (e) {
+           console.log(Bun.inspect(e));
+         }`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The throwing frame is in `internal:streams/from`; the excerpt is the caller's line.
+    expect(stdout).toContain("internal:streams/from");
+    expect(codeFrameLines(stdout).at(-1)).toContain("Readable.from(42)");
+    expect(stdout).toContain("ERR_INVALID_ARG_TYPE");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   // `node:worker_threads` builds the value it gives `worker.on("error")` inside
   // the builtin, from a native event dispatch, so every frame of that error is
-  // in `node:worker_threads`. The printer hides such frames from the code
-  // frame, so there is no source to excerpt and none may be printed.
-  const codeFrameLines = text => text.split("\n").filter(line => /^\s*\d+ \|/.test(line));
-
+  // in `node:worker_threads`.
   test("prints no code frame when the worker entry point does not resolve", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -530,4 +530,25 @@ describe.concurrent("code frame of an error thrown inside a bun builtin module",
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
+
+  // The other side of the line: code `eval` compiles when a timer calls it
+  // directly has no source URL and no user frame below it, but it is user code,
+  // so its excerpt (read from JSC, there is no file) stays.
+  test("still excerpts user code that has no source URL and no caller", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("uncaughtException", e => console.log(Bun.inspect(e)));
+         setTimeout(eval, 0, "\\nthrow new Error('from eval, called by a timer')");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(codeFrameLines(stdout).at(-1)).toContain("throw new Error('from eval, called by a timer')");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -456,3 +456,51 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe.concurrent("an error a bun builtin created with no user frame below it", () => {
+  // `node:worker_threads` builds the value it gives `worker.on("error")` inside
+  // the builtin, from a native event dispatch, so every frame of that error is
+  // in `node:worker_threads`. The printer hides such frames from the code
+  // frame, so there is no source to excerpt and none may be printed.
+  const codeFrameLines = text => text.split("\n").filter(line => /^\s*\d+ \|/.test(line));
+
+  test("prints no code frame when the worker entry point does not resolve", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker("/does-not-resolve-xyz.mjs");
+         w.on("error", e => console.log(Bun.inspect(e)));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(codeFrameLines(stdout)).toEqual([]);
+    expect(stdout).toContain("Cannot find module '/does-not-resolve-xyz.mjs'");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("prints no code frame when the worker throws a value that cannot be cloned", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker("throw Symbol('uncloneable')", { eval: true });
+         w.on("error", e => console.log(Bun.inspect(e)));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(codeFrameLines(stdout)).toEqual([]);
+    expect(stdout).toContain("Symbol(uncloneable)");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -458,10 +458,39 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
 });
 
 describe.concurrent("code frame of an error thrown inside a bun builtin module", () => {
-  // Frames in bun's bundled modules (`node:*`, `bun:*`, `internal:*`) have no
+  // Frames in bun's bundled modules (`node:*`, `bun:*`, `internal:*`, and the
+  // `src/js/thirdparty` ones that run under a bare name such as `ws`) have no
   // file to excerpt: the code frame comes from the first user frame below them,
   // and when there is none, no code frame is printed at all.
   const codeFrameLines = text => text.split("\n").filter(line => /^\s*(?:\d+|-) \|/.test(line));
+
+  test("points at the caller when a bundled module with a bare name throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { WebSocketServer } = require("ws");
+         try {
+           new WebSocketServer({});
+         } catch (e) {
+           console.log(Bun.inspect(e));
+         }`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The throwing frame is in bun's `ws` module; the excerpt and the caret are the caller's.
+    expect(stdout).toContain("at new WebSocketServer (ws:");
+    const frame = codeFrameLines(stdout);
+    expect(frame.at(-1)).toContain("new WebSocketServer({});");
+    const caret = stdout.split("\n")[stdout.split("\n").indexOf(frame.at(-1)) + 1];
+    expect(caret.trim()).toBe("^");
+    expect(caret.indexOf("^")).toBe(frame.at(-1).indexOf("new WebSocketServer"));
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 
   test("points at the caller when an internal: module throws", async () => {
     await using proc = Bun.spawn({

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
+import { EventEmitter } from "node:events";
 import {
   compileFunction,
   constants,
@@ -491,6 +492,118 @@ describe("Script", () => {
     } finally {
       Error.prepareStackTrace = prev;
     }
+  });
+});
+
+// The code frame bun prints above an error is the line of the first frame that
+// is in one of the user's sources. A vm script (like eval and new Function) has
+// no source map, so that line is cut out of the source JSC compiled. When the
+// error is thrown inside a JS builtin or one of bun's own modules, the user's
+// frame is not frame 0; the excerpt used to be cut out of frame 0's source
+// regardless, i.e. it showed the builtin's own text and line number.
+describe("code frame of an error thrown inside a builtin called from a source without a source map", () => {
+  type Expected = {
+    // Names the user's source in the stack; the excerpt has to be its line.
+    filename: string;
+    // The `name: message` line printed under the code frame.
+    header: string;
+    // The text of the line that calls into the builtin.
+    excerpt: string;
+  };
+
+  function expectCodeFrame(printed: string, { filename, header, excerpt }: Expected) {
+    const lines = printed.split("\n");
+    const headerIndex = lines.indexOf(header);
+    expect(headerIndex).toBeGreaterThanOrEqual(2);
+    const userFrame = printed.match(new RegExp(`${RegExp.escape(filename)}:(\\d+):\\d+`));
+    expect(userFrame).not.toBeNull();
+    // Directly above the header are the excerpt and the caret. The excerpt is
+    // labelled with the line the user's frame reports (line 2 of the source
+    // below; for new Function, 2 plus its `function anonymous(\n) {` wrapper).
+    expect(lines.slice(headerIndex - 2, headerIndex)).toEqual([
+      `${userFrame![1]} | ${excerpt}`,
+      expect.stringMatching(/^ +\^$/),
+    ]);
+  }
+
+  // The builtin is called from line 2 so that the excerpt's line number has to
+  // come from the user's frame as well as its text.
+  const source = '"line 1";\n[].reduce((a, b) => a);';
+  const reduce = {
+    excerpt: "[].reduce((a, b) => a);",
+    header: "TypeError: reduce of empty array with no initial value",
+  };
+  // displayErrors: false keeps node:vm from rewriting err.stack; the code frame
+  // under test is the one bun's error printer builds from the error's frames.
+  const displayErrors = false;
+
+  const cases: (Expected & { name: string; run(filename: string): unknown })[] = [
+    {
+      name: "vm.Script",
+      filename: "/virtual/script.js",
+      ...reduce,
+      run: filename => new Script(source, { filename }).runInThisContext({ displayErrors }),
+    },
+    {
+      name: "runInNewContext",
+      filename: "/virtual/new-context.js",
+      ...reduce,
+      run: filename => runInNewContext(source, {}, { filename, displayErrors }),
+    },
+    {
+      name: "eval",
+      filename: "/virtual/eval.js",
+      ...reduce,
+      run: filename => (0, eval)(`${source}\n//# sourceURL=${filename}`),
+    },
+    {
+      name: "new Function",
+      filename: "/virtual/function.js",
+      ...reduce,
+      run: filename => new Function(`${source}\n//# sourceURL=${filename}`)(),
+    },
+    {
+      // emit() with no "error" listener throws from inside bun's node:events,
+      // so the frame on top is a node:events frame rather than a JS builtin's.
+      name: "node: module on top of the stack",
+      filename: "/virtual/events.js",
+      header: "error: Unhandled error. (undefined)",
+      excerpt: 'emitter.emit("error");',
+      run: filename =>
+        runInNewContext(
+          '"line 1";\nemitter.emit("error");',
+          { emitter: new EventEmitter() },
+          { filename, displayErrors },
+        ),
+    },
+  ];
+
+  test.each(cases)("Bun.inspect: $name", testCase => {
+    let thrown: unknown;
+    try {
+      testCase.run(testCase.filename);
+    } catch (e) {
+      thrown = e;
+    }
+    expectCodeFrame(Bun.inspect(thrown), testCase);
+  });
+
+  test("uncaught error", async () => {
+    const filename = "/virtual/uncaught.js";
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("node:vm").runInThisContext(${JSON.stringify(source)}, ${JSON.stringify({ filename, displayErrors })})`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expectCodeFrame(stderr, { filename, ...reduce });
+    expect(exitCode).toBe(1);
   });
 });
 

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -509,12 +509,16 @@ describe("code frame of an error thrown inside a builtin called from a source wi
     header: string;
     // The text of the line that calls into the builtin.
     excerpt: string;
+    // How the first `at ...` line starts: the builtin's frame is on top.
+    topFrame: string;
   };
 
-  function expectCodeFrame(printed: string, { filename, header, excerpt }: Expected) {
+  function expectCodeFrame(printed: string, { filename, header, excerpt, topFrame }: Expected) {
     const lines = printed.split("\n");
     const headerIndex = lines.indexOf(header);
     expect(headerIndex).toBeGreaterThanOrEqual(2);
+    const firstFrame = lines.slice(headerIndex + 1).find(line => line.trim().startsWith("at "));
+    expect(firstFrame?.trim()).toStartWith(topFrame);
     const userFrame = printed.match(new RegExp(`${RegExp.escape(filename)}:(\\d+):\\d+`));
     expect(userFrame).not.toBeNull();
     // Directly above the header are the excerpt and the caret. The excerpt is
@@ -532,6 +536,7 @@ describe("code frame of an error thrown inside a builtin called from a source wi
   const reduce = {
     excerpt: "[].reduce((a, b) => a);",
     header: "TypeError: reduce of empty array with no initial value",
+    topFrame: "at reduce (",
   };
   // displayErrors: false keeps node:vm from rewriting err.stack; the code frame
   // under test is the one bun's error printer builds from the error's frames.
@@ -569,6 +574,7 @@ describe("code frame of an error thrown inside a builtin called from a source wi
       filename: "/virtual/events.js",
       header: "error: Unhandled error. (undefined)",
       excerpt: 'emitter.emit("error");',
+      topFrame: "at emitError (node:events:",
       run: filename =>
         runInNewContext(
           '"line 1";\nemitter.emit("error");',


### PR DESCRIPTION
### Problem
- An error thrown inside a JS builtin or one of bun's bundled modules is attributed to that frame. `Readable.from(42)` prints `19 | throw @makeErrorWithCode(112, ...)` from `internal:streams/from` as the code frame. `new (require("ws").WebSocketServer)({})` prints bundled `ws` source. `[].reduce((a, b) => a)` inside `eval` prints the `Array.prototype.reduce` source. Under `GITHUB_ACTIONS=true`, `[].reduce(...)` in `x.js` prints `::error file=,line=1,col=11`, with the caret at the builtin's column.
- Cause: each consumer in `src/jsc/VirtualMachine.rs` kept its own URL list for "not the user's frame". `remap_zig_exception` missed `internal:` and bare-named modules. The caret loop skipped only `bun:` and `node:`. `print_github_annotation` took `frames[0]`. `collect_source_lines` (`ZigException.cpp`) excerpted frame 0 whatever frame was picked.

### Fix
- `ZigStackFrame` gets an `is_builtin` flag, set from JSC's `isBuiltinFunction()` on the frame's code block. One predicate, `has_user_source()` (not builtin, no `bun:` / `node:` / `internal:` URL, no empty, `native`, `unknown` or `[source:...]` placeholder), serves all three consumers.
- `ZigException__collectSourceLines` takes the index of the picked frame and excerpts it. When that frame is builtin code (no user frame exists), nothing is excerpted.
- Self-reviewed: 7 concerns raised, 7 addressed. The main one (bare-named modules such as `ws` slipped past a URL-prefix list) led to the `is_builtin` flag.
- Verified: new cases in `inspect-error.test.js`, `vm.test.ts`, `bun-test.test.ts`, `stack.test.ts` fail on 1.4.3 (17 of 18, one is a guard) and pass here.

### Background
- Code frame: the source lines, caret and `name: message` above the `at ...` list. `remap_zig_exception` picks its frame and re-reads the file when bun transpiled it. Otherwise `collect_source_lines` cuts lines out of the frame's `JSC::SourceProvider`.
- Bun's `src/js` modules are builtin executables to JSC, nested functions included. Their URL is `node:*`, `bun:*`, `internal:*`, or a bare name (`ws`).
- Frames parsed back out of `error.stack` have no code block and spell builtins as `native` / `unknown`.

<details><summary>Notes</summary>

- This PR consolidates three PRs that changed the same frame-selection logic: #38335 (the shared predicate for the annotation and the caret, with the `bun-test.test.ts` and `stack.test.ts` tests), #38356 (excerpt the picked frame instead of frame 0, the `ZigException.cpp` change and the `vm.test.ts` tests), and the first revision of this PR (the `internal:` prefix and the all-builtin fallback, `inspect-error.test.js`). #38335 and #38356 are closed in favor of this one.
- #38324 (worker error locations across structured clone) independently carries two of these pieces: a shared `preview_frame()` predicate for the excerpt and the caret, and a frame index into a rewritten `collectSourceLines`. It does not cover `internal:` / bare-named modules or the annotation. The two PRs conflict textually in `VirtualMachine.rs`, `ZigException.{rs,cpp}` and `headers-handwritten.h`; on top of #38324 this PR reduces to the predicate (with `is_builtin`), the annotation pick and the excerpt gate. Whichever lands second, I will do that rebase.
- Other symptoms of the same cause, all fixed here: `::error file=native,...` and `file=unknown,line=1,col=1` once `error.stack` was read, `file=node%3Aevents,line=59,col=31` for `emitter.emit("error")` with no listener, and six numbered lines of `node:worker_threads` `#onError` above `error: Cannot find module` for `new Worker("/nope.mjs").on("error", ...)`. With no user frame at all the annotation is `::error title=...` without a location. URL-less user code (`eval` called directly by a timer) keeps its excerpt: it is not builtin code.
- A `node:vm` script with the default `displayErrors: true` is unchanged: node:vm materializes `err.stack` first, so the printer works from parsed frames and prints no code frame before or after.
- Difference from the earlier revision here: a user frame below a bun-module frame in a source without a source map (a vm script that calls `emitter.emit("error")`) now shows the user's line. Before, the excerpt was skipped whenever frame 0 was a bun module. The excerpt now follows `top`, and is skipped only when `top` itself is builtin code.
- `is_builtin` takes the padding byte before `jsc_stack_frame_index` on both sides of the FFI struct, so its size and the offsets of the other fields are unchanged.
- The old `OnlySourceLines` loop also re-ran `populateStackFramePosition` on every other frame with null buffers. That only rewrote positions with the values the `OnlyPosition` pass had stored, and nothing read them, so the loop is gone with the `is_top` parameter. The source provider ref taken for the excerpt is still one per call, released in `ZigException::deinit`.
- `BUN_SHOW_BUN_STACKFRAMES=1` (`hide_bun_stackframes = false`) keeps the old frame choice for the code frame and the caret. The annotation is not gated on it: an empty `file=` is wrong either way. GitHub attaches an `::error file=F,...` annotation to `F` only when `F` is a file in the checkout.
- Also green on the debug build: `inspect.test.js`, `reportError.test.ts`, `capture-stack-trace.test.js`, `worker_threads.test.ts`, `vm-sourceUrl.test.ts`, `test/js/bun/sourcemap/`, `23022-stack-trace-iterator.test.ts`, `test-test.test.ts`, `test/cli/inspect/inspect.test.ts`, all of `bun-test.test.ts`.
- Related and left separate: #38349 derives the caret column from the excerpt text (needed for `node:vm` `columnOffset`); after both land, the printer's frame loop only decides whether a caret is drawn. #41876 (one annotation per failed test) also changes the `print_github_annotation` frame pick, to skip `node_modules`; the two compose and whichever lands second has a few-line rebase in that block. #38328 and #38308 change how an `error.stack` string is parsed back into frames.
- Known and unchanged in spirit: a stack of only a JSC builtin frame over URL-less `eval` code (for example `setTimeout(eval, 0, "[].reduce((a, b) => a)")`) now prints no excerpt where main printed the builtin's text; neither is the eval'd line. After `error.stack` was read, a bare-named module frame (`ws`) has no code block and no URL prefix to go by, so it is treated as user code, as on main.
- `ZigStackFrame` now has a `static_assert` / `assert_ffi_layout!` pair (72 bytes, align 8) like `ResolvedSource` and `ErrorableString`.
- Before / after on the probes (release 1.4.3 vs this branch):

```
$ printf '[].reduce((a, b) => a);\n' > reduce.js && GITHUB_ACTIONS=true bun reduce.js
before: ::error file=,line=1,col=11,title=TypeError: reduce of empty array with no initial value::...
after:  ::error file=reduce.js,line=1,col=4,title=TypeError: reduce of empty array with no initial value::...

$ bun -e 'new (require("node:vm").Script)("\"line 1\";\n[].reduce((a, b) => a)", { filename: "/virtual/r.js" }).runInThisContext({ displayErrors: false })'
before: 1 | (function (callback )
after:  2 | [].reduce((a, b) => a)

$ bun -e 'require("node:stream").Readable.from(42)'
before: 19 |     throw @makeErrorWithCode(112, "iterable", ["Iterable"], iterable);
after:  1 | require("node:stream").Readable.from(42)

$ bun -e 'new (require("ws").WebSocketServer)({})'
before: 933 |     if (port == null && !server && !noServer || ...   (bundled ws source)
after:  1 | new (require("ws").WebSocketServer)({})

$ bun -e 'new (require("node:worker_threads").Worker)("/nope.mjs").on("error", e => console.log(Bun.inspect(e)))'
before: six numbered lines of node:worker_threads #onError above the error
after:  error: Cannot find module '/nope.mjs' ... at #onError (node:worker_threads:...)
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts, test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->