### PR TITLE
pm pkg set --json: parse values as strict JSON and error like npm

### DIFF
--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -16,10 +16,8 @@ use crate::json_stage2::Parser;
 pub struct JSONOptions {
     pub allow_comments: bool,
     pub allow_trailing_commas: bool,
-    /// Reject the JavaScript lexical forms that `JSON.parse` rejects: single-quoted strings,
-    /// `0x10` / `010` / `1_000` / `.5` / `5.` / `- 5` numbers, `\x41` / `\v` escapes,
-    /// `\u`-escaped keywords, and whitespace other than space, tab, `\n` and `\r`.
-    /// Comments and trailing commas keep their own flags.
+    /// `JSON.parse` token grammar: no single quotes, JS-only number forms (`0x10`, `010`, `1_000`,
+    /// `.5`, `5.`, `- 5`) or escapes, escaped keywords, or Unicode whitespace. Comments keep their flag.
     pub strict: bool,
     pub ignore_leading_escape_sequences: bool,
     pub json_warn_duplicate_keys: bool,
@@ -336,9 +334,8 @@ pub fn parse_utf8_impl<const CHECK_LEN: bool>(
     Ok(parse_classic(source, log, bump, JSON_OPTS, CHECK_LEN)?.root)
 }
 
-/// Parse exactly what `JSON.parse` accepts into the classic `E::Object` / `E::Array` AST.
-/// Unlike [`parse_utf8`], this rejects single-quoted strings, JavaScript number forms,
-/// content after the root value, and an empty document.
+/// Exactly what `JSON.parse` accepts ([`JSONOptions::strict`], nothing after the root value, not
+/// empty) into the classic `E::Object` / `E::Array` AST.
 pub fn parse_strict(
     source: &bun_ast::Source,
     log: &mut bun_ast::Log,

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -16,6 +16,11 @@ use crate::json_stage2::Parser;
 pub struct JSONOptions {
     pub allow_comments: bool,
     pub allow_trailing_commas: bool,
+    /// Reject the JavaScript lexical forms that `JSON.parse` rejects: single-quoted strings,
+    /// `0x10` / `010` / `1_000` / `.5` / `5.` / `- 5` numbers, `\x41` / `\v` escapes,
+    /// `\u`-escaped keywords, and whitespace other than space, tab, `\n` and `\r`.
+    /// Comments and trailing commas keep their own flags.
+    pub strict: bool,
     pub ignore_leading_escape_sequences: bool,
     pub json_warn_duplicate_keys: bool,
     pub was_originally_macro: bool,
@@ -27,6 +32,7 @@ impl JSONOptions {
     pub const DEFAULT: JSONOptions = JSONOptions {
         allow_comments: false,
         allow_trailing_commas: false,
+        strict: false,
         ignore_leading_escape_sequences: false,
         json_warn_duplicate_keys: true,
         was_originally_macro: false,
@@ -36,6 +42,11 @@ impl JSONOptions {
 }
 
 const JSON_OPTS: JSONOptions = JSONOptions::DEFAULT;
+
+const STRICT_JSON_OPTS: JSONOptions = JSONOptions {
+    strict: true,
+    ..JSONOptions::DEFAULT
+};
 
 const DOTENV_JSON_OPTS: JSONOptions = JSONOptions {
     allow_trailing_commas: true,
@@ -325,6 +336,17 @@ pub fn parse_utf8_impl<const CHECK_LEN: bool>(
     Ok(parse_classic(source, log, bump, JSON_OPTS, CHECK_LEN)?.root)
 }
 
+/// Parse exactly what `JSON.parse` accepts into the classic `E::Object` / `E::Array` AST.
+/// Unlike [`parse_utf8`], this rejects single-quoted strings, JavaScript number forms,
+/// content after the root value, and an empty document.
+pub fn parse_strict(
+    source: &bun_ast::Source,
+    log: &mut bun_ast::Log,
+    bump: &Bump,
+) -> crate::Result<Expr> {
+    Ok(parse_classic(source, log, bump, STRICT_JSON_OPTS, true)?.root)
+}
+
 fn parse_classic(
     source: &bun_ast::Source,
     log: &mut bun_ast::Log,
@@ -356,7 +378,7 @@ fn parse_classic(
 }
 
 impl ParsedJson {
-    /// Strict JSON.
+    /// Plain JSON: no comments or trailing commas.
     pub fn parse_json(
         source: &bun_ast::Source,
         log: &mut bun_ast::Log,
@@ -1061,6 +1083,8 @@ mod tests {
         errors: usize,
         warnings: usize,
         first_msg: String,
+        /// `(offset, length)` of the first message.
+        first_loc: Option<(usize, usize)>,
         _bump: Box<Bump>,
         _tape: Option<Box<E::JsonTape>>,
         _scope: js_ast::StoreResetGuard,
@@ -1075,6 +1099,7 @@ mod tests {
         let mut tape = None;
         let r = match which {
             Which::Utf8 => parse_utf8(&source, &mut log, &bump),
+            Which::Strict => parse_strict(&source, &mut log, &bump),
             Which::TsConfig => parse_ts_config(&source, &mut log, &bump),
             Which::Env => parse_env_json(&source, &mut log, &bump),
             Which::PackageJson => parse_package_json_utf8(&source, &mut log, &bump),
@@ -1094,11 +1119,17 @@ mod tests {
             .first()
             .map(|m| String::from_utf8_lossy(&m.data.text).into_owned())
             .unwrap_or_default();
+        let first_loc = log
+            .msgs
+            .first()
+            .and_then(|m| m.data.location.as_ref())
+            .map(|l| (l.offset, l.length));
         Parsed {
             root: r.ok(),
             errors: log.errors as usize,
             warnings: log.warnings as usize,
             first_msg,
+            first_loc,
             _bump: bump,
             _tape: tape,
             _scope: scope,
@@ -1108,6 +1139,7 @@ mod tests {
     #[derive(Clone, Copy)]
     enum Which {
         Utf8,
+        Strict,
         TsConfig,
         Env,
         PackageJson,
@@ -1408,6 +1440,102 @@ mod tests {
                 panic!("{src}")
             };
             assert_eq!(n.value(), want, "{src}");
+        }
+    }
+
+    #[test]
+    fn strict_mode_matches_json_parse() {
+        for (src, msg) in [
+            ("'a'", "JSON strings must use double quotes"),
+            ("{'a': 1}", "JSON strings must use double quotes"),
+            ("{\"a\": ['b']}", "JSON strings must use double quotes"),
+            ("0x10", "JSON does not support hexadecimal numbers"),
+            ("[0X1f]", "JSON does not support hexadecimal numbers"),
+            ("0b11", "JSON does not support binary numbers"),
+            ("0o17", "JSON does not support octal numbers"),
+            ("010", "JSON does not support numbers with leading zeros"),
+            ("08", "JSON does not support numbers with leading zeros"),
+            ("00", "JSON does not support numbers with leading zeros"),
+            ("[-01]", "JSON does not support numbers with leading zeros"),
+            ("0_1", "JSON does not support numeric separators"),
+            ("1_000", "JSON does not support numeric separators"),
+            ("1.0_1", "JSON does not support numeric separators"),
+            ("1e1_0", "JSON does not support numeric separators"),
+            (".5", "JSON numbers must have a digit before \".\""),
+            ("-.5", "JSON numbers must have a digit before \".\""),
+            ("5.", "JSON numbers must have a digit after \".\""),
+            ("[5.e1]", "JSON numbers must have a digit after \".\""),
+            ("- 5", "JSON numbers must have a digit after \"-\""),
+            ("[-\t5]", "JSON numbers must have a digit after \"-\""),
+            ("-Infinity", "Expected number"),
+            ("+1", "Operators are not allowed in JSON"),
+            ("1/0", "Operators are not allowed in JSON"),
+            ("\"\\v\"", "Syntax Error"),
+            ("\"\\x41\"", "Syntax Error"),
+            ("[\"\\8\"]", "Syntax Error"),
+            ("\"\\'\"", "Syntax Error"),
+            ("\"a\tb\"", "Syntax Error"),
+            ("[\\u0074rue]", "Unexpected \\u0074rue"),
+            ("\u{feff}1", "Unexpected \u{feff}1"),
+            ("[1,\u{a0}2]", "Unexpected \u{a0}2"),
+            ("{\x0b\"a\": 1}", "Expected string"),
+            ("{\"a\":1}\u{2028}", "Unexpected \u{2028}"),
+            ("undefined", "Unexpected undefined"),
+            ("NaN", "Unexpected NaN"),
+            ("1 2", "Unexpected 2"),
+            ("{} {}", "Unexpected {"),
+            ("\"a\" \"b\"", "Unexpected \"b\""),
+            ("", "Unexpected end of file"),
+            (" ", "Unexpected end of file"),
+            ("[1,]", "JSON does not support trailing commas"),
+            ("{\"a\":1,}", "JSON does not support trailing commas"),
+            ("[1] // c", "JSON does not support comments"),
+            ("/* c */ 1", "JSON does not support comments"),
+        ] {
+            let p = run(src.as_bytes(), Which::Strict);
+            assert!(p.root.is_none(), "{src:?}: expected an error");
+            assert!(p.errors > 0, "{src:?}: expected an error in the log");
+            assert!(
+                p.first_msg.contains(msg),
+                "{src:?}: expected {msg:?}, got {:?}",
+                p.first_msg
+            );
+        }
+        for (src, loc) in [
+            ("{\"a\": 0x10}", (6, 4)),
+            ("[1_0 , 2]", (1, 3)),
+            ("{\"a\": 'bc'}", (6, 4)),
+            ("[- 1]", (1, 1)),
+        ] {
+            let p = run(src.as_bytes(), Which::Strict);
+            assert_eq!(p.first_loc, Some(loc), "{src:?}");
+        }
+
+        for (src, want) in [
+            ("0", "0"),
+            ("-0", "-0"),
+            ("105", "105"),
+            ("-10.25e-1", "-1.025"),
+            ("[0.5,1E+2,1e400]", "[0.5,100,inf]"),
+            ("true", "true"),
+            ("null", "null"),
+            ("\"\"", "\"\""),
+            (
+                "\"\\u00e9\\n\\\"\\\\\\/\\b\\f\\r\\t \u{e9}\u{2028}\"",
+                "\"é\\n\\\"\\\\/\\u0008\\u000c\\u000d\\u0009 é\u{2028}\"",
+            ),
+            (r#""\ud83d\ude00""#, "\"😀\""),
+            (" \t\r\n[ 1 ,\n2 ]\r\n ", "[1,2]"),
+            (
+                "{\"a\":{\"b\":[false,{}],\"\":[]},\"a b\":\"c\"}",
+                "{\"a\":{\"b\":[false,{}],\"\":[]},\"a b\":\"c\"}",
+            ),
+        ] {
+            let p = run(src.as_bytes(), Which::Strict);
+            assert_eq!(p.errors, 0, "{src:?}: {}", p.first_msg);
+            let mut got = String::new();
+            to_json_string(p.root.as_ref().unwrap(), &mut got);
+            assert_eq!(got, want, "{src:?}");
         }
     }
 

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -16,8 +16,7 @@ use crate::json_stage2::Parser;
 pub struct JSONOptions {
     pub allow_comments: bool,
     pub allow_trailing_commas: bool,
-    /// `JSON.parse` token grammar: no single quotes, JS-only number forms (`0x10`, `010`, `1_000`,
-    /// `.5`, `5.`, `- 5`) or escapes, escaped keywords, or Unicode whitespace. Comments keep their flag.
+    /// `JSON.parse` tokens only: no `'s'`, `0x10`/`010`/`1_000`/`.5`/`5.`/`- 5`, `\xHH`/`\v`, `\u0074rue`, or Unicode whitespace.
     pub strict: bool,
     pub ignore_leading_escape_sequences: bool,
     pub json_warn_duplicate_keys: bool,
@@ -334,8 +333,7 @@ pub fn parse_utf8_impl<const CHECK_LEN: bool>(
     Ok(parse_classic(source, log, bump, JSON_OPTS, CHECK_LEN)?.root)
 }
 
-/// Exactly what `JSON.parse` accepts ([`JSONOptions::strict`], nothing after the root value, not
-/// empty) into the classic `E::Object` / `E::Array` AST.
+/// Exactly what `JSON.parse` accepts ([`JSONOptions::strict`], one root value, not empty) into the classic AST.
 pub fn parse_strict(
     source: &bun_ast::Source,
     log: &mut bun_ast::Log,

--- a/src/parsers/json_stage2.rs
+++ b/src/parsers/json_stage2.rs
@@ -301,7 +301,7 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
             return (0xFF, p);
         }
         let b = self.contents[p];
-        if b >= 0x80 || b == 0x0B || b == 0x0C {
+        if (b >= 0x80 || b == 0x0B || b == 0x0C) && !self.opts.strict {
             let b = match self.skip_unicode_ws() {
                 None => 0xFF,
                 Some(np) => self.contents[np],
@@ -483,6 +483,10 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
         let close = self.pos_at(i + 1);
         let quote = self.contents[open];
         self.token_start = open;
+        if quote != b'"' && self.opts.strict {
+            let r = self.token_range(i);
+            return Err(self.strict_error(r, format_args!("JSON strings must use double quotes")));
+        }
         if close >= self.contents.len() || self.contents[close] != quote {
             self.add_default_error(b"Unterminated string literal")?;
             unreachable!()
@@ -552,7 +556,8 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
 
     #[inline]
     fn decode_escapes(&mut self, body: &[u8], buf: &mut Vec<u8>) -> PResult {
-        decode_string_escapes::<false, _>(self, body, buf)
+        let strict = self.opts.strict;
+        decode_string_escapes::<false, _>(self, body, buf, strict)
     }
 
     fn parse_scalar(&mut self, loc: Loc) -> PResult<Expr> {
@@ -608,6 +613,7 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
                     }
                     _ => return false,
                 },
+                _ if self.opts.strict => return false,
                 _ => {
                     let iterator = strings::CodepointIterator::init(&rest[i..]);
                     let mut iter = strings::Cursor::default();
@@ -922,6 +928,16 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
             self.expected(self.cursor, "number");
             return Err(self.unexpected(self.cursor));
         }
+        if q != minus_pos + 1 && self.opts.strict {
+            let r = Range {
+                loc: usize2loc(minus_pos),
+                len: 1,
+            };
+            return Err(self.strict_error(
+                r,
+                format_args!("JSON numbers must have a digit after \"-\""),
+            ));
+        }
         self.token_start = q;
         let run = &contents[q..self.pos_at(self.cursor + 1)];
         let (value, used) = self.parse_number_text(run, q)?;
@@ -951,9 +967,17 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
         let n = t.len();
         let first = t[0];
         let mut i = 1;
+        let strict = self.opts.strict;
 
         if first == b'.' && (n < 2 || !t[1].is_ascii_digit()) {
             return Err(self.syntax_err_at(pos));
+        }
+        if first == b'.' && strict {
+            return Err(self.strict_number_error(
+                t,
+                pos,
+                format_args!("JSON numbers must have a digit before \".\""),
+            ));
         }
 
         if first == b'0' && n > 1 {
@@ -965,6 +989,20 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
                 b'8' | b'9' => (10, 1, true),
                 _ => (0, 0, false),
             };
+            if radix != 0 && strict {
+                let what = match t[1] {
+                    b'b' | b'B' => "binary numbers",
+                    b'o' | b'O' => "octal numbers",
+                    b'x' | b'X' => "hexadecimal numbers",
+                    b'_' => "numeric separators",
+                    _ => "numbers with leading zeros",
+                };
+                return Err(self.strict_number_error(
+                    t,
+                    pos,
+                    format_args!("JSON does not support {what}"),
+                ));
+            }
             if radix != 0 {
                 return self.parse_radix_number(t, pos, radix, prefix_len, legacy_octal);
             }
@@ -979,6 +1017,13 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
                     match t[i] {
                         b'0'..=b'9' => i += 1,
                         b'_' => {
+                            if strict {
+                                return Err(self.strict_number_error(
+                                    t,
+                                    pos,
+                                    format_args!("JSON does not support numeric separators"),
+                                ));
+                            }
                             if last_underscore_end != usize::MAX && i == last_underscore_end + 1 {
                                 return Err(self.syntax_err_at(pos));
                             }
@@ -1003,6 +1048,13 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
             }
             has_dot_or_exp = true;
             i += 1;
+            if strict && (i >= n || !t[i].is_ascii_digit()) {
+                return Err(self.strict_number_error(
+                    t,
+                    pos,
+                    format_args!("JSON numbers must have a digit after \".\""),
+                ));
+            }
             if i < n && t[i] == b'_' {
                 return Err(self.syntax_err_at(pos));
             }
@@ -1151,13 +1203,37 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
         }
     }
 
+    /// A form the JavaScript lexer accepts and `JSON.parse` rejects (`opts.strict`).
+    #[cold]
+    fn strict_error(&mut self, r: Range, args: core::fmt::Arguments<'_>) -> crate::Error {
+        let _ = self.add_range_error(r, args);
+        crate::Error::SyntaxError
+    }
+
+    #[cold]
+    fn strict_number_error(
+        &mut self,
+        t: &[u8],
+        pos: usize,
+        args: core::fmt::Arguments<'_>,
+    ) -> crate::Error {
+        let len = strings::index_of_any(t, b" \t\n\r/")
+            .unwrap_or(t.len())
+            .max(1);
+        let r = Range {
+            loc: usize2loc(pos),
+            len: len as i32,
+        };
+        self.strict_error(r, args)
+    }
+
     #[cold]
     fn parse_scalar_cold(&mut self, loc: Loc) -> PResult<Expr> {
         let cursor = self.cursor;
         let run = self.run(cursor);
         let start = self.pos_at(cursor);
 
-        if run[0] >= 0x80 || run[0] == 0x0B || run[0] == 0x0C {
+        if (run[0] >= 0x80 || run[0] == 0x0B || run[0] == 0x0C) && !self.opts.strict {
             let Some(p) = self.skip_unicode_ws() else {
                 self.token_start = self.contents.len();
                 return Err(self.unexpected(self.cursor));
@@ -1231,6 +1307,9 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
         let cursor = self.cursor;
         let run = &self.contents[start..self.pos_at(cursor + 1)];
         self.token_start = start;
+        if self.opts.strict {
+            return Err(self.unexpected(cursor));
+        }
         let mut i = 0;
         while i < run.len() {
             let c = run[i];
@@ -1315,10 +1394,12 @@ fn read_trail_surrogate_escape(
     Some(value as u16)
 }
 
+/// `strict` accepts only the escapes JSON defines; otherwise `\v`, `\xHH`, `\8` and `\9` decode too.
 fn decode_string_escapes<'s, const ALLOW_RAW_CONTROL: bool, L: LexerLog<'s, Err = crate::Error>>(
     l: &mut L,
     body: &[u8],
     buf: &mut Vec<u8>,
+    strict: bool,
 ) -> PResult {
     let iterator = strings::CodepointIterator::init(body);
     let mut iter = strings::Cursor::default();
@@ -1346,9 +1427,9 @@ fn decode_string_escapes<'s, const ALLOW_RAW_CONTROL: bool, L: LexerLog<'s, Err 
             0x6E => buf.push(0x0a),
             0x72 => buf.push(0x0d),
             0x74 => buf.push(0x09),
-            0x76 => buf.push(0x0b),
-            0x38 | 0x39 => push_codepoint(buf, c2),
-            0x78 => {
+            0x76 if !strict => buf.push(0x0b),
+            0x38 | 0x39 if !strict => push_codepoint(buf, c2),
+            0x78 if !strict => {
                 let mut value: CodePoint = 0;
                 for _ in 0..2 {
                     if !iterator.next(&mut iter) {
@@ -1428,6 +1509,6 @@ pub(crate) fn decode_auto_quoted(
         body = &body[1..];
     }
     let mut buf: Vec<u8> = Vec::with_capacity(body.len());
-    decode_string_escapes::<true, _>(&mut l, body, &mut buf)?;
+    decode_string_escapes::<true, _>(&mut l, body, &mut buf, opts.strict)?;
     Ok(E::String::init(bump.alloc_slice_copy(&buf)))
 }

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -321,7 +321,8 @@ impl PmPkgCommand {
                 Global::exit(1);
             }
 
-            Self::set_value(&mut root, key, value, parse_json)?;
+            let expr = Self::parse_value(key, value, parse_json);
+            Self::set_value(&mut root, key, expr)?;
             modified = true;
         }
 
@@ -393,7 +394,8 @@ impl PmPkgCommand {
                 let lowercase: Vec<u8> = name_str.iter().map(|b| b.to_ascii_lowercase()).collect();
 
                 if !strings::eql(name_str, &lowercase) {
-                    Self::set_value(&mut root, b"name", &lowercase, false)?;
+                    let value = Self::parse_value(b"name", &lowercase, false);
+                    Self::set_value(&mut root, b"name", value)?;
                     modified = true;
                 }
             }
@@ -614,7 +616,7 @@ impl PmPkgCommand {
         Ok(path_parts)
     }
 
-    fn set_value(root: &mut Expr, key: &[u8], value: &[u8], parse_json: bool) -> Result<(), Error> {
+    fn set_value(root: &mut Expr, key: &[u8], value: Expr) -> Result<(), Error> {
         if !matches!(root.data, ExprData::EObject(_)) {
             return Err(crate::Error::InvalidRoot);
         }
@@ -626,25 +628,18 @@ impl PmPkgCommand {
         }
 
         if path_parts.len() == 1 {
-            let expr = Self::parse_value(value, parse_json)?;
-
             root.data
                 .e_object_mut()
                 .unwrap()
-                .put(dummy_bump(), path_parts[0], expr)?;
+                .put(dummy_bump(), path_parts[0], value)?;
 
             return Ok(());
         }
 
-        Self::set_nested(root, &path_parts, value, parse_json)
+        Self::set_nested(root, &path_parts, value)
     }
 
-    fn set_nested(
-        root: &mut Expr,
-        path: &[&[u8]],
-        value: &[u8],
-        parse_json: bool,
-    ) -> Result<(), Error> {
+    fn set_nested(root: &mut Expr, path: &[&[u8]], value: Expr) -> Result<(), Error> {
         if path.is_empty() {
             return Ok(());
         }
@@ -653,12 +648,10 @@ impl PmPkgCommand {
         let remaining_path = &path[1..];
 
         if remaining_path.is_empty() {
-            let expr = Self::parse_value(value, parse_json)?;
-
             root.data
                 .e_object_mut()
                 .unwrap()
-                .put(dummy_bump(), current_key, expr)?;
+                .put(dummy_bump(), current_key, value)?;
 
             return Ok(());
         }
@@ -682,40 +675,32 @@ impl PmPkgCommand {
         }
 
         let mut nested = nested_obj.unwrap();
-        Self::set_nested(&mut nested, remaining_path, value, parse_json)
+        Self::set_nested(&mut nested, remaining_path, value)
     }
 
-    fn parse_value(value: &[u8], parse_json: bool) -> Result<Expr, Error> {
-        if parse_json {
-            if value == b"true" {
-                return Ok(Expr::init(E::Boolean { value: true }, Loc::EMPTY));
-            } else if value == b"false" {
-                return Ok(Expr::init(E::Boolean { value: false }, Loc::EMPTY));
-            } else if value == b"null" {
-                return Ok(Expr::init(E::Null {}, Loc::EMPTY));
-            }
+    /// With `--json` the value must parse exactly as `JSON.parse` would, like `npm pkg set --json`.
+    fn parse_value(key: &[u8], value: &[u8], parse_json: bool) -> Expr {
+        let data: &[u8] = dummy_bump().alloc_slice_copy(value);
+        if !parse_json {
+            return Expr::init(E::String::init(data), Loc::EMPTY);
+        }
 
-            if let Some(int_val) = bun_core::fmt::parse_decimal::<i64>(value) {
-                return Ok(Expr::init(E::Number::new(int_val as f64), Loc::EMPTY));
+        let source = Source::init_path_string(key, data);
+        let mut log = Log::init();
+        match json::parse_strict(&source, &mut log, dummy_bump()) {
+            Ok(expr) => expr,
+            Err(_) => {
+                let reason: &[u8] = log
+                    .msgs
+                    .iter()
+                    .find(|msg| msg.kind == bun_ast::Kind::Err)
+                    .map_or(b"Syntax Error", |msg| &msg.data.text);
+                Output::err_generic(
+                    "Invalid JSON value for <b>\"{s}\"<r>: {s}",
+                    (bstr::BStr::new(key), bstr::BStr::new(reason)),
+                );
+                Global::exit(1);
             }
-
-            if let Some(float_val) = parse_f64(value) {
-                return Ok(Expr::init(E::Number::new(float_val), Loc::EMPTY));
-            }
-
-            let temp_source = Source::init_path_string(b"package.json", value);
-            let mut temp_log = Log::init();
-            if let Ok(json_expr) =
-                json::parse_package_json_utf8(&temp_source, &mut temp_log, dummy_bump())
-            {
-                return Ok(json_expr);
-            } else {
-                let data: &[u8] = dummy_bump().alloc_slice_copy(value);
-                return Ok(Expr::init(E::String::init(data), Loc::EMPTY));
-            }
-        } else {
-            let data: &[u8] = dummy_bump().alloc_slice_copy(value);
-            Ok(Expr::init(E::String::init(data), Loc::EMPTY))
         }
     }
 
@@ -864,7 +849,3 @@ impl PmPkgCommand {
         Ok(())
     }
 }
-
-// ───── helpers ────────────────────────────────────────────────────────────
-
-use bun_core::fmt::parse_f64;

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -699,6 +699,9 @@ impl PmPkgCommand {
                     "Invalid JSON value for <b>\"{s}\"<r>: {s}",
                     (bstr::BStr::new(key), bstr::BStr::new(reason)),
                 );
+                bun_core::pretty_errorln!(
+                    "<blue>note<r><d>:<r> --json parses each value as JSON. To store the text as a string, drop --json."
+                );
                 Global::exit(1);
             }
         }

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -272,6 +272,70 @@ describe.concurrent("bun pm pkg", () => {
       expect((await readPkg(dir)).newArray).toEqual(["one", "two", "three"]);
     });
 
+    it("should accept any valid JSON value with --json flag", async () => {
+      using dir = tempDir("pm-pkg-json-valid", {
+        "package.json": JSON.stringify({ name: "x", version: "1.0.0" }, null, 2),
+      });
+      const { error, code } = await runPmPkg(
+        [
+          "set",
+          "a=0",
+          "b=-1.5e3",
+          "c=1E+2",
+          'd="str \\u00e9\\n"',
+          'e={"k":[1,{"m":null}],"":""}',
+          "f= [ true ,\tfalse ]\n",
+          "--json",
+        ],
+        dir,
+      );
+      expect(error).toBe("");
+      expect(await readPkg(dir)).toEqual({
+        name: "x",
+        version: "1.0.0",
+        a: 0,
+        b: -1500,
+        c: 100,
+        d: "str \u00e9\n",
+        e: { k: [1, { m: null }], "": "" },
+        f: [true, false],
+      });
+      expect(code).toBe(0);
+    });
+
+    // npm runs the value through JSON.parse and refuses to write on failure.
+    // Anything JSON.parse rejects must be an error here too, never a lenient
+    // parse (`010` -> 8 or 10) and never a silent fallback to a string.
+    it.each([
+      ["undefined", "Unexpected undefined"],
+      ["NaN", "Unexpected NaN"],
+      ["Infinity", "Unexpected Infinity"],
+      ["1/0", "Unsupported syntax: Operators are not allowed in JSON"],
+      ["+1", "Unsupported syntax: Operators are not allowed in JSON"],
+      ["'single'", "JSON strings must use double quotes"],
+      ["0x10", "JSON does not support hexadecimal numbers"],
+      ["0b11", "JSON does not support binary numbers"],
+      ["010", "JSON does not support numbers with leading zeros"],
+      ["1_000", "JSON does not support numeric separators"],
+      [".5", 'JSON numbers must have a digit before "."'],
+      ["5.", 'JSON numbers must have a digit after "."'],
+      ["- 5", 'JSON numbers must have a digit after "-"'],
+      ["[1,]", "JSON does not support trailing commas"],
+      ['{"a":1,}', "JSON does not support trailing commas"],
+      ["//c 1", "JSON does not support comments"],
+      ['"\\v"', "Syntax Error"],
+      ["1 2", "Unexpected 2"],
+      ["[1] {}", "Unexpected {"],
+    ])("should reject the invalid JSON value %s with --json flag", async (value, message) => {
+      using dir = makeTestDir();
+      const before = await Bun.file(join(dir, "package.json")).text();
+      const { output, error, code } = await runPmPkg(["set", `x=${value}`, "--json"], dir, false);
+      expect(output).toBe("");
+      expect(error).toContain(`error: Invalid JSON value for "x": ${message}\n`);
+      expect(await Bun.file(join(dir, "package.json")).text()).toBe(before);
+      expect(code).toBe(1);
+    });
+
     it("should treat values as strings without --json flag", async () => {
       using dir = makeTestDir();
       const { code } = await runPmPkg(


### PR DESCRIPTION
### Problem
- `bun pm pkg set --json k=v` never rejects a bad value. `x=undefined` writes the string `"undefined"`, `x=010` writes `10`, and `x=NaN` writes a package.json that does not parse. All exit 0. npm runs `JSON.parse(value)` and exits 1 without writing.
- The cause is `parse_value` in `src/runtime/cli/pm_pkg_command.rs`. It tried `parse_decimal`, `parse_f64`, and the lenient package.json parser, then fell back to a string on error.

### Fix
- `JSONOptions` gains `strict`. With it, stage 2 rejects what `JSON.parse` rejects: single-quoted strings, the numbers `0x10`, `010`, `1_000`, `.5`, `5.`, `- 5`, the escapes `\v` and `\xHH`, `\u`-escaped keywords, and Unicode whitespace.
- `json::parse_strict` combines `strict` with no comments, no trailing commas, and the trailing-content check. No other caller changes.
- `parse_value` calls `parse_strict`. On failure it prints `error: Invalid JSON value for "<key>": <reason>` and exits 1 without writing.
- Verified: `test/cli/install/bun-pm-pkg.test.ts` (20 new cases, 19 fail on bun 1.4.3) and the `bun_parsers` unit test `strict_mode_matches_json_parse`. Self-reviewed by hand (each strict branch and the lenient path it gates): no changes needed.

### Background
- `bun pm pkg` is the `npm pkg` equivalent (#20855, added in #21046). npm's `--json` is `JSON.parse(value)`.
- Bun's JSON parser is a SIMD structural indexer plus a recursive-descent stage 2 (`src/parsers/json_stage2.rs`). Its token grammar came from the JS lexer, so every dialect accepts single quotes and JS number forms. `JSONOptions` gated only comments and trailing commas.
- Open PRs #40826, #35070 and #35072 tighten that grammar for other callers. I will rebase onto whichever lands first.

<details><summary>Notes</summary>

- Behavior with this PR, debug build:

  ```
  $ bun pm pkg set --json x=undefined
  error: Invalid JSON value for "x": Unexpected undefined
  note: --json parses each value as JSON. To store the text as a string, drop --json.
  ```

  | value | before (1.4.3) | after |
  |---|---|---|
  | `010` | `10` | error: JSON does not support numbers with leading zeros |
  | `0x10` | `16` | error: JSON does not support hexadecimal numbers |
  | `+1` | `1` | error: Unsupported syntax: Operators are not allowed in JSON |
  | `.5` / `5.` | `0.5` / `5` | error: JSON numbers must have a digit before/after "." |
  | `1_000` | `1000` | error: JSON does not support numeric separators |
  | `'sq'` | `"sq"` | error: JSON strings must use double quotes |
  | `[1,]` | `[1]` | error: JSON does not support trailing commas |
  | `//c 1` | `"//c1"` | error: JSON does not support comments |
  | `undefined`, `1/0` | the strings `"undefined"`, `"1/0"` | error |
  | `NaN`, `Infinity` | bare `NaN` / `Infinity` (invalid package.json) | error |
  | `- 5`, `1 2`, `[1] x` | `-5`, `1`, `[1]` | error |
  | `42`, `-1.5e3`, `"s"`, `{"a":[1]}`, `true`, `null`, ` [1] ` | unchanged | unchanged |

- Without `--json` the value is still stored as a string, as before.
- `1e400` still parses (valid JSON grammar, `JSON.parse` gives `Infinity`). How the printer writes a non-finite number is a separate issue.
- The two number readers no longer disagree for this command: `pm pkg set --json x=010` used to store decimal 10 while a literal `010` in package.json reads as legacy octal 8.
- Other suites run locally with the debug build: `test/js/bun/jsonc/` (3 files), `test/js/bun/resolve/jsonc.test.ts`, `test/bundler/bundler_loader.test.ts` and `test/bundler/esbuild/loader.test.ts` (`-t json`), `test/bundler/bundler_packagejson.test.ts`, `test/cli/run/env.test.ts`, `test/internal/source-lints/`, and all 39 `bun_parsers` unit tests via `scripts/bench-json-rust.sh --test`.
- The strict checks sit on cold paths (`#[cold]` helpers, the non-ASCII whitespace branch, the radix branch, the escape slow path), so the lenient dialects pay one extra boolean test in places that were already off the fast path.

</details>
