### PR TITLE
pack: skip a UTF-8 BOM at the start of .npmignore and .gitignore

### DIFF
--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3730,7 +3730,7 @@ impl IgnorePatterns {
 
         let mut has_rel_path = false;
 
-        for line in strings::split(&contents, b"\n") {
+        for line in strings::split(strings::without_utf8_bom(&contents), b"\n") {
             if line.is_empty() {
                 continue;
             }

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1875,6 +1875,25 @@ describe.concurrent(".gitignore/.npmignore", () => {
 
     expect(tarballEntries(join(dir, "pack-ignore-2-1.2.1.tgz"))).toEqual(["package/package.json"]);
   });
+
+  // git's add_patterns_from_buffer() skips a UTF-8 BOM before it splits lines
+  test.each([".gitignore", ".npmignore"])("skips a UTF-8 BOM at the start of %s", async ignoreFile => {
+    using dir = tempDir("pack-ignore-bom", {
+      "package.json": JSON.stringify({ name: "pack-ignore-bom", version: "1.0.0" }),
+      [ignoreFile]: "\uFEFFsecrets/\n*.log\n",
+      "secrets/token.txt": "secret",
+      "debug.log": "log",
+      "index.js": indexJs,
+    });
+
+    const { err, exitCode } = await runPack(dir);
+    expect(err).toBe("");
+    expect(tarballEntries(join(dir, "pack-ignore-bom-1.0.0.tgz"))).toEqual([
+      "package/package.json",
+      "package/index.js",
+    ]);
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe.concurrent("bins", () => {


### PR DESCRIPTION
### Problem
- A `.npmignore` (or the fallback `.gitignore`) that starts with a UTF-8 BOM keeps the bytes `EF BB BF` in its first pattern. That pattern never matches, so `bun pm pack` and `bun publish` ship the files it names. Editors that save "UTF-8 with BOM" and PowerShell `Out-File` produce such files.
- The cause is `IgnorePatterns::read_from_disk` (`src/runtime/cli/pack_command.rs:3733`). It splits the raw file contents on `\n` with no BOM handling. git (`add_patterns_from_buffer` in `dir.c`) and npm-packlist strip the BOM first.

### Fix
- Pass the contents through the existing `strings::without_utf8_bom` before the line split.
- Correct because a BOM at offset 0 is an encoding signature, not pattern text, and both reference implementations drop it. A BOM anywhere else stays literal, the same as in git.
- Verified: `test/cli/install/bun-pack.test.ts` ("skips a UTF-8 BOM at the start of .gitignore/.npmignore", fails on bun 1.4.3). The whole file (88 tests) passes.

### Background
- `bun pm pack`, `bun publish`, and `bun pm diff` share one ignore reader, `IgnorePatterns::read_from_disk`. It reads `.npmignore`, falls back to `.gitignore`, and turns each line into a `Pattern`.
- `strings::without_utf8_bom` (`src/bun_core/string/immutable.rs`) returns the slice without a leading `EF BB BF`. The `.env` loader and `Blob`/`FormData` already use it.

<details><summary>Notes</summary>

Repro on bun 1.4.3:

```sh
printf '{"name":"bomdemo","version":"1.0.0"}' > package.json
mkdir secrets && echo tok > secrets/token.txt
printf '\xef\xbb\xbfsecrets/\n*.log\n' > .npmignore
bun pm pack --dry-run | grep packed
# packed package.json / packed secrets/token.txt
cp .npmignore .gitignore && git init -q && git check-ignore -v secrets/token.txt
# .gitignore:1:secrets/  secrets/token.txt
```

Only a real first-line pattern is affected. A BOM followed by a comment line or a blank line was already harmless.

The related trailing-space case (`secrets/ ` with an unescaped trailing space never matching) is the `trim_trailing_spaces` stub in the same reader. #41531 already ports git's `trim_trailing_spaces`, so this PR leaves that function alone to avoid a conflicting change.
</details>
