### PR TITLE
bun test: do not let test.failing absorb an unhandled error as its expected failure

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -252,6 +252,8 @@ test.failing("fixed bug", () => {
 
 Use it to track known bugs you plan to fix later, or for test-driven development.
 
+Only the test function's own failure is inverted: a thrown error, a failed `expect()`, a rejected promise, or `done(err)`. A timeout still fails the test, and so does an uncaught error or unhandled promise rejection that happens while the test runs (for example from a timer callback). That error is printed and the test fails, as it would without `.failing()`.
+
 ## Conditional Tests for Describe Blocks
 
 The conditional modifiers `.if()`, `.skipIf()`, and `.todoIf()` also work on `describe` blocks, affecting all tests in the suite:

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -161,7 +161,7 @@ math.test.ts:
  1 fail
 ```
 
-With this flag, failing todo tests do not cause an error, but Bun marks todo tests that pass as failing so you can remove the todo mark or fix the test.
+With this flag, failing todo tests do not cause an error, but Bun marks todo tests that pass as failing so you can remove the todo mark or fix the test. As with [`test.failing`](#test-failing), only the test function's own failure counts as the expected one. An uncaught error or unhandled promise rejection that happens while a todo test runs still fails it.
 
 ### test.only
 

--- a/src/runtime/test_runner/DoneCallback.rs
+++ b/src/runtime/test_runner/DoneCallback.rs
@@ -2,22 +2,31 @@ use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSValue, JsClass as _, JsRe
 use bun_core::String as BunString;
 use bun_ptr::RefPtr;
 
-use crate::test_runner::bun_test::{group_begin, BunTest, RefData};
+use crate::test_runner::bun_test::{group_begin, BunTest, BunTestPtrWeak, RefData, RefDataValue};
 
 #[bun_jsc::JsClass(no_construct, no_constructor)] // codegen wires to_js / from_js
 pub struct DoneCallback {
     /// Some = not called yet. None = done already called, no-op.
     pub(crate) r#ref: Option<RefPtr<RefData>>,
     pub(crate) called: bool, // = false
+    /// The entry this `done` was created for; `done(err)` is charged to it.
+    pub(crate) buntest_weak: BunTestPtrWeak,
+    pub(crate) owner: RefDataValue,
 }
 
 impl DoneCallback {
-    pub(crate) fn create_unbound(global: &JSGlobalObject) -> JSValue {
+    pub(crate) fn create_unbound(
+        global: &JSGlobalObject,
+        buntest_weak: BunTestPtrWeak,
+        owner: RefDataValue,
+    ) -> JSValue {
         let _g = group_begin!();
 
         let done_callback = DoneCallback {
             r#ref: None,
             called: false,
+            buntest_weak,
+            owner,
         };
 
         // `JsClass::to_js` boxes `self` and hands the raw pointer to the JS

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -45,7 +45,7 @@ use bun_core::scoped_log;
 
 use super::debug::group as group_log; // bun_test.debug.group
 use super::bun_test::{
-    group_begin, AddedInPhase, BunTest, BunTestPtr, EntryData, ExecutionEntry,
+    group_begin, AddedInPhase, BunTest, BunTestPtr, EntryData, ErrorSource, ExecutionEntry,
     HandleUncaughtExceptionResult, Order, RefDataValue, ScopeMode, StepResult,
 };
 use crate::cli::test_command;
@@ -767,6 +767,7 @@ impl Execution {
     pub(crate) fn handle_uncaught_exception(
         &mut self,
         user_data: &RefDataValue,
+        source: ErrorSource,
     ) -> HandleUncaughtExceptionResult {
         let _g = group_begin!();
 
@@ -788,20 +789,28 @@ impl Execution {
             return HandleUncaughtExceptionResult::ShowHandledError;
         }
 
-        match sequence.entry_mode() {
-            ScopeMode::Failing => {
+        match (sequence.entry_mode(), source) {
+            (ScopeMode::Failing, ErrorSource::Callback) => {
                 if sequence.result == Result::Pending {
                     sequence.result = Result::Pass; // executing test() callback
                 }
                 HandleUncaughtExceptionResult::HideError // failing tests prevent the error from being displayed
             }
-            ScopeMode::Todo => {
+            (ScopeMode::Todo, ErrorSource::Callback) => {
                 if sequence.result == Result::Pending {
                     sequence.result = Result::Todo; // executing test() callback
                 }
                 HandleUncaughtExceptionResult::ShowHandledError // todo tests with --todo will still display the error
             }
-            _ => {
+            (ScopeMode::Failing | ScopeMode::Todo, ErrorSource::Unhandled) => {
+                // Not the callback's outcome, so not inverted, and it overrides a
+                // verdict the inversion already produced.
+                if matches!(sequence.result, Result::Pending | Result::Pass | Result::Todo) {
+                    sequence.result = Result::Fail;
+                }
+                HandleUncaughtExceptionResult::ShowHandledError
+            }
+            (_, ErrorSource::Callback | ErrorSource::Unhandled) => {
                 if sequence.result == Result::Pending {
                     sequence.result = Result::Fail;
                 }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -803,8 +803,7 @@ impl Execution {
                 HandleUncaughtExceptionResult::ShowHandledError // todo tests with --todo will still display the error
             }
             (ScopeMode::Failing | ScopeMode::Todo, ErrorSource::Unhandled) => {
-                // Not the callback's outcome, so not inverted, and it overrides a
-                // verdict the inversion already produced.
+                // Never inverted, and it overrides a verdict the inversion already produced.
                 if matches!(sequence.result, Result::Pending | Result::Pass | Result::Todo) {
                     sequence.result = Result::Fail;
                 }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -765,7 +765,7 @@ impl BunTest {
         let this = this_strong.get();
 
         if is_catch {
-            this.on_uncaught_exception(global_this, Some(result), true, &refdata.phase);
+            this.on_uncaught_exception(global_this, Some(result), ErrorSource::Callback, &refdata.phase);
         }
         if !has_one_ref && !is_catch {
             bun_core::scoped_log!(bun_test_group, "bunTestThenOrCatch -> refdata has multiple refs; don't add result until the last ref");
@@ -808,22 +808,26 @@ impl BunTest {
         let was_error = !value.is_empty_or_undefined_or_null();
         // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
         // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
-        if unsafe { (*this).called } {
-            // in Bun 1.2.20, this is a no-op
-            // in Jest, this is "Expected done to be called once, but it was called multiple times."
-            // Vitest does not support done callbacks
-        } else {
-            // error is only reported for the first done() call
-            if was_error {
-                let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
+        let first_call = !unsafe { core::mem::replace(&mut (*this).called, true) };
+        // Only the first done() reports its error. A repeated call is a no-op (Jest
+        // reports "Expected done to be called once"; Vitest has no done callbacks).
+        if first_call && was_error {
+            // Keyed by the entry this `done` was created for, like a throw or a rejection
+            // from the same callback, rather than by whatever happens to be running now.
+            // SAFETY: see above; both fields are read before any JS can run.
+            let (buntest, owner) = unsafe { ((*this).buntest_weak.upgrade(), (*this).owner) };
+            match buntest {
+                Some(strong) => {
+                    strong.get().on_uncaught_exception(global_this, Some(value), ErrorSource::Callback, &owner)
+                }
+                // Its file is already torn down; report it like any stray error.
+                None => {
+                    let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
+                }
             }
         }
         // SAFETY: see above — `this` is a live `*mut DoneCallback`.
-        let ref_in = unsafe {
-            (*this).called = true;
-            (*this).r#ref.take()
-        };
-        let Some(ref_in) = ref_in else {
+        let Some(ref_in) = (unsafe { (*this).r#ref.take() }) else {
             return Ok(JSValue::UNDEFINED);
         };
 
@@ -869,7 +873,7 @@ impl BunTest {
                 Phase::Collection => {}
                 Phase::Execution => {
                     if let Err(e) = (*this).execution.handle_timeout(global) {
-                        (*this).on_uncaught_exception(global, Some(global.take_exception(e)), false, &RefDataValue::Done);
+                        (*this).on_uncaught_exception(global, Some(global.take_exception(e)), ErrorSource::Unhandled, &RefDataValue::Done);
                     }
                 }
                 Phase::Done => {}
@@ -877,7 +881,7 @@ impl BunTest {
         }
         if let Err(e) = Self::run(this_strong, global) {
             // SAFETY: re-derive after `run` returned; no `&mut` was held across it.
-            unsafe { (*this).on_uncaught_exception(global, Some(global.take_exception(e)), false, &RefDataValue::Done) };
+            unsafe { (*this).on_uncaught_exception(global, Some(global.take_exception(e)), ErrorSource::Unhandled, &RefDataValue::Done) };
         }
     }
 
@@ -1123,12 +1127,12 @@ impl BunTest {
 
         if cfg_done_parameter {
             bun_core::scoped_log!(bun_test_group, "callTestCallback -> appending done callback param: data {}", cfg_data);
-            done_callback = DoneCallback::create_unbound(global_this);
+            done_callback = DoneCallback::create_unbound(global_this, Rc::downgrade(this_strong), cfg_data);
             done_arg = match DoneCallback::bind(done_callback, global_this) {
                 Ok(v) => v,
                 Err(e) => {
                     // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point.
-                    unsafe { (*this).on_uncaught_exception(global_this, Some(global_this.take_exception(e)), false, &cfg_data) };
+                    unsafe { (*this).on_uncaught_exception(global_this, Some(global_this.take_exception(e)), ErrorSource::Unhandled, &cfg_data) };
                     JSValue::ZERO // failed to bind done callback
                 }
             };
@@ -1147,7 +1151,7 @@ impl BunTest {
             Err(_) => {
                 global_this.clear_termination_exception();
                 // SAFETY: re-derive after JS callback returned; no outer `&mut` was held across it.
-                unsafe { (*this).on_uncaught_exception(global_this, global_this.try_take_exception(), false, &cfg_data) };
+                unsafe { (*this).on_uncaught_exception(global_this, global_this.try_take_exception(), ErrorSource::Callback, &cfg_data) };
                 bun_core::scoped_log!(bun_test_group, "callTestCallback -> error");
                 JSValue::ZERO
             }
@@ -1247,7 +1251,7 @@ impl BunTest {
                         let value = bun_jsc::JSPromise::opaque_mut(promise).result(global_this.vm());
                         // SAFETY: re-derive via `UnsafeCell` after the JS/microtask
                         // drain above; sole `&mut` at this point.
-                        unsafe { (*this).on_uncaught_exception(global_this, Some(value), true, &cfg_data) };
+                        unsafe { (*this).on_uncaught_exception(global_this, Some(value), ErrorSource::Callback, &cfg_data) };
 
                         // We previously marked it as handled above.
 
@@ -1272,17 +1276,15 @@ impl BunTest {
         &mut self,
         global_this: &JSGlobalObject,
         exception: Option<JSValue>,
-        is_rejection: bool,
+        source: ErrorSource,
         user_data: &RefDataValue,
     ) {
         let _g = group_begin!();
 
-        let _ = is_rejection;
-
         let handle_status: HandleUncaughtExceptionResult = match self.phase {
             Phase::Collection => self.collection.handle_uncaught_exception(user_data),
             Phase::Done => HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests,
-            Phase::Execution => self.execution.handle_uncaught_exception(user_data),
+            Phase::Execution => self.execution.handle_uncaught_exception(user_data, source),
         };
 
         bun_core::scoped_log!(bun_test_group, "onUncaughtException -> {}", <&'static str>::from(handle_status));
@@ -1541,12 +1543,24 @@ impl RunTestsTask {
             bt.on_uncaught_exception(
                 &this.global_this,
                 Some(this.global_this.take_exception(e)),
-                false,
+                ErrorSource::Unhandled,
                 &this.phase,
             );
         }
         Ok(())
     }
+}
+
+/// `test.failing` / `test.todo` only invert a `Callback` error.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum ErrorSource {
+    /// The outcome of the entry's own callback: it threw, the promise it
+    /// returned rejected, or it called `done(err)`.
+    Callback,
+    /// An uncaught exception or unhandled rejection that landed while the
+    /// entry was active (a timer, a floating promise, something an earlier
+    /// test leaked), or an error from the runner itself.
+    Unhandled,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -809,11 +809,9 @@ impl BunTest {
         // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
         // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
         let first_call = !unsafe { core::mem::replace(&mut (*this).called, true) };
-        // Only the first done() reports its error. A repeated call is a no-op (Jest
-        // reports "Expected done to be called once"; Vitest has no done callbacks).
+        // A repeated done() is a no-op (Jest: "Expected done to be called once"; Vitest: no done callbacks).
         if first_call && was_error {
-            // Keyed by the entry this `done` was created for, like a throw or a rejection
-            // from the same callback, rather than by whatever happens to be running now.
+            // Charged to the entry this `done` was created for, like a throw from the same callback.
             // SAFETY: see above; both fields are read before any JS can run.
             let (buntest, owner) = unsafe { ((*this).buntest_weak.upgrade(), (*this).owner) };
             match buntest {
@@ -1554,12 +1552,9 @@ impl RunTestsTask {
 /// `test.failing` / `test.todo` only invert a `Callback` error.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ErrorSource {
-    /// The outcome of the entry's own callback: it threw, the promise it
-    /// returned rejected, or it called `done(err)`.
+    /// The entry's own callback threw, the promise it returned rejected, or it called `done(err)`.
     Callback,
-    /// An uncaught exception or unhandled rejection that landed while the
-    /// entry was active (a timer, a floating promise, something an earlier
-    /// test leaked), or an error from the runner itself.
+    /// An uncaught exception or unhandled rejection while the entry was active, or a runner error.
     Unhandled,
 }
 

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -620,7 +620,7 @@ pub(crate) mod on_unhandled_rejection {
             buntest.on_uncaught_exception(
                 global_object,
                 Some(rejection),
-                true,
+                bun_test::ErrorSource::Unhandled,
                 &current_state_data,
             );
             buntest.add_result(current_state_data);
@@ -635,7 +635,7 @@ pub(crate) mod on_unhandled_rejection {
                     buntest.on_uncaught_exception(
                         global_object,
                         Some(global_object.take_exception(e)),
-                        false,
+                        bun_test::ErrorSource::Unhandled,
                         &phase,
                     );
                 }

--- a/test/js/bun/test/bun_test.fixture.ts
+++ b/test/js/bun/test/bun_test.fixture.ts
@@ -157,8 +157,8 @@ test("expect.assertions combined with timeout", async () => {
   await Bun.sleep(100);
 }, 1);
 
-// === timing edge case ===
-test.failing("more functions called after delayed done", done => {
+// === timing edge case: an error after done() in the same tick still fails this test ===
+test("more functions called after delayed done", done => {
   process.nextTick(() => {
     done();
     expect(true).toBe(false);
@@ -172,7 +172,7 @@ test("misattributed error", () => {
     expect(true).toBe(false);
   }, 10);
 });
-test.failing("passes because it catches the misattributed error", done => {
+test("fails because it receives the misattributed error", done => {
   setTimeout(done, 50);
 });
 
@@ -265,7 +265,7 @@ describe("done parameter", () => {
   });
 });
 
-test.failing("microtasks and rejections are drained after the test callback is executed", () => {
+test("microtasks and rejections are drained after the test callback is executed", () => {
   Promise.reject(new Error("uh oh!"));
 });
 

--- a/test/js/bun/test/bun_test.test.ts
+++ b/test/js/bun/test/bun_test.test.ts
@@ -68,10 +68,34 @@ test("describe/test", async () => {
     (pass) expect.assertions works
     (fail) expect.assertions combined with timeout
       ^ this test timed out after 1ms.
-    (pass) more functions called after delayed done
+    159 | 
+    160 | // === timing edge case: an error after done() in the same tick still fails this test ===
+    161 | test("more functions called after delayed done", done => {
+    162 |   process.nextTick(() => {
+    163 |     done();
+    164 |     expect(true).toBe(false);
+                           ^
+    error: expect(received).toBe(expected)
+
+    Expected: false
+    Received: true
+        at <anonymous> (file:NN:NN)
+    (fail) more functions called after delayed done
     (pass) another test
     (pass) misattributed error
-    (pass) passes because it catches the misattributed error
+    167 | test("another test", async () => {});
+    168 | 
+    169 | // === timing failure case. if this is fixed in the future, update the test ===
+    170 | test("misattributed error", () => {
+    171 |   setTimeout(() => {
+    172 |     expect(true).toBe(false);
+                           ^
+    error: expect(received).toBe(expected)
+
+    Expected: false
+    Received: true
+        at <anonymous> (file:NN:NN)
+    (fail) fails because it receives the misattributed error
     (pass) hooks > test1
     (pass) hooks > test2
     (pass) done parameter > instant done
@@ -100,7 +124,16 @@ test("describe/test", async () => {
     promise error
     (fail) done parameter > done combined with promise error conditions > promise errors only
     (pass) done parameter > second call of done callback ignores triggers error
-    (pass) microtasks and rejections are drained after the test callback is executed
+    264 |     done("uh oh!");
+    265 |   });
+    266 | });
+    267 | 
+    268 | test("microtasks and rejections are drained after the test callback is executed", () => {
+    269 |   Promise.reject(new Error("uh oh!"));
+                               ^
+    error: uh oh!
+        at <anonymous> (file:NN:NN)
+    (fail) microtasks and rejections are drained after the test callback is executed
     (pass) after inside test > the test 1
     (pass) after inside test > the test 2
     (pass) beforeEach inside test fails
@@ -115,7 +148,7 @@ test("describe/test", async () => {
     (todo) failing todo passes
 
 
-    10 tests failed:
+    13 tests failed:
     (fail) actual tests > more functions called after delayed done
     (fail) LINE 68
       ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
@@ -126,15 +159,18 @@ test("describe/test", async () => {
     (fail) expect.assertions
     (fail) expect.assertions combined with timeout
       ^ this test timed out after 1ms.
+    (fail) more functions called after delayed done
+    (fail) fails because it receives the misattributed error
     (fail) done parameter > done combined with promise > fails when completion is not incremented
     (fail) done parameter > done combined with promise error conditions > both error and done resolves first
     (fail) done parameter > done combined with promise error conditions > done errors only
     (fail) done parameter > done combined with promise error conditions > promise errors only
+    (fail) microtasks and rejections are drained after the test callback is executed
 
-     32 pass
+     29 pass
      2 skip
      2 todo
-     10 fail
+     13 fail
      1 error
      2 snapshots, 10 expect() calls
     Ran 46 tests across 1 file."

--- a/test/js/bun/test/fixtures/failing-test-unhandled-error.fixture.ts
+++ b/test/js/bun/test/fixtures/failing-test-unhandled-error.fixture.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+// `.failing` inverts only the outcome of the test callback itself. An error
+// that merely lands while the test is running is a real failure.
+
+describe("callback outcome is still inverted", () => {
+  test.failing("body throws", () => {
+    throw new Error("expected failure");
+  });
+
+  test.failing("done(err)", done => {
+    setTimeout(() => done(new Error("expected failure")), 0);
+  });
+});
+
+describe("unhandled errors are not inverted", () => {
+  test.failing("body resolves, stray timer throws meanwhile", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setTimeout(() => {
+      setTimeout(resolve, 0);
+      throw new Error("stray timer error");
+    }, 0);
+    await promise;
+  });
+
+  test.failing("body resolves, floating promise rejects meanwhile", async () => {
+    Promise.reject(new Error("floating rejection"));
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+  });
+
+  test.failing("body rejects, floating promise rejects first", async () => {
+    Promise.reject(new Error("floating rejection before expected failure"));
+    throw new Error("expected failure");
+  });
+
+  test.failing("done(err) first, then a nextTick throws", done => {
+    process.nextTick(() => {
+      throw new Error("nextTick error after done(err)");
+    });
+    done(new Error("expected failure"));
+  });
+
+  test.failing("expect() throws inside a timer, done() is never reached", done => {
+    setTimeout(() => {
+      expect(1).toBe(2);
+      done();
+    }, 0);
+  });
+});
+
+describe("an error leaked by the previous test", () => {
+  const leaked = Promise.withResolvers<void>();
+
+  test("leaks a timer that throws", () => {
+    setTimeout(() => {
+      leaked.resolve();
+      throw new Error("leaked from the previous test");
+    }, 0);
+  });
+
+  test.failing("lands during a .failing test whose body passes", async () => {
+    await leaked.promise;
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+  });
+});

--- a/test/js/bun/test/test-error-code-done-callback.test.ts
+++ b/test/js/bun/test/test-error-code-done-callback.test.ts
@@ -80,7 +80,6 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:42:14)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:37:3)
     (fail) error done callback (async)
     43 |   });
     44 | });
@@ -111,7 +110,6 @@ test("verify we print error messages passed to done callbacks", () => {
     ^
     error: you should see this(async, nextTick)
     at <anonymous> (<dir>/test-error-done-callback-fixture.ts:60:14)
-    at <anonymous> (<dir>/test-error-done-callback-fixture.ts:54:5)
     (fail) error done callback (async, nextTick)
     62 | });
     63 |

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -77,7 +77,7 @@ describe("test.failing", () => {
       cmd: [bunExe(), "test", "./failing-test-unhandled-error.fixture.ts"],
       cwd: fixtureDir,
       env: bunEnv,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/js/bun/test/test-failing.test.ts
+++ b/test/js/bun/test/test-failing.test.ts
@@ -1,9 +1,19 @@
 import { fail } from "assert";
 import { $ } from "bun";
-import { bunExe } from "harness";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 const fixtureDir = path.join(import.meta.dir, "fixtures");
+
+/** The `(pass)`/`(fail)` lines, verdict notes, error messages and section markers of a `bun test` run, in order. */
+function outline(stderr: string): string[] {
+  return stderr
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => /^(\((pass|fail|todo|skip)\) |error: |\^ |# Unhandled error)/.test(line))
+    .map(line => line.replace(/ \[\d+(\.\d+)?ms\]$/, ""));
+}
+
 describe("test.failing", () => {
   it("is a function", () => {
     expect(test.failing).toBeFunction();
@@ -56,6 +66,41 @@ describe("test.failing", () => {
     }
     expect(stderr).toContain(" 0 pass\n");
     expect(stderr).toMatch(/timed out after \d+ms/i);
+  });
+
+  // Only the test callback's own outcome (throw, rejected promise, done(err)) is
+  // inverted. An uncaught exception or unhandled rejection that lands while a
+  // `.failing` test runs fails it and is printed, like it would for any other
+  // test, even when it was leaked by an earlier test. Matches Jest.
+  it("does not invert an unhandled error that lands during the test", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./failing-test-unhandled-error.fixture.ts"],
+      cwd: fixtureDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(outline(stderr)).toEqual([
+      "(pass) callback outcome is still inverted > body throws",
+      "(pass) callback outcome is still inverted > done(err)",
+      "error: stray timer error",
+      "(fail) unhandled errors are not inverted > body resolves, stray timer throws meanwhile",
+      "error: floating rejection",
+      "(fail) unhandled errors are not inverted > body resolves, floating promise rejects meanwhile",
+      "error: floating rejection before expected failure",
+      "(fail) unhandled errors are not inverted > body rejects, floating promise rejects first",
+      "error: nextTick error after done(err)",
+      "(fail) unhandled errors are not inverted > done(err) first, then a nextTick throws",
+      "error: expect(received).toBe(expected)",
+      "(fail) unhandled errors are not inverted > expect() throws inside a timer, done() is never reached",
+      "(pass) an error leaked by the previous test > leaks a timer that throws",
+      "error: leaked from the previous test",
+      "(fail) an error leaked by the previous test > lands during a .failing test whose body passes",
+    ]);
+    expect(stderr).toContain("\n 3 pass\n");
+    expect(stderr).toContain("\n 6 fail\n");
+    expect(exitCode).toBe(1);
   });
 
   describe("when using a done() callback", () => {

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -538,6 +538,31 @@ it("test.todo doesnt cause exit code 1", () => {
   expect(exitCode).toBe(0);
 });
 
+it("test.todo --todo does not count an unhandled error during the test as the expected failure", () => {
+  const { stderr, exitCode } = spawnSync({
+    cmd: [bunExe(), "test", "./todo-test-fixture-3.js", "--todo"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+    cwd: import.meta.dir,
+  });
+
+  const err = stderr!.toString();
+  const statusLines = err
+    .split("\n")
+    .map(line => line.trim().replace(/ \[\d+(\.\d+)?ms\]$/, ""))
+    .filter(line => /^(\((pass|fail|todo)\) |error: )/.test(line));
+  expect(statusLines).toEqual([
+    "error: expected failure",
+    "(todo) todo whose body throws",
+    "error: stray timer error",
+    "(fail) todo whose body passes while a stray timer throws",
+  ]);
+  expect(err).toContain("\n 1 todo\n");
+  expect(err).toContain("\n 1 fail\n");
+  expect(exitCode).toBe(1);
+});
+
 it("test timeouts when expected", () => {
   const path = join(tmp, "test-timeout.test.js");
   copyFileSync(join(import.meta.dir, "timeout-test-fixture.js"), path);

--- a/test/js/bun/test/todo-test-fixture-3.js
+++ b/test/js/bun/test/todo-test-fixture-3.js
@@ -1,0 +1,17 @@
+import { test } from "bun:test";
+
+// Under --todo, a todo test whose callback fails stays todo. An unhandled error
+// that merely lands while it runs is not the callback's outcome: it fails the test.
+
+test.todo("todo whose body throws", () => {
+  throw new Error("expected failure");
+});
+
+test.todo("todo whose body passes while a stray timer throws", async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  setTimeout(() => {
+    setTimeout(resolve, 0);
+    throw new Error("stray timer error");
+  }, 0);
+  await promise;
+});


### PR DESCRIPTION
### Problem
- `test.failing` counts any error that lands while it runs as its expected failure: a throwing timer, a floating `Promise.reject()`, an error leaked by the previous test. The test reports `(pass)` and the error is never printed. `test.todo` under `--todo` does the same.
- Cause: `Execution::handle_uncaught_exception` (`src/runtime/test_runner/Execution.rs:791`) returns `Pass` + `HideError` for every error that resolves to a `.failing` test. It cannot tell the callback's own outcome from a stray error that the VM hook (`jest::on_unhandled_rejection`) blamed on the running test.

### Fix
- `on_uncaught_exception` takes an `ErrorSource`: `Callback` (the callback threw, its promise rejected, `done(err)`) or `Unhandled` (the VM hook, internal runner errors). `.failing`/`.todo` invert only `Callback`. An `Unhandled` error fails the test and is printed. This matches Jest 30 (verified locally).
- `done(err)` went through the same VM hook as a stray error. The `DoneCallback` now records its entry and reports `done(err)` against it directly. That is the part of #39112 this fix needs. Either PR rebases cleanly on the other.
- Verified: `test/js/bun/test/test-failing.test.ts` (6 of 9 fixture cases flip on stock bun) and `test-test.test.ts` (`--todo`). Also green: the neighbouring `test/js/bun/test/` suites, `bun-test.test.ts`, `junit.test.js`, `node-test.test.ts`.

### Background
- A `RefDataValue` names "group, sequence, entry, repeat". Each completion of a test callback hands one back. A stale one is ignored.
- A stray error has no owner. The VM hook blames the running test and ends it early. That can name the wrong test. This PR keeps the blame. It only stops turning it into a pass.

<details><summary>Notes</summary>

- Repro from the report, `bun test ./a.test.ts` on 1.4.2 and canary: `2 pass, 0 fail`, exit 0. With this change the `.failing` test fails with `error: leaked-from-previous-test` printed under it, exit 1.
- Bun already does not invert a timeout of a `.failing` test, for the same reason.
- Jest 30 on the same files: the stray error fails the test in every variant (body passes, body rejects, done-style with `expect()` throwing in a timer), and `done(err)` in a `.failing` test passes. Bun now agrees on all of them. One difference remains by design: bun ends a test at its first uncaught error instead of waiting for the body or the timeout, as it already does for ordinary tests.
- An `Unhandled` error also overrides a verdict the inversion already produced in the same tick (for example `done(err)` followed by a throwing `process.nextTick`), covered by the fixture.
- A `.failing` test that is cut short by a stray error and whose body rejects later prints that late rejection as `Unhandled error between tests`. This is the existing behavior for any test cut short (by a stray error or a timeout) and is unchanged here.
- `test-error-code-done-callback.test.ts` loses two stack frames from its snapshot. They belonged to the previous test's `done()` call: the old path advanced the runner synchronously inside `done(err)`, so the next test's body ran on top of that frame. The next test now starts on the next tick, as it already did after `done()` without an error.
- Internal runner errors (`RunTestsTask::call`, the timeout callback, a failed `DoneCallback::bind`) are reported as `Unhandled`: they are not the callback's outcome and must not turn into a pass.
- `test/js/bun/test/bun_test.fixture.ts` had three cases that used `.failing` to absorb an uncaught error (an `expect()` after `done()` in the same tick, an error leaked by the previous test, a floating `Promise.reject()`). They are plain tests now, and the snapshot in `bun_test.test.ts` shows each error printed under the test it lands in, followed by `(fail)`.
- #34041 (second `done()` call) touches the same lines in `bun_test_done_callback` and rebases mechanically.
- `docs/test/writing-tests.mdx` gains one paragraph that states what `.failing()` inverts.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts

<!-- robobun:evidence:end -->