### PR TITLE
redis: read REDIS_URL and VALKEY_URL from process.env when a client is constructed

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -334,6 +334,13 @@ impl JSGlobalObject {
         JSGlobalObject__setTimeZone(self, time_zone)
     }
 
+    /// The live `process.env` object (also `Bun.env` and `import.meta.env`).
+    /// Reads through it see runtime writes from JS. `bun_vm().env_loader()`
+    /// does not: it is the snapshot taken at startup.
+    pub fn process_env(&self) -> JsResult<JSValue> {
+        crate::cpp::JSGlobalObject__processEnv(self)
+    }
+
     #[inline]
     pub fn to_js_value(&self) -> JSValue {
         // JSValue is #[repr(transparent)] over the encoded pointer-width word; a

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3202,6 +3202,17 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);
 }
 
+// The live `process.env` object (also `Bun.env` and `import.meta.env`), as
+// opposed to the env loader map, which is a snapshot taken at startup.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSGlobalObject__processEnv(JSC::JSGlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* env = defaultGlobalObject(globalObject)->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(env);
+}
+
 extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, const EncodedSlice* timeZone)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -485,15 +485,17 @@ impl JSValkeyClient {
     ) -> JsResult<*mut JSValkeyClient> {
         let global_object = GlobalRef::from(global_object);
         let vm: &'static VirtualMachine = global_object.bun_vm();
-        let vm_ref = vm;
 
         let url_str = if arguments.len() >= 1 && !arguments[0].is_undefined_or_null() {
             arguments[0].to_bun_string(&global_object)?
         } else {
-            let env = vm_ref.env_loader();
-            match env.get(b"REDIS_URL").or_else(|| env.get(b"VALKEY_URL")) {
-                Some(url) => BunString::borrow_utf8(url),
-                None => BunString::static_("valkey://localhost:6379"),
+            let env = global_object.process_env()?;
+            match env.get_stringish(&global_object, "REDIS_URL")? {
+                Some(url) => url,
+                None => match env.get_stringish(&global_object, "VALKEY_URL")? {
+                    Some(url) => url,
+                    None => BunString::static_("valkey://localhost:6379"),
+                },
             }
         };
         let mut fallback_url_buf = [0u8; 2048];

--- a/test/js/valkey/valkey-default-url.test.ts
+++ b/test/js/valkey/valkey-default-url.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Removes one complete `*N\r\n` array of `$len\r\n<bytes>\r\n` bulk strings from
+// the front of `state.buf` and returns its items, or null while it is incomplete.
+function takeCommand(state: { buf: string }): string[] | null {
+  const { buf } = state;
+  if (!buf.startsWith("*")) return null;
+  let eol = buf.indexOf("\r\n");
+  if (eol === -1) return null;
+  const count = Number(buf.slice(1, eol));
+  const args: string[] = [];
+  let off = eol + 2;
+  for (let i = 0; i < count; i++) {
+    if (buf[off] !== "$") return null;
+    eol = buf.indexOf("\r\n", off);
+    if (eol === -1) return null;
+    const len = Number(buf.slice(off + 1, eol));
+    if (buf.length < eol + 2 + len + 2) return null;
+    args.push(buf.slice(eol + 2, eol + 2 + len));
+    off = eol + 2 + len + 2;
+  }
+  state.buf = buf.slice(off);
+  return args;
+}
+
+// A RESP stub that records the username each connection authenticates as
+// (`HELLO 3 AUTH <user> <pass>`). It answers PING with +PONG and everything
+// else with +OK.
+function authRecordingServer() {
+  const users: string[] = [];
+  const server = Bun.listen<{ buf: string }>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.data = { buf: "" };
+      },
+      data(socket, chunk) {
+        socket.data.buf += chunk.toString("latin1");
+        let args: string[] | null;
+        while ((args = takeCommand(socket.data)) !== null) {
+          const command = args[0].toUpperCase();
+          if (command === "HELLO") {
+            const auth = args.findIndex(arg => arg.toUpperCase() === "AUTH");
+            users.push(auth === -1 ? "(no auth)" : args[auth + 1]);
+          }
+          socket.write(command === "PING" ? "+PONG\r\n" : "+OK\r\n");
+        }
+      },
+    },
+  });
+  return {
+    port: server.port,
+    users,
+    [Symbol.dispose]() {
+      server.stop(true);
+    },
+  };
+}
+
+// Builds each client with no URL argument, so the URL comes from the
+// environment: REDIS_URL, then VALKEY_URL, then valkey://localhost:6379.
+const fixture = /* js */ `
+  import { RedisClient } from "bun";
+  const url = user => "redis://" + user + ":pw@127.0.0.1:" + process.env.STUB_PORT;
+  const replies = [];
+  async function probe() {
+    const client = new RedisClient(undefined, { autoReconnect: false, connectionTimeout: 5000 });
+    try {
+      replies.push(await client.send("PING", []));
+    } catch (err) {
+      replies.push(err.code);
+    } finally {
+      client.close();
+    }
+  }
+  if (process.env.REDIS_URL) await probe();
+  process.env.REDIS_URL = url("runtime1");
+  await probe();
+  delete process.env.REDIS_URL;
+  process.env.VALKEY_URL = url("valkey1");
+  await probe();
+  process.env.REDIS_URL = url("runtime2");
+  await probe();
+  console.log(JSON.stringify(replies));
+`;
+
+async function runFixture(stubPort: number, launchEnv: Record<string, string>) {
+  const env: Record<string, string | undefined> = { ...bunEnv, STUB_PORT: String(stubPort) };
+  delete env.REDIS_URL;
+  delete env.VALKEY_URL;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...env, ...launchEnv },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { replies: JSON.parse(stdout.trim() || "null"), stderr, exitCode };
+}
+
+describe.concurrent("new RedisClient() with no URL", () => {
+  test("reads REDIS_URL and VALKEY_URL from process.env when the client is constructed", async () => {
+    using stub = authRecordingServer();
+    const result = await runFixture(stub.port, { REDIS_URL: `redis://launch:pw@127.0.0.1:${stub.port}` });
+    expect({ users: stub.users, ...result }).toEqual({
+      users: ["launch", "runtime1", "valkey1", "runtime2"],
+      replies: ["PONG", "PONG", "PONG", "PONG"],
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("uses a REDIS_URL assigned at runtime when none was set at startup", async () => {
+    using stub = authRecordingServer();
+    const result = await runFixture(stub.port, {});
+    expect({ users: stub.users, ...result }).toEqual({
+      users: ["runtime1", "valkey1", "runtime2"],
+      replies: ["PONG", "PONG", "PONG"],
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `new RedisClient()` with no URL argument (and the lazy `Bun.redis` client) takes its default URL from the environment as it was at startup. A `process.env.REDIS_URL = ...` assigned at runtime is ignored: the client dials `localhost:6379`. After `delete process.env.REDIS_URL` or a reassignment, every new client still dials the launch URL and sends the launch `AUTH user pass`.
- The cause is `create_no_js_no_pubsub` (`src/runtime/valkey_jsc/js_valkey.rs:493`). It reads `REDIS_URL` / `VALKEY_URL` from `vm.env_loader()`, the native env map. That map is a snapshot taken at startup. Writes to `process.env` do not reach it (only the six proxy variables are synced back).

### Fix
- Read the two variables from the live `process.env` object at construction, the same way `Bun.SQL` resolves `DATABASE_URL` from `Bun.env`. A new accessor, `JSGlobalObject::process_env()` (C++ `JSGlobalObject__processEnv`, which returns `processEnvObject()`), gives Rust code that object.
- The order is unchanged: the argument, then `REDIS_URL`, then `VALKEY_URL`, then `valkey://localhost:6379`. One visible difference: an empty `REDIS_URL` or `VALKEY_URL` now counts as unset instead of throwing `Invalid URL format`. This matches `Bun.SQL` and is what #41552 proposes on its own.
- This also fixes a `Worker` created with an `env` option: a client built inside it now sees that env, not the parent process environment.
- Verified: `test/js/valkey/valkey-default-url.test.ts` (new, both tests fail on 1.4.3). Also `test/js/valkey/valkey.test.ts -t "URL parsing|argument validation"`, `test/regression/issue/24385.test.ts`, `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`.

### Background
- `process.env` (also `Bun.env` and `import.meta.env`) is a lazy JS object, `m_processEnvObject` on the global. Its keys come from the native env map at first use. After that, ordinary writes stay on the JS object only.
- The native env map (`vm.env_loader()`) is what `.env` loading and the CLI fill before any JS runs. Native code that reads it later sees launch-time values.
- The test runs a small RESP stub in the test process. It records the user name from each `HELLO 3 AUTH <user> <pass>` and answers `PING`. A child process builds four clients with no URL while it sets, deletes, and reassigns `REDIS_URL` / `VALKEY_URL`.

<details><summary>Notes</summary>

- Repro on 1.4.3, child launched with `REDIS_URL=redis://launch:pw@127.0.0.1:PORT`: the stub sees `["launch","launch","launch","launch"]` for the four probes (as launched, `REDIS_URL=...runtime1`, `delete` + `VALKEY_URL=...valkey1`, `REDIS_URL=...runtime2`). Expected `["launch","runtime1","valkey1","runtime2"]`. Launched without the variable, the stub sees no connection at all.
- Worker case on 1.4.3: `new Worker(url, { env: { REDIS_URL } })` then `new Bun.RedisClient()` inside the worker dials `localhost:6379`. With this change it dials the given URL.
- `process_env()` goes through `defaultGlobalObject(global)->processEnvObject()`, so it follows the `SHARE_ENV` swap in `ensureSharedEnvStoreForWorker` and the Windows `Proxy` wrapper. The property read uses the same `getIfPropertyExists` path as option-object parsing, which stops at `Object.prototype`.
- `new RedisClient("")` with an explicit empty string still throws `Invalid URL format`. Only the environment lookup treats empty as unset.
- Overlaps: #41552 (empty `REDIS_URL` as unset) touches the same lines and becomes unnecessary with this change. #41418 (expose `url` / `options`) moves this lookup into a stored field and needs a small rebase after whichever lands first.
- The test is a new file because `valkey.test.ts` is the docker-backed suite (7.5k lines) and this check needs no server.
- Ran with `BUN_JSC_validateExceptionChecks=1`: empty `REDIS_URL` falling through to `VALKEY_URL`, `Bun.redis` first access after a runtime assignment, and a non-string `process.env` value all behave.

</details>
