### PR TITLE
install: link registry packages' bins before the bins of workspace and other local directory packages

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -696,12 +696,10 @@ impl<'a> NamesIterator<'a> {
     }
 }
 
-/// The order in which the packages of one `node_modules` folder link their bins
-/// into its `.bin` folder. The first package to link a bin name keeps it
-/// (`Linker::seen`), so when two packages declare the same bin name, the one in
-/// the earlier group wins. Within a group, packages link in dependency name
-/// order. npm uses the same two groups: it links the bins of every extracted
-/// package before the bins of linked local directories.
+/// Packages that share a `node_modules/.bin` link their bins in this order, then
+/// in dependency name order. The first link for a bin name wins (`Linker::seen`),
+/// so an extracted package keeps its bin over a local directory that declares the
+/// same name. npm links in the same order.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum LinkOrder {
     /// Registry, tarball and git packages.
@@ -722,22 +720,16 @@ impl LinkOrder {
     }
 }
 
-// BACKREF — `PackageInstaller` holds a `&mut Lockfile` alongside a
-// `Box<[TreeContext]>` whose `binaries` queues read the same `Lockfile`; a
-// `&'a Lockfile` borrow here would force the `TreeContext.binaries` field to
-// carry an unsatisfiable `'static` (the installer outlives no concrete lifetime
-// for its own self-borrowed lockfile).
+// BACKREF — the `PackageInstaller` that owns these queues also borrows the
+// `Lockfile` mutably, so this cannot be a `&'a Lockfile`.
 pub struct PriorityQueueContext {
     pub(crate) lockfile: bun_ptr::BackRef<Lockfile>,
 }
 
 impl PriorityQueueContext {
     fn order(&self, a: DependencyID, b: DependencyID) -> core::cmp::Ordering {
-        // The `Lockfile` is kept alive for the entire install (the
-        // `PackageInstaller` that owns this queue borrows the same one). Its
-        // buffers and its package list can grow during the install (see
-        // `fix_cached_lockfile_package_slices`), which is why the slices are
-        // re-read on every compare instead of cached.
+        // Re-read the slices on every compare: the buffers and the package list
+        // can grow during the install (`fix_cached_lockfile_package_slices`).
         let lockfile = &*self.lockfile;
         let deps = lockfile.buffers.dependencies.as_slice();
         let string_buf = lockfile.buffers.string_bytes.as_slice();

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -21,6 +21,9 @@ use bun_sys::{self as sys, Fd, FdExt as _};
 use crate::bun_json::{Expr, ExprData};
 use crate::dependency::{Dependency, DependencyExt as _};
 use crate::install::{DependencyID, ExternalStringList};
+use crate::lockfile::Lockfile;
+use crate::lockfile::package::PackageColumns as _;
+use crate::resolution;
 #[cfg(windows)]
 use crate::windows_shim::BinLinkingShim as WinBinLinkingShim;
 #[cfg(windows)]
@@ -693,41 +696,75 @@ impl<'a> NamesIterator<'a> {
     }
 }
 
-// BACKREF — `PackageInstaller` holds a
-// `&mut Lockfile` alongside a `Box<[TreeContext]>` whose `binaries` queues
-// alias into `lockfile.buffers`; a `&'a Vec<_>` borrow here would force the
-// `TreeContext.binaries` field to carry an unsatisfiable `'static` (the
-// installer outlives no concrete lifetime for its own self-borrowed buffers).
+/// The order in which the packages of one `node_modules` folder link their bins
+/// into its `.bin` folder. The first package to link a bin name keeps it
+/// (`Linker::seen`), so when two packages declare the same bin name, the one in
+/// the earlier group wins. Within a group, packages link in dependency name
+/// order. npm uses the same two groups: it links the bins of every extracted
+/// package before the bins of linked local directories.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum LinkOrder {
+    /// Registry, tarball and git packages.
+    ExtractedPackage,
+    /// Workspace packages, `file:` and `link:` directories, and the root package.
+    LocalDirectory,
+}
+
+impl LinkOrder {
+    pub(crate) fn of(resolution: resolution::Tag) -> LinkOrder {
+        match resolution {
+            resolution::Tag::Root
+            | resolution::Tag::Workspace
+            | resolution::Tag::Folder
+            | resolution::Tag::Symlink => LinkOrder::LocalDirectory,
+            _ => LinkOrder::ExtractedPackage,
+        }
+    }
+}
+
+// BACKREF — `PackageInstaller` holds a `&mut Lockfile` alongside a
+// `Box<[TreeContext]>` whose `binaries` queues read the same `Lockfile`; a
+// `&'a Lockfile` borrow here would force the `TreeContext.binaries` field to
+// carry an unsatisfiable `'static` (the installer outlives no concrete lifetime
+// for its own self-borrowed lockfile).
 pub struct PriorityQueueContext {
-    pub(crate) dependencies: bun_ptr::BackRef<Vec<Dependency>>,
-    pub(crate) string_buf: bun_ptr::BackRef<Vec<u8>>,
+    pub(crate) lockfile: bun_ptr::BackRef<Lockfile>,
 }
 
 impl PriorityQueueContext {
-    fn less_than(&self, a: DependencyID, b: DependencyID) -> core::cmp::Ordering {
-        // `dependencies` / `string_buf` point at
-        // `lockfile.buffers.{dependencies,string_bytes}`, which are kept alive
-        // for the entire install (the `PackageInstaller` that owns this queue
-        // also borrows the same `Lockfile`). The Vecs may be reallocated by
-        // `fix_cached_lockfile_package_slices`, which is why we re-deref the
-        // `BackRef<Vec>` (header) on every compare instead of caching a slice.
-        let deps = self.dependencies.as_slice();
-        let buf = self.string_buf.as_slice();
-        let a_name = deps[a as usize].name.slice(buf);
-        let b_name = deps[b as usize].name.slice(buf);
-        strings::order(a_name, b_name)
+    fn order(&self, a: DependencyID, b: DependencyID) -> core::cmp::Ordering {
+        // The `Lockfile` is kept alive for the entire install (the
+        // `PackageInstaller` that owns this queue borrows the same one). Its
+        // buffers and its package list can grow during the install (see
+        // `fix_cached_lockfile_package_slices`), which is why the slices are
+        // re-read on every compare instead of cached.
+        let lockfile = &*self.lockfile;
+        let deps = lockfile.buffers.dependencies.as_slice();
+        let string_buf = lockfile.buffers.string_bytes.as_slice();
+        let resolutions = lockfile.buffers.resolutions.as_slice();
+        let pkg_resolutions = lockfile.packages.items_resolution();
+        let link_order = |dep_id: DependencyID| {
+            LinkOrder::of(pkg_resolutions[resolutions[dep_id as usize] as usize].tag)
+        };
+
+        link_order(a).cmp(&link_order(b)).then_with(|| {
+            strings::order(
+                deps[a as usize].name.slice(string_buf),
+                deps[b as usize].name.slice(string_buf),
+            )
+        })
     }
 }
 
 impl bun_collections::PriorityCompare<DependencyID> for PriorityQueueContext {
     #[inline]
     fn compare(&self, a: &DependencyID, b: &DependencyID) -> core::cmp::Ordering {
-        self.less_than(*a, *b)
+        self.order(*a, *b)
     }
 }
 
 // Port of `std.PriorityQueue(DependencyID, PriorityQueueContext, lessThan)`.
-// Min-heap keyed by `PriorityQueueContext::less_than` (string-order of dep names).
+// Min-heap keyed by `PriorityQueueContext::order` (`LinkOrder`, then dep name).
 pub(crate) type PriorityQueue = bun_collections::PriorityQueue<DependencyID, PriorityQueueContext>;
 
 // https://github.com/npm/npm-normalize-package-bin/blob/574e6d7cd21b2f3dee28a216ec2053c2551f7af9/lib/index.js#L38
@@ -896,6 +933,14 @@ impl<'a> Linker<'a> {
             // Skip seen destinations for this tree
             // https://github.com/npm/cli/blob/22731831e22011e32fa0ca12178e242c2ee2b33d/node_modules/bin-links/lib/link-gently.js#L30
             if seen.contains_key(abs_dest.as_bytes()) {
+                if crate::PackageManager::verbose_install() {
+                    bun_core::pretty_errorln!(
+                        "<d>[Bin Linker]<r> skipping {} of {}: another package already linked {}",
+                        bstr::BStr::new(path::basename(abs_dest.as_bytes())),
+                        bstr::BStr::new(self.package_name.slice()),
+                        bstr::BStr::new(abs_dest.as_bytes()),
+                    );
+                }
                 return;
             }
         }

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -392,8 +392,7 @@ pub(crate) fn install_hoisted_packages(
                     for _i in 0..trees_count {
                         trees.push(TreeContext {
                             binaries: bin::PriorityQueue::init(bin::PriorityQueueContext {
-                                dependencies: buf_deps,
-                                string_buf: buf_strings,
+                                lockfile: lockfile_ref,
                             }),
                             pending_installs: Vec::new(),
                             install_count: 0,

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2333,8 +2333,7 @@ impl<'a> Installer<'a> {
             Which::Staging,
         );
 
-        // `deps` is in dependency name order. Link in `LinkOrder` groups, each
-        // group in that order.
+        // `deps` is sorted by name, which is the order within each `LinkOrder`.
         let deps = entry_deps[parent_entry_id.get() as usize].slice();
         let pkg_resolutions = pkgs.items_resolution();
         let link_order_of = |dep: &store::entry::DependenciesItem| {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2333,7 +2333,22 @@ impl<'a> Installer<'a> {
             Which::Staging,
         );
 
-        for dep in entry_deps[parent_entry_id.get() as usize].slice() {
+        // `deps` is in dependency name order. Link in `LinkOrder` groups, each
+        // group in that order.
+        let deps = entry_deps[parent_entry_id.get() as usize].slice();
+        let pkg_resolutions = pkgs.items_resolution();
+        let link_order_of = |dep: &store::entry::DependenciesItem| {
+            let node_id = entry_node_ids[dep.entry_id.get() as usize];
+            bin_real::LinkOrder::of(pkg_resolutions[node_pkg_ids[node_id.get() as usize] as usize].tag)
+        };
+        let ordered_deps = [
+            bin_real::LinkOrder::ExtractedPackage,
+            bin_real::LinkOrder::LocalDirectory,
+        ]
+        .into_iter()
+        .flat_map(|order| deps.iter().filter(move |dep| link_order_of(dep) == order));
+
+        for dep in ordered_deps {
             let node_id = entry_node_ids[dep.entry_id.get() as usize];
             let dep_id = node_dep_ids[node_id.get() as usize];
             let pkg_id = node_pkg_ids[node_id.get() as usize];

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2339,7 +2339,9 @@ impl<'a> Installer<'a> {
         let pkg_resolutions = pkgs.items_resolution();
         let link_order_of = |dep: &store::entry::DependenciesItem| {
             let node_id = entry_node_ids[dep.entry_id.get() as usize];
-            bin_real::LinkOrder::of(pkg_resolutions[node_pkg_ids[node_id.get() as usize] as usize].tag)
+            bin_real::LinkOrder::of(
+                pkg_resolutions[node_pkg_ids[node_id.get() as usize] as usize].tag,
+            )
         };
         let ordered_deps = [
             bin_real::LinkOrder::ExtractedPackage,

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -11,6 +11,7 @@ import {
   readdirSorted,
   runBunInstall,
   runBunUpdate,
+  toBeValidBin,
   toMatchNodeModulesAt,
   VerdaccioRegistry,
 } from "harness";
@@ -18,7 +19,7 @@ import { join } from "path";
 
 const { parseLockfile } = install_test_helpers;
 
-expect.extend({ toMatchNodeModulesAt });
+expect.extend({ toBeValidBin, toMatchNodeModulesAt });
 
 var verdaccio: VerdaccioRegistry;
 
@@ -2882,4 +2883,96 @@ test.concurrent("a copyfile install over a workspace's hardlinked files does not
   expect(cached).toHaveLength(1);
   expect(readJson(join(cacheDir, cached[0], "package.json"))).toEqual({ name: "no-deps", version: "2.0.0" });
   expect(statSync(join(cacheDir, cached[0], "index.js")).size).toBeGreaterThan(0);
+});
+
+// Two packages in one node_modules folder can declare the same bin name, and only one
+// of them gets `node_modules/.bin/<name>`. Registry packages link their bins before
+// workspace packages do, as in npm, so a workspace package never takes the bin of a
+// registry dependency, whichever way the two package names sort.
+describe("a workspace package's bin does not replace the bin of a registry dependency", () => {
+  // "aaa" sorts before "what-bin". Bins used to be linked in name order alone, so
+  // `aaa` took `.bin/what-bin`.
+  async function writeWorkspacePackageWithWhatBin(packageDir: string) {
+    await Promise.all([
+      write(
+        join(packageDir, "packages", "aaa", "package.json"),
+        JSON.stringify({ name: "aaa", version: "1.0.0", bin: { "what-bin": "fake.js" } }),
+      ),
+      write(join(packageDir, "packages", "aaa", "fake.js"), "#!/usr/bin/env node\n"),
+    ]);
+  }
+
+  async function run(ctx: TestCtx, args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: ctx.packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: ctx.env,
+    });
+    const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(exitCode).toBe(0);
+  }
+
+  const registryBin = join("..", "what-bin", "what-bin.js");
+  const workspaceBin = join("..", "aaa", "fake.js");
+
+  test.concurrent("hoisted: dependency of the root", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({ name: "foo", workspaces: ["packages/*"], dependencies: { "what-bin": "1.0.0" } }),
+      ),
+      writeWorkspacePackageWithWhatBin(packageDir),
+    ]);
+
+    await run(ctx, ["install", "--linker", "hoisted"]);
+    expect(join(packageDir, "node_modules", ".bin", "what-bin")).toBeValidBin(registryBin);
+
+    // and again with node_modules already in place
+    await rm(join(packageDir, "bun.lock"));
+    await run(ctx, ["install", "--linker", "hoisted"]);
+    expect(join(packageDir, "node_modules", ".bin", "what-bin")).toBeValidBin(registryBin);
+  });
+
+  test.concurrent("hoisted: adding the registry dependency afterwards takes the bin over", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "foo", workspaces: ["packages/*"] })),
+      writeWorkspacePackageWithWhatBin(packageDir),
+    ]);
+
+    await run(ctx, ["install", "--linker", "hoisted"]);
+    // nothing else declares a `what-bin` bin yet
+    expect(join(packageDir, "node_modules", ".bin", "what-bin")).toBeValidBin(workspaceBin);
+
+    await run(ctx, ["add", "what-bin@1.0.0", "--linker", "hoisted"]);
+    expect(join(packageDir, "node_modules", ".bin", "what-bin")).toBeValidBin(registryBin);
+  });
+
+  test.concurrent("isolated: workspace package that depends on both", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "foo", workspaces: ["packages/*"] })),
+      write(
+        join(packageDir, "packages", "app", "package.json"),
+        JSON.stringify({ name: "app", dependencies: { aaa: "workspace:*", "what-bin": "1.0.0" } }),
+      ),
+      writeWorkspacePackageWithWhatBin(packageDir),
+    ]);
+
+    await run(ctx, ["install", "--linker", "isolated"]);
+    expect(join(packageDir, "packages", "app", "node_modules", ".bin", "what-bin")).toBeValidBin(registryBin);
+
+    // and again with node_modules already in place
+    await rm(join(packageDir, "bun.lock"));
+    await run(ctx, ["install", "--linker", "isolated"]);
+    expect(join(packageDir, "packages", "app", "node_modules", ".bin", "what-bin")).toBeValidBin(registryBin);
+  });
 });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2975,4 +2975,21 @@ describe("a workspace package's bin does not replace the bin of a registry depen
     await run(ctx, ["install", "--linker", "isolated"]);
     expect(join(packageDir, "packages", "app", "node_modules", ".bin", "what-bin")).toBeValidBin(registryBin);
   });
+
+  // A `file:` directory dependency is a local directory too and links in the same
+  // group as workspace packages.
+  test.concurrent("hoisted: file: directory dependency of the root", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({ name: "foo", dependencies: { aaa: "file:./packages/aaa", "what-bin": "1.0.0" } }),
+      ),
+      writeWorkspacePackageWithWhatBin(packageDir),
+    ]);
+
+    await run(ctx, ["install", "--linker", "hoisted"]);
+    expect(join(packageDir, "node_modules", ".bin", "what-bin")).toBeValidBin(registryBin);
+  });
 });


### PR DESCRIPTION
### Problem
- In a workspace, a member package's `bin` name took over the same-named bin of a registry dependency in `node_modules/.bin`, with no message. A member `evil` with `"bin": {"tsc": "evil.sh"}` next to a root `devDependencies: {"typescript": "^5"}` gave `node_modules/.bin/tsc -> ../evil/evil.sh` (hoisted linker), and the same in `packages/app/node_modules/.bin` for a sibling that declares both `typescript` and `"evil": "workspace:*"` (isolated linker). npm 11 keeps `typescript`'s `tsc` on the same tree.
- The cause: the bins of one `node_modules` folder link in dependency name order alone, and the first link for a name wins (`PriorityQueueContext` in `src/install/bin.rs`, the name-ordered entry dependencies in `Installer::link_dependency_bins`). `evil` sorts before `typescript`, so it wins. A member named `zevil` lost.

### Fix
- Add `bin::LinkOrder`: extracted packages (registry, tarball, git) link their bins before local directory packages (workspace, `file:` directory, `link:`, root). Each group keeps name order. The hoisted linker's per-tree bin queue compares `(LinkOrder, name)`. The isolated linker walks an entry's dependencies group by group.
- This is npm's order. arborist's `rebuild.js` builds regular nodes first and `isLink` nodes (workspaces, `file:` directories, `npm link`) second, and `bin-links` never replaces a bin it already linked in that pass. Bun had ported the first-wins `seen` set but not the second group.
- `bun install --verbose` now prints a `[Bin Linker] skipping ...` line when a bin is skipped because another package already linked that name. Default output is unchanged: same-name bins are common and fine (for example `jest` and `jest-cli` both declare `jest`), and npm and pnpm stay quiet too.
- Verified: `test/cli/install/bun-workspaces.test.ts` (4 new tests, all fail on 1.4.3-canary `d316760e8`, pass with this branch). Also ran `bun-install.test.ts`, `bun-install-registry.test.ts`, `isolated-install.test.ts`, `isolated-relink.test.ts`, `bun-link.test.ts` and `bun-install-native-binlink.test.ts`.

### Background
- Every package in a `node_modules` folder links its `bin` entries into that folder's `.bin`. Two packages can declare the same bin name, and only one symlink (or `.exe`/`.bunx` shim on Windows) can exist per name.
- The hoisted linker queues the bin-carrying dependencies of each tree in a `bin::PriorityQueue` and links them once the whole tree is installed, with one `seen` set per tree. The isolated linker links the bins of each store entry's direct dependencies into that entry's own `node_modules/.bin`, also with a `seen` set.
- On a re-install every bin is linked again in the same order and an existing entry is replaced, so the result does not depend on install history. That is why `bun add what-bin` after the fact takes the bin back (second test).

<details><summary>Notes</summary>

- npm reference: `workspaces/arborist/lib/arborist/rebuild.js` (`#retrieveNodesByType`, "build link deps" after "build regular deps", `#linkAllBins` sorted by depth then path) and `bin-links/lib/link-gently.js` (module-level `seen`, never clobbers a link that points into another package).
- pnpm picks a winner by "bin name equals package name", then package name, and logs conflicts at debug level only. Yarn classic prefers direct dependencies over transitive ones. There is no cross-manager rule beyond the case fixed here, so this PR only adds npm's grouping and leaves the name order inside a group as it was.
- `LinkOrder::LocalDirectory` covers `Root`, `Workspace`, `Folder` and `Symlink` resolutions. Local and remote tarballs and git packages are extracted artifacts and stay in the first group, as in npm (they are not `Link` nodes there).
- The hoisted queue's context now holds a `BackRef<Lockfile>` instead of two `BackRef<Vec<_>>` into its buffers, because the order also needs `buffers.resolutions` and the package resolutions column. Slices are still re-read on every compare since both can grow during an install.
- The debug-build verification ran on Windows x64 (my Linux machine was out of disk at the time); fail-before ran on both Linux and Windows with the release canary.

</details>

