### PR TITLE
Bun.serve: release the FIFO file reader when the client disconnects

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1781,6 +1781,23 @@ impl WindowsBufferedReader {
         }
     }
 
+    /// Hands the fd close to the file source when a threadpool op is still in
+    /// flight: `complete()` closes the fd once the op's callback fires, and
+    /// `on_close_complete` then frees the source. Returns `false` when idle,
+    /// in which case the caller still closes the fd itself.
+    pub fn close_fd_after_pending_op(&mut self) -> bool {
+        if let Some(Source::File(file) | Source::SyncFile(file)) = self.source.as_mut() {
+            if matches!(
+                file.state,
+                crate::source::FileState::Operating | crate::source::FileState::Canceling
+            ) {
+                file.close_after_operation = true;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Close the reader and call the done callback.
     /// If a file operation is in progress, defers the done callback until
     /// the operation completes to ensure proper cleanup ordering.

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -324,6 +324,14 @@ impl PosixBufferedReader {
         // clearAndFree — release capacity, not just length.
         self._buffer = Vec::new();
         self.close_without_reporting();
+        self.release_poll();
+    }
+
+    /// `CLOSE_HANDLE` says who closes the fd. The `FilePoll` is always the
+    /// reader's, so a reader that goes away returns it even when the fd stays
+    /// with the parent.
+    fn release_poll(&mut self) {
+        self.handle.close_without_closing_fd();
     }
 
     fn close_without_reporting(&mut self) {
@@ -976,6 +984,7 @@ impl Drop for PosixBufferedReader {
     fn drop(&mut self) {
         MaxBuf::remove_from_pipereader(&mut self.maxbuf);
         self.close_without_reporting();
+        self.release_poll();
     }
 }
 
@@ -1779,23 +1788,6 @@ impl WindowsBufferedReader {
                 self.done();
             }
         }
-    }
-
-    /// Hands the fd close to the file source when a threadpool op is still in
-    /// flight: `complete()` closes the fd once the op's callback fires, and
-    /// `on_close_complete` then frees the source. Returns `false` when idle,
-    /// in which case the caller still closes the fd itself.
-    pub fn close_fd_after_pending_op(&mut self) -> bool {
-        if let Some(Source::File(file) | Source::SyncFile(file)) = self.source.as_mut() {
-            if matches!(
-                file.state,
-                crate::source::FileState::Operating | crate::source::FileState::Canceling
-            ) {
-                file.close_after_operation = true;
-                return true;
-            }
-        }
-        false
     }
 
     /// Close the reader and call the done callback.

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -574,6 +574,17 @@ impl FileResponseStream {
             resp.close_if_done_and_marked();
         }
 
+        if self.mode.get() == Mode::Reader {
+            // An abort can land while the read is parked on a poll that never
+            // fires (a FIFO with an idle writer), or re-entrantly from inside
+            // the read loop, which would re-arm the poll on its way out. The
+            // pause unregisters the poll and blocks that re-arm, so the stream
+            // can be freed without a poll still pointing at it.
+            self.reader_mut().pause();
+            // No reader callback is coming to adopt the in-flight read ref.
+            drop(self.take_read_ref());
+        }
+
         // Release the owner ref from `heap::into_raw` in `start()`. Every entry
         // point that can reach here holds its own ref, so the free lands on
         // that guard's drop, not here.
@@ -628,12 +639,25 @@ bun_io::impl_buffered_reader_parent! {
 impl Drop for FileResponseStream {
     fn drop(&mut self) {
         bun_output::scoped_log!(FileResponseStream, "deinit");
-        // `self.reader` (BufferedReader) is torn down by its own `Drop` as a
-        // field — closes the poll handle. `bun.destroy(this)` is owned by
-        // `heap::take` in `deref`, not here.
+        // `start()` cleared CLOSE_HANDLE, so the reader's own `Drop` leaves
+        // the poll handle alone: return the FilePoll to the loop here, and
+        // close the fd below if `auto_close` owns it.
+        #[cfg(unix)]
+        self.reader
+            .with_mut(|reader| reader.handle.close_without_closing_fd());
         if self.auto_close.get() {
             #[cfg(windows)]
-            Closer::close(self.fd.get(), bun_sys::windows::libuv::Loop::get());
+            {
+                // A read already running on the libuv threadpool cannot be
+                // cancelled: let the detached source close the fd once that
+                // read completes, instead of closing it out from under it.
+                if !self
+                    .reader
+                    .with_mut(|reader| reader.close_fd_after_pending_op())
+                {
+                    Closer::close(self.fd.get(), bun_sys::windows::libuv::Loop::get());
+                }
+            }
             #[cfg(not(windows))]
             Closer::close(self.fd.get(), ());
         }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -252,6 +252,17 @@ impl FileResponseStream {
             return;
         }
 
+        // A Windows file read runs on the libuv threadpool and cannot be
+        // cancelled once it runs, so only the reader's file source can close
+        // the fd safely: it closes after the read in flight. Hand it the fd.
+        #[cfg(windows)]
+        if opts.auto_close {
+            this_ref
+                .reader
+                .with_mut(|reader| reader.flags.insert(ReaderFlags::CLOSE_HANDLE));
+            this_ref.auto_close.set(false);
+        }
+
         // SAFETY: as above — `update_ref` re-enters `event_loop` through the parent pointer.
         this_ref.reader_mut().update_ref(true);
 
@@ -639,25 +650,12 @@ bun_io::impl_buffered_reader_parent! {
 impl Drop for FileResponseStream {
     fn drop(&mut self) {
         bun_output::scoped_log!(FileResponseStream, "deinit");
-        // `start()` cleared CLOSE_HANDLE, so the reader's own `Drop` leaves
-        // the poll handle alone: return the FilePoll to the loop here, and
-        // close the fd below if `auto_close` owns it.
-        #[cfg(unix)]
-        self.reader
-            .with_mut(|reader| reader.handle.close_without_closing_fd());
+        // `self.reader` (BufferedReader) is torn down by its own `Drop` as a
+        // field — closes the poll handle. `bun.destroy(this)` is owned by
+        // `heap::take` in `deref`, not here.
         if self.auto_close.get() {
             #[cfg(windows)]
-            {
-                // A read already running on the libuv threadpool cannot be
-                // cancelled: let the detached source close the fd once that
-                // read completes, instead of closing it out from under it.
-                if !self
-                    .reader
-                    .with_mut(|reader| reader.close_fd_after_pending_op())
-                {
-                    Closer::close(self.fd.get(), bun_sys::windows::libuv::Loop::get());
-                }
-            }
+            Closer::close(self.fd.get(), bun_sys::windows::libuv::Loop::get());
             #[cfg(not(windows))]
             Closer::close(self.fd.get(), ());
         }

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -3,8 +3,6 @@
 //! *NOTE* This type is reference counted via `Arc`; see the `Drop` impl note.
 
 use core::cell::UnsafeCell;
-#[cfg(not(windows))]
-use core::ffi::c_void;
 
 use bun_sys::{self as sys, Fd};
 
@@ -395,12 +393,9 @@ impl Drop for IOReader {
             }
             #[cfg(not(windows))]
             {
-                // We cleared CLOSE_HANDLE in init(), so reader Drop will not
-                // return the FilePoll to its pool. Do it explicitly (without
-                // closing the fd — we own that and close it ourselves below).
-                if matches!(r.handle, bun_io::pipes::PollOrFd::Poll(_)) {
-                    r.handle.close_impl(None, None::<fn(*mut c_void)>, false);
-                }
+                // Release the poll before closing the fd it watches. With
+                // CLOSE_HANDLE cleared in init(), `deinit` leaves the fd to us.
+                r.deinit();
                 let _ = sys::close(s.fd);
             }
         }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1267,9 +1267,10 @@ const server = Bun.serve({
   },
 });
 
-// Sends a request and resolves once \`until\` matches what arrived. A dead
-// client leaves as soon as the head is in, with the server's read parked.
-async function request(until) {
+// Sends a request, then \`marker\` into the pipe, and resolves once \`until\`
+// matches what arrived. The head goes to the wire with the first body chunk,
+// so a dead client leaves after its marker, with the server's read parked.
+async function request(until, marker) {
   const socket = connect({ port: server.port, host: "127.0.0.1" });
   socket.on("error", () => {});
   await new Promise(resolve => socket.once("connect", resolve));
@@ -1280,12 +1281,13 @@ async function request(until) {
     if (until.test(received)) resolve(received);
   });
   socket.write("GET / HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n");
+  if (marker) writeSync(writerFd, marker);
   const out = await promise;
   socket.destroy();
   return out;
 }
 
-for (let i = 0; i < 3; i++) await request(/\\r\\n\\r\\n/);
+for (let i = 0; i < 3; i++) await request(/dead-\\d/, "dead-" + i);
 
 // The producer writes after the dead clients left. Only the live client may
 // see these bytes.
@@ -1299,6 +1301,7 @@ const parked = connect({ port: server.port, host: "127.0.0.1" });
 parked.on("error", () => {});
 await new Promise(resolve => parked.once("connect", resolve));
 parked.write("GET / HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n");
+writeSync(writerFd, "parked");
 await new Promise(resolve => parked.once("data", resolve));
 server.stop(true);
 parked.destroy();

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1101,9 +1101,8 @@ if (then === "resume") {
   socket.resume();
   await waitForRead("resumed");
 
-  // Stop reading again before the disconnect. A stream that waits for pipe
-  // data when its client disconnects stays allocated while the pipe is open,
-  // and the leak check at exit reports it. A paused stream is freed.
+  // Stop reading again before the disconnect, so the pause after a resume is
+  // covered too and the abort lands on a paused reader as in the other cases.
   socket.pause();
   await waitForStall();
   socket.destroy();
@@ -1253,16 +1252,20 @@ test.concurrent.skipIf(isWindows)(
     using dir = tempDir("serve-fifo-abort-steal", {
       "fixture.ts": `
 import { connect } from "node:net";
-import { openSync, writeSync } from "node:fs";
+import { constants, openSync, readSync, writeSync } from "node:fs";
 
 const [fifoPath] = process.argv.slice(2);
-const writerFd = openSync(fifoPath, "r+");
+// Read+write and non-blocking: this fd is the idle producer, and a read from it
+// shows what is still in the pipe (EAGAIN when the pipe is empty).
+const writerFd = openSync(fifoPath, constants.O_RDWR | constants.O_NONBLOCK);
+const LINES = "line-1\\nline-2\\nline-3\\nline-4\\nline-5\\n";
 
 const server = Bun.serve({
   port: 0,
   hostname: "127.0.0.1",
   idleTimeout: 0,
-  fetch() {
+  fetch(req) {
+    if (new URL(req.url).pathname === "/alive") return new Response("alive");
     return new Response(Bun.file(fifoPath));
   },
 });
@@ -1287,11 +1290,34 @@ async function request(until, marker) {
   return out;
 }
 
-for (let i = 0; i < 3; i++) await request(/dead-\\d/, "dead-" + i);
+// A request to this same server makes its event loop poll for I/O, so an
+// aborted stream whose poll is still armed reads the pipe during it.
+async function poll() {
+  const res = await fetch("http://127.0.0.1:" + server.port + "/alive");
+  await res.text();
+}
 
-// The producer writes after the dead clients left. Only the live client may
-// see these bytes.
-writeSync(writerFd, "line-1\\nline-2\\nline-3\\nline-4\\nline-5\\n");
+for (let i = 0; i < 3; i++) await request(/dead-\\d/, "dead-" + i);
+for (let i = 0; i < 3; i++) await poll();
+
+// The producer writes after the dead clients left. Nothing may read the pipe
+// now, so the bytes are still there when this process looks. A broken build
+// fails here with a message instead of a live client that waits forever.
+writeSync(writerFd, LINES);
+for (let i = 0; i < 3; i++) await poll();
+let pending = 0;
+try {
+  pending = readSync(writerFd, Buffer.alloc(256), 0, 256, null);
+} catch (err) {
+  if (err.code !== "EAGAIN") throw err;
+}
+if (pending !== LINES.length) {
+  console.log("aborted streams consumed the pipe: " + pending + " of " + LINES.length + " bytes left");
+  process.exit(1);
+}
+
+// End to end: a live client gets what the producer writes.
+writeSync(writerFd, LINES);
 const body = (await request(/line-5\\n/)).split("\\r\\n\\r\\n")[1];
 console.log(body.match(/line-\\d/g).join(" "));
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1148,6 +1148,182 @@ process.exit(0);
   );
 }
 
+// A client that disconnects while the server waits for more pipe data must
+// release the server's reader fd at abort time. The stream held a ref for the
+// read that is parked on the poll, and only a reader callback released it, so
+// the fd and its poll lived until the pipe's writer closed. N disconnected
+// clients pinned N fds.
+for (const source of ["fetch", "route"] as const) {
+  test.concurrent.skipIf(isWindows)(
+    `Bun.file(FIFO) response (${source}) closes its reader fd when the client disconnects`,
+    async () => {
+      using dir = tempDir("serve-fifo-abort-fd", {
+        "fixture.ts": `
+import { connect } from "node:net";
+import { openSync, readdirSync, writeSync } from "node:fs";
+
+const [fifoPath, source, count] = process.argv.slice(2);
+const N = Number(count);
+
+// The writer stays open and idle for the whole run, so the server's reader
+// never sees EOF. Its read parks on the poll after each chunk.
+const writerFd = openSync(fifoPath, "r+");
+
+let aborted = 0;
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  idleTimeout: 0,
+  routes: { "/route": Bun.file(fifoPath) },
+  fetch(req) {
+    req.signal.addEventListener("abort", () => aborted++);
+    return new Response(Bun.file(fifoPath));
+  },
+});
+
+// Every open fd of this process. A leaked reader shows up as a count that
+// stays above the baseline.
+const openFds = () => readdirSync("/dev/fd").length;
+
+// Gets the response head and the first body chunk (so the server's read is
+// parked on the poll when the disconnect lands), then drops the connection.
+async function requestAndDisconnect(i) {
+  const socket = connect({ port: server.port, host: "127.0.0.1" });
+  socket.on("error", () => {});
+  await new Promise(resolve => socket.once("connect", resolve));
+  const marker = "chunk-" + i;
+  const { promise, resolve } = Promise.withResolvers();
+  let received = "";
+  socket.on("data", d => {
+    received += d.toString("latin1");
+    if (received.includes(marker)) resolve();
+  });
+  socket.write("GET /" + source + " HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n");
+  writeSync(writerFd, marker);
+  await promise;
+  socket.destroy();
+}
+
+const baseline = openFds();
+for (let i = 0; i < N; i++) await requestAndDisconnect(i);
+
+// The abort is reported from the socket close, and the fd close is async;
+// wait for the count to settle with a bound instead of a fixed delay.
+let fds = openFds();
+for (let i = 0; i < 200 && fds > baseline; i++) {
+  await Bun.sleep(10);
+  fds = openFds();
+}
+console.log(JSON.stringify({ leaked: Math.max(0, fds - baseline), aborted: source === "fetch" ? aborted : N }));
+
+server.stop(true);
+process.exit(0);
+`,
+      });
+
+      const fifoPath = join(String(dir), "abort.fifo");
+      mkfifo(fifoPath);
+      const N = 20;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.ts", fifoPath, source, String(N)],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout.trim())).toEqual({ leaked: 0, aborted: N });
+      expect(exitCode).toBe(0);
+    },
+  );
+}
+
+// The same leak has a second face: the poll of an aborted stream stayed armed,
+// so when the pipe's producer wrote later, the dead streams read the bytes
+// first and a live client got nothing. After the abort the reader must be
+// unregistered before the fd is closed. server.stop(true) aborts the same way,
+// and the process must be able to exit afterwards.
+test.concurrent.skipIf(isWindows)(
+  "Bun.file(FIFO) response: aborted streams do not consume bytes written after the disconnect",
+  async () => {
+    using dir = tempDir("serve-fifo-abort-steal", {
+      "fixture.ts": `
+import { connect } from "node:net";
+import { openSync, writeSync } from "node:fs";
+
+const [fifoPath] = process.argv.slice(2);
+const writerFd = openSync(fifoPath, "r+");
+
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  idleTimeout: 0,
+  fetch() {
+    return new Response(Bun.file(fifoPath));
+  },
+});
+
+// Sends a request and resolves once \`until\` matches what arrived. A dead
+// client leaves as soon as the head is in, with the server's read parked.
+async function request(until) {
+  const socket = connect({ port: server.port, host: "127.0.0.1" });
+  socket.on("error", () => {});
+  await new Promise(resolve => socket.once("connect", resolve));
+  const { promise, resolve } = Promise.withResolvers();
+  let received = "";
+  socket.on("data", d => {
+    received += d.toString("latin1");
+    if (until.test(received)) resolve(received);
+  });
+  socket.write("GET / HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n");
+  const out = await promise;
+  socket.destroy();
+  return out;
+}
+
+for (let i = 0; i < 3; i++) await request(/\\r\\n\\r\\n/);
+
+// The producer writes after the dead clients left. Only the live client may
+// see these bytes.
+writeSync(writerFd, "line-1\\nline-2\\nline-3\\nline-4\\nline-5\\n");
+const body = (await request(/line-5\\n/)).split("\\r\\n\\r\\n")[1];
+console.log(body.match(/line-\\d/g).join(" "));
+
+// A live stream is aborted by the stop. The process must exit on its own:
+// a stream that still holds its poll keeps the event loop alive.
+const parked = connect({ port: server.port, host: "127.0.0.1" });
+parked.on("error", () => {});
+await new Promise(resolve => parked.once("connect", resolve));
+parked.write("GET / HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n");
+await new Promise(resolve => parked.once("data", resolve));
+server.stop(true);
+parked.destroy();
+`,
+    });
+
+    const fifoPath = join(String(dir), "steal.fifo");
+    mkfifo(fifoPath);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts", fifoPath],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("line-1 line-2 line-3 line-4 line-5");
+    expect(exitCode).toBe(0);
+  },
+);
+
 // A FIFO's stat size is 0, but the body length is unknown until EOF. Writing
 // Content-Length from the stat size and then streaming the pipe to EOF puts
 // body bytes on the wire past the declared length; on a keep-alive connection


### PR DESCRIPTION
### Problem
- `Bun.serve` with `new Response(Bun.file(fifo))` (or a `routes:` file route, or `Bun.file(fifo).stream()`): when the client disconnects, `request.signal` aborts but the server keeps its FIFO reader fd open until the pipe's writer closes. N disconnected clients pin N fds, and the dead readers consume the bytes the producer writes later, so a live client gets nothing.
- Cause 1: `FileResponseStream::on_aborted` reaches `finish()` (`src/runtime/server/FileResponseStream.rs:576`), which releases the owner ref but not the ref that `start()` took for the read in flight (`READ_REF_HELD`). Only a reader callback released that ref, and with an idle writer none comes. The stream, its armed `FilePoll` and the fd stay alive.
- Cause 2: `start()` clears the reader's `CLOSE_HANDLE` because the stream owns the fd, and `PosixBufferedReader`'s teardown touched its poll handle only under that flag (`src/io/PipeReader.rs:329`). So even a freed stream never returned its `FilePoll`.

### Fix
- `finish()` pauses the reader (this unregisters the poll and blocks a re-arm from inside the read loop) and drops the read ref. No reader callback can adopt it once the stream is finished.
- `PosixBufferedReader::deinit` and `Drop` always return the `FilePoll` (`release_poll`). `CLOSE_HANDLE` now decides only who closes the fd. The shell `IOReader` drops its hand-rolled copy of this and calls `deinit()`.
- Windows: after `start()`, the stream hands the fd to the reader (`CLOSE_HANDLE`). A `uv_fs_read` on the threadpool cannot be cancelled, and the reader's file source already closes the fd after the read in flight (`File::detach`).
- Verified: `test/js/bun/http/bun-serve-file.test.ts`, three new tests, all fail on 1.4.3 and pass here. Also the rest of that file, `serve.test.ts`, `bun-serve-static`, `tls-bunfile-leak`, `serve-file-slice-read-error`, `body-stream`, `spawn.test.ts`, the shell suites, and on Windows `bun-serve-file`, `serve.test.ts`, `bun-serve-static` plus a 3000-abort stress. Self-reviewed: 5 concerns raised, 5 addressed (see Notes).

### Background
- `FileResponseStream` streams an open fd into a uWS response. For a pollable fd it uses a `BufferedReader`, which reads until EAGAIN and then arms a `FilePoll` (an epoll/kqueue registration) to continue.
- The stream is intrusively refcounted. `start()` takes one ref for the object and one for the read in flight. uWS callbacks (`on_aborted`, `on_writable`) and reader callbacks each hold a guard ref while they run.
- `CLOSE_HANDLE` is a reader flag: set means the reader closes the fd when it is done. `FileResponseStream` and the shell `IOReader` clear it because they close the fd themselves.

<details><summary>Notes</summary>

**Repro (from the report)**: 100 clients request a FIFO body and disconnect (half RST, half FIN). 1.4.3: `signal aborted=100 pendingRequests=0 FIFO reader fds open=100`, released only when the writer closes. With this change: 0 retained for `new Response(Bun.file(F))`, `routes: {"/f": Bun.file(F)}` and `new Response(Bun.file(F).stream())`.

**Second face**: three clients leave, then the producer writes `line-1..5`, then a live client requests. 1.4.3: the live client gets nothing (the three dead readers drain the pipe). With this change it gets all five lines. `server.stop(true)` goes through the same `on_aborted` path, and the fixture exits on its own afterwards.

**Why pause in `finish()`**: an abort can also arrive re-entrantly while the read loop is on the stack. The loop re-arms the poll after EAGAIN unless the reader is paused (`try_register_poll` honours `IS_PAUSED`), so the pause is what guarantees no poll points at the stream when the last ref drops. #41244 added the same pause for the backpressure case.

**Review concerns and what changed**:
1. Poll release hand-rolled in the parent's `Drop` (second copy after `IOReader`): moved into `PosixBufferedReader::deinit`/`Drop`; `IOReader` now calls `deinit()`.
2. A one-caller Windows API that duplicated `File::detach`: removed; the stream sets `CLOSE_HANDLE` after `start()` instead, so the existing detach path closes the fd after a pending read.
3. No Windows test: the new tests need `mkfifo` and are POSIX-only. On Windows the changed path is covered by the existing abort tests in `serve.test.ts` and `bun-serve-file.test.ts` (all pass), plus a manual run of 3000 mid-read disconnects of an 8 MiB file with the handle count flat (191 to 194) and complete responses still correct.
4. and 5. Comment accuracy and the stale note in the backpressure test: updated.

**Prior art**: #37083 (August) fixed the same two leaks with the release in the parent's `Drop`. It is stale and conflicts with main after #38886, #40478 and #41244. This PR supersedes it.

**Pre-existing failures seen locally, unchanged by this diff**: `serve.test.ts` "root range port (#7187)" and "/bun:info loopback" (container runs as root, no IPv6), `bun-write.test.js` "copyFileRange is not available, large files" (also fails on the released binary here).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->