### PR TITLE
install: verify the store package.json before the isolated linker reports an npm package as installed

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -805,9 +805,9 @@ pub(crate) fn installed_package_json_matches(
     package_json_checker.found_name() == name
 }
 
-/// Reads the `package.json` at `path` into `buf` (scratch, reused across
-/// calls) and checks it with [`installed_package_json_matches`]. A missing or
-/// unreadable file is a mismatch.
+/// Reads the `package.json` at `path` into `buf` and checks it with
+/// [`installed_package_json_matches`]. A missing or unreadable file is a
+/// mismatch. Safe to call from any thread.
 pub(crate) fn installed_package_json_at_path_matches(
     path: &ZStr,
     buf: &mut Vec<u8>,

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -742,11 +742,7 @@ impl UninstallTask {
 
 // ─────────────────────── installed package.json verification ───────────────────────
 
-/// Whether an installed `package.json` still names the package the lockfile
-/// expects at its path. This is the "is it installed" test both linkers apply:
-/// hoisted to `node_modules/<pkg>`, isolated to a store entry. Build metadata
-/// is ignored on both sides (https://github.com/oven-sh/bun/issues/13563) and
-/// a leading `v`, `=` or whitespace on the installed version is tolerated.
+/// Both linkers' "is it installed" test: `source` (a `package.json`) names `name` at `version`. The caller sets up the AST store.
 pub(crate) fn installed_package_json_matches(
     source: &bun_ast::Source,
     name: &[u8],
@@ -754,9 +750,6 @@ pub(crate) fn installed_package_json_matches(
     version_required: bool,
 ) -> bool {
     let mut log = bun_ast::Log::init();
-
-    initialize_store();
-
     let mut package_json_checker = bun_json::PackageJSONVersionChecker::init(source, &mut log);
     if package_json_checker.parse().is_err() {
         return false;
@@ -770,12 +763,10 @@ pub(crate) fn installed_package_json_matches(
 
     let found_version = package_json_checker.found_version();
 
-    // exclude build tags from comparsion
-    // https://github.com/oven-sh/bun/issues/13563
+    // build metadata is not part of the comparison (https://github.com/oven-sh/bun/issues/13563)
     let found_version_end =
         strings::last_index_of_char(found_version, b'+').unwrap_or(found_version.len());
     let expected_version_end = strings::last_index_of_char(version, b'+').unwrap_or(version.len());
-    // Check if the version matches
     if found_version[..found_version_end] != version[..expected_version_end] {
         let offset = 'brk: {
             // ASCII only.
@@ -790,23 +781,19 @@ pub(crate) fn installed_package_json_matches(
                     _ => break 'brk c,
                 }
             }
-            // If we didn't find any of these characters, there's no point in checking the version again.
-            // it will never match.
+            // nothing but separators, so no version to compare
             return false;
         };
 
-        if found_version[offset..] != *version {
+        if found_version[offset..found_version_end] != version[..expected_version_end] {
             return false;
         }
     }
 
-    // lastly, check the name.
     package_json_checker.found_name() == name
 }
 
-/// Reads the `package.json` at `path` into `buf` and checks it with
-/// [`installed_package_json_matches`]. A missing or unreadable file is a
-/// mismatch. Safe to call from any thread.
+/// [`installed_package_json_matches`] on the file at `path`, for thread-pool callers. A missing, unreadable or non-regular file is a mismatch.
 pub(crate) fn installed_package_json_at_path_matches(
     path: &ZStr,
     buf: &mut Vec<u8>,
@@ -815,20 +802,30 @@ pub(crate) fn installed_package_json_at_path_matches(
 ) -> bool {
     buf.clear();
     {
-        // Closed on drop, before parsing: the longer the file stays open, the
-        // more likely it causes issues for other processes on Windows.
-        let Ok(fd) = sys::openat(Fd::cwd(), path, sys::O::RDONLY, 0) else {
+        // NOFOLLOW (and NONBLOCK on posix) so a symlink or fifo left where the file should be fails instead of hanging
+        #[cfg(windows)]
+        let flags = sys::O::RDONLY | sys::O::NOFOLLOW;
+        #[cfg(not(windows))]
+        let flags = sys::O::RDONLY | sys::O::NOFOLLOW | sys::O::NONBLOCK;
+        let Ok(fd) = sys::openat(Fd::cwd(), path, flags, 0) else {
             return false;
         };
-        if sys::File::from_fd(fd).read_to_end_into(buf).is_err() {
+        let file = sys::File::from_fd(fd);
+        if !matches!(file.kind(), Ok(sys::FileKind::File)) {
+            return false;
+        }
+        if file.read_to_end_into(buf).is_err() {
             return false;
         }
     }
 
-    // If it's not long enough to have {"name": "foo", "version": "1.2.0"}, there's no way it's valid
+    // too short to hold {"name":"<name>","version":"<version>"}
     if buf.len() < br#"{"name":"","version":""}"#.len() + name.len() + version.len() {
         return false;
     }
+
+    // the per-thread mini store, as for manifest parsing on the pool, instead of a full AST store per worker
+    crate::initialize_mini_store();
 
     let source = bun_ast::Source::init_path_string(path.as_bytes(), &buf[..]);
     installed_package_json_matches(&source, name, version, true)
@@ -1042,6 +1039,8 @@ impl<'a> PackageInstall<'a> {
         else {
             return false;
         };
+
+        initialize_store();
 
         installed_package_json_matches(
             &source,

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -774,8 +774,7 @@ pub(crate) fn installed_package_json_matches(
     // https://github.com/oven-sh/bun/issues/13563
     let found_version_end =
         strings::last_index_of_char(found_version, b'+').unwrap_or(found_version.len());
-    let expected_version_end =
-        strings::last_index_of_char(version, b'+').unwrap_or(version.len());
+    let expected_version_end = strings::last_index_of_char(version, b'+').unwrap_or(version.len());
     // Check if the version matches
     if found_version[..found_version_end] != version[..expected_version_end] {
         let offset = 'brk: {

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -740,6 +740,101 @@ impl UninstallTask {
     }
 }
 
+// ─────────────────────── installed package.json verification ───────────────────────
+
+/// Whether an installed `package.json` still names the package the lockfile
+/// expects at its path. This is the "is it installed" test both linkers apply:
+/// hoisted to `node_modules/<pkg>`, isolated to a store entry. Build metadata
+/// is ignored on both sides (https://github.com/oven-sh/bun/issues/13563) and
+/// a leading `v`, `=` or whitespace on the installed version is tolerated.
+pub(crate) fn installed_package_json_matches(
+    source: &bun_ast::Source,
+    name: &[u8],
+    version: &[u8],
+    version_required: bool,
+) -> bool {
+    let mut log = bun_ast::Log::init();
+
+    initialize_store();
+
+    let mut package_json_checker = bun_json::PackageJSONVersionChecker::init(source, &mut log);
+    if package_json_checker.parse().is_err() {
+        return false;
+    }
+    if package_json_checker.has_errors() || !package_json_checker.has_found_name {
+        return false;
+    }
+    if !package_json_checker.has_found_version && version_required {
+        return false;
+    }
+
+    let found_version = package_json_checker.found_version();
+
+    // exclude build tags from comparsion
+    // https://github.com/oven-sh/bun/issues/13563
+    let found_version_end =
+        strings::last_index_of_char(found_version, b'+').unwrap_or(found_version.len());
+    let expected_version_end =
+        strings::last_index_of_char(version, b'+').unwrap_or(version.len());
+    // Check if the version matches
+    if found_version[..found_version_end] != version[..expected_version_end] {
+        let offset = 'brk: {
+            // ASCII only.
+            for c in 0..found_version.len() {
+                match found_version[c] {
+                    // newlines & whitespace
+                    b' ' | b'\t' | b'\n' | b'\r'
+                    | 0x0B /* VT */
+                    | 0x0C /* FF */
+                    // version separators
+                    | b'v' | b'=' => {}
+                    _ => break 'brk c,
+                }
+            }
+            // If we didn't find any of these characters, there's no point in checking the version again.
+            // it will never match.
+            return false;
+        };
+
+        if found_version[offset..] != *version {
+            return false;
+        }
+    }
+
+    // lastly, check the name.
+    package_json_checker.found_name() == name
+}
+
+/// Reads the `package.json` at `path` into `buf` (scratch, reused across
+/// calls) and checks it with [`installed_package_json_matches`]. A missing or
+/// unreadable file is a mismatch.
+pub(crate) fn installed_package_json_at_path_matches(
+    path: &ZStr,
+    buf: &mut Vec<u8>,
+    name: &[u8],
+    version: &[u8],
+) -> bool {
+    buf.clear();
+    {
+        // Closed on drop, before parsing: the longer the file stays open, the
+        // more likely it causes issues for other processes on Windows.
+        let Ok(fd) = sys::openat(Fd::cwd(), path, sys::O::RDONLY, 0) else {
+            return false;
+        };
+        if sys::File::from_fd(fd).read_to_end_into(buf).is_err() {
+            return false;
+        }
+    }
+
+    // If it's not long enough to have {"name": "foo", "version": "1.2.0"}, there's no way it's valid
+    if buf.len() < br#"{"name":"","version":""}"#.len() + name.len() + version.len() {
+        return false;
+    }
+
+    let source = bun_ast::Source::init_path_string(path.as_bytes(), &buf[..]);
+    installed_package_json_matches(&source, name, version, true)
+}
+
 // ───────────────────────────── impl PackageInstall ─────────────────────────────
 
 impl<'a> PackageInstall<'a> {
@@ -948,60 +1043,14 @@ impl<'a> PackageInstall<'a> {
         else {
             return false;
         };
-        let source = &source;
 
-        let mut log = bun_ast::Log::init();
-
-        initialize_store();
-
-        let mut package_json_checker = bun_json::PackageJSONVersionChecker::init(source, &mut log);
-        if package_json_checker.parse().is_err() {
-            return false;
-        }
-        if package_json_checker.has_errors() || !package_json_checker.has_found_name {
-            return false;
-        }
-        // workspaces aren't required to have a version
-        if !package_json_checker.has_found_version && resolution_tag != resolution::Tag::Workspace {
-            return false;
-        }
-
-        let found_version = package_json_checker.found_version();
-
-        // exclude build tags from comparsion
-        // https://github.com/oven-sh/bun/issues/13563
-        let found_version_end =
-            strings::last_index_of_char(found_version, b'+').unwrap_or(found_version.len());
-        let expected_version_end = strings::last_index_of_char(self.package_version, b'+')
-            .unwrap_or(self.package_version.len());
-        // Check if the version matches
-        if found_version[..found_version_end] != self.package_version[..expected_version_end] {
-            let offset = 'brk: {
-                // ASCII only.
-                for c in 0..found_version.len() {
-                    match found_version[c] {
-                        // newlines & whitespace
-                        b' ' | b'\t' | b'\n' | b'\r'
-                        | 0x0B /* VT */
-                        | 0x0C /* FF */
-                        // version separators
-                        | b'v' | b'=' => {}
-                        _ => break 'brk c,
-                    }
-                }
-                // If we didn't find any of these characters, there's no point in checking the version again.
-                // it will never match.
-                return false;
-            };
-
-            if found_version[offset..] != *self.package_version {
-                return false;
-            }
-        }
-
-        // lastly, check the name.
-        package_json_checker.found_name()
-            == self.package_name.slice(&self.lockfile.buffers.string_bytes)
+        installed_package_json_matches(
+            &source,
+            self.package_name.slice(&self.lockfile.buffers.string_bytes),
+            self.package_version,
+            // workspaces aren't required to have a version
+            resolution_tag != resolution::Tag::Workspace,
+        )
     }
 
     // ───────────────────────────── install backends ─────────────────────────────

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2104,6 +2104,9 @@ pub(crate) fn install_isolated_packages(
         installer
             .manager_mut()
             .increment_pending_tasks(u32::try_from(store.entries.len()).expect("int cast"));
+        // Scratch for reading each existing entry's package.json, reused across entries.
+        let mut package_json_buf: Vec<u8> = Vec::new();
+        let mut expected_version_buf: Vec<u8> = Vec::new();
         for _entry_id in 0..store.entries.len() {
             let entry_id = store::entry::Id::from(u32::try_from(_entry_id).expect("int cast"));
 
@@ -2240,12 +2243,32 @@ pub(crate) fn install_isolated_packages(
                             // Capture the length instead of a `ResetScope` so
                             // `store_path` stays unborrowed.
                             let scope_for_patch_tag_path = store_path.len();
-                            if pkg_res_tag == ResolutionTag::Npm {
-                                // if it's from npm, it should always have a package.json.
-                                // in other cases, probably yes but i'm less confident.
+                            let exists = if pkg_res_tag == ResolutionTag::Npm {
+                                // An npm package always has a package.json. Read the
+                                // name and version back out of it, as the hoisted
+                                // linker does for `node_modules/<pkg>`, so an entry
+                                // holding some other package's files (an interrupted
+                                // or foreign write) is rebuilt instead of trusted
+                                // because the file exists.
                                 store_path.append(b"package.json").assume_ok();
-                            }
-                            let exists = sys::exists_z(store_path.slice_z());
+                                expected_version_buf.clear();
+                                write!(
+                                    &mut expected_version_buf,
+                                    "{}",
+                                    pkg_res.npm().version.fmt(string_buf)
+                                )
+                                .expect("formatting into a Vec is infallible");
+                                crate::package_install::installed_package_json_at_path_matches(
+                                    store_path.slice_z(),
+                                    &mut package_json_buf,
+                                    pkg_name.slice(string_buf),
+                                    &expected_version_buf,
+                                )
+                            } else {
+                                // in other cases there is probably a package.json
+                                // too, but the directory is the safer signal.
+                                sys::exists_z(store_path.slice_z())
+                            };
 
                             break 'needs_install match &patch_info {
                                 installer::PatchInfo::None => !exists,

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2104,9 +2104,17 @@ pub(crate) fn install_isolated_packages(
         installer
             .manager_mut()
             .increment_pending_tasks(u32::try_from(store.entries.len()).expect("int cast"));
-        // Scratch for reading each existing entry's package.json, reused across entries.
-        let mut package_json_buf: Vec<u8> = Vec::new();
-        let mut expected_version_buf: Vec<u8> = Vec::new();
+
+        // npm entries whose existing store directory holds the package the
+        // lockfile expects. Left empty when every project-local entry is
+        // about to be (re)installed regardless.
+        let verified_npm_entries =
+            if installer.manager().options.enable.force_install() || is_new_bun_modules {
+                DynamicBitSet::init_empty(store.entries.len())?
+            } else {
+                installer.verify_npm_store_entries()?
+            };
+
         for _entry_id in 0..store.entries.len() {
             let entry_id = store::entry::Id::from(u32::try_from(_entry_id).expect("int cast"));
 
@@ -2239,45 +2247,31 @@ pub(crate) fn install_isolated_packages(
                                     .ok()
                                     .unwrap_or(false);
                             }
+                            // An npm package always has a package.json, and
+                            // `verify_npm_store_entries` read its name and version
+                            // back above, as the hoisted linker does for
+                            // `node_modules/<pkg>`. An entry that holds some other
+                            // package's files (an interrupted or foreign write) is
+                            // rebuilt instead of trusted because it exists.
+                            if pkg_res_tag == ResolutionTag::Npm
+                                && !verified_npm_entries.is_set(entry_id.get() as usize)
+                            {
+                                break 'needs_install true;
+                            }
                             installer.append_real_store_path(&mut store_path, entry_id, installer::Which::Final);
-                            // Capture the length instead of a `ResetScope` so
-                            // `store_path` stays unborrowed.
-                            let scope_for_patch_tag_path = store_path.len();
-                            let exists = if pkg_res_tag == ResolutionTag::Npm {
-                                // An npm package always has a package.json. Read the
-                                // name and version back out of it, as the hoisted
-                                // linker does for `node_modules/<pkg>`, so an entry
-                                // holding some other package's files (an interrupted
-                                // or foreign write) is rebuilt instead of trusted
-                                // because the file exists.
-                                store_path.append(b"package.json").assume_ok();
-                                expected_version_buf.clear();
-                                write!(
-                                    &mut expected_version_buf,
-                                    "{}",
-                                    pkg_res.npm().version.fmt(string_buf)
-                                )
-                                .expect("formatting into a Vec is infallible");
-                                crate::package_install::installed_package_json_at_path_matches(
-                                    store_path.slice_z(),
-                                    &mut package_json_buf,
-                                    pkg_name.slice(string_buf),
-                                    &expected_version_buf,
-                                )
-                            } else {
-                                // in other cases there is probably a package.json
-                                // too, but the directory is the safer signal.
-                                sys::exists_z(store_path.slice_z())
-                            };
 
                             break 'needs_install match &patch_info {
-                                installer::PatchInfo::None => !exists,
+                                // in other cases there is probably a package.json
+                                // too, but the directory is the safer signal.
+                                installer::PatchInfo::None => {
+                                    pkg_res_tag != ResolutionTag::Npm
+                                        && !sys::exists_z(store_path.slice_z())
+                                }
                                 // checked above
                                 installer::PatchInfo::Remove(_) => unreachable!(),
                                 installer::PatchInfo::Patch(patch) => {
                                     let mut hash_buf: install::BuntagHashBuf = Default::default();
                                     let hash = install::buntaghashbuf_make(&mut hash_buf, patch.contents_hash);
-                                    store_path.set_length(scope_for_patch_tag_path);
                                     store_path.append(&*hash).assume_ok();
                                     !sys::exists_z(store_path.slice_z())
                                 }

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2105,9 +2105,7 @@ pub(crate) fn install_isolated_packages(
             .manager_mut()
             .increment_pending_tasks(u32::try_from(store.entries.len()).expect("int cast"));
 
-        // npm entries whose existing store directory holds the package the
-        // lockfile expects. Left empty when every project-local entry is
-        // about to be (re)installed regardless.
+        // left empty when every project-local entry is about to be (re)installed anyway
         let verified_npm_entries =
             if installer.manager().options.enable.force_install() || is_new_bun_modules {
                 DynamicBitSet::init_empty(store.entries.len())?
@@ -2247,26 +2245,15 @@ pub(crate) fn install_isolated_packages(
                                     .ok()
                                     .unwrap_or(false);
                             }
-                            // An npm package always has a package.json, and
-                            // `verify_npm_store_entries` read its name and version
-                            // back above, as the hoisted linker does for
-                            // `node_modules/<pkg>`. An entry that holds some other
-                            // package's files (an interrupted or foreign write) is
-                            // rebuilt instead of trusted because it exists.
-                            if pkg_res_tag == ResolutionTag::Npm
-                                && !verified_npm_entries.is_set(entry_id.get() as usize)
-                            {
-                                break 'needs_install true;
-                            }
                             installer.append_real_store_path(&mut store_path, entry_id, installer::Which::Final);
 
                             break 'needs_install match &patch_info {
-                                // in other cases there is probably a package.json
-                                // too, but the directory is the safer signal.
-                                installer::PatchInfo::None => {
-                                    pkg_res_tag != ResolutionTag::Npm
-                                        && !sys::exists_z(store_path.slice_z())
+                                // an npm entry whose package.json names something else (an interrupted or foreign write) is rebuilt, as the hoisted linker does
+                                installer::PatchInfo::None if pkg_res_tag == ResolutionTag::Npm => {
+                                    !verified_npm_entries.is_set(entry_id.get() as usize)
                                 }
+                                // other resolutions probably have a package.json too, but the directory is the safer signal
+                                installer::PatchInfo::None => !sys::exists_z(store_path.slice_z()),
                                 // checked above
                                 installer::PatchInfo::Remove(_) => unreachable!(),
                                 installer::PatchInfo::Patch(patch) => {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2470,8 +2470,11 @@ impl<'a> Installer<'a> {
                 continue;
             }
             // a patched entry is vouched for by its `.bun-tag` instead (the patch may edit package.json)
-            let patch_info =
-                self.package_patch_info(pkg_names[pkg_id as usize], pkg_name_hashes[pkg_id as usize], pkg_res);
+            let patch_info = self.package_patch_info(
+                pkg_names[pkg_id as usize],
+                pkg_name_hashes[pkg_id as usize],
+                pkg_res,
+            );
             if !matches!(patch_info, Ok(PatchInfo::None)) {
                 continue;
             }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::io::Write as _;
 
 use bun_ast::Log;
@@ -2426,6 +2426,101 @@ impl<'a> Installer<'a> {
         }
 
         Ok(())
+    }
+
+    /// For every project-local npm entry, whether the `package.json` in its
+    /// store directory names the package and version the lockfile expects: the
+    /// check `PackageInstall::verify` applies to `node_modules/<pkg>` under the
+    /// hoisted linker. A set bit means the entry's files can be reused. The
+    /// reads run on the thread pool because this is an open, a read and a parse
+    /// per entry, which is most of the work of an install with nothing to do.
+    pub(crate) fn verify_npm_store_entries(
+        &self,
+    ) -> core::result::Result<Bitset, bun_alloc::AllocError> {
+        #[derive(Clone, Copy)]
+        struct Job {
+            entry_id: StoreEntryId,
+            path_offset: usize,
+            path_len: usize,
+            name: SemverString,
+            version: bun_semver::Version,
+        }
+        struct Shared<'b> {
+            /// Every job's NUL-terminated `package.json` path, back to back.
+            paths: &'b [u8],
+            string_buf: &'b [u8],
+            matches: &'b [AtomicBool],
+        }
+
+        let lockfile = self.lockfile();
+        let string_buf = lockfile.buffers.string_bytes.as_slice();
+        let pkgs = lockfile.packages.slice();
+        let pkg_names = pkgs.items_name();
+        let pkg_resolutions = pkgs.items_resolution();
+        let entry_node_ids = self.store.entries.items_node_id();
+        let node_pkg_ids = self.store.nodes.items_pkg_id();
+
+        let mut verified = Bitset::init_empty(self.store.entries.len())?;
+
+        let mut jobs: Vec<Job> = Vec::new();
+        let mut paths: Vec<u8> = Vec::new();
+        let mut path = AutoAbsPath::init_top_level_dir();
+        let top_level_dir_len = path.len();
+        for entry_index in 0..self.store.entries.len() {
+            let entry_id = StoreEntryId::from(u32::try_from(entry_index).expect("int cast"));
+            let pkg_id = node_pkg_ids[entry_node_ids[entry_index].get() as usize];
+            let pkg_res = &pkg_resolutions[pkg_id as usize];
+            if pkg_res.tag != ResolutionTag::Npm || self.entry_uses_global_store(entry_id) {
+                continue;
+            }
+            path.set_length(top_level_dir_len);
+            self.append_real_store_path(&mut path, entry_id, Which::Final);
+            path.append(b"package.json").assume_ok();
+            jobs.push(Job {
+                entry_id,
+                path_offset: paths.len(),
+                path_len: path.len(),
+                name: pkg_names[pkg_id as usize],
+                version: pkg_res.npm().version,
+            });
+            paths.extend_from_slice(path.slice());
+            paths.push(0);
+        }
+        if jobs.is_empty() {
+            return Ok(verified);
+        }
+
+        let matches: Vec<AtomicBool> = jobs.iter().map(|_| AtomicBool::new(false)).collect();
+        self.manager().thread_pool.each(
+            Shared {
+                paths: &paths,
+                string_buf,
+                matches: &matches,
+            },
+            |shared: &Shared<'_>, job: Job, i: usize| {
+                let path = ZStr::from_buf(&shared.paths[job.path_offset..], job.path_len);
+                let mut version: Vec<u8> = Vec::new();
+                write!(&mut version, "{}", job.version.fmt(shared.string_buf))
+                    .expect("formatting into a Vec is infallible");
+                let mut contents: Vec<u8> = Vec::new();
+                shared.matches[i].store(
+                    crate::package_install::installed_package_json_at_path_matches(
+                        path,
+                        &mut contents,
+                        job.name.slice(shared.string_buf),
+                        &version,
+                    ),
+                    Ordering::Relaxed,
+                );
+            },
+            &mut jobs,
+        );
+        for (job, matches) in jobs.iter().zip(&matches) {
+            if matches.load(Ordering::Relaxed) {
+                verified.set(job.entry_id.get() as usize);
+            }
+        }
+        Ok(verified)
     }
 
     /// True when this entry should live in the shared global virtual store

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2428,12 +2428,7 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
-    /// For every project-local npm entry, whether the `package.json` in its
-    /// store directory names the package and version the lockfile expects: the
-    /// check `PackageInstall::verify` applies to `node_modules/<pkg>` under the
-    /// hoisted linker. A set bit means the entry's files can be reused. The
-    /// reads run on the thread pool because this is an open, a read and a parse
-    /// per entry, which is most of the work of an install with nothing to do.
+    /// Project-local npm entries whose store `package.json` names the expected name and version, read on the thread pool.
     pub(crate) fn verify_npm_store_entries(
         &self,
     ) -> core::result::Result<Bitset, bun_alloc::AllocError> {
@@ -2456,6 +2451,7 @@ impl<'a> Installer<'a> {
         let string_buf = lockfile.buffers.string_bytes.as_slice();
         let pkgs = lockfile.packages.slice();
         let pkg_names = pkgs.items_name();
+        let pkg_name_hashes = pkgs.items_name_hash();
         let pkg_resolutions = pkgs.items_resolution();
         let entry_node_ids = self.store.entries.items_node_id();
         let node_pkg_ids = self.store.nodes.items_pkg_id();
@@ -2471,6 +2467,12 @@ impl<'a> Installer<'a> {
             let pkg_id = node_pkg_ids[entry_node_ids[entry_index].get() as usize];
             let pkg_res = &pkg_resolutions[pkg_id as usize];
             if pkg_res.tag != ResolutionTag::Npm || self.entry_uses_global_store(entry_id) {
+                continue;
+            }
+            // a patched entry is vouched for by its `.bun-tag` instead (the patch may edit package.json)
+            let patch_info =
+                self.package_patch_info(pkg_names[pkg_id as usize], pkg_name_hashes[pkg_id as usize], pkg_res);
+            if !matches!(patch_info, Ok(PatchInfo::None)) {
                 continue;
             }
             path.set_length(top_level_dir_len);

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2010,10 +2010,21 @@ test("same resolution, different dependency name", async () => {
 test("reinstalls a store entry whose package.json does not match the lockfile", async () => {
   const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
-  await write(packageJson, JSON.stringify({ name: "test-pkg-stale-store-entry", dependencies: { "no-deps": "1.0.0" } }));
+  await write(
+    packageJson,
+    JSON.stringify({ name: "test-pkg-stale-store-entry", dependencies: { "no-deps": "1.0.0" } }),
+  );
   await runBunInstall(bunEnv, packageDir);
 
-  const storePackageJson = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps", "package.json");
+  const storePackageJson = join(
+    packageDir,
+    "node_modules",
+    ".bun",
+    "no-deps@1.0.0",
+    "node_modules",
+    "no-deps",
+    "package.json",
+  );
   expect(await file(storePackageJson).json()).toEqual({ name: "no-deps", version: "1.0.0" });
 
   // Another version's contents under this entry's path (an interrupted or

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2007,6 +2007,40 @@ test("same resolution, different dependency name", async () => {
   expect(await readdirSorted(join(packageDir, "node_modules", ".bun"))).toEqual(["no-deps@1.0.0", "node_modules"]);
 });
 
+test("reinstalls a store entry whose package.json does not match the lockfile", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(packageJson, JSON.stringify({ name: "test-pkg-stale-store-entry", dependencies: { "no-deps": "1.0.0" } }));
+  await runBunInstall(bunEnv, packageDir);
+
+  const storePackageJson = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps", "package.json");
+  expect(await file(storePackageJson).json()).toEqual({ name: "no-deps", version: "1.0.0" });
+
+  // Another version's contents under this entry's path (an interrupted or
+  // foreign write). The hoisted linker reads name and version back out of
+  // node_modules/<pkg>/package.json, so it repairs this; the isolated linker
+  // must not treat the entry as installed just because the file exists.
+  await rm(storePackageJson);
+  await write(storePackageJson, JSON.stringify({ name: "no-deps", version: "0.9.0" }));
+
+  let { out } = await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+  expect(out).toContain("1 package installed");
+  expect(await file(storePackageJson).json()).toEqual({ name: "no-deps", version: "1.0.0" });
+
+  // Same for a package.json with the right version but the wrong name.
+  await rm(storePackageJson);
+  await write(storePackageJson, JSON.stringify({ name: "not-no-deps", version: "1.0.0" }));
+
+  ({ out } = await runBunInstall(bunEnv, packageDir, { savesLockfile: false }));
+  expect(out).toContain("1 package installed");
+  expect(await file(storePackageJson).json()).toEqual({ name: "no-deps", version: "1.0.0" });
+
+  // Once repaired, the next install is a no-op again.
+  ({ out } = await runBunInstall(bunEnv, packageDir, { savesLockfile: false }));
+  expect(out).not.toContain("package installed");
+  expect(out).toContain("(no changes)");
+});
+
 test("successfully removes and corrects symlinks", async () => {
   const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
   await Promise.all([


### PR DESCRIPTION
### Problem
- With `--linker isolated`, a store entry that holds another version's files (an interrupted or foreign write) passes every later `bun install` as `(no changes)`, `--frozen-lockfile` included. The installed version disagrees with `bun.lock` forever.
- Cause: the up-to-date check in `install_isolated_packages` (`src/install/isolated_install.rs`, the `'needs_install` block) only calls `sys::exists_z` on the entry's `package.json`. The hoisted linker reads name and version from `node_modules/<pkg>/package.json` (`PackageInstall::verify`), so it repairs the same damage.

### Fix
- Move the name and version comparison into `installed_package_json_matches`, shared by both linkers. The hoisted path is unchanged.
- New `Installer::verify_npm_store_entries` reads each project-local npm entry's store `package.json` on the thread pool before the per-entry loop. An entry that does not match is reinstalled (`LinkPackage` already deletes the old tree first). Git, tarball and global-store entries keep the directory check.
- Cost: one open, read and top-level parse per npm entry, in parallel. A 1,254-entry warm no-op stayed at 30 ms on 16 cores (release build) and went from 31 ms to 36 ms on 2 cores.
- Verified: `test/cli/install/isolated-install.test.ts` (new test fails on 1.4.3), plus the install suites listed in Notes.

### Background
- A store entry is `node_modules/.bun/<name>@<version>/node_modules/<name>`. The isolated linker links each package there once and symlinks dependents to it. The main thread decides `needs_install` per entry.
- The hoisted layout has no version in the path, so `PackageInstall::verify` has always parsed `package.json` for the top-level `name` and `version`.
- `ThreadPool::each` runs one closure per item on the pool and blocks until all finish.

<details><summary>Notes</summary>

- Suites run on the debug build: `isolated-install` (86 pass), `isolated-relink`, `bun-install-registry`, `bun-add`, `bun-patch`, `bun-install-patch`, `bun-workspaces`, `bun-install-lifecycle-scripts`.
- Repro on 1.4.3: `bun install --linker isolated` a project with `no-deps@1.0.0`, replace `node_modules/.bun/no-deps@1.0.0/node_modules/no-deps/package.json` with `{"name":"no-deps","version":"0.9.0"}`, run `bun install` again: `Done! Checked 2 packages (no changes)`. With this change: `1 package installed` and the file is back to 1.0.0. The test replaces the file instead of editing it in place because the store copy is a hardlink of the cache copy.
- Benchmark: 15 top-level dependencies (next, jest, webpack, eslint, vite, firebase-tools, storybook, ...) resolving to 1,254 store entries, `bun install --ignore-scripts` with nothing to do. Release builds from this branch's build graph with `--lto=off`, 80 interleaved runs per binary on a shared and noisy 16-core host, so the low percentiles are the signal. Before: min 29.8 ms, p10 32.0, median 45.6. This change: min 28.7, p10 30.6, median 45.1. An earlier revision that did the reads on the main thread: min 39.6, p10 40.7, median 61.5. Pinned to 2 cores with `taskset`: before 30.6 / 45.1 (min / median), this change 36.2 / 54.5, main-thread reads 40.3 / 56.3. A cold page cache pays one extra small read per entry on top.
- The pre-pass is skipped under `--force` and when `node_modules/.bun` was just created, because every project-local entry is installed in those cases anyway.
- Patched npm entries are not read. Their `.bun-tag-<hash>` marker is written after the patch applies, so it already vouches for the tree, and a patch may edit `package.json` itself (review feedback).
- The read opens with `O_NOFOLLOW` (plus `O_NONBLOCK` on POSIX) and only reads a regular file, so a symlink, FIFO or device left where `package.json` should be counts as a mismatch and is replaced instead of hanging the install (review feedback). Checked by hand with a FIFO and a `/dev/zero` symlink.
- The pool-side parse uses the per-thread mini AST store, as manifest parsing on the pool does, instead of a full AST store per worker (review feedback).
- After a stripped `v`, `=` or whitespace prefix the version is compared without build metadata too. Before, only the unprefixed comparison ignored it (review feedback, applies to the hoisted linker as well).
- Review so far: 4 concerns raised, 4 addressed (the four items above). Nine lint threads about multi-line comments addressed by shortening them.
- #38783 (stage project-local entries and rename them into place) removes the interrupted-install producer. This change covers what is left (a complete-looking entry with the wrong contents) and makes the two linkers agree on what "installed" means for npm packages. #40011 (skip the install when a fingerprint of its inputs matches) would make a true no-op skip these reads entirely.
- Only npm entries are read because only they are guaranteed a `package.json` whose version matches the lockfile string. Tarball and git resolutions carry a URL or commit in the lockfile, which the hoisted linker compares against `.bun-tag` or not at all. Global-store entries are renamed into place whole, and an existing test pins that they only heal under `--force`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->