### PR TITLE
Emit rejectionHandled for late handlers on promises rejected by a reaction job

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -841,6 +841,9 @@ impl<'a> Run<'a> {
 
                 let _ = self.macro_.vm();
                 let vm = VirtualMachine::get();
+                // A rejection is reported below through `unhandled_rejection`; keep the
+                // tracker from also reporting it while the loop spins.
+                promise.set_handled(vm.jsc_vm());
                 // The VM stopped before the macro's promise settled: throw its termination and unwind.
                 vm.as_mut()
                     .wait_for_promise(promise)

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -254,6 +254,9 @@ impl JSPromise {
         JSPromise::opaque_ref(p).status()
     }
 
+    /// The settled value, or an empty `JSValue` while pending. Reading a
+    /// rejection does not mark it handled: native code that consumes one
+    /// calls [`set_handled`](Self::set_handled) itself.
     pub fn result(&mut self, vm: &VM) -> JSValue {
         JSC__JSPromise__result(self, vm)
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3993,20 +3993,9 @@ JSC::JSPromise* JSC__JSPromise__resolvedPromise(JSC::JSGlobalObject* globalObjec
 {
     UNUSED_PARAM(arg1);
 
-    // if the promise is rejected we automatically mark it as handled so it
-    // doesn't end up in the promise rejection tracker
-    switch (promise->status()) {
-    case JSC::JSPromise::Status::Rejected: {
-        if (!(promise->flags() & JSC::JSPromise::isFirstResolvingFunctionCalledFlag))
-            promise->markAsHandled();
-    }
-    // fallthrough intended
-    case JSC::JSPromise::Status::Fulfilled: {
-        return JSValue::encode(promise->result());
-    }
-    default:
+    if (promise->status() == JSC::JSPromise::Status::Pending)
         return JSValue::encode(JSValue {});
-    }
+    return JSValue::encode(promise->result());
 }
 
 [[ZIG_EXPORT(nothrow)]] uint32_t JSC__JSPromise__status(const JSC::JSPromise* arg0)

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1452,9 +1452,6 @@ impl Run<'_> {
                     }
                 }
 
-                // SAFETY: `vm.jsc_vm` set in `init`.
-                let _ = promise.result(unsafe { &mut *vm.jsc_vm });
-
                 if log_has_msgs(vm) {
                     dump_build_error(vm);
                     log_clear_msgs(vm);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2924,6 +2924,8 @@ impl TestCommand {
                     // `unhandled_rejection(&mut self, ...)` can reborrow.
                     let global = vm.global();
                     let p = jsc::JSInternalPromise::opaque_mut(promise);
+                    // Reported right here; the tracker must not report it a second time.
+                    p.set_handled();
                     let (result, promise_js) = (p.result(global.vm()), p.to_js());
                     vm.unhandled_rejection(global, result, promise_js);
                     reporter.summary().fail += 1;

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -12,7 +12,7 @@ use bun_uws_sys::{Opcode, SendStatus};
 
 use crate::server::WebSocketServerHandler;
 use crate::server::jsc::{
-    self, AbortSignal, ArrayBuffer, CallFrame, CommonAbortReason, JSGlobalObject, JSType, JSValue,
+    AbortSignal, ArrayBuffer, CallFrame, CommonAbortReason, JSGlobalObject, JSType, JSValue,
     JsError, JsRef, JsResult,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
@@ -533,28 +533,13 @@ impl ServerWebSocket {
         };
 
         ws.cork(&mut corker, Corker::run);
-        let result = match corker.result {
-            Ok(result) => result,
-            Err(e) => {
-                let err_value = global_object.take_error(e);
-                return self
-                    .handler()
-                    .run_error_callback(on_error, global_object, err_value);
-            }
-        };
-
-        if let Some(promise) = result.as_any_promise() {
-            match promise.status() {
-                jsc::js_promise::Status::Rejected => {
-                    // Value discarded; the side
-                    // effect (JSC__JSPromise__result) conditionally sets
-                    // `isHandledFlag` so this doesn't surface as an
-                    // unhandledRejection.
-                    let _ = promise.result(global_object.vm());
-                    return Ok(());
-                }
-                _ => {}
-            }
+        // A returned promise that rejects is left to unhandled-rejection
+        // tracking, like the other handlers' promises.
+        if let Err(e) = corker.result {
+            let err_value = global_object.take_error(e);
+            return self
+                .handler()
+                .run_error_callback(on_error, global_object, err_value);
         }
         Ok(())
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1079,6 +1079,8 @@ impl ServePlugins {
                         return Ok(());
                     }
                     jsc::js_promise::Status::Rejected => {
+                        // `handle_on_reject` reports it; keep it off the unhandled list.
+                        promise.set_handled(global.vm());
                         let value = promise.result(global.vm());
                         self.handle_on_reject(global, value);
                         return Ok(());

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1742,9 +1742,13 @@ impl FileSink {
                         self.handle_resolve_stream();
                     }
                     bun_jsc::js_promise::Status::Rejected => {
-                        // These don't ref().
+                        // These don't ref(). Consumed here like the `then` in the
+                        // Pending arm consumes it, so it is not also unhandled.
                         // SAFETY: `js_promise` is non-null (`as_any_promise`).
-                        let result = unsafe { (*js_promise).result(global_this.vm()) };
+                        let result = unsafe {
+                            (*js_promise).set_handled();
+                            (*js_promise).result(global_this.vm())
+                        };
                         crate::dispatch::fold(self.handle_reject_stream(global_this, result));
                     }
                 }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1685,6 +1685,79 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
+  it("emits rejectionHandled for a late catch no matter how the promise was rejected", async () => {
+    // A promise rejected by a reaction job (a throwing .then() handler, a
+    // .finally() passthrough, a native stream erroring, an aborted timer) used
+    // to get 'unhandledRejection' but never 'rejectionHandled', because reading
+    // the rejection reason in order to report it marked the promise as handled.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { setTimeout: sleep } = require("node:timers/promises");
+          const events = [];
+          const names = new Map();
+          // timers/promises rejects with an AbortError whose cause is the signal's reason.
+          process.on("unhandledRejection", (reason, promise) => events.push("unhandledRejection:" + names.get(promise) + ":" + (reason.cause ?? reason).message));
+          process.on("rejectionHandled", promise => events.push("rejectionHandled:" + names.get(promise)));
+          const erroring = message => new ReadableStream({ start(c) { c.error(new Error(message)); } });
+          const kinds = {
+            direct: () => Promise.reject(new Error("direct")),
+            executor: () => new Promise((_, reject) => reject(new Error("executor"))),
+            asyncFn: () => (async () => { throw new Error("asyncFn"); })(),
+            thenThrows: () => Promise.resolve().then(() => { throw new Error("thenThrows"); }),
+            thenRejects: () => Promise.resolve().then(() => Promise.reject(new Error("thenRejects"))),
+            catchRethrows: () => Promise.reject(1).catch(() => { throw new Error("catchRethrows"); }),
+            finallyPassthrough: () => Promise.reject(new Error("finallyPassthrough")).finally(() => {}),
+            allSettledThen: () => Promise.allSettled([]).then(() => { throw new Error("allSettledThen"); }),
+            erroredBody: () => new Response(erroring("erroredBody")).text(),
+            readableStreamToText: () => Bun.readableStreamToText(erroring("readableStreamToText")),
+            abortedTimer: () => {
+              const controller = new AbortController();
+              const promise = sleep(60_000, undefined, { signal: controller.signal });
+              controller.abort(new Error("abortedTimer"));
+              return promise;
+            },
+          };
+          const turn = () => new Promise(r => setImmediate(r));
+          for (const [name, make] of Object.entries(kinds)) {
+            const promise = make();
+            names.set(promise, name);
+            while (Bun.peek.status(promise) === "pending") await turn();
+            await turn();
+            await turn();
+            promise.catch(() => {});
+            await turn();
+            await turn();
+          }
+          console.log(JSON.stringify(events));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(
+      [
+        "direct",
+        "executor",
+        "asyncFn",
+        "thenThrows",
+        "thenRejects",
+        "catchRethrows",
+        "finallyPassthrough",
+        "allSettledThen",
+        "erroredBody",
+        "readableStreamToText",
+        "abortedTimer",
+      ].flatMap(name => [`unhandledRejection:${name}:${name}`, `rejectionHandled:${name}`]),
+    );
+    expect(exitCode).toBe(0);
+  });
+
   it("aborts when the uncaughtException handler throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
       stderr: "pipe",


### PR DESCRIPTION
### Problem
- `process.on("rejectionHandled")` never fired for a late `.catch()` on a promise that a reaction job rejected: `.then(() => { throw e })`, `.catch()` rethrow, `.finally()` passthrough, `allSettled().then(throw)`, `Response`/`Bun.file` body reads over an errored stream, `Bun.readableStreamTo*`, `Readable.from(gen).toArray()`, an aborted `timers/promises` timer. `unhandledRejection` did fire for them, so tools that retract an "unhandled" warning on `rejectionHandled` never retracted for the most common shape. Node emits both for every kind.
- Cause: `JSC__JSPromise__result` (`src/jsc/bindings/bindings.cpp`) marked a rejected promise as handled as a side effect of reading it, but only when `isFirstResolvingFunctionCalled` was unset, which is exactly the promises `rejectPromise()` settles directly from a reaction job. The unhandled-rejection reporter (`Bun__handleRejectedPromise`) reads the reason through it, so reporting a promise marked it handled and the later `.catch()` saw `isHandled()` and emitted nothing.

### Fix
- `JSC__JSPromise__result` is a pure accessor. Reading a rejection no longer changes the promise.
- The native consumers that read a rejection and handle it themselves now say so with `set_handled()`: `ServePlugins` (reports through `run_error_handler`), `FileSink::assign_to_stream` (same as the `then` its Pending arm attaches), the macro runner (reports through `unhandled_rejection`; marked before the wait so the tracker does not report it too), and the `bun test` file entry promise. `ServerWebSocket` `message` no longer swallows a returned rejected `.then()` chain; it is reported like a rejected `async` handler already was. A dead `promise.result()` call in `run_command.rs` is gone.
- Correct because "handled" now means only what JSC means by it: something consumed the rejection. Every other Rust reader of `result()` on a rejected promise already called `set_handled()`/`unwrap(MarkHandled)`, or reads a module-loader promise that JSC marks handled itself; the audit is in the notes.
- Verified: `test/js/node/process/process.test.js` "emits rejectionHandled for a late catch no matter how the promise was rejected" (11 kinds; 8 fail on 1.4.3, all pass here). Also ran the suites listed below with the ASAN debug build.

### Background
- JSC reports rejections through `promiseRejectionTracker`: `rejectPromise` calls it with `Reject` for a promise that is not `isHandled()`, and `performPromiseThen` on an already rejected, not-handled promise calls it with `Handle`. Bun queues `Reject`ed promises, reports the still-unhandled ones at the end of the event-loop turn, and turns a later `Handle` into `rejectionHandled`.
- `isHandled` is a flag on the promise: `markAsHandled()` / `set_handled()` is how native code says "this rejection is consumed here". A `.then()` on a handled promise emits nothing.
- `isFirstResolvingFunctionCalled` is set by `JSPromise::reject()`/`resolve()` (the resolving-functions path: `Promise.reject`, executor `reject`, async functions, native `promise.reject`) but not by `rejectPromise()` called from a reaction job. It says nothing about whether anyone handled the promise, which is why keying `markAsHandled` on it split `.then()` chains from `Promise.reject()`.

<details><summary>Notes</summary>

- The side effect dates from 2022, when `result()` was the way native code consumed a rejection; the flag check made `Promise.reject()` + late catch pass while `.then()` chains stayed broken.
- The other half of this report family, natively created rejected promises that were never tracked at all (`fetch()` validation, the `Bun.write` fast path, `server.fetch()`, `Bun.resolve()`), landed separately in #41796. An earlier revision of this branch carried that change too; it was dropped after the rebase.
- Audit of every Rust `result()` reader on a possibly rejected promise: `expect.rs` (`.resolves/.rejects`, async matchers), `repl.rs`, `cron.rs`, `html_rewriter.rs`, `server/mod.rs`, `FetchTasklet.rs`, `s3/client.rs`, `Blob.rs` already `set_handled()` first; `bun_test.rs` marks in its drain loop; `RequestContext.rs`, `blob/write_file.rs`, `JSBundler.rs`, `bake` use `unwrap(MarkHandled)`; `run_command.rs`, `web_worker.rs`, `VirtualMachine.rs` read module-loader promises that `JSModuleLoader::loadAndEvaluateModule` marks handled; `virtual_machine_exports.rs` is the reporter itself and must not mark.
- Suites run with the debug build: `process.test.js`, `expect.test.js`, `test-test`, `bun-test.test.ts`, `macro-test`, `bun-serve-html`, `serve-plugins-dev-server`, `websocket-server`, `spawn-stdin-readable-stream`, `spawn-stdin-readable-stream-edge-cases`, `hot.test.ts` (error and sourcemap cases), `fetch-args`, `bun-write`, `body`, `body-stream`, `fuzzy-wuzzy`, and the `test-promise-unhandled-*` / `test-promises-unhandled-*` Node parallel tests.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->