### PR TITLE
cli: do not resolve relative entry points or package.json scripts against the executable's directory when the cwd was deleted

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4063,11 +4063,7 @@ pub fn getcwd(buf: &mut PathBuffer) -> crate::CrateResult<&ZStr> {
     Ok(ZStr::from_buf(&buf.0, len))
 }
 
-/// The directory that holds the running executable, or the filesystem root if
-/// that is unavailable or longer than a `PathBuffer`. The runtime uses it as a
-/// stand-in working directory when the real one was deleted before startup
-/// (like Node's `Environment::GetCwd`), so `bun -e` and the REPL still boot
-/// and `process.cwd()` reports the error instead.
+/// The running executable's directory, or the filesystem root if that is unavailable or too long.
 pub fn self_exe_dir() -> &'static [u8] {
     self_exe_path()
         .ok()

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4063,26 +4063,17 @@ pub fn getcwd(buf: &mut PathBuffer) -> crate::CrateResult<&ZStr> {
     Ok(ZStr::from_buf(&buf.0, len))
 }
 
-/// `getcwd` tolerating an unreachable cwd (e.g. deleted while we run): falls
-/// back to the executable's directory like Node's `Environment::GetCwd`, so
-/// startup proceeds and `process.cwd()` surfaces the real error later.
-pub fn getcwd_or_exe_dir(buf: &mut PathBuffer) -> &ZStr {
-    let len = match getcwd_len(buf) {
-        Ok(n) => n,
-        Err(_) => {
-            let dir: &[u8] = self_exe_path()
-                .ok()
-                .and_then(|p| dirname(p.as_bytes()))
-                // Reject a dir that can't fit with its NUL (paths from
-                // /proc/self/exe are not bounded by MAX_PATH_BYTES).
-                .filter(|d| d.len() < buf.0.len())
-                .unwrap_or(if cfg!(windows) { b"C:\\" } else { b"/" });
-            buf.0[..dir.len()].copy_from_slice(dir);
-            buf.0[dir.len()] = 0;
-            dir.len()
-        }
-    };
-    ZStr::from_buf(&buf.0, len)
+/// The directory that holds the running executable, or the filesystem root if
+/// that is unavailable or longer than a `PathBuffer`. The runtime uses it as a
+/// stand-in working directory when the real one was deleted before startup
+/// (like Node's `Environment::GetCwd`), so `bun -e` and the REPL still boot
+/// and `process.cwd()` reports the error instead.
+pub fn self_exe_dir() -> &'static [u8] {
+    self_exe_path()
+        .ok()
+        .and_then(|p| dirname(p.as_bytes()))
+        .filter(|d| d.len() < MAX_PATH_BYTES)
+        .unwrap_or(if cfg!(windows) { b"C:\\" } else { b"/" })
 }
 
 /// Length-returning core of [`getcwd`]; `buf` holds the NUL-terminated path.

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -203,7 +203,17 @@ pub fn load_config(
             let mut secondbuf = bun_paths::path_buffer_pool::get();
             let cwd_len = match bun_sys::getcwd(&mut *secondbuf) {
                 Ok(n) => n,
-                Err(_) => return Ok(()),
+                // Nothing to auto-load without a working directory, but an
+                // explicit relative --config cannot be resolved either.
+                Err(_) if auto_loaded => return Ok(()),
+                Err(err) => {
+                    bun_core::pretty_errorln!(
+                        "{}\nwhile reading config \"{}\"",
+                        err,
+                        BStr::new(config_path_),
+                    );
+                    Global::exit(1);
+                }
             };
             ctx.args.absolute_working_dir = Some(Box::<[u8]>::from(&secondbuf[..cwd_len]));
         }

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -203,8 +203,7 @@ pub fn load_config(
             let mut secondbuf = bun_paths::path_buffer_pool::get();
             let cwd_len = match bun_sys::getcwd(&mut *secondbuf) {
                 Ok(n) => n,
-                // Nothing to auto-load without a working directory, but an
-                // explicit relative --config cannot be resolved either.
+                // No cwd (deleted): nothing to auto-load, but an explicit --config is an error.
                 Err(_) if auto_loaded => return Ok(()),
                 Err(err) => {
                     bun_core::pretty_errorln!(

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -822,9 +822,9 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     }
 
     // ── --cwd ────────────────────────────────────────────────────────────────
-    // `api::TransformOptions.absolute_working_dir` is `Option<Box<[u8]>>`,
-    // so we dupe into a plain `Box<[u8]>`.
-    let cwd: Box<[u8]> = if let Some(cwd_arg) = args.option(b"--cwd") {
+    // `None` only when the process started inside a deleted directory and the
+    // command can still run code without one (see the `getcwd` arm below).
+    let cwd: Option<Box<[u8]>> = if let Some(cwd_arg) = args.option(b"--cwd") {
         let mut outbuf = bun_paths::path_buffer_pool::get();
         // An absolute --cwd needs no base; a relative one still requires a
         // live cwd (an exe-dir base would silently chdir somewhere else).
@@ -850,23 +850,33 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         // Store the post-chdir physical path (mirrors process.chdir) so
         // process.cwd(), path.resolve, and the resolver agree on one form.
         let mut phys = bun_paths::path_buffer_pool::get();
-        match bun_core::getcwd(&mut phys) {
+        Some(match bun_core::getcwd(&mut phys) {
             Ok(p) => Box::<[u8]>::from(p.as_bytes()),
             Err(_) => Box::<[u8]>::from(out_z.as_bytes()),
-        }
-    } else if matches!(
-        cmd,
-        CommandTag::AutoCommand | CommandTag::RunCommand | CommandTag::RunAsNodeCommand
-    ) {
-        // A deleted cwd must not abort the runtime (Node boots and lets
-        // `process.cwd()` throw later); fall back to the executable's dir.
-        let mut temp = bun_paths::path_buffer_pool::get();
-        Box::<[u8]>::from(bun_core::getcwd_or_exe_dir(&mut temp).as_bytes())
+        })
     } else {
-        // Everything else (install/test/build/...) must not silently act on
-        // whatever project happens to live above the executable.
         let mut temp = bun_paths::path_buffer_pool::get();
-        Box::<[u8]>::from(bun_core::getcwd(&mut temp)?.as_bytes())
+        match bun_core::getcwd(&mut temp) {
+            Ok(cwd) => Some(Box::<[u8]>::from(cwd.as_bytes())),
+            // A deleted cwd must not abort the runtime itself: `bun -e`, the
+            // REPL, stdin and an absolute entry path need no working directory
+            // (Node boots too and lets `process.cwd()` throw). `RunCommand`
+            // seeds the executable's directory as a stand-in once it knows
+            // nothing is left to resolve against the cwd. A relative entry
+            // path, a package.json script and every other command
+            // (install/test/build/...) must not silently act on whatever
+            // project happens to live above the executable, so they keep the
+            // error: here, or in `FileSystem::init` when it asks again.
+            Err(bun_core::Error::CurrentWorkingDirectoryUnlinked)
+                if matches!(
+                    cmd,
+                    CommandTag::AutoCommand | CommandTag::RunCommand | CommandTag::RunAsNodeCommand
+                ) =>
+            {
+                None
+            }
+            Err(err) => return Err(err.into()),
+        }
     };
 
     // Not gated on .BunxCommand: bunx skips Arguments.parse entirely
@@ -910,7 +920,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         parse_test_command_options(&args, ctx);
     }
 
-    ctx.args.absolute_working_dir = Some(cwd);
+    ctx.args.absolute_working_dir = cwd;
     ctx.positionals = slice_to_owned(args.positionals());
 
     if command::LOADS_CONFIG[cmd] {
@@ -961,14 +971,14 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         });
     }
 
-    opts.tsconfig_override = args.option(b"--tsconfig-override").map(|ts| {
+    if let Some(ts) = args.option(b"--tsconfig-override") {
+        let Some(cwd) = ctx.args.absolute_working_dir.as_deref() else {
+            return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into());
+        };
         let mut spill = Vec::new();
-        Box::from(resolve_path::join_abs_string_spill::<platform::Auto>(
-            ctx.args.absolute_working_dir.as_deref().unwrap(),
-            &mut spill,
-            &[ts],
-        ))
-    });
+        let joined = resolve_path::join_abs_string_spill::<platform::Auto>(cwd, &mut spill, &[ts]);
+        opts.tsconfig_override = Some(Box::from(joined));
+    }
 
     opts.main_fields = slice_to_owned(args.options(b"--main-fields"));
     // we never actually supported inject.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -972,11 +972,15 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     }
 
     if let Some(ts) = args.option(b"--tsconfig-override") {
-        let Some(cwd) = ctx.args.absolute_working_dir.as_deref() else {
-            return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into());
+        let base: &[u8] = match ctx.args.absolute_working_dir.as_deref() {
+            Some(cwd) => cwd,
+            // Like --cwd above: an absolute path needs no base, a relative one
+            // cannot be resolved once the cwd was deleted.
+            None if bun_paths::is_absolute(ts) => b"/",
+            None => return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into()),
         };
         let mut spill = Vec::new();
-        let joined = resolve_path::join_abs_string_spill::<platform::Auto>(cwd, &mut spill, &[ts]);
+        let joined = resolve_path::join_abs_string_spill::<platform::Auto>(base, &mut spill, &[ts]);
         opts.tsconfig_override = Some(Box::from(joined));
     }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -822,8 +822,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     }
 
     // ── --cwd ────────────────────────────────────────────────────────────────
-    // `None` only when the process started inside a deleted directory and the
-    // command can still run code without one (see the `getcwd` arm below).
+    // `None` only when the process started inside a deleted directory (see the `getcwd` arm).
     let cwd: Option<Box<[u8]>> = if let Some(cwd_arg) = args.option(b"--cwd") {
         let mut outbuf = bun_paths::path_buffer_pool::get();
         // An absolute --cwd needs no base; a relative one still requires a
@@ -858,15 +857,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         let mut temp = bun_paths::path_buffer_pool::get();
         match bun_core::getcwd(&mut temp) {
             Ok(cwd) => Some(Box::<[u8]>::from(cwd.as_bytes())),
-            // A deleted cwd must not abort the runtime itself: `bun -e`, the
-            // REPL, stdin and an absolute entry path need no working directory
-            // (Node boots too and lets `process.cwd()` throw). `RunCommand`
-            // seeds the executable's directory as a stand-in once it knows
-            // nothing is left to resolve against the cwd. A relative entry
-            // path, a package.json script and every other command
-            // (install/test/build/...) must not silently act on whatever
-            // project happens to live above the executable, so they keep the
-            // error: here, or in `FileSystem::init` when it asks again.
+            // These can still run code without a cwd, like Node; `RunCommand::cwd_or_exe_dir` decides.
             Err(bun_core::Error::CurrentWorkingDirectoryUnlinked)
                 if matches!(
                     cmd,
@@ -974,8 +965,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
     if let Some(ts) = args.option(b"--tsconfig-override") {
         let base: &[u8] = match ctx.args.absolute_working_dir.as_deref() {
             Some(cwd) => cwd,
-            // Like --cwd above: an absolute path needs no base, a relative one
-            // cannot be resolved once the cwd was deleted.
+            // As with --cwd: an absolute path needs no base.
             None if bun_paths::is_absolute(ts) => b"/",
             None => return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into()),
         };

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -747,6 +747,14 @@ fn replace_pid_placeholder(name: &[u8]) -> Box<[u8]> {
     out.into_boxed_slice()
 }
 
+/// `load_preloads` resolves anything but an absolute path or a builtin against the working directory.
+fn preload_needs_cwd(specifier: &[u8]) -> bool {
+    let path = specifier
+        .strip_prefix(b"file://".as_slice())
+        .unwrap_or(specifier);
+    !(bun_paths::is_absolute(path) || path.starts_with(b"node:") || path.starts_with(b"bun:"))
+}
+
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) enum BunCAStore {
@@ -1042,6 +1050,12 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                     all.push(Box::<[u8]>::from(p));
                 }
                 ctx.preloads = all;
+            }
+            // Without a cwd (deleted), only an absolute or builtin preload can be resolved (Node refuses too).
+            if ctx.args.absolute_working_dir.is_none()
+                && ctx.preloads.iter().any(|p| preload_needs_cwd(p))
+            {
+                return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into());
             }
         }
 

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -27,6 +27,7 @@ use repl::Repl;
 
 use crate::Command;
 use crate::cli::Arguments;
+use crate::cli::run_command::RunCommand;
 
 pub(crate) struct ReplCommand;
 
@@ -54,6 +55,9 @@ impl ReplCommand {
                 ctx,
             )?;
         }
+
+        // Like `bun --interactive`, the REPL boots from a deleted cwd.
+        RunCommand::cwd_or_exe_dir(ctx)?;
 
         jsc::initialize(jsc::InitializeOptions {
             eval_mode: true,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -921,6 +921,44 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         crate::shell::Interpreter::init_and_run_from_file(ctx, mini, entry_path, &src)
     }
 
+    /// The working directory the runtime starts from. `Arguments::parse`
+    /// records it for `bun run`, `bun <file>` and node mode; contexts built
+    /// without it (bunx, compiled executables) ask `getcwd` here. If the
+    /// process started inside a deleted directory, the executable's directory
+    /// stands in (what Node's `Environment::GetCwd` does), so `bun -e`, the
+    /// REPLs, stdin, an absolute entry path and compiled executables still
+    /// boot while `process.cwd()` reports ENOENT. Only for callers with nothing
+    /// left to resolve against the real cwd; a relative entry path or a
+    /// package.json script must fail with `CurrentWorkingDirectoryUnlinked`
+    /// instead of acting on whatever lives next to the executable.
+    pub(crate) fn cwd_or_exe_dir(ctx: &mut ContextData) -> crate::Result<&[u8]> {
+        let cwd: &[u8] = match ctx.args.absolute_working_dir {
+            Some(ref cwd) => cwd,
+            None => {
+                let mut buf = bun_paths::path_buffer_pool::get();
+                let dir: Box<[u8]> = match bun_core::getcwd(&mut buf) {
+                    Ok(cwd) => Box::from(cwd.as_bytes()),
+                    Err(bun_core::Error::CurrentWorkingDirectoryUnlinked) => {
+                        Box::from(bun_core::self_exe_dir())
+                    }
+                    Err(err) => return Err(err.into()),
+                };
+                ctx.args.absolute_working_dir.insert(dir)
+            }
+        };
+        Ok(cwd)
+    }
+
+    /// `<cwd><trigger>` (e.g. `cwd/[eval]`): the key under which the module
+    /// loader serves `eval_source` instead of reading a file.
+    fn synthetic_entry_path(ctx: &mut ContextData, trigger: &[u8]) -> crate::Result<Box<[u8]>> {
+        let cwd = Self::cwd_or_exe_dir(ctx)?;
+        let mut path: Vec<u8> = Vec::with_capacity(cwd.len() + trigger.len());
+        path.extend_from_slice(cwd);
+        path.extend_from_slice(trigger);
+        Ok(path.into_boxed_slice())
+    }
+
     /// `VirtualMachine::init`,
     /// hand off CLI state, then enter `Run::start` under the JSC API lock.
     pub(crate) fn boot(
@@ -942,6 +980,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             let exit_code = Self::boot_bun_shell(ctx, &entry_path)?;
             Global::exit(exit_code as u32);
         }
+
+        // `entry_path` is absolute or synthetic by now, so the VM may start
+        // from the stand-in directory if the real cwd was deleted.
+        Self::cwd_or_exe_dir(ctx)?;
 
         // `bun_jsc::initialize`
         // is real (calls `JSCInitialize` over `bun_sys::environ()`); the
@@ -1029,13 +1071,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 runner_arena().alloc_slice_copy(cron_script.as_bytes());
 
             // entry_path must end with /[eval] for the transpiler to use eval_source
-            let mut cwd_buf = bun_paths::path_buffer_pool::get();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
-            let cwd_bytes = cwd.as_bytes();
-            let mut eval_path: Vec<u8> = Vec::with_capacity(cwd_bytes.len() + EVAL_TRIGGER.len());
-            eval_path.extend_from_slice(cwd_bytes);
-            eval_path.extend_from_slice(EVAL_TRIGGER);
-            let heap_entry: &'static [u8] = runner_arena().alloc_slice_copy(&eval_path);
+            let heap_entry: &'static [u8] =
+                runner_arena().alloc_slice_copy(&Self::synthetic_entry_path(ctx, EVAL_TRIGGER)?);
 
             vm.module_loader.eval_source = Some(Box::new(bun_ast::Source::init_path_string(
                 heap_entry,
@@ -1138,6 +1175,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 ctx,
             )?;
         }
+
+        // The entry point is embedded, so nothing needs the real cwd to boot.
+        Self::cwd_or_exe_dir(ctx)?;
 
         // layering — `Options::graph` is the resolver's trait object
         // (`&'static dyn bun_resolver::StandaloneModuleGraph`); the concrete
@@ -2332,6 +2372,17 @@ impl RunCommand {
             return Ok(true);
         }
 
+        // Everything below resolves `target_name` against the working
+        // directory (package.json scripts, the module resolver,
+        // node_modules/.bin). A process started inside a deleted directory has
+        // none (`Arguments::parse`), and only stdin can run without one.
+        if ctx.args.absolute_working_dir.is_none() {
+            if target_name == b"-" {
+                return Self::exec_stdin(ctx);
+            }
+            return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into());
+        }
+
         // ── setup (unconditional) ────────────────────────────────────────────
         // out-param init — `Transpiler` is NOT all-zero-valid POD (holds
         // `&Arena`/`Box`/enum fields), so use `MaybeUninit` and let
@@ -2837,14 +2888,7 @@ impl RunCommand {
         #[cfg(not(windows))]
         const STDIN_TRIGGER: &[u8] = b"/[stdin]";
 
-        let mut entry_point_buf = [0u8; MAX_PATH_BYTES + STDIN_TRIGGER.len()];
-        let mut cwd_buf = bun_paths::path_buffer_pool::get();
-        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
-        let cwd_bytes = cwd.as_bytes();
-        let cwd_len = cwd_bytes.len();
-        entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
-        entry_point_buf[cwd_len..cwd_len + STDIN_TRIGGER.len()].copy_from_slice(STDIN_TRIGGER);
-        let entry_path = &entry_point_buf[..cwd_len + STDIN_TRIGGER.len()];
+        let entry_path = Self::synthetic_entry_path(ctx, STDIN_TRIGGER)?;
 
         // Prepend "-" to `ctx.passthrough` so `process.argv[1]` matches
         // Node's `node -` semantics.
@@ -2858,8 +2902,7 @@ impl RunCommand {
         // `configure_allocator(long_running=true)` / `.md` checks and prints
         // `basename(target_name)` (= "-"), not `basename(entry_path)`
         // (= "[stdin]"), in the error message.
-        let owned: Box<[u8]> = entry_path.to_vec().into_boxed_slice();
-        if let Err(err) = Self::boot(ctx, owned, None) {
+        if let Err(err) = Self::boot(ctx, entry_path, None) {
             Self::boot_failed_exit(ctx, b"-", &err);
         }
         Ok(true)
@@ -2886,8 +2929,7 @@ impl RunCommand {
     /// Synthetic `cwd/[eval]`
     /// entry point + boot. `Arguments::parse` has already stashed the script
     /// in `ctx.runtime_options.eval.script`. Public so `Command::start` can
-    /// route the `-e`/`-p` AutoCommand path here without re-implementing the
-    /// path-buffer dance.
+    /// route the `-e`/`-p` AutoCommand path here.
     pub(crate) fn exec_eval(ctx: &mut ContextData) -> crate::Result<()> {
         // prepend positionals into the existing passthrough vec
         // (cold path, single allocation).
@@ -2899,16 +2941,7 @@ impl RunCommand {
             ctx.passthrough = merged;
         }
 
-        let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
-        let mut cwd_buf = bun_paths::path_buffer_pool::get();
-        let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
-        let cwd_bytes = cwd.as_bytes();
-        let cwd_len = cwd_bytes.len();
-        entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
-        entry_point_buf[cwd_len..cwd_len + EVAL_TRIGGER.len()].copy_from_slice(EVAL_TRIGGER);
-        let entry: Box<[u8]> = entry_point_buf[..cwd_len + EVAL_TRIGGER.len()]
-            .to_vec()
-            .into_boxed_slice();
+        let entry = Self::synthetic_entry_path(ctx, EVAL_TRIGGER)?;
         Self::boot(ctx, entry, None)
     }
 
@@ -2933,17 +2966,7 @@ impl RunCommand {
         }
 
         if !ctx.runtime_options.eval.script.is_empty() {
-            // synthetic `[eval]` path under cwd
-            let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
-            let mut cwd_buf = bun_paths::path_buffer_pool::get();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
-            let cwd_bytes = cwd.as_bytes();
-            let cwd_len = cwd_bytes.len();
-            entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
-            entry_point_buf[cwd_len..cwd_len + EVAL_TRIGGER.len()].copy_from_slice(EVAL_TRIGGER);
-            let entry: Box<[u8]> = entry_point_buf[..cwd_len + EVAL_TRIGGER.len()]
-                .to_vec()
-                .into_boxed_slice();
+            let entry = Self::synthetic_entry_path(ctx, EVAL_TRIGGER)?;
             return Self::boot(ctx, entry, None);
         }
 
@@ -2965,13 +2988,18 @@ impl RunCommand {
         let normalized: Box<[u8]> = if paths::is_absolute(&filename) {
             filename
         } else {
+            // A relative script needs the real cwd; Node fails here too when
+            // the directory was deleted (`path.resolve` → `process.cwd()`).
+            let Some(cwd) = ctx.args.absolute_working_dir.as_deref() else {
+                return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into());
+            };
             // Note: write
             // `cwd_buf[cwd_len] = b'/'` (always `/`, NOT the
             // platform separator) and then run the result through
             // `join_abs_string_buf::<Loose>` to collapse `.`/`..`.
             let mut cwd_buf = bun_paths::path_buffer_pool::get();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
-            let cwd_len = cwd.as_bytes().len();
+            let cwd_len = cwd.len();
+            cwd_buf[..cwd_len].copy_from_slice(cwd);
             cwd_buf[cwd_len] = b'/';
             let mut out_buf = bun_paths::path_buffer_pool::get();
             let joined = paths::resolve_path::join_abs_string_buf::<paths::platform::Loose>(

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -921,19 +921,11 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         crate::shell::Interpreter::init_and_run_from_file(ctx, mini, entry_path, &src)
     }
 
-    /// The working directory the runtime starts from. `Arguments::parse`
-    /// records it for `bun run`, `bun <file>` and node mode; contexts built
-    /// without it (the Windows `.bunx` fast path) ask `getcwd` here. If the
-    /// process started inside a deleted directory, the executable's directory
-    /// stands in (what Node's `Environment::GetCwd` does), so `bun -e`, the
-    /// REPLs, stdin and an absolute entry path still boot while
-    /// `process.cwd()` reports ENOENT. Only for callers with nothing left to
-    /// resolve against the real cwd; a relative entry path or a package.json
-    /// script must fail with `CurrentWorkingDirectoryUnlinked` instead of
-    /// acting on whatever lives next to the executable.
+    /// The startup cwd, or the executable's directory if the cwd was deleted (as in Node); only once the entry is absolute or synthetic.
     pub(crate) fn cwd_or_exe_dir(ctx: &mut ContextData) -> crate::Result<&[u8]> {
         let cwd: &[u8] = match ctx.args.absolute_working_dir {
             Some(ref cwd) => cwd,
+            // Not recorded: `Arguments::parse` saw a deleted cwd, or did not run (Windows `.bunx` fast path).
             None => {
                 let mut buf = bun_paths::path_buffer_pool::get();
                 let dir: Box<[u8]> = match bun_core::getcwd(&mut buf) {
@@ -949,8 +941,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         Ok(cwd)
     }
 
-    /// `<cwd><trigger>` (e.g. `cwd/[eval]`): the key under which the module
-    /// loader serves `eval_source` instead of reading a file.
+    /// `<cwd><trigger>`, e.g. `cwd/[eval]`: the key the module loader serves `eval_source` under.
     fn synthetic_entry_path(ctx: &mut ContextData, trigger: &[u8]) -> crate::Result<Box<[u8]>> {
         let cwd = Self::cwd_or_exe_dir(ctx)?;
         let mut path: Vec<u8> = Vec::with_capacity(cwd.len() + trigger.len());
@@ -981,8 +972,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             Global::exit(exit_code as u32);
         }
 
-        // `entry_path` is absolute or synthetic by now, so the VM may start
-        // from the stand-in directory if the real cwd was deleted.
+        // `entry_path` is absolute or synthetic here, so a deleted cwd may fall back to the exe dir.
         Self::cwd_or_exe_dir(ctx)?;
 
         // `bun_jsc::initialize`
@@ -2364,20 +2354,20 @@ impl RunCommand {
             );
         }
 
-        // ── try fast run (file exists & not a dir → boot VM) ────────────────
-        if try_fast_run && Self::maybe_open_with_bun_js(ctx, target_name) {
-            return Ok(true);
-        }
-
-        // Everything below resolves `target_name` against the working
-        // directory (package.json scripts, the module resolver,
-        // node_modules/.bin). A process started inside a deleted directory has
-        // none (`Arguments::parse`), and only stdin can run without one.
+        // ── no cwd (started inside a deleted directory): only stdin or an absolute file can run ──
         if ctx.args.absolute_working_dir.is_none() {
             if target_name == b"-" {
                 return Self::exec_stdin(ctx);
             }
+            if paths::is_absolute(target_name) && Self::maybe_open_with_bun_js(ctx, target_name) {
+                return Ok(true);
+            }
             return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into());
+        }
+
+        // ── try fast run (file exists & not a dir → boot VM) ────────────────
+        if try_fast_run && Self::maybe_open_with_bun_js(ctx, target_name) {
+            return Ok(true);
         }
 
         // ── setup (unconditional) ────────────────────────────────────────────
@@ -2985,8 +2975,7 @@ impl RunCommand {
         let normalized: Box<[u8]> = if paths::is_absolute(&filename) {
             filename
         } else {
-            // A relative script needs the real cwd; Node fails here too when
-            // the directory was deleted (`path.resolve` → `process.cwd()`).
+            // A relative script needs the real cwd (Node fails here too when it was deleted).
             let Some(cwd) = ctx.args.absolute_working_dir.as_deref() else {
                 return Err(bun_core::Error::CurrentWorkingDirectoryUnlinked.into());
             };

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -925,7 +925,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     pub(crate) fn cwd_or_exe_dir(ctx: &mut ContextData) -> crate::Result<&[u8]> {
         let cwd: &[u8] = match ctx.args.absolute_working_dir {
             Some(ref cwd) => cwd,
-            // Not recorded: `Arguments::parse` saw a deleted cwd, or did not run (Windows `.bunx` fast path).
+            // Not recorded: `Arguments::parse` saw a deleted cwd, or did not run (compiled executable, `.bunx` fast path).
             None => {
                 let mut buf = bun_paths::path_buffer_pool::get();
                 let dir: Box<[u8]> = match bun_core::getcwd(&mut buf) {
@@ -972,7 +972,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             Global::exit(exit_code as u32);
         }
 
-        // `entry_path` is absolute or synthetic here, so a deleted cwd may fall back to the exe dir.
+        // `entry_path` is absolute or synthetic and `Arguments::parse` refused relative preloads: safe to stand in.
         Self::cwd_or_exe_dir(ctx)?;
 
         // `bun_jsc::initialize`
@@ -1165,6 +1165,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 ctx,
             )?;
         }
+
+        // The entry point is embedded, so a compiled executable starts without a cwd like any program.
+        Self::cwd_or_exe_dir(ctx)?;
 
         // layering — `Options::graph` is the resolver's trait object
         // (`&'static dyn bun_resolver::StandaloneModuleGraph`); the concrete

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -923,14 +923,14 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
     /// The working directory the runtime starts from. `Arguments::parse`
     /// records it for `bun run`, `bun <file>` and node mode; contexts built
-    /// without it (bunx, compiled executables) ask `getcwd` here. If the
+    /// without it (the Windows `.bunx` fast path) ask `getcwd` here. If the
     /// process started inside a deleted directory, the executable's directory
     /// stands in (what Node's `Environment::GetCwd` does), so `bun -e`, the
-    /// REPLs, stdin, an absolute entry path and compiled executables still
-    /// boot while `process.cwd()` reports ENOENT. Only for callers with nothing
-    /// left to resolve against the real cwd; a relative entry path or a
-    /// package.json script must fail with `CurrentWorkingDirectoryUnlinked`
-    /// instead of acting on whatever lives next to the executable.
+    /// REPLs, stdin and an absolute entry path still boot while
+    /// `process.cwd()` reports ENOENT. Only for callers with nothing left to
+    /// resolve against the real cwd; a relative entry path or a package.json
+    /// script must fail with `CurrentWorkingDirectoryUnlinked` instead of
+    /// acting on whatever lives next to the executable.
     pub(crate) fn cwd_or_exe_dir(ctx: &mut ContextData) -> crate::Result<&[u8]> {
         let cwd: &[u8] = match ctx.args.absolute_working_dir {
             Some(ref cwd) => cwd,
@@ -1175,9 +1175,6 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
                 ctx,
             )?;
         }
-
-        // The entry point is embedded, so nothing needs the real cwd to boot.
-        Self::cwd_or_exe_dir(ctx)?;
 
         // layering — `Options::graph` is the resolver's trait object
         // (`&'static dyn bun_resolver::StandaloneModuleGraph`); the concrete

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -899,15 +899,12 @@ if (process.platform === "android") {
   });
 }
 
-// A standalone compiled binary bypasses `Arguments::parse` (no `--cwd`/global
-// flags, no baked exec-argv), so `absolute_working_dir` stays unset and the
-// FIRST `getcwd` of the whole startup is the one inside `Transpiler::init`.
-// When the cwd has been deleted that `getcwd` fails with ENOENT; the bug was
-// that the per-VM init hook swallowed the error and left `vm.transpiler`
-// zeroed, so the next read (`configure_defines` → `run_env_loader`) hit a null
-// deref and the binary crashed (the segfault users saw launching a compiled
-// CLI from a directory that had been removed). It must instead exit cleanly
-// with the ENOENT message.
+// A compiled executable launched from a directory that has been removed
+// starts like any other program (and like `node app.js`): the executable's
+// directory stands in for the unreadable one, and `process.cwd()` reports the
+// error if the program asks. It once segfaulted here, and later refused to
+// start; one built with `--compile-exec-argv` takes a different startup path
+// (`Arguments::parse`) and must behave the same.
 //
 // POSIX-only: a process can keep a deleted directory as its cwd until the last
 // fd to it closes, whereas Windows refuses to remove a directory that is any
@@ -915,16 +912,16 @@ if (process.platform === "android") {
 // removed AFTER the process starts, which `Bun.spawn`'s `cwd` can't do, so a
 // shell wrapper `cd`s in, `rmdir`s, then execs the binary (how a user hits it).
 describe("compiled binary in a deleted cwd", () => {
-  test.if(isPosix)(
-    "exits cleanly instead of crashing",
-    async () => {
+  test.concurrent.skipIf(!isPosix).each([[[]], [["--compile-exec-argv=--smol"]]])(
+    "starts, and process.cwd() reports the error (extra build flags: %j)",
+    async extraFlags => {
       using dir = tempDir("build-compile-deleted-cwd", {
-        "app.js": `console.log("should-not-run");`,
+        "app.js": `let code; try { process.cwd(); } catch (e) { code = e.code; } console.log(JSON.stringify({ ran: true, code }));`,
       });
       const outfile = join(String(dir), "app");
 
       await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--compile", join(String(dir), "app.js"), "--outfile", outfile],
+        cmd: [bunExe(), "build", "--compile", ...extraFlags, join(String(dir), "app.js"), "--outfile", outfile],
         env: bunEnv,
         cwd: String(dir),
         stdout: "pipe",
@@ -947,9 +944,9 @@ describe("compiled binary in a deleted cwd", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(stdout).toBe("");
-      expect(stderr).toContain("The current working directory was deleted");
-      expect(exitCode).toBe(1);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ ran: true, code: "ENOENT" });
+      expect(exitCode).toBe(0);
     },
     60_000,
   );

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -212,6 +212,7 @@ describe.if(isPosix)("cwd deleted before startup", () => {
     beforeAll(() => {
       planted = tempDir("cwd-unlinked-planted", {
         "bin/x.cjs": `console.log("ran " + __filename);`,
+        "bin/tsconfig.json": `{}`,
         "package.json": JSON.stringify({ name: "above-the-executable", scripts: { canary: "echo canary script ran" } }),
       });
       bin = path.join(String(planted), "bin");
@@ -283,6 +284,24 @@ describe.if(isPosix)("cwd deleted before startup", () => {
       const { stderr, exitCode } = await runFromDeletedCwd("bun repl", `process.exit(42)\n`);
       expect(stderr).toBe("");
       expect(exitCode).toBe(42);
+    });
+
+    // Option values follow the same rule: an absolute path needs no cwd, a
+    // relative one is an error rather than silently ignored.
+    test.concurrent("an absolute --tsconfig-override still runs", async () => {
+      const tsconfig = path.join(bin, "tsconfig.json");
+      expect(await runFromDeletedCwd(`bun --tsconfig-override=${tsconfig} -p 6*7`)).toEqual({
+        stdout: "42\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("a relative --config is an error, not skipped", async () => {
+      const { stdout, stderr, exitCode } = await runFromDeletedCwd(`bun --config=bunfig.custom.toml -p 6*7`);
+      expect(stdout).toBe("");
+      expect(stderr).toContain(`while reading config "bunfig.custom.toml"`);
+      expect(exitCode).toBe(1);
     });
   });
 });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,7 +1,7 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
-import { linkSync, rmSync, symlinkSync } from "node:fs";
+import { linkSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
@@ -221,12 +221,14 @@ describe.if(isPosix)("cwd deleted before startup", () => {
     });
     afterAll(() => planted?.[Symbol.dispose]());
 
-    // `cmd` is "bun ..." or "node ..."; it runs <planted>/bin/<argv0> from a
-    // directory that is removed right before the exec.
+    // `cmd` is "bun ..." or "node ..."; it runs <planted>/bin/<argv0> from
+    // <planted>/gone-N, which is removed right before the exec (so the kernel
+    // still resolves ".." from it to <planted>).
+    let goneCount = 0;
     async function runFromDeletedCwd(cmd: string, stdin?: string) {
       const [argv0, ...args] = cmd.split(" ");
-      using dir = tempDir("cwd-unlinked-gone", {});
-      const gone = String(dir);
+      const gone = path.join(String(planted), `gone-${goneCount++}`);
+      mkdirSync(gone);
       await using proc = Bun.spawn({
         cmd: [
           "/bin/sh",
@@ -249,6 +251,7 @@ describe.if(isPosix)("cwd deleted before startup", () => {
     test.concurrent.each([
       "bun x.cjs",
       "bun ./x.cjs",
+      "bun ./../bin/x.cjs",
       "bun run x.cjs",
       "bun run canary",
       "bun canary",

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,7 +1,7 @@
 import { crash_handler } from "bun:internal-for-testing";
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
-import { rmSync } from "node:fs";
+import { linkSync, rmSync, symlinkSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
@@ -188,6 +188,102 @@ describe.if(isPosix)("cwd deleted before startup", () => {
     expect(stdout).toBe("1\n");
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
+  });
+
+  // The executable's directory stands in for the missing cwd only inside the
+  // runtime. A relative entry path or a package.json script must not resolve
+  // against it: with bun placed at <planted>/bin/{bun,node}, next to x.cjs and
+  // below a package.json with a "canary" script, nothing planted may run.
+  describe("user paths do not resolve against the executable's directory", () => {
+    let planted: ReturnType<typeof tempDir>;
+    let bin: string;
+
+    // Hard link so the executable really lives in <planted>/bin; where that is
+    // not possible (tmp on another filesystem) a symlink still gives the same
+    // argv[0], and the error/exit-code expectations below hold either way.
+    const placeExe = (dest: string) => {
+      try {
+        linkSync(bunExe(), dest);
+      } catch {
+        symlinkSync(bunExe(), dest);
+      }
+    };
+
+    beforeAll(() => {
+      planted = tempDir("cwd-unlinked-planted", {
+        "bin/x.cjs": `console.log("ran " + __filename);`,
+        "package.json": JSON.stringify({ name: "above-the-executable", scripts: { canary: "echo canary script ran" } }),
+      });
+      bin = path.join(String(planted), "bin");
+      placeExe(path.join(bin, "bun"));
+      placeExe(path.join(bin, "node"));
+    });
+    afterAll(() => planted?.[Symbol.dispose]());
+
+    // `cmd` is "bun ..." or "node ..."; it runs <planted>/bin/<argv0> from a
+    // directory that is removed right before the exec.
+    async function runFromDeletedCwd(cmd: string, stdin?: string) {
+      const [argv0, ...args] = cmd.split(" ");
+      using dir = tempDir("cwd-unlinked-gone", {});
+      const gone = String(dir);
+      await using proc = Bun.spawn({
+        cmd: [
+          "/bin/sh",
+          "-c",
+          `cd "$1" && rmdir "$1" && shift && exec "$@"`,
+          "sh",
+          gone,
+          path.join(bin, argv0),
+          ...args,
+        ],
+        env: bunEnv,
+        stdin: stdin === undefined ? "ignore" : Buffer.from(stdin),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test.concurrent.each([
+      "bun x.cjs",
+      "bun ./x.cjs",
+      "bun run x.cjs",
+      "bun run canary",
+      "bun canary",
+      "bun run",
+      "node x.cjs",
+    ])("%s refuses with the cwd-deleted hint", async cmd => {
+      expect(await runFromDeletedCwd(cmd)).toEqual({
+        stdout: "",
+        stderr: expect.stringContaining("The current working directory was deleted"),
+        exitCode: 1,
+      });
+    });
+
+    // What needs no working directory keeps booting, like Node.
+    test.concurrent.each(["bun", "bun run", "node"])("%s <absolute path> still runs", async cmd => {
+      const abs = path.join(bin, "x.cjs");
+      expect(await runFromDeletedCwd(`${cmd} ${abs}`)).toEqual({
+        stdout: `ran ${abs}\n`,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("bun - (stdin) still runs", async () => {
+      expect(await runFromDeletedCwd("bun -", `console.log("stdin ran")`)).toEqual({
+        stdout: "stdin ran\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("bun repl still starts", async () => {
+      const { stderr, exitCode } = await runFromDeletedCwd("bun repl", `process.exit(42)\n`);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(42);
+    });
   });
 });
 

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -290,11 +290,11 @@ describe.if(isPosix)("cwd deleted before startup", () => {
     // relative one is an error rather than silently ignored.
     test.concurrent("an absolute --tsconfig-override still runs", async () => {
       const tsconfig = path.join(bin, "tsconfig.json");
-      expect(await runFromDeletedCwd(`bun --tsconfig-override=${tsconfig} -p 6*7`)).toEqual({
-        stdout: "42\n",
-        stderr: "",
-        exitCode: 0,
-      });
+      // stderr is not checked: --tsconfig-override prints an unrelated
+      // "directory mismatch" note in any cwd.
+      const { stdout, exitCode } = await runFromDeletedCwd(`bun --tsconfig-override=${tsconfig} -p 6*7`);
+      expect(stdout).toBe("42\n");
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("a relative --config is an error, not skipped", async () => {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -191,9 +191,12 @@ describe.if(isPosix)("cwd deleted before startup", () => {
   });
 
   // The executable's directory stands in for the missing cwd only inside the
-  // runtime. A relative entry path or a package.json script must not resolve
-  // against it: with bun placed at <planted>/bin/{bun,node}, next to x.cjs and
-  // below a package.json with a "canary" script, nothing planted may run.
+  // runtime. A relative entry path, preload or config, or a package.json
+  // script, must not resolve against it: with bun placed at
+  // <planted>/bin/{bun,node} next to x.cjs, a bunfig.toml that preloads
+  // preload.cjs, and below a package.json with a "canary" script, nothing
+  // planted may run unless named by absolute path (the exact-stdout
+  // expectations below would show a stray "preloaded" line).
   describe("user paths do not resolve against the executable's directory", () => {
     let planted: ReturnType<typeof tempDir>;
     let bin: string;
@@ -212,6 +215,8 @@ describe.if(isPosix)("cwd deleted before startup", () => {
     beforeAll(() => {
       planted = tempDir("cwd-unlinked-planted", {
         "bin/x.cjs": `console.log("ran " + __filename);`,
+        "bin/preload.cjs": `console.log("preloaded " + __filename);`,
+        "bin/bunfig.toml": `preload = ["./preload.cjs"]\n`,
         "bin/tsconfig.json": `{}`,
         "package.json": JSON.stringify({ name: "above-the-executable", scripts: { canary: "echo canary script ran" } }),
       });
@@ -256,7 +261,9 @@ describe.if(isPosix)("cwd deleted before startup", () => {
       "bun run canary",
       "bun canary",
       "bun run",
+      "bun -r ./x.cjs -e 0",
       "node x.cjs",
+      "node -r ./x.cjs -e 0",
     ])("%s refuses with the cwd-deleted hint", async cmd => {
       expect(await runFromDeletedCwd(cmd)).toEqual({
         stdout: "",
@@ -270,6 +277,15 @@ describe.if(isPosix)("cwd deleted before startup", () => {
       const abs = path.join(bin, "x.cjs");
       expect(await runFromDeletedCwd(`${cmd} ${abs}`)).toEqual({
         stdout: `ran ${abs}\n`,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("an absolute preload still runs", async () => {
+      const abs = path.join(bin, "x.cjs");
+      expect(await runFromDeletedCwd(`bun -r ${abs} -p 6*7`)).toEqual({
+        stdout: `ran ${abs}\n42\n`,
         stderr: "",
         exitCode: 0,
       });


### PR DESCRIPTION
### Problem
- Start bun 1.4 from a deleted directory. `bun x.cjs` runs `<bun binary dir>/x.cjs`. `bun run build` runs the `build` script of the first `package.json` above that directory. `node x.cjs`, `-r ./x.cjs` and the auto-loaded `bunfig.toml` resolve there too, all exit 0. 1.3.14 refused.
- Cause: `Arguments::parse` (`src/runtime/cli/Arguments.rs:857`) seeded the working directory for run/auto/node commands from `getcwd_or_exe_dir`, which substitutes the executable's directory when `getcwd` fails. #34660 added it so `bun -e` and the REPL boot from a deleted cwd like Node, but every command-line path used it.

### Fix
- On ENOENT, `Arguments::parse` records no working directory. `RunCommand::cwd_or_exe_dir` seeds the substitute later (`boot`, `boot_standalone`, `[eval]`/`[stdin]`, `bun repl`), once the entry is absolute, synthetic or embedded.
- Without a cwd, `exec_with_cfg` runs only stdin (`-`) or an absolute file and fails the rest with `CurrentWorkingDirectoryUnlinked` before any lookup. A relative `node <file>`, preload, `--tsconfig-override` or `--config` fails too.
- Result: `bun -e`, the REPLs, `bun -`, `bun /abs/file.js`, absolute preloads and compiled executables boot. `bun x.cjs`, `bun run <script>`, `bun run`, `node x.cjs` and `-r ./x.cjs` print the cwd-deleted hint and exit 1.
- Verified: `test/cli/run/run-crash-handler.test.ts` (18 new cases, 15 fail on 1.4.3), `bun-build-compile.test.ts`, the `test-cwd-enoent*.js` Node tests.

### Background
- `top_level_dir` is the directory bun captures at startup. The entry point, preloads, the `package.json` lookup and `path.resolve()` resolve against it. `process.cwd()` calls `getcwd` itself, so it throws ENOENT regardless.
- Node splits it alike: `node -e` and `node /abs.js` boot, `node rel.js` and `-r ./rel.js` throw.

<details><summary>Notes</summary>

- Inside `bun -e` started from a deleted cwd, `require("./x")` and bare `require("pkg")` resolve against the executable's directory. Node does the same from `-e` (checked with a copied `node` binary next to a planted `mod.cjs`: `require("./mod.cjs")` and `import("./mod.cjs")` load it, and `module.paths[0]` is `<exe dir>/node_modules`). `path.resolve("x")`, `fs.realpathSync(".")` and `Bun.cwd` also report the substitute there, where Node throws because it asks `process.cwd()` live. That is the cached-cwd design and is not changed here.
- `bun run -` / `bun -` from a deleted cwd keep working: `exec_with_cfg` hands `-` to `exec_stdin` before the project setup that needs a directory.
- The no-cwd check sits ahead of `maybe_open_with_bun_js` because the kernel still resolves `..` from a deleted directory: `bun ./../x.cjs` could otherwise open a file through it and boot with the stand-in. Covered by the `bun ./../bin/x.cjs` case.
- Preloads: `load_preloads` resolves everything except an absolute path or a `node:`/`bun:` builtin against `top_level_dir`, so `--preload`/`--require`/`--import`, `BUN_INSPECT_PRELOAD` and bunfig `preload` entries of that kind are refused in `Arguments::parse` when no cwd was recorded. Node's `_preloadModules` also throws for `-r ./x` from a deleted cwd and keeps `-r /abs/x` working (`test-cwd-enoent-preload.js`).
- Compiled executables: the entry point is embedded, so `boot_standalone` seeds the stand-in and the binary starts with `process.cwd()` throwing ENOENT, with or without `--compile-exec-argv` (before, only the exec-argv variant started, because it goes through `Arguments::parse`). This is the behaviour #40372 (40b532de0f) describes for standalone executables; the `test/bundler/bun-build-compile.test.ts` case is rewritten the same way and gains an exec-argv variant.
- `cwd_or_exe_dir` asks `getcwd` itself when nothing was recorded, because `boot` is also reached from contexts that never ran `Arguments::parse` (compiled executables, the Windows `.bunx` fast path). `None` there means "not read yet", not "deleted".
- Option values: `--cwd <abs>` already worked and `--cwd <rel>` already failed. `--tsconfig-override <abs>` keeps working, `<rel>` fails with the hint. An explicit relative `--config` used to be joined with the executable's directory (`ENOENT: <exe dir>/bunfig.custom.toml`); it now prints the `getcwd` error `while reading config "<as given>"` and exits 1. The auto-loaded `bunfig.toml` is skipped without a cwd; before, `<exe dir>/bunfig.toml` was loaded (the test plants one with a preload to prove it no longer is).
- `bun --filter`/`--workspaces`/`--parallel`, `bun install`, `bun test`, `bun build` and `bunx` already refused from a deleted cwd and still do.
- `bun /abs/script.sh` from a deleted cwd now fails with `CurrentWorkingDirectoryUnlinked` (the shell needs a cwd) instead of `bunsh: No such file or directory:`.
- `--tsconfig-override` prints `Internal error: directory mismatch for directory ".../tsconfig.json"` on 1.4.3 in any cwd; unrelated and unchanged, which is why that test case does not assert an empty stderr.
- `getcwd` errors other than ENOENT (a cwd longer than PATH_MAX: ERANGE/ENAMETOOLONG) now stop run/auto/node commands like every other command, with the generic error text. #38363 (open) gives that case a dedicated message and errno mapping; it still applies on top. #40372 (open) centralizes the working directory in `bun_core::cwd`; the policy here (substitute only inside the runtime, never to resolve command-line input) carries over to its `starts_without_cwd` split.
- Suites run on the debug build: `run-crash-handler`, `run-eval`, `as-node`, `env`, `if-present`, `run_command`, `run-shell`, `tsconfig-override`, `preload-test` (all in `test/cli/run/`), `test/bundler/bun-build-compile.test.ts` and `test/cli/bunfig-test-options.test.ts`.
- Self-reviewed: 3 concerns raised, 3 addressed (relative preloads, the `boot()` invariant comment, compiled executables with and without exec argv). Earlier bot findings addressed too: absolute `--tsconfig-override` and silent `--config` (464ec4b), relative target ahead of the file probe (a5803cb).
- Repro used for the report:
  ```sh
  T=$(mktemp -d); mkdir $T/bin; cp "$(command -v bun)" $T/bin/bun
  echo 'console.log("RAN", __filename)' > $T/bin/x.cjs
  echo '{"scripts":{"build":"echo CANARY from $(pwd)"}}' > $T/package.json
  mkdir $T/gone; cd $T/gone; rmdir $T/gone
  $T/bin/bun x.cjs        # 1.4.3: RAN /tmp/.../bin/x.cjs, exit 0
  $T/bin/bun run build    # 1.4.3: CANARY from /tmp/..., exit 0
  ```
</details>
