### PR TITLE
install: read trustedDependencies from the root package.json only

### DIFF
--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -65,6 +65,12 @@ Defining `trustedDependencies` in `package.json` **replaces** the default list r
 
 Set `trustedDependencies: []` when you want to opt out of the default allow list entirely without passing `--ignore-scripts` on every install. If you define `trustedDependencies` with an explicit list, include any packages from the [default list](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt) whose lifecycle scripts you still need (for example, `sharp` or `esbuild`). Bun no longer trusts those packages implicitly.
 
+### Workspaces
+
+In a [monorepo](/pm/workspaces), `bun install` reads `trustedDependencies` from the root `package.json` only. The list applies to the dependencies of every workspace. A `trustedDependencies` field in a workspace package's own `package.json` has no effect, and `bun install` prints a warning for it. `bun add --trust <pkg>` and `bun pm trust <pkg>` write to the root `package.json` even when you run them inside a workspace.
+
+The lifecycle scripts of the workspace packages themselves always run. They are your own code, not a dependency.
+
 ---
 
 ## `--ignore-scripts`

--- a/src/install/PackageManager/package_json_write_back.rs
+++ b/src/install/PackageManager/package_json_write_back.rs
@@ -377,14 +377,14 @@ fn unchanged_on_disk(manager: &mut PackageManager, target: &WorkspaceTarget) -> 
     File::read_from(Fd::cwd(), &target.package_json_path).is_ok_and(|on_disk| on_disk == printed)
 }
 
-/// Phase 2 (after bun.lock is saved): add `trustedDependencies` learned during the install and write every edited entry whose bytes differ from disk.
+/// Phase 2 (after bun.lock is saved): add `trustedDependencies` learned during the install to the root package.json (the only one `bun install` reads them from) and write every edited entry whose bytes differ from disk.
 pub(crate) fn flush(manager: &mut PackageManager) -> Result<(), crate::Error> {
     if manager.edited_package_jsons.is_empty()
         || !manager.options.do_.contains(Do::WRITE_PACKAGE_JSON)
     {
         return Ok(());
     }
-    let edited = core::mem::take(&mut manager.edited_package_jsons);
+    let mut edited = core::mem::take(&mut manager.edited_package_jsons);
     let mut trusted: Vec<Box<[u8]>> = if manager
         .options
         .do_
@@ -395,14 +395,17 @@ pub(crate) fn flush(manager: &mut PackageManager) -> Result<(), crate::Error> {
         Vec::new()
     };
 
+    if !trusted.is_empty() && edited.iter().any(|e| e.received_requests) {
+        let root = root_target();
+        let entry = fetch_entry(manager, &root);
+        let mut root_json = entry.root;
+        PackageJSONEditor::edit_trusted_dependencies(&mut root_json, &mut trusted)?;
+        print_package_json_into_cache_entry(entry, root_json);
+        push(&mut edited, root, false);
+    }
+
     let mut any_failed = false;
     for e in &edited {
-        if e.received_requests && !trusted.is_empty() {
-            let entry = fetch_entry(manager, &e.target);
-            let mut root = entry.root;
-            PackageJSONEditor::edit_trusted_dependencies(&mut root, &mut trusted)?;
-            print_package_json_into_cache_entry(entry, root);
-        }
         if unchanged_on_disk(manager, &e.target) {
             continue;
         }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2927,6 +2927,16 @@ impl Package<u64> {
                             ),
                         );
                     }
+                    if entry.has_trusted_dependencies {
+                        log.add_warning_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "\"trustedDependencies\" in {}/package.json is ignored. bun only reads it from the root package.json; move the entries there",
+                                bstr::BStr::new(strings::without_trailing_slash(path_)),
+                            ),
+                        );
+                    }
 
                     let workspace_version = 'brk: {
                         if let Some(version_string) = &entry.version {

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -32,6 +32,9 @@ pub struct Entry {
     /// An `installConfig.hoistingLimits` value other than "workspaces" or "none", kept so
     /// the caller can warn about it (outside `process_names_array`'s log window).
     pub(crate) unsupported_hoisting_limits: Option<Box<[u8]>>,
+    /// The workspace's package.json has a `trustedDependencies` field. Only the root's is
+    /// read, so the caller warns about it.
+    pub(crate) has_trusted_dependencies: bool,
 }
 
 impl WorkspaceMap {
@@ -93,13 +96,7 @@ impl WorkspaceMap {
             *entry.key_ptr = Box::<[u8]>::from(key);
         }
         // old value (incl. owned `name`) dropped automatically on assignment
-        *entry.value_ptr = Entry {
-            name: value.name,
-            version: value.version,
-            name_loc: value.name_loc,
-            hoisting_limits: value.hoisting_limits,
-            unsupported_hoisting_limits: value.unsupported_hoisting_limits,
-        };
+        *entry.value_ptr = value;
         Ok(())
     }
 }
@@ -205,6 +202,7 @@ fn process_workspace_name(
             Some(v) if !matches!(&*v, b"workspaces" | b"none") => Some(v),
             _ => None,
         },
+        has_trusted_dependencies: workspace_json.root.get(b"trustedDependencies").is_some(),
         version: 'brk: {
             if let Some(version_expr) = workspace_json.root.get(b"version") {
                 if let Some(version) = version_expr.as_string_cloned(&scratch)? {
@@ -397,16 +395,7 @@ impl WorkspaceMap {
                 }
             }
 
-            workspace_names.insert(
-                rel_input_path,
-                Entry {
-                    name: workspace_entry.name,
-                    name_loc: workspace_entry.name_loc,
-                    version: workspace_entry.version,
-                    hoisting_limits: workspace_entry.hoisting_limits,
-                    unsupported_hoisting_limits: workspace_entry.unsupported_hoisting_limits,
-                },
-            )?;
+            workspace_names.insert(rel_input_path, workspace_entry)?;
         }
 
         if workspace_globs.len() > 0 {
@@ -593,17 +582,7 @@ impl WorkspaceMap {
                         }
                     }
 
-                    workspace_names.insert(
-                        workspace_path,
-                        Entry {
-                            name: workspace_entry.name,
-                            version: workspace_entry.version,
-                            name_loc: workspace_entry.name_loc,
-                            hoisting_limits: workspace_entry.hoisting_limits,
-                            unsupported_hoisting_limits: workspace_entry
-                                .unsupported_hoisting_limits,
-                        },
-                    )?;
+                    workspace_names.insert(workspace_path, workspace_entry)?;
                 }
             }
         }

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1255,7 +1255,6 @@ impl Features {
         dev_dependencies: true,
         is_workspace: true,
         optional_dependencies: true,
-        trusted_dependencies: true,
         ..Self::base()
     };
 

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -2169,24 +2169,53 @@ test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
   },
 );
 
-test.concurrent("--trust --filter writes trustedDependencies into every target, not the root", async () => {
-  const dir = await makeMonorepo({ root: '{ "name": "root", "workspaces": ["packages/*"] }' });
-  const rootBefore = await pkgText(dir, "root");
+// `bun install` reads trustedDependencies from the root package.json only, so that is where `--trust` records the name.
+test.concurrent("--trust --filter writes trustedDependencies into the root, not the targets", async () => {
+  const dir = await makeMonorepo();
 
   const { stderr, exitCode } = await run(["add", "uses-what-bin@1.0.0", "--trust", "--filter", "pkg-*"], dir, {
     linker: "hoisted",
   });
   expect(stderr).not.toContain("error:");
+  expect(stderr).not.toContain("warn:");
   expect(exitCode).toBe(0);
 
   expect(await allPackageJsons(dir)).toStrictEqual([
-    ROOT,
+    { ...ROOT, trustedDependencies: ["uses-what-bin"] },
     API,
     WEB,
-    { name: "pkg-a", dependencies: { "uses-what-bin": "1.0.0" }, trustedDependencies: ["uses-what-bin"] },
-    { name: "pkg-b", dependencies: { "uses-what-bin": "1.0.0" }, trustedDependencies: ["uses-what-bin"] },
+    { name: "pkg-a", dependencies: { "uses-what-bin": "1.0.0" } },
+    { name: "pkg-b", dependencies: { "uses-what-bin": "1.0.0" } },
   ]);
-  expect(await pkgText(dir, "root")).toBe(rootBefore);
+  expect((await lockfileJson(dir)).trustedDependencies).toStrictEqual(["uses-what-bin"]);
+  expect(await exists(join(dir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+
+  // A later install from the manifests alone still trusts it.
+  await rm(join(dir, "node_modules"), { recursive: true, force: true });
+  await rm(join(dir, "bun.lock"), { force: true });
+  await installOk(dir, "hoisted");
+  expect(await exists(join(dir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+});
+
+test.concurrent("--trust from inside a workspace writes trustedDependencies into the root", async () => {
+  const dir = await makeMonorepo();
+
+  const { stderr, exitCode } = await run(["add", "uses-what-bin@1.0.0", "--trust"], dir, {
+    linker: "hoisted",
+    cwd: join(dir, "packages", "pkg-a"),
+  });
+  expect(stderr).not.toContain("error:");
+  expect(stderr).not.toContain("warn:");
+  expect(exitCode).toBe(0);
+
+  expect(await allPackageJsons(dir)).toStrictEqual([
+    { ...ROOT, trustedDependencies: ["uses-what-bin"] },
+    API,
+    WEB,
+    { name: "pkg-a", dependencies: { "uses-what-bin": "1.0.0" } },
+    PKG_B,
+  ]);
+  expect((await lockfileJson(dir)).trustedDependencies).toStrictEqual(["uses-what-bin"]);
   expect(await exists(join(dir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
 });
 

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -732,6 +732,86 @@ test.concurrent(
   },
 );
 
+describe.concurrent("trustedDependencies in a workspace member's package.json", () => {
+  async function writeWorkspace(packageDir: string, root: object, members: Record<string, object>) {
+    await writeFile(join(packageDir, "package.json"), JSON.stringify({ workspaces: ["packages/*"], ...root }));
+    for (const [dir, json] of Object.entries(members)) {
+      await mkdir(join(packageDir, "packages", dir), { recursive: true });
+      await writeFile(join(packageDir, "packages", dir, "package.json"), JSON.stringify(json));
+    }
+  }
+
+  async function install(cwd: string, env: Record<string, string>, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  test("does not grant trust to a dependency that only a sibling declares", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+
+    await writeWorkspace(
+      packageDir,
+      { name: "foo" },
+      {
+        lib: { name: "lib", dependencies: { "all-lifecycle-scripts": "1.0.0" } },
+        leaf: { name: "leaf", trustedDependencies: ["all-lifecycle-scripts"] },
+      },
+    );
+
+    const { out, err, exitCode } = await install(packageDir, env);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(err).toContain(
+      'warn: "trustedDependencies" in packages/leaf/package.json is ignored. bun only reads it from the root package.json; move the entries there',
+    );
+    expect(err).not.toContain("packages/lib/package.json");
+    expect(out).toContain("Blocked 3 postinstalls. Run `bun pm untrusted` for details.");
+    expect(await exists(join(packageDir, "node_modules", "all-lifecycle-scripts", "postinstall.txt"))).toBeFalse();
+    expect(await file(join(packageDir, "bun.lock")).text()).not.toContain("trustedDependencies");
+    expect(exitCode).toBe(0);
+
+    // Same with bun.lock present and the member left out of the install.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    const filtered = await install(packageDir, env, "--filter", "!leaf");
+    expect(filtered.err).not.toContain("error:");
+    expect(filtered.out).toContain("2 packages installed");
+    expect(await exists(join(packageDir, "node_modules", "all-lifecycle-scripts", "package.json"))).toBeTrue();
+    expect(await exists(join(packageDir, "node_modules", "all-lifecycle-scripts", "postinstall.txt"))).toBeFalse();
+    expect(filtered.exitCode).toBe(0);
+  });
+
+  test("does not replace the default trusted dependencies list for the rest of the project", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+
+    // `electron` is on the default list, so the root needs no trustedDependencies
+    // entry for its preinstall to run.
+    await writeWorkspace(
+      packageDir,
+      { name: "foo", dependencies: { electron: "1.0.0" } },
+      { leaf: { name: "leaf", trustedDependencies: [] } },
+    );
+
+    const { out, err, exitCode } = await install(packageDir, env);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).not.toContain("Blocked");
+    expect(await file(join(packageDir, "node_modules", "electron", "preinstall.txt")).text()).toBe(
+      "preinstall success!",
+    );
+    expect(exitCode).toBe(0);
+  });
+});
+
 // waiter thread is only a thing on Linux.
 for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
   describe.concurrent("lifecycle scripts" + (forceWaiterThread ? " (waiter thread)" : ""), async () => {


### PR DESCRIPTION
### Problem
- `bun install` merged the `trustedDependencies` of every workspace package into one project-wide allow-list. A leaf `packages/evil/package.json` with `"trustedDependencies": ["x"]` ran `x`'s postinstall although only a sibling depends on `x`, even under `--filter '!evil'`.
- A workspace package that only defines the field (`[]`) turned off the default trusted list for the whole project. The root's `esbuild`-style postinstalls were blocked.
- Cause: `Features::WORKSPACE` set `trusted_dependencies: true` (`src/install_types/resolver_hooks.rs:1258`), so `Package::parse_with_json` (`src/install/lockfile/Package.rs:2525`) added every member's entries to `lockfile.trusted_dependencies`.

### Fix
- Read `trustedDependencies` from the root package.json only, like `overrides`, `patchedDependencies` (#39816) and catalogs. A workspace package's field is ignored with a warning that names the file.
- `bun add --trust` inside a workspace, or with `--filter`, writes the trusted name into the root package.json, where `bun pm trust` already writes.
- Behavior change: a repo with the list only in a workspace package gets those scripts blocked, with the warning as the signal. pnpm and yarn are root-only too. Notes has the reach and the alternative.
- Verified: four tests in `bun-install-lifecycle-scripts.test.ts` and `bun-add-filter.test.ts`, all fail on 1.4.3. The other workspace, lockfile and `bun pm` trust suites pass.

### Background
- `trustedDependencies` lists the packages whose lifecycle scripts `bun install` runs. Without the field a built-in default list applies to npm packages. Defining it, even as `[]`, replaces that list.
- `Features` is the per-manifest parse configuration: `MAIN` for the root, `WORKSPACE` for workspace packages.
- The root parse reads each workspace package.json once through `WorkspaceMap`. The warning is raised there, once per install.

<details><summary>Notes</summary>

Registry-free reproduction on 1.4.3 (both linkers):

```sh
mkdir -p mk/package mono/vendor mono/packages/lib mono/packages/evil && cd mono
printf '{"name":"scripted2","version":"1.0.0","scripts":{"postinstall":"echo SCRIPTED2-RAN >> %s/MARKS"}}' "$PWD" > ../mk/package/package.json
(cd ../mk && tar czf ../mono/vendor/scripted2.tgz package)
printf '{"name":"mono","private":true,"workspaces":["packages/*"]}' > package.json
printf '{"name":"lib","version":"1.0.0","dependencies":{"scripted2":"file:../../vendor/scripted2.tgz"}}' > packages/lib/package.json
printf '{"name":"evil","version":"1.0.0","trustedDependencies":["scripted2"]}' > packages/evil/package.json
bun install; cat MARKS                    # SCRIPTED2-RAN (blocked without the evil line)
rm -rf node_modules MARKS
bun install --filter '!evil'; cat MARKS   # SCRIPTED2-RAN again
```

With this change both installs block the script, bun.lock has no top-level `trustedDependencies`, and stderr has:

```
warn: "trustedDependencies" in packages/evil/package.json is ignored. bun only reads it from the root package.json; move the entries there
```

The `--trust` write-back: names learned during the install are collected in `trusted_deps_to_add_to_package_json` and written in `package_json_write_back::flush` after bun.lock is saved. Before, `flush` added them to every edited manifest that received the positionals (the cwd workspace, or each `--filter` target). Now it adds them to the root manifest and writes that file too. In a single-package project the root is the cwd manifest, so nothing changes there.

Reach of the behavior change: GitHub code search finds on the order of 1,000 `package.json` files under `apps/` or `packages/` paths that contain `trustedDependencies`. Some are templates or single projects, some are bun workspaces with no root-level list (written by `bun add --trust` run inside a workspace, which has targeted the workspace's own manifest since the field shipped). After upgrading, such a repo sees the warning on every install and, with the hoisted linker, the `Blocked N postinstalls` line; moving the entries to the root (or `bun pm trust <pkg>`) restores them.

The alternative considered: keep honoring a workspace package's entries but only for that package's own dependencies, never let its field change the default-list mode, and store per-workspace lists in bun.lock so `bun pm untrusted` stays accurate. That touches the lockfile formats, the manifest differ, both installers and the `bun pm` commands, and needs a decision on hoisted layouts where one copy serves several workspaces. No other package manager has per-workspace script trust. Left for a maintainer to ask for.

#41803 goes the other way: it keeps workspace packages as trust declarers and fixes the differ so an entry added to a member manifest later is picked up. The two PRs are alternatives. If this one lands, #41803 is not needed.

Lockfile churn on upgrade: a bun.lock whose top-level `trustedDependencies` came from a member manifest loses those entries on the next `bun install` (one `Saved lockfile`). `--frozen-lockfile` and `bun ci` do not fail on it, because `Lockfile::eql` does not compare the trusted list.

Two pre-existing reporting gaps showed up while testing and are tracked separately: the isolated linker never prints the `Blocked N postinstalls` summary, and the hoisted linker does not print it on a reinstall from an existing bun.lock. The new tests do not depend on either.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts, test/cli/install/bun-add-filter.test.ts

<!-- robobun:evidence:end -->