### PR TITLE
node:fs: keep sub-millisecond times in cp, cpSync and promises.cp with preserveTimestamps

### DIFF
--- a/src/js/internal/fs/cp-sync.ts
+++ b/src/js/internal/fs/cp-sync.ts
@@ -417,8 +417,21 @@ function setDestTimestamps(src, dest) {
   // The initial srcStat.atime cannot be trusted
   // because it is modified by the read(2) system call
   // (See https://nodejs.org/api/fs.html#fs_stat_time_values)
-  const updatedSrcStat = statSync(src);
-  return utimesSync(dest, updatedSrcStat.atime, updatedSrcStat.mtime);
+  const updatedSrcStat = statSync(src, { bigint: true });
+  return utimesSync(dest, utimesTime(updatedSrcStat.atimeNs), utimesTime(updatedSrcStat.mtimeNs));
+}
+
+const kNsPerSec = 1_000_000_000n;
+const kNsPerMs = 1_000_000n;
+
+// A stat time in the most precise form utimes accepts. A Date (what node's JS
+// walker passes) only carries milliseconds, so build the same
+// `tv_sec + tv_nsec / 1e9` seconds node's native cpSync passes:
+// https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L3607-L3608
+// utimes maps a negative number to "now", so a pre-epoch time stays a Date.
+function utimesTime(ns) {
+  if (ns < 0n) return new Date(Number(ns / kNsPerMs));
+  return Number(ns / kNsPerSec) + Number(ns % kNsPerSec) / 1e9;
 }
 
 function onDir(srcStat, destStat, src, dest, opts) {
@@ -523,4 +536,5 @@ export default {
   fsEisdirError,
   areIdentical,
   isSrcSubdir,
+  utimesTime,
 };

--- a/src/js/internal/fs/cp.ts
+++ b/src/js/internal/fs/cp.ts
@@ -12,6 +12,7 @@ const {
   fsEisdirError,
   areIdentical,
   isSrcSubdir,
+  utimesTime,
 } = require("internal/fs/cp-sync");
 
 const {
@@ -310,8 +311,8 @@ async function setDestTimestamps(src, dest) {
   // The initial srcStat.atime cannot be trusted
   // because it is modified by the read(2) system call
   // (See https://nodejs.org/api/fs.html#fs_stat_time_values)
-  const updatedSrcStat = await stat(src);
-  return utimes(dest, updatedSrcStat.atime, updatedSrcStat.mtime);
+  const updatedSrcStat = await stat(src, { bigint: true });
+  return utimes(dest, utimesTime(updatedSrcStat.atimeNs), utimesTime(updatedSrcStat.mtimeNs));
 }
 
 function onDir(srcStat, destStat, src, dest, opts) {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -301,6 +301,43 @@ for (const [name, copy] of impls) {
       });
     });
 
+    test("preserveTimestamps keeps the sub-millisecond part of mtime", async () => {
+      await using basename = tempDir("cp", {
+        "from/f.txt": "x",
+        "single.txt": "y",
+      });
+      // utimes takes seconds as a double, which holds about 0.1µs at this
+      // magnitude. The walker used to hand utimes a Date, so a copy kept whole
+      // milliseconds only and this source time came out ~778µs early.
+      const time = 1614834367.111777555;
+      fs.utimesSync(join(basename, "from", "f.txt"), time, time);
+      fs.utimesSync(join(basename, "single.txt"), time, time);
+
+      await copy(join(basename, "from"), join(basename, "result"), { recursive: true, preserveTimestamps: true });
+      await copy(join(basename, "single.txt"), join(basename, "single-copy.txt"), { preserveTimestamps: true });
+
+      const mtimeNs = (...parts: string[]) => fs.statSync(join(basename, ...parts), { bigint: true }).mtimeNs;
+      expect(Number(mtimeNs("result", "f.txt") - mtimeNs("from", "f.txt"))).toBeWithin(-999, 1000);
+      expect(Number(mtimeNs("single-copy.txt") - mtimeNs("single.txt"))).toBeWithin(-999, 1000);
+    });
+
+    // Skipped on Windows, where fs.stat reads a pre-1970 mtime back as a 2096
+    // date (the seconds wrap at 2^32, same in node), so there is no pre-epoch
+    // source time to copy.
+    test.skipIf(isWindows)("preserveTimestamps keeps a pre-epoch mtime", async () => {
+      await using basename = tempDir("cp", {
+        "from/f.txt": "x",
+      });
+      // A negative number of seconds means "now" to utimes, so a time before
+      // 1970 has to reach it as a Date.
+      const time = new Date("1960-01-02T03:04:05.123Z");
+      fs.utimesSync(join(basename, "from", "f.txt"), time, time);
+
+      await copy(join(basename, "from"), join(basename, "result"), { recursive: true, preserveTimestamps: true });
+
+      expect(fs.statSync(join(basename, "result", "f.txt")).mtime.toISOString()).toBe(time.toISOString());
+    });
+
     test.skipIf(isWindows)("recursive - FIFO inside the tree is rejected with ERR_FS_CP_FIFO_PIPE", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",


### PR DESCRIPTION
### Problem
- `fs.cp`, `fs.cpSync` and `fs.promises.cp` with `{ preserveTimestamps: true }` drop the sub-millisecond part of the source atime/mtime. A source mtime of `…07.111222333` comes out as `…07.111000000` in all three forms. node v26's `cpSync` gives `…07.111222267`.
- The cause is `setDestTimestamps` in `src/js/internal/fs/cp-sync.ts:416` and `src/js/internal/fs/cp.ts:309`. Both pass `stat.atime` / `stat.mtime` (Dates, whole milliseconds) to `utimes`.

### Fix
- Stat the source with `{ bigint: true }` and pass `utimes` the seconds as `tv_sec + tv_nsec / 1e9`. This is the value node's native `cpSync` passes ([`CopyUtimes`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L3607-L3608)), so bun's `cpSync` now lands on the same nanosecond as node's for a recursive copy.
- A pre-1970 time still reaches `utimes` as a Date. `utimes` maps a negative number of seconds to "now" (node does the same), and the Date path handles negative times, so those copies keep working as before.
- Deliberate difference from node: node's JS `fs.cp` / `promises.cp` (and its single-file `cpSync` into a missing destination) still pass Dates and keep only milliseconds. bun keeps the sub-millisecond part in all three forms rather than copying that loss.
- Verified: `test/js/node/fs/cp.test.ts` (two new tests per form, stock bun fails the precision one by 777µs on Linux and Windows). Also `cp-symlink-target.test.ts` and the upstream `test-fs-cp-*preserve-timestamps*` files, on Linux and Windows.

### Background
- `fs.utimes` takes a time as a number of seconds, a Date, or a numeric string. A double holds about 0.1µs at today's epoch, a Date holds whole milliseconds. Neither bun nor node accept a BigInt there, so exact nanoseconds cannot pass through this API.
- With `preserveTimestamps` set, `fs.cpSync` never takes bun's native copy path (`src/js/node/fs.ts` `cpSync`), so the ported JS walker is the only place that sets the times.
- On Windows libuv converts the seconds to a `FILETIME` with double arithmetic, which has about 1.6µs granularity. A copied time stays within 1µs of the source, hence the tolerance in the test.

<details><summary>Notes</summary>

Repro from the report, source mtime set with `touch -d '2021-03-04 05:06:07.111222333'`:

```
node v26.3.0   {"src":"…111222333","cpSync":"…111222267","promisesCp":"…111000061","cb":"…111000061","singleFile":"…111000061"}
bun 1.4.3      {"src":"…111222333","cpSync":"…111000000","promisesCp":"…111000000","cb":"…111000000","singleFile":"…111000000"}
bun, this PR   {"src":"…111222333","cpSync":"…111222267","promisesCp":"…111222267","cb":"…111222267","singleFile":"…111222267"}
```

The pre-epoch test is skipped on Windows: `fs.stat` there reads a 1960 mtime back as a 2096 date (the seconds wrap at 2^32, node reads the same value), so there is no pre-epoch source time to copy. The file time itself is set correctly (PowerShell shows 1960).

Suites run with the debug build: `test/js/node/fs/cp.test.ts`, `test/js/node/fs/cp-symlink-target.test.ts` (Linux and Windows), `test-fs-cp-sync-preserve-timestamps.mjs`, `test-fs-cp-async-preserve-timestamps.mjs`, `test-fs-cp-sync-preserve-timestamps-readonly.mjs`, `test-fs-cp-async-preserve-timestamps-readonly-file.mjs`, `test-fs-cp-sync-copy-symlinks-to-existing-symlinks.mjs`, `test-fs-cp-async-same-dir-twice.mjs`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->