### PR TITLE
Bun.serve: never duplicate the handshake's own fields from upgrade({ headers })

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1038,9 +1038,10 @@ declare module "bun" {
                * Send any additional headers while upgrading, like cookies.
                *
                * `Sec-WebSocket-Protocol` selects the subprotocol the handshake
-               * announces. The handshake's own fields (`Upgrade`, `Connection`,
-               * `Sec-WebSocket-Accept`) and `Content-Length` / `Transfer-Encoding`
-               * are written by the server and ignored here.
+               * announces. The server writes the handshake's own fields
+               * (`Upgrade`, `Connection`, `Sec-WebSocket-Accept`) itself, so
+               * those names are ignored here, as are `Sec-WebSocket-Key`,
+               * `Sec-WebSocket-Version`, `Content-Length` and `Transfer-Encoding`.
                */
               headers?: HeadersInit;
 
@@ -1072,9 +1073,10 @@ declare module "bun" {
                * Send any additional headers while upgrading, like cookies.
                *
                * `Sec-WebSocket-Protocol` selects the subprotocol the handshake
-               * announces. The handshake's own fields (`Upgrade`, `Connection`,
-               * `Sec-WebSocket-Accept`) and `Content-Length` / `Transfer-Encoding`
-               * are written by the server and ignored here.
+               * announces. The server writes the handshake's own fields
+               * (`Upgrade`, `Connection`, `Sec-WebSocket-Accept`) itself, so
+               * those names are ignored here, as are `Sec-WebSocket-Key`,
+               * `Sec-WebSocket-Version`, `Content-Length` and `Transfer-Encoding`.
                */
               headers?: HeadersInit;
 

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1035,7 +1035,12 @@ declare module "bun" {
         ? [
             options?: {
               /**
-               * Send any additional headers while upgrading, like cookies
+               * Send any additional headers while upgrading, like cookies.
+               *
+               * `Sec-WebSocket-Protocol` selects the subprotocol the handshake
+               * announces. The handshake's own fields (`Upgrade`, `Connection`,
+               * `Sec-WebSocket-Accept`) and `Content-Length` / `Transfer-Encoding`
+               * are written by the server and ignored here.
                */
               headers?: HeadersInit;
 
@@ -1064,7 +1069,12 @@ declare module "bun" {
         : [
             options: {
               /**
-               * Send any additional headers while upgrading, like cookies
+               * Send any additional headers while upgrading, like cookies.
+               *
+               * `Sec-WebSocket-Protocol` selects the subprotocol the handshake
+               * announces. The handshake's own fields (`Upgrade`, `Connection`,
+               * `Sec-WebSocket-Accept`) and `Content-Length` / `Transfer-Encoding`
+               * are written by the server and ignored here.
                */
               headers?: HeadersInit;
 

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1038,10 +1038,12 @@ declare module "bun" {
                * Send any additional headers while upgrading, like cookies.
                *
                * `Sec-WebSocket-Protocol` selects the subprotocol the handshake
-               * announces. The server writes the handshake's own fields
-               * (`Upgrade`, `Connection`, `Sec-WebSocket-Accept`) itself, so
-               * those names are ignored here, as are `Sec-WebSocket-Key`,
-               * `Sec-WebSocket-Version`, `Content-Length` and `Transfer-Encoding`.
+               * announces, and `Sec-WebSocket-Extensions` replaces the client's
+               * extension offer in the `permessage-deflate` negotiation. The
+               * server writes the handshake's own fields (`Upgrade`, `Connection`,
+               * `Sec-WebSocket-Accept`) itself, so those names are ignored here,
+               * as are `Sec-WebSocket-Key`, `Sec-WebSocket-Version`,
+               * `Content-Length` and `Transfer-Encoding`.
                */
               headers?: HeadersInit;
 
@@ -1073,10 +1075,12 @@ declare module "bun" {
                * Send any additional headers while upgrading, like cookies.
                *
                * `Sec-WebSocket-Protocol` selects the subprotocol the handshake
-               * announces. The server writes the handshake's own fields
-               * (`Upgrade`, `Connection`, `Sec-WebSocket-Accept`) itself, so
-               * those names are ignored here, as are `Sec-WebSocket-Key`,
-               * `Sec-WebSocket-Version`, `Content-Length` and `Transfer-Encoding`.
+               * announces, and `Sec-WebSocket-Extensions` replaces the client's
+               * extension offer in the `permessage-deflate` negotiation. The
+               * server writes the handshake's own fields (`Upgrade`, `Connection`,
+               * `Sec-WebSocket-Accept`) itself, so those names are ignored here,
+               * as are `Sec-WebSocket-Key`, `Sec-WebSocket-Version`,
+               * `Content-Length` and `Transfer-Encoding`.
                */
               headers?: HeadersInit;
 

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -188,11 +188,7 @@ impl FetchHeaders {
         WebCore__FetchHeaders__toUWSResponse(self, kind, uws_response)
     }
 
-    /// Writes these headers into the 101 of a WebSocket upgrade on an HTTP/1
-    /// `uws::Response`. Skips every field the handshake writes itself
-    /// (`Upgrade`, `Connection`, `Sec-WebSocket-*`) and the framing fields a
-    /// 1xx cannot carry, so the caller's `resp.upgrade()` lines are the only
-    /// ones on the wire. Does not mutate `self`.
+    /// For the 101 of an HTTP/1 WebSocket upgrade: skips the fields `upgrade()` writes itself.
     pub fn to_uws_response_for_websocket_upgrade(&mut self, ssl: bool, uws_response: *mut c_void) {
         WebCore__FetchHeaders__toUWSResponseForWebSocketUpgrade(self, ssl, uws_response)
     }

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -76,6 +76,11 @@ unsafe extern "C" {
         kind: ResponseKind,
         arg2: *mut c_void,
     );
+    safe fn WebCore__FetchHeaders__toUWSResponseForWebSocketUpgrade(
+        arg0: &mut FetchHeaders,
+        ssl: bool,
+        arg1: *mut c_void,
+    );
     safe fn WebCore__FetchHeaders__createFromH3(arg0: *mut c_void) -> *mut FetchHeaders;
 
     safe fn WebCore__FetchHeaders__createFromJS(
@@ -181,6 +186,15 @@ impl FetchHeaders {
 
     pub fn to_uws_response(&mut self, kind: ResponseKind, uws_response: *mut c_void) {
         WebCore__FetchHeaders__toUWSResponse(self, kind, uws_response)
+    }
+
+    /// Writes these headers into the 101 of a WebSocket upgrade on an HTTP/1
+    /// `uws::Response`. Skips every field the handshake writes itself
+    /// (`Upgrade`, `Connection`, `Sec-WebSocket-*`) and the framing fields a
+    /// 1xx cannot carry, so the caller's `resp.upgrade()` lines are the only
+    /// ones on the wire. Does not mutate `self`.
+    pub fn to_uws_response_for_websocket_upgrade(&mut self, ssl: bool, uws_response: *mut c_void) {
+        WebCore__FetchHeaders__toUWSResponseForWebSocketUpgrade(self, ssl, uws_response)
     }
 
     pub fn create_empty() -> NonNull<FetchHeaders> {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -396,8 +396,7 @@ static bool connectionValueHasClose(const WTF::String& value)
     return false;
 }
 
-// Fields HttpResponse::upgrade() writes itself (RFC 6455 §4.2.2), plus the
-// framing fields a 1xx must not carry (RFC 9110 §8.6, RFC 9112 §6.1).
+// Written by HttpResponse::upgrade() itself (RFC 6455 §4.2.2), or not allowed in a 1xx (RFC 9110 §8.6).
 static bool isWebSocketHandshakeOwnedHeader(WebCore::HTTPHeaderName name)
 {
     switch (name) {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -396,7 +396,30 @@ static bool connectionValueHasClose(const WTF::String& value)
     return false;
 }
 
-template<bool isSSL>
+// Field names that HttpResponse::upgrade() writes itself in the 101
+// (RFC 6455 §4.2.2), plus the two framing fields a 1xx response must not
+// carry (RFC 9110 §8.6, RFC 9112 §6.1). server.upgrade() reads the
+// Sec-WebSocket-Protocol and -Extensions values out of options.headers and
+// hands them to upgrade(); the rest have no valid user-supplied value.
+static bool isWebSocketHandshakeOwnedHeader(WebCore::HTTPHeaderName name)
+{
+    switch (name) {
+    case WebCore::HTTPHeaderName::Upgrade:
+    case WebCore::HTTPHeaderName::Connection:
+    case WebCore::HTTPHeaderName::SecWebSocketAccept:
+    case WebCore::HTTPHeaderName::SecWebSocketKey:
+    case WebCore::HTTPHeaderName::SecWebSocketVersion:
+    case WebCore::HTTPHeaderName::SecWebSocketProtocol:
+    case WebCore::HTTPHeaderName::SecWebSocketExtensions:
+    case WebCore::HTTPHeaderName::ContentLength:
+    case WebCore::HTTPHeaderName::TransferEncoding:
+        return true;
+    default:
+        return false;
+    }
+}
+
+template<bool isSSL, bool forWebSocketUpgrade = false>
 static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::HttpResponse<isSSL>* res)
 {
     auto& internalHeaders = headers.internalHeaders();
@@ -409,6 +432,10 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     auto* data = res->getHttpResponseData();
 
     for (const auto& header : internalHeaders.commonHeaders()) {
+        if constexpr (forWebSocketUpgrade) {
+            if (isWebSocketHandshakeOwnedHeader(header.key))
+                continue;
+        }
 
         const auto& name = WebCore::httpHeaderNameString(header.key);
         const auto& value = header.value;
@@ -887,6 +914,15 @@ extern "C" void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0
     case UWSResponseKind::H3:
         writeFetchHeadersToStreamResponse<uWS::Http3Response, uWS::Http3ResponseData>(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));
         break;
+    }
+}
+
+extern "C" void WebCore__FetchHeaders__toUWSResponseForWebSocketUpgrade(WebCore::FetchHeaders* arg0, bool isSSL, void* arg1)
+{
+    if (isSSL) {
+        writeFetchHeadersToUWSResponse<true, true>(*arg0, reinterpret_cast<uWS::HttpResponse<true>*>(arg1));
+    } else {
+        writeFetchHeadersToUWSResponse<false, true>(*arg0, reinterpret_cast<uWS::HttpResponse<false>*>(arg1));
     }
 }
 

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -396,11 +396,8 @@ static bool connectionValueHasClose(const WTF::String& value)
     return false;
 }
 
-// Field names that HttpResponse::upgrade() writes itself in the 101
-// (RFC 6455 §4.2.2), plus the two framing fields a 1xx response must not
-// carry (RFC 9110 §8.6, RFC 9112 §6.1). server.upgrade() reads the
-// Sec-WebSocket-Protocol and -Extensions values out of options.headers and
-// hands them to upgrade(); the rest have no valid user-supplied value.
+// Fields HttpResponse::upgrade() writes itself (RFC 6455 §4.2.2), plus the
+// framing fields a 1xx must not carry (RFC 9110 §8.6, RFC 9112 §6.1).
 static bool isWebSocketHandshakeOwnedHeader(WebCore::HTTPHeaderName name)
 {
     switch (name) {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -83,6 +83,7 @@ CPP_DECL void WebCore__FetchHeaders__get_(WebCore::FetchHeaders* arg0, const Enc
 CPP_DECL bool WebCore__FetchHeaders__isEmpty(WebCore::FetchHeaders* arg0);
 CPP_DECL JSC::EncodedJSValue WebCore__FetchHeaders__toJS(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0, UWSResponseKind kind, void* arg2);
+CPP_DECL void WebCore__FetchHeaders__toUWSResponseForWebSocketUpgrade(WebCore::FetchHeaders* arg0, bool isSSL, void* arg1);
 CPP_DECL JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::EncodedJSValue SystemError__toTypeErrorInstance(const SystemError* arg0, JSC::JSGlobalObject* arg1);
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1743,8 +1743,7 @@ where
                         let fetch_headers_to_use =
                             bun_opaque::opaque_deref_mut(fetch_headers_to_use);
 
-                        // `upgrade()` writes these two itself from the values
-                        // passed to it; the writer below skips them.
+                        // upgrade() writes these two itself; the writer below skips them.
                         if let Some(protocol) =
                             fetch_headers_to_use.fast_get(HTTPHeaderName::SecWebSocketProtocol)
                         {
@@ -1944,8 +1943,7 @@ where
 
                     // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
                     let fh = bun_opaque::opaque_deref_mut(fh);
-                    // `resp.upgrade()` writes these two itself from the values
-                    // passed to it; the writer below skips them.
+                    // resp.upgrade() writes these two itself; the writer below skips them.
                     if let Some(p) = fh.fast_get(HTTPHeaderName::SecWebSocketProtocol) {
                         sec_websocket_protocol = p.to_utf8().into_owned();
                     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1697,8 +1697,6 @@ where
                 }
             });
 
-            // Copied out of `options.headers` because `fast_remove` frees the
-            // entry they would otherwise borrow.
             let mut sec_websocket_protocol = Utf8Bytes::EMPTY;
             let mut sec_websocket_extensions = Utf8Bytes::EMPTY;
 
@@ -1745,31 +1743,23 @@ where
                         let fetch_headers_to_use =
                             bun_opaque::opaque_deref_mut(fetch_headers_to_use);
 
+                        // `upgrade()` writes these two itself from the values
+                        // passed to it; the writer below skips them.
                         if let Some(protocol) =
                             fetch_headers_to_use.fast_get(HTTPHeaderName::SecWebSocketProtocol)
                         {
                             sec_websocket_protocol = protocol.to_utf8().into_owned();
-                            // Remove from headers so it's not written twice (once here and once by upgrade())
-                            fetch_headers_to_use.fast_remove(HTTPHeaderName::SecWebSocketProtocol);
                         }
-
                         if let Some(extensions) =
                             fetch_headers_to_use.fast_get(HTTPHeaderName::SecWebSocketExtensions)
                         {
                             sec_websocket_extensions = extensions.to_utf8().into_owned();
-                            // Remove from headers so it's not written twice (once here and once by upgrade())
-                            fetch_headers_to_use
-                                .fast_remove(HTTPHeaderName::SecWebSocketExtensions);
                         }
                         if let Some(raw_response) = node_http_response.raw_response.get() {
                             // we must write the status first so that 200 OK isn't written
                             raw_response.write_status(b"101 Switching Protocols");
-                            fetch_headers_to_use.to_uws_response(
-                                if SSL {
-                                    ResponseKind::Ssl
-                                } else {
-                                    ResponseKind::Tcp
-                                },
+                            fetch_headers_to_use.to_uws_response_for_websocket_upgrade(
+                                SSL,
                                 raw_response.socket().cast::<c_void>(),
                             );
                         }
@@ -1954,14 +1944,13 @@ where
 
                     // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
                     let fh = bun_opaque::opaque_deref_mut(fh);
-                    // Copied out because `fast_remove` frees the entry.
+                    // `resp.upgrade()` writes these two itself from the values
+                    // passed to it; the writer below skips them.
                     if let Some(p) = fh.fast_get(HTTPHeaderName::SecWebSocketProtocol) {
                         sec_websocket_protocol = p.to_utf8().into_owned();
-                        fh.fast_remove(HTTPHeaderName::SecWebSocketProtocol);
                     }
                     if let Some(e) = fh.fast_get(HTTPHeaderName::SecWebSocketExtensions) {
                         sec_websocket_extensions = e.to_utf8().into_owned();
-                        fh.fast_remove(HTTPHeaderName::SecWebSocketExtensions);
                     }
                 }
             }
@@ -1983,14 +1972,8 @@ where
             resp.write_status(b"101 Switching Protocols");
             if let Some(h) = fetch_headers_to_use {
                 // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
-                bun_opaque::opaque_deref_mut(h).to_uws_response(
-                    if SSL {
-                        ResponseKind::Ssl
-                    } else {
-                        ResponseKind::Tcp
-                    },
-                    resp.socket().cast::<c_void>(),
-                );
+                bun_opaque::opaque_deref_mut(h)
+                    .to_uws_response_for_websocket_upgrade(SSL, resp.socket().cast::<c_void>());
             }
             if let Some(c) = cookies_to_write.as_mut() {
                 c.write(

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -2298,6 +2298,159 @@ describe("server.upgrade() validates the opening handshake", () => {
   });
 });
 
+// RFC 6455 §4.2.2 fixes the Upgrade, Connection and Sec-WebSocket-Accept lines
+// of the server's 101, and a 1xx carries no Content-Length or Transfer-Encoding
+// (RFC 9110 §8.6). upgrade() writes its own lines. The same names passed in
+// options.headers used to be written as well, so a client saw two
+// Sec-WebSocket-Accept values (or `Upgrade: h2c` next to `Upgrade: websocket`)
+// and failed the handshake after the server had already run open().
+describe.concurrent("server.upgrade() options.headers cannot duplicate the handshake's own fields", () => {
+  const K = "dGhlIHNhbXBsZSBub25jZQ==";
+  // RFC 6455 §1.3: the accept value for the sample nonce above.
+  const ACCEPT = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
+  const rawHandshake = (port: number, extra: string[] = []) =>
+    new Promise<string[]>(resolve => {
+      let buf = "";
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        sock.destroy();
+        const head = buf.split("\r\n\r\n", 1)[0] ?? "";
+        resolve(head.split("\r\n"));
+      };
+      const sock = net.connect({ port, host: "127.0.0.1" }, () => {
+        sock.write(
+          [
+            "GET /ws HTTP/1.1",
+            "Host: x",
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            `Sec-WebSocket-Key: ${K}`,
+            "Sec-WebSocket-Version: 13",
+            ...extra,
+            "",
+            "",
+          ].join("\r\n"),
+        );
+      });
+      sock.on("data", d => {
+        buf += d.toString("latin1");
+        if (buf.includes("\r\n\r\n")) done();
+      });
+      sock.on("error", done);
+      sock.on("close", done);
+    });
+
+  // Lower-cases the field name only, drops the Date line, and sorts, so the
+  // comparison does not depend on write order.
+  const fields = (lines: string[]) =>
+    lines
+      .slice(1)
+      .map(line => {
+        const i = line.indexOf(":");
+        return line.slice(0, i).toLowerCase() + ":" + line.slice(i + 1);
+      })
+      .filter(line => !line.startsWith("date:"))
+      .sort();
+
+  const clientOpens = (url: string, protocols?: string[]) =>
+    new Promise<string>(resolve => {
+      const ws = new WebSocket(url, protocols);
+      ws.onopen = () => {
+        resolve(`open protocol=${ws.protocol}`);
+        ws.close();
+      };
+      ws.onerror = e => resolve(`error: ${(e as ErrorEvent).message}`);
+    });
+
+  it("from a plain object", async () => {
+    const opened: string[] = [];
+    using server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, srv) {
+        if (
+          srv.upgrade(req, {
+            data: new URL(req.url).pathname,
+            headers: {
+              "Upgrade": "h2c",
+              "Connection": "close",
+              "Sec-WebSocket-Accept": "AAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+              "Sec-WebSocket-Key": "not-for-a-response",
+              "Sec-WebSocket-Version": "8",
+              "Content-Length": "5",
+              "Transfer-Encoding": "chunked",
+              "X-Custom": "yes",
+              "Set-Cookie": "a=b",
+            },
+          })
+        )
+          return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          opened.push(ws.data as string);
+        },
+        message() {},
+      },
+    });
+
+    const lines = await rawHandshake(server.port);
+    expect(lines[0]).toBe("HTTP/1.1 101 Switching Protocols");
+    expect(fields(lines)).toEqual(
+      [
+        "connection: Upgrade",
+        `sec-websocket-accept: ${ACCEPT}`,
+        "set-cookie: a=b",
+        "upgrade: websocket",
+        "x-custom: yes",
+      ].sort(),
+    );
+    expect(await clientOpens(`ws://127.0.0.1:${server.port}/client`)).toBe("open protocol=");
+    expect(opened).toEqual(["/ws", "/client"]);
+  });
+
+  it("from a Headers object, which is left unmodified", async () => {
+    const headers = new Headers({
+      "Sec-WebSocket-Protocol": "chat",
+      "Connection": "keep-alive",
+      "X-H": "1",
+    });
+    using server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, srv) {
+        if (srv.upgrade(req, { headers })) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: { message() {} },
+    });
+
+    const lines = await rawHandshake(server.port, ["Sec-WebSocket-Protocol: superchat, chat"]);
+    expect(lines[0]).toBe("HTTP/1.1 101 Switching Protocols");
+    // The Sec-WebSocket-Protocol in options.headers selects the subprotocol
+    // that upgrade() announces; it is written once, by upgrade().
+    expect(fields(lines)).toEqual(
+      [
+        "connection: Upgrade",
+        `sec-websocket-accept: ${ACCEPT}`,
+        "sec-websocket-protocol: chat",
+        "upgrade: websocket",
+        "x-h: 1",
+      ].sort(),
+    );
+    expect(await clientOpens(`ws://127.0.0.1:${server.port}/`, ["superchat", "chat"])).toBe("open protocol=chat");
+    expect([...headers]).toEqual([
+      ["connection", "keep-alive"],
+      ["sec-websocket-protocol", "chat"],
+      ["x-h", "1"],
+    ]);
+  });
+});
+
 // The 101 switches protocols: the connection stops being HTTP, so the HTTP
 // layer's "close after this response" (the request said Connection: close or
 // was HTTP/1.0, or a graceful server.stop() marked the connection to close

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -335,6 +335,49 @@ describe("WebSocketServer", () => {
     await promise;
   });
 
+  // The subprotocol handleProtocols picks goes to server.upgrade() in
+  // options.headers; the 101 must carry it exactly once.
+  it("handleProtocols selects the subprotocol announced in the 101", async () => {
+    const wss = new WebSocketServer({
+      port: 0,
+      handleProtocols: protocols => (protocols.has("chat") ? "chat" : false),
+    });
+    try {
+      await once(wss, "listening");
+      const port = (wss.address() as AddressInfo).port;
+
+      const { promise: raw, resolve } = Promise.withResolvers<string[]>();
+      let buf = "";
+      const sock = connect(port, "127.0.0.1", () => {
+        sock.write(
+          "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n" +
+            "Sec-WebSocket-Protocol: superchat, chat\r\n\r\n",
+        );
+      });
+      sock.on("data", d => {
+        buf += d.toString("latin1");
+        if (buf.includes("\r\n\r\n")) {
+          sock.destroy();
+          resolve(buf.split("\r\n\r\n", 1)[0].split("\r\n"));
+        }
+      });
+      sock.on("error", () => resolve(buf.split("\r\n")));
+      const lines = await raw;
+      expect(lines[0]).toBe("HTTP/1.1 101 Switching Protocols");
+      expect(lines.filter(l => l.toLowerCase().startsWith("sec-websocket-protocol:"))).toEqual([
+        "Sec-WebSocket-Protocol: chat",
+      ]);
+
+      const client = new WebSocket("ws://127.0.0.1:" + port, ["superchat", "chat"]);
+      await once(client, "open");
+      expect(client.protocol).toBe("chat");
+      client.close();
+    } finally {
+      wss.close();
+    }
+  });
+
   describe("binaryType", () => {
     type Received = { event: string; shape: string; bytes: number[]; isBinary?: boolean };
 

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -362,7 +362,10 @@ describe("WebSocketServer", () => {
           resolve(buf.split("\r\n\r\n", 1)[0].split("\r\n"));
         }
       });
+      // Settle on every terminal event so a short or missing head fails the
+      // assertions below instead of hanging.
       sock.on("error", () => resolve(buf.split("\r\n")));
+      sock.on("close", () => resolve(buf.split("\r\n")));
       const lines = await raw;
       expect(lines[0]).toBe("HTTP/1.1 101 Switching Protocols");
       expect(lines.filter(l => l.toLowerCase().startsWith("sec-websocket-protocol:"))).toEqual([


### PR DESCRIPTION
### Problem
- `server.upgrade(req, { headers })` wrote every `options.headers` entry into the 101 ahead of the lines uWS `upgrade()` writes itself. A `Sec-WebSocket-Accept`, `Upgrade`, `Connection`, `Content-Length` or `Transfer-Encoding` in `options.headers` went on the wire next to the generated ones. Bun's client fails with `Mismatch websocket accept header` or `Invalid upgrade header`, while `upgrade()` returned `true` and `open()` already ran.
- Cause: `on_upgrade` (`src/runtime/server/server_body.rs`) filtered only `Sec-WebSocket-Protocol` and `-Extensions` (with `fast_remove` on the caller's `Headers`) and sent the rest through the general response-header writer.

### Fix
- Add `WebCore__FetchHeaders__toUWSResponseForWebSocketUpgrade` (`NodeHTTP.cpp`): the same writer with a compile-time flag that skips `Upgrade`, `Connection`, `Sec-WebSocket-*`, `Content-Length` and `Transfer-Encoding`. Both upgrade paths (`Request` and `NodeHTTPResponse`) use it.
- `Sec-WebSocket-Protocol` and `-Extensions` from `options.headers` keep their meaning: read with `fast_get`, handed to `upgrade()`, written once. Without `fast_remove`, a caller's `Headers` object is no longer modified.
- Drop, not throw: each skipped name has one valid value in a 101 and `upgrade()` writes it. Throwing instead is a small change if preferred. Self-reviewed: no blocking concerns; two doc/test nits addressed.
- Verified: `test/js/bun/websocket/websocket-server.test.ts` (two new tests, both fail on 1.4.3) and a `ws` `handleProtocols` test for the node:http path. Also the rest of both files and `websocket-custom-headers.test.ts`.

### Background
- RFC 6455 §4.2.2 fixes the server's 101: `Upgrade: websocket`, `Connection: Upgrade`, `Sec-WebSocket-Accept` derived from the client's key. A client MUST fail on any other accept or upgrade value. RFC 9110 §8.6 forbids `Content-Length` in a 1xx.
- uWS `HttpResponse::upgrade()` writes the status and those lines, then the protocol and negotiated extensions, then ends the head. Anything Bun writes before it lands above them in the same head.
- WebCore `FetchHeaders` stores well-known names as an `HTTPHeaderName` enum (`commonHeaders()`). All skipped names are enum members, so the filter is one switch in that loop.

<details><summary>Notes</summary>

- Wire capture on 1.4.3 for `headers: { "Sec-WebSocket-Accept": "AAAA…=" }`: `Sec-WebSocket-Accept: AAAA…=`, then `Upgrade: websocket`, `Connection: Upgrade`, `Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`. For `{ Upgrade: "h2c", Connection: "close" }`: both pairs present, client error `Invalid upgrade header`. For `{ "Content-Length": "5", "Transfer-Encoding": "chunked" }`: both inside the 101 (RFC 9112 §6.1 also forbids `Transfer-Encoding` there).
- `Sec-WebSocket-Key` and `Sec-WebSocket-Version` are request fields with no meaning in a 101; they are skipped too.
- uWS state bits the skipped branches used to set (`HTTP_WROTE_CONTENT_LENGTH_HEADER`, `HTTP_CONNECTION_CLOSE`, `HTTP_WROTE_TRANSFER_ENCODING_HEADER`) are not read on the upgrade path: `upgrade()` ends the head through `endUpgradeHandshake()` and destroys the `HttpResponseData`. A user `Date` still replaces the generated one.
- Header names are case-insensitive and validated as tokens before they reach `FetchHeaders`, so a reserved name cannot arrive as an "uncommon" header.
- `Date` and `Server` in `options.headers` already replace the generated ones. Invalid names or values (CRLF, NUL, non-ASCII names) already throw before anything is written. Neither changes here.
- Why drop rather than throw: the result is always the handshake the caller could have meant, and a header set copied from another response keeps working. No input that produced a valid handshake before produces a different one now.
- Not changed: a `Sec-WebSocket-Protocol` value the client did not offer is still sent as given. Checking it against the client's offer is a separate question.
- The `.d.ts` comment for `options.headers` now says which names are ignored and that `Sec-WebSocket-Protocol` selects the subprotocol.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->