### PR TITLE
Clamp code frame source lines on a UTF-8 character boundary

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6210,6 +6210,18 @@ impl VirtualMachine {
         const MAX_LINE_LENGTH_WITH_DIVOT: usize = 512;
         const MAX_LINE_LENGTH: usize = 1024;
 
+        /// Truncates to `MAX_LINE_LENGTH` on a UTF-8 character boundary.
+        fn clamp_line(line: &[u8]) -> &[u8] {
+            if line.len() <= MAX_LINE_LENGTH {
+                return line;
+            }
+            let mut end = MAX_LINE_LENGTH;
+            while end > 0 && !bun_core::strings::is_utf8_char_boundary(line[end]) {
+                end -= 1;
+            }
+            &line[..end]
+        }
+
         // SAFETY: `source_lines_numbers[..source_lines_len]` is the
         // caller-owned buffer (see ZigStackTrace contract).
         let line_numbers = exception.stack.source_line_numbers();
@@ -6226,7 +6238,7 @@ impl VirtualMachine {
             splat_space(writer, pad)?;
 
             let trimmed = source.trimmed_text();
-            let clamped = &trimmed[..trimmed.len().min(MAX_LINE_LENGTH)];
+            let clamped = clamp_line(trimmed);
 
             let hl = bun_core::fmt::fmt_javascript(
                 clamped,
@@ -6316,7 +6328,7 @@ impl VirtualMachine {
 
                 if top_frame.is_none() || top_frame.unwrap().position.is_invalid() {
                     did_print_name = true;
-                    let clamped = &trimmed[..trimmed.len().min(MAX_LINE_LENGTH)];
+                    let clamped = clamp_line(trimmed);
                     let hl = bun_core::fmt::fmt_javascript(
                         clamped,
                         bun_core::fmt::HighlighterOptions {
@@ -6353,7 +6365,7 @@ impl VirtualMachine {
                     let pad = max_line_number_pad.saturating_sub(int_size);
                     splat_space(writer, pad)?;
 
-                    let clamped = &trimmed[..trimmed.len().min(MAX_LINE_LENGTH)];
+                    let clamped = clamp_line(trimmed);
                     let hl = bun_core::fmt::fmt_javascript(
                         clamped,
                         bun_core::fmt::HighlighterOptions {

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -468,7 +468,7 @@ describe.concurrent("code frame clamps a long source line on a character boundar
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `const s = "${filler}"; throw new Error("boom");`],
       env: { ...bunEnv, NO_COLOR: "1" },
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.bytes(), proc.exited]);

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -456,3 +456,27 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// The code frame caps a source line at 1024 bytes. The cut has to land on a
+// character boundary, or the frame writes a partial UTF-8 sequence to stderr.
+describe.concurrent("code frame clamps a long source line on a character boundary", () => {
+  test.each([
+    // "1 | const s = \"" is 15 bytes, so byte 1024 of the line lands inside a character in both cases.
+    ["cjk (3-byte)", Buffer.alloc(3000, "中文字").toString(), "中文字中"],
+    ["emoji (4-byte)", Buffer.alloc(4000, "😀").toString(), "😀😀😀😀"],
+  ])("%s", async (_label, filler, expectedTail) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const s = "${filler}"; throw new Error("boom");`],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.bytes(), proc.exited]);
+    const frameLine = stderr.subarray(0, stderr.indexOf(0x0a));
+    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(frameLine);
+    expect(decoded.startsWith('1 | const s = "')).toBe(true);
+    expect(decoded.endsWith(expectedTail)).toBe(true);
+    expect(frameLine.length).toBeLessThanOrEqual("1 | ".length + 1024);
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
### Problem
- The uncaught-error code frame caps each displayed source line at 1024 bytes. The cap sliced the UTF-8 bytes directly (`&trimmed[..trimmed.len().min(MAX_LINE_LENGTH)]`, three sites in `src/jsc/VirtualMachine.rs` near line 6229), so a long line of CJK or emoji was cut mid-sequence and the frame wrote invalid UTF-8 to stderr.
- Repro: a 9 KB line of `中文字` that throws. `NO_COLOR=1 bun l.js 2>&1 | head -1` is invalid UTF-8 at byte 1026 of 1029 on bun 1.4.2 and canary. Minified bundles with non-ASCII string tables hit this.

### Fix
- `clamp_line` cuts at 1024 bytes and backs up to the previous UTF-8 lead byte. All three sites use it.
- Correct because `SourceLine::text` is `Utf8Bytes` (`src/jsc/ZigStackTrace.rs:117`), so a lead-byte check finds a character boundary within 3 steps.
- The `| ... truncated` marker is unchanged: it still prints only with colors, as the existing snapshots in `inspect-error.test.js` expect.
- Verified: `test/js/bun/util/inspect-error.test.js` (`code frame clamps a long source line on a character boundary`, CJK and emoji). Stock bun fails both with `ERR_ENCODING_INVALID_ENCODED_DATA`. The whole file passes (31 tests).

### Background
- When an error reaches the top level, `VirtualMachine::print_error_instance_body` prints the source lines around the top frame, then the caret, name, and message.
- #9832 added the 1024-byte cap so a minified bundle does not dump 100 KB into the terminal. The cap was a byte slice with no regard to character boundaries.
