### PR TITLE
test --isolate: restore signal dispositions and kill Bun.$ children at the file swap

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -117,7 +117,7 @@ test(
 
 ### 🧟 Zombie Process Killer
 
-When a test times out, Bun kills any still-running processes that the test spawned with `Bun.spawn`, `Bun.spawnSync`, or `node:child_process`, and logs a message to the console. This prevents zombie processes from lingering after timed-out tests.
+When a test times out, Bun kills any still-running processes that the test spawned with `Bun.spawn`, `Bun.spawnSync`, `Bun.$`, or `node:child_process`, and logs a message to the console. This prevents zombie processes from lingering after timed-out tests.
 
 ## Test Modifiers
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4377,6 +4377,13 @@ extern "C" void Zig__GlobalObject__forbidExecution(Zig::GlobalObject* globalObje
 extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::GlobalObject* globalObject)
 {
     Bun::retireWebViewsForTestIsolation(globalObject);
+    // A `process.on(<signal>)` listener installs a process-wide sigaction (a uv_signal_t on
+    // Windows) that is only torn down when the listener count drops to zero. Dropping the
+    // listeners with the global skips that, so the next file inherits a caught signal with no
+    // JS target. Remove them through the emitter so onDidChangeListeners restores SIG_DFL and
+    // releases the memoryPressure and IPC hooks, exactly as process.off() would have.
+    if (globalObject->hasProcessObject())
+        globalObject->processObject()->wrapped().removeAllListeners();
     globalObject->scriptExecutionContext()->prepareForDestruction();
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4377,11 +4377,8 @@ extern "C" void Zig__GlobalObject__forbidExecution(Zig::GlobalObject* globalObje
 extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::GlobalObject* globalObject)
 {
     Bun::retireWebViewsForTestIsolation(globalObject);
-    // A `process.on(<signal>)` listener installs a process-wide sigaction (a uv_signal_t on
-    // Windows) that is only torn down when the listener count drops to zero. Dropping the
-    // listeners with the global skips that, so the next file inherits a caught signal with no
-    // JS target. Remove them through the emitter so onDidChangeListeners restores SIG_DFL and
-    // releases the memoryPressure and IPC hooks, exactly as process.off() would have.
+    // Through the emitter, so onDidChangeListeners restores SIG_DFL for process.on(<signal>)
+    // listeners and drops the memoryPressure/IPC hooks, as the last process.off() would.
     if (globalObject->hasProcessObject())
         globalObject->processObject()->wrapped().removeAllListeners();
     globalObject->scriptExecutionContext()->prepareForDestruction();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4377,8 +4377,7 @@ extern "C" void Zig__GlobalObject__forbidExecution(Zig::GlobalObject* globalObje
 extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::GlobalObject* globalObject)
 {
     Bun::retireWebViewsForTestIsolation(globalObject);
-    // Through the emitter, so onDidChangeListeners restores SIG_DFL for process.on(<signal>)
-    // listeners and drops the memoryPressure/IPC hooks, as the last process.off() would.
+    // onDidChangeListeners restores SIG_DFL for the file's process.on(<signal>) listeners.
     if (globalObject->hasProcessObject())
         globalObject->processObject()->wrapped().removeAllListeners();
     globalObject->scriptExecutionContext()->prepareForDestruction();

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -923,11 +923,15 @@ impl ShellSubprocess {
     /// next to `Bun.spawn` children; `on_process_exit` takes it off again.
     fn register_with_auto_killer(&self) {
         let Some(vm) = self.js_vm() else { return };
-        let Some(handle) = self.process.as_ref() else { return };
+        let Some(handle) = self.process.as_ref() else {
+            return;
+        };
         if handle.has_exited() {
             return;
         }
-        let Some(process) = NonNull::new(handle.as_ptr()) else { return };
+        let Some(process) = NonNull::new(handle.as_ptr()) else {
+            return;
+        };
         // SAFETY: `vm` is the live VM that owns `event_loop`; JS thread only.
         unsafe { (*vm.as_ptr()).on_subprocess_spawn(process) };
     }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1,4 +1,5 @@
 use core::ffi::{c_char, c_void};
+use core::ptr::NonNull;
 use std::sync::Arc;
 
 #[cfg(unix)]
@@ -193,6 +194,8 @@ pub struct ShellSubprocess {
 
     pub closed: EnumSet<StdioKind>,
 
+    event_loop: EventLoopHandle,
+
     ctrl_c_child: Option<bun_spawn::ctrl_c::Child>,
 }
 
@@ -234,9 +237,11 @@ impl JscSubprocess::static_pipe_writer::StaticPipeWriterProcess for ShellSubproc
 
 bun_spawn::link_impl_ProcessExit! {
     Shell for ShellSubprocess => |this| {
-        // Forwarded raw, not autoref'd: the callee may free `*this`.
-        on_process_exit(_process, status, _rusage) =>
-            ShellSubprocess::on_process_exit(this, &status),
+        // Forwarded raw, not autoref'd: the callee may free `*this`. `process`
+        // stays raw too so `VirtualMachine::on_subprocess_exit` gets its
+        // mutable provenance.
+        on_process_exit(process, status, _rusage) =>
+            ShellSubprocess::on_process_exit(this, process, &status),
     }
 }
 
@@ -787,6 +792,7 @@ impl ShellSubprocess {
                 stderr,
                 cmd_parent,
                 closed: EnumSet::empty(),
+                event_loop,
                 ctrl_c_child,
             });
         }
@@ -843,7 +849,10 @@ impl ShellSubprocess {
 
         // SAFETY: scoped access; `watch` does not re-enter the subprocess.
         match unsafe { (*subprocess).proc().watch() } {
-            bun_sys::Result::Ok(()) => {}
+            bun_sys::Result::Ok(()) => {
+                // SAFETY: `subprocess` is live; scoped access.
+                unsafe { (*subprocess).register_with_auto_killer() };
+            }
             bun_sys::Result::Err(_) => {
                 *notify_caller_process_already_exited = true;
                 spawn_args.lazy = false;
@@ -903,10 +912,37 @@ impl ShellSubprocess {
         Ok(())
     }
 
+    /// The owning VM when the shell runs on a JS event loop, `None` on a mini
+    /// event loop (`bun run` scripts, lifecycle scripts).
+    fn js_vm(&self) -> Option<NonNull<jsc::virtual_machine::VirtualMachine>> {
+        NonNull::new(self.event_loop.bun_vm().cast())
+    }
+
+    /// `bun test` kills the subprocesses that a timed-out test or a finished
+    /// `--isolate` file left running. This puts a shell command on that list,
+    /// next to `Bun.spawn` children; `on_process_exit` takes it off again.
+    fn register_with_auto_killer(&self) {
+        let Some(vm) = self.js_vm() else { return };
+        let Some(handle) = self.process.as_ref() else { return };
+        if handle.has_exited() {
+            return;
+        }
+        let Some(process) = NonNull::new(handle.as_ptr()) else { return };
+        // SAFETY: `vm` is the live VM that owns `event_loop`; JS thread only.
+        unsafe { (*vm.as_ptr()).on_subprocess_spawn(process) };
+    }
+
     /// # Safety
     /// `this` must be live and unborrowed; the Yield run here may free it.
-    unsafe fn on_process_exit(this: *mut Self, status: &Status) {
+    /// `process` is the live `*mut Process` threaded from the
+    /// `link_impl_ProcessExit!` vtable thunk.
+    unsafe fn on_process_exit(this: *mut Self, process: *mut Process, status: &Status) {
         log!("onProcessExit({:x})", this as usize);
+        // SAFETY: caller contract; the borrow ends at the `;`.
+        if let (Some(vm), Some(process)) = (unsafe { (*this).js_vm() }, NonNull::new(process)) {
+            // SAFETY: `vm` is the live VM that owns `event_loop`; JS thread only.
+            unsafe { (*vm.as_ptr()).on_subprocess_exit(process) };
+        }
         // SAFETY: caller contract; the borrow ends at the `;`.
         let interrupted = unsafe { (*this).ctrl_c_child.take() }.is_some()
             && bun_spawn::ctrl_c::child_died_of_it(status);

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -237,9 +237,7 @@ impl JscSubprocess::static_pipe_writer::StaticPipeWriterProcess for ShellSubproc
 
 bun_spawn::link_impl_ProcessExit! {
     Shell for ShellSubprocess => |this| {
-        // Forwarded raw, not autoref'd: the callee may free `*this`. `process`
-        // stays raw too so `VirtualMachine::on_subprocess_exit` gets its
-        // mutable provenance.
+        // Both forwarded raw, not autoref'd: the callee may free `*this`.
         on_process_exit(process, status, _rusage) =>
             ShellSubprocess::on_process_exit(this, process, &status),
     }
@@ -849,10 +847,7 @@ impl ShellSubprocess {
 
         // SAFETY: scoped access; `watch` does not re-enter the subprocess.
         match unsafe { (*subprocess).proc().watch() } {
-            bun_sys::Result::Ok(()) => {
-                // SAFETY: `subprocess` is live; scoped access.
-                unsafe { (*subprocess).register_with_auto_killer() };
-            }
+            bun_sys::Result::Ok(()) => {}
             bun_sys::Result::Err(_) => {
                 *notify_caller_process_already_exited = true;
                 spawn_args.lazy = false;
@@ -907,20 +902,26 @@ impl ShellSubprocess {
             return Err(ShellErr::Sys(sys_err));
         }
 
+        // After the last fallible start, so `abort_after_failed_start` (which
+        // drops the exit handler) never leaves a registered entry behind.
+        if !*notify_caller_process_already_exited {
+            // SAFETY: `subprocess` is live; the exit handler only runs from the
+            // event loop, after this returns.
+            unsafe { (*subprocess).register_with_auto_killer() };
+        }
+
         log!("returning");
 
         Ok(())
     }
 
-    /// The owning VM when the shell runs on a JS event loop, `None` on a mini
-    /// event loop (`bun run` scripts, lifecycle scripts).
+    /// `None` on a mini event loop (`bun run` scripts, lifecycle scripts).
     fn js_vm(&self) -> Option<NonNull<jsc::virtual_machine::VirtualMachine>> {
         NonNull::new(self.event_loop.bun_vm().cast())
     }
 
-    /// `bun test` kills the subprocesses that a timed-out test or a finished
-    /// `--isolate` file left running. This puts a shell command on that list,
-    /// next to `Bun.spawn` children; `on_process_exit` takes it off again.
+    /// Lets `bun test` kill this child on a test timeout or `--isolate` swap,
+    /// like a `Bun.spawn` child. `on_process_exit` unregisters it.
     fn register_with_auto_killer(&self) {
         let Some(vm) = self.js_vm() else { return };
         let Some(handle) = self.process.as_ref() else {
@@ -938,8 +939,7 @@ impl ShellSubprocess {
 
     /// # Safety
     /// `this` must be live and unborrowed; the Yield run here may free it.
-    /// `process` is the live `*mut Process` threaded from the
-    /// `link_impl_ProcessExit!` vtable thunk.
+    /// `process` is the live `*mut Process` from the exit-handler thunk.
     unsafe fn on_process_exit(this: *mut Self, process: *mut Process, status: &Status) {
         log!("onProcessExit({:x})", this as usize);
         // SAFETY: caller contract; the borrow ends at the `;`.

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -902,11 +902,9 @@ impl ShellSubprocess {
             return Err(ShellErr::Sys(sys_err));
         }
 
-        // After the last fallible start, so `abort_after_failed_start` (which
-        // drops the exit handler) never leaves a registered entry behind.
+        // Last, so a failed start (which drops the exit handler) never leaves an entry behind.
         if !*notify_caller_process_already_exited {
-            // SAFETY: `subprocess` is live; the exit handler only runs from the
-            // event loop, after this returns.
+            // SAFETY: `subprocess` is live; its exit handler only runs from the event loop.
             unsafe { (*subprocess).register_with_auto_killer() };
         }
 
@@ -920,8 +918,7 @@ impl ShellSubprocess {
         NonNull::new(self.event_loop.bun_vm().cast())
     }
 
-    /// Lets `bun test` kill this child on a test timeout or `--isolate` swap,
-    /// like a `Bun.spawn` child. `on_process_exit` unregisters it.
+    /// Lets `bun test` kill this child on a timeout or `--isolate` swap, like a `Bun.spawn` child.
     fn register_with_auto_killer(&self) {
         let Some(vm) = self.js_vm() else { return };
         let Some(handle) = self.process.as_ref() else {

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -698,8 +698,8 @@ describe.concurrent("bun test --isolate", () => {
 
   test("with --isolate, a leaked Bun.$ subprocess is killed before the next file", async () => {
     using dir = tempDir("isolate-shell-subprocess", {
-      "sleeper.js": `
-        const fs = require("fs");
+      "sleeper.mjs": `
+        import fs from "node:fs";
         fs.writeFileSync(process.env.PID_FILE + ".tmp", String(process.pid));
         fs.renameSync(process.env.PID_FILE + ".tmp", process.env.PID_FILE);
         setInterval(() => {}, 1e6);
@@ -710,7 +710,7 @@ describe.concurrent("bun test --isolate", () => {
         import fs from "node:fs";
         test("leak a sleeper through Bun.$", async () => {
           // Not awaited: the shell, and the sleeper under it, are still running when this file ends.
-          $\`\${process.execPath} sleeper.js\`.quiet().then(() => {}, () => {});
+          $\`\${process.execPath} sleeper.mjs\`.quiet().then(() => {}, () => {});
           while (!fs.existsSync(process.env.PID_FILE!)) await Bun.sleep(10);
           expect(Number(fs.readFileSync(process.env.PID_FILE!, "utf8"))).toBeGreaterThan(0);
         });

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
 import fs from "node:fs";
 import net from "node:net";
 import { join } from "node:path";
@@ -695,6 +695,99 @@ describe.concurrent("bun test --isolate", () => {
       }
     }
   });
+
+  test("with --isolate, a leaked Bun.$ subprocess is killed before the next file", async () => {
+    using dir = tempDir("isolate-shell-subprocess", {
+      "sleeper.js": `
+        const fs = require("fs");
+        fs.writeFileSync(process.env.PID_FILE + ".tmp", String(process.pid));
+        fs.renameSync(process.env.PID_FILE + ".tmp", process.env.PID_FILE);
+        setInterval(() => {}, 1e6);
+      `,
+      "a-shell.test.ts": `
+        import { test, expect } from "bun:test";
+        import { $ } from "bun";
+        import fs from "node:fs";
+        test("leak a sleeper through Bun.$", async () => {
+          // Not awaited: the shell, and the sleeper under it, are still running when this file ends.
+          $\`\${process.execPath} sleeper.js\`.quiet().then(() => {}, () => {});
+          while (!fs.existsSync(process.env.PID_FILE!)) await Bun.sleep(10);
+          expect(Number(fs.readFileSync(process.env.PID_FILE!, "utf8"))).toBeGreaterThan(0);
+        });
+      `,
+      "b-check.test.ts": `
+        import { test, expect } from "bun:test";
+        import fs from "node:fs";
+        const isAlive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+        test("the previous file's Bun.$ sleeper was killed by isolation", async () => {
+          const pid = Number(fs.readFileSync(process.env.PID_FILE!, "utf8"));
+          expect(pid).toBeGreaterThan(0);
+          // The swap sends SIGTERM; the sleeper may still be getting reaped.
+          const deadline = Date.now() + 3_000;
+          while (isAlive(pid) && Date.now() < deadline) await Bun.sleep(10);
+          expect(isAlive(pid)).toBe(false);
+        });
+      `,
+    });
+    const pidFile = join(String(dir), "pid.txt");
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./a-shell.test.ts", "./b-check.test.ts"],
+        env: { ...bunEnv, PID_FILE: pidFile },
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(normalizeBunSnapshot(stderr, dir)).toContain("2 pass");
+      expect(normalizeBunSnapshot(stderr, dir)).toContain("0 fail");
+      expect(exitCode).toBe(0);
+    } finally {
+      try {
+        process.kill(Number(fs.readFileSync(pidFile, "utf8")));
+      } catch {}
+    }
+  });
+
+  // process.on(<signal>) installs one process-wide handler. The listener goes
+  // away with the finished file's global, so the handler has to go too, or the
+  // next file inherits a caught signal that no JS code observes.
+  test.skipIf(isWindows)(
+    "with --isolate, a leaked process.on('SIGTERM') listener does not leave SIGTERM caught for the next file",
+    async () => {
+      using dir = tempDir("isolate-signal-listener", {
+        "a-signal.test.ts": `
+          import { test, expect } from "bun:test";
+          test("leak a SIGTERM listener", () => {
+            process.on("SIGTERM", () => console.error("[A listener] got SIGTERM"));
+            expect(process.listenerCount("SIGTERM")).toBe(1);
+          });
+        `,
+        "b-signal.test.ts": `
+          import { test, expect } from "bun:test";
+          test("SIGTERM with no listener ends the run", () => {
+            console.error("[B] listenerCount=" + process.listenerCount("SIGTERM"));
+            // Default disposition: the kernel terminates the process inside this call.
+            process.kill(process.pid, "SIGTERM");
+            console.error("[B] survived SIGTERM");
+            expect.unreachable();
+          });
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./a-signal.test.ts", "./b-signal.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("[B] listenerCount=0");
+      expect(stderr).not.toContain("[A listener] got SIGTERM");
+      expect(stderr).not.toContain("[B] survived SIGTERM");
+      expect(proc.signalCode).toBe("SIGTERM");
+    },
+  );
 });
 
 // --isolate raises JSC's FTL warm-up threshold. JSC options are set once per


### PR DESCRIPTION
### Problem
- `bun test --isolate` / `--parallel`: a `process.on("SIGTERM", fn)` that a finished file never removed is gone from JS after the swap, but the signal stays caught. A SIGTERM (or SIGINT, SIGHUP) sent during a later file is swallowed and the run exits 0. The old emitter dies with its global, so the count-to-zero teardown in `onDidChangeListeners` (`BunProcess.cpp`) never runs and `SIG_DFL` is never restored.
- A `Bun.$` child that a finished file leaves running survives into the next file. `ShellSubprocess` (`shell/subproc.rs`) never called `on_subprocess_spawn`, so the auto-killer only knew `Bun.spawn` children.

### Fix
- The isolation stop hook calls `removeAllListeners()` on the outgoing process emitter. That runs the same teardown as the last `process.off()`: `SIG_DFL` restored, memoryPressure and IPC hooks released.
- `ShellSubprocess` registers its `Process` with the auto-killer after `watch()` and unregisters it on exit, like `Bun.spawn` (JS event loop only). The test-timeout killer now covers `Bun.$` too, and the docs say so.
- Verified: two new cases in `test/cli/test/isolation.test.ts`, both fail on stock bun.

### Background
- `--isolate` keeps one JSC VM and swaps in a fresh global per file. Process-wide state must be undone at the swap by hand.
- The first `process.on(<signal>)` installs a `sigaction` and records it in a static map. The last `removeListener` restores `SIG_DFL`.
- The auto-killer (`ProcessAutoKiller.rs`) is the VM's set of live children, killed on a test timeout and at every swap. `ProcessHandle::drop` detaches the exit handler, so the set's extra ref never dispatches into a freed owner.

<details><summary>Notes</summary>

- Other suites run on the debug ASAN build: all of `test/cli/test/isolation.test.ts`, `test/cli/test/parallel.test.ts`, `test/cli/test/test-timeout-behavior.test.ts`, `test/js/bun/shell/bunshell.test.ts`, `test/js/bun/shell/leak.test.ts -t external`, `test/js/node/process/process-signal-listener-count.test.ts`.
- Windows: the same teardown closes the `uv_signal_t`. The Windows debug build passes the new shell case (which fails on stock bun there too). The signal case is skipped on Windows because `process.kill` terminates regardless of handlers, but a manual `--isolate` run with a leaked `process.on("SIGINT")` swaps cleanly and the next file can re-register.
- Killing the shell's child does not cancel the shell interpreter itself: a script like `sleep 10 && echo done` settles its promise in the dead realm right after the kill, which is the same fate a leaked `Bun.spawn(...).exited` continuation already has. The child no longer outlives the file, which is what `docs/test/parallel.mdx` promises.
- `removeAllListeners()` runs before `prepareForDestruction()` so `onDidChangeListeners` still sees a live `ScriptExecutionContext` for the memoryPressure/IPC branches.
- `leak.test.ts -t external` asserts no retained `ShellInterpreter`s after 100 external commands inside the runner. It passes and is not slower than with main's `subproc.rs`.
- The lcov item from the same report (`DA:` hit counts under `--parallel=N` scale with N) comes from `DA:` values being byte-span lengths rather than execution counts. #35725 makes them real counts, after which the coordinator's per-line sum is the right merge. Not touched here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/isolation.test.ts

<!-- robobun:evidence:end -->