### PR TITLE
bun test: apply every --reporter flag, reject --reporter-outfile without junit

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -125,15 +125,15 @@
         },
         {
           "name": "reporter",
-          "description": "Test output reporter format. Available: 'junit' (requires --reporter-outfile). Default: console output.",
+          "description": "Add a test reporter. Available: 'junit' (requires --reporter-outfile), 'dots'. Default: console output.",
           "hasValue": true,
           "valueType": "val",
           "required": false,
-          "multiple": false
+          "multiple": true
         },
         {
           "name": "reporter-outfile",
-          "description": "Output file path for the reporter format (required with --reporter).",
+          "description": "File that --reporter=junit writes the XML report to.",
           "hasValue": true,
           "valueType": "val",
           "required": false,

--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -51,12 +51,12 @@ bun test <patterns>
 ### Reporting
 
 <ParamField path="--reporter" type="string">
-  Test output reporter format. Available: <code>junit</code> (requires --reporter-outfile), <code>dots</code>. Default:
-  console output.
+  Add a test reporter. Available: <code>junit</code> (requires --reporter-outfile), <code>dots</code>. Can be passed
+  more than once. Default: console output.
 </ParamField>
 
 <ParamField path="--reporter-outfile" type="string">
-  Output file path for the reporter format (required with --reporter=junit)
+  File that --reporter=junit writes the XML report to (required with --reporter=junit)
 </ParamField>
 
 <ParamField path="--dots" type="boolean">

--- a/docs/test/reporters.mdx
+++ b/docs/test/reporters.mdx
@@ -62,7 +62,7 @@ To generate a JUnit XML report, use the `--reporter=junit` flag along with `--re
 bun test --reporter=junit --reporter-outfile=./junit.xml
 ```
 
-Console output is unchanged; Bun writes the JUnit XML report to the specified path at the end of the test run.
+Console output is unchanged; Bun writes the JUnit XML report to the specified path at the end of the test run. `--reporter` can be passed more than once, so `--reporter=junit --reporter-outfile=./junit.xml --reporter=dots` writes the report and prints dots.
 
 #### Configuring via bunfig.toml
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -599,10 +599,10 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
         "-t, --test-name-pattern/--grep <STR>    Run only tests with a name that matches the given regex."
     ),
     parse_param!(
-        "--reporter <STR>                 Test output reporter format. Available: 'junit' (requires --reporter-outfile), 'dots'. Default: console output."
+        "--reporter <STR>...              Add a test reporter. Available: 'junit' (requires --reporter-outfile), 'dots'. Default: console output."
     ),
     parse_param!(
-        "--reporter-outfile <STR>         Output file path for the reporter format (required with --reporter)."
+        "--reporter-outfile <STR>         File that --reporter=junit writes the XML report to."
     ),
     parse_param!(
         "--dots                           Enable dots reporter. Shorthand for --reporter=dots."
@@ -1778,7 +1778,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         ctx.test_options.reporter_outfile = Some(reporter_outfile.into());
     }
 
-    if let Some(reporter) = args.option(b"--reporter") {
+    for &reporter in args.options(b"--reporter") {
         if reporter == b"junit" {
             // A `--parallel` worker only collects for the coordinator's file.
             if ctx.test_options.reporter_outfile.is_none() && !args.flag(b"--test-worker") {
@@ -1798,6 +1798,13 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
             );
             Global::crash();
         }
+    }
+    if ctx.test_options.reporter_outfile.is_some() && !ctx.test_options.reporters.junit {
+        Output::err_generic(
+            "--reporter-outfile is the path of the JUnit report and requires --reporter=junit",
+            (),
+        );
+        Global::crash();
     }
 
     // Handle --dots flag as shorthand for --reporter=dots

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -608,6 +608,65 @@ describe("junit reporter", () => {
     expect(longPathCase.failure[0]._).toContain(`at fromLongPath (${longPath}:1:`);
     expect(pathCase.failure[0]._).toContain("at fromPath (generated.js:1:");
   });
+
+  it("applies every --reporter flag, so junit and dots can be combined in either order", async () => {
+    await using tmpDir = tempDir("junit-two-reporters", {
+      "package.json": "{}",
+      "a.test.js": `
+        import { test, expect } from "bun:test";
+        test("one", () => expect(1).toBe(1));
+        test("two", () => expect(2).toBe(2));
+      `,
+    });
+
+    for (const order of [
+      ["--reporter=junit", "--reporter=dots"],
+      ["--reporter=dots", "--reporter=junit"],
+    ]) {
+      const junitPath = join(tmpDir, `junit-${order[0].slice("--reporter=".length)}-first.xml`);
+      await using proc = spawn([bunExe(), "test", ...order, "--reporter-outfile", junitPath], {
+        cwd: tmpDir,
+        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      // dots: no per-test "(pass)" lines
+      expect(stderr).not.toContain("(pass)");
+      expect(stderr).toContain("2 pass");
+      // junit: the report exists and lists both tests
+      const xmlContent = await file(junitPath).text();
+      expect(xmlContent).toContain('name="one"');
+      expect(xmlContent).toContain('name="two"');
+      expect(exitCode).toBe(0);
+    }
+  });
+
+  it("rejects --reporter-outfile when no junit reporter is enabled", async () => {
+    await using tmpDir = tempDir("junit-outfile-alone", {
+      "package.json": "{}",
+      "a.test.js": `
+        import { test, expect } from "bun:test";
+        test("one", () => expect(1).toBe(1));
+      `,
+    });
+
+    for (const args of [["--reporter-outfile=report.xml"], ["--reporter=dots", "--reporter-outfile=report.xml"]]) {
+      await using proc = spawn([bunExe(), "test", ...args], {
+        cwd: tmpDir,
+        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(
+        "error: --reporter-outfile is the path of the JUnit report and requires --reporter=junit",
+      );
+      expect(stderr).not.toContain("1 pass");
+      expect(exitCode).toBe(1);
+    }
+    expect(await file(join(tmpDir, "report.xml")).exists()).toBe(false);
+  });
 });
 
 function filterJunitXmlOutput(xmlContent) {

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -630,7 +630,7 @@ describe("junit reporter", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       // dots: no per-test "(pass)" lines
       expect(stderr).not.toContain("(pass)");
       expect(stderr).toContain("2 pass");
@@ -658,7 +658,7 @@ describe("junit reporter", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toContain(
         "error: --reporter-outfile is the path of the JUnit report and requires --reporter=junit",
       );


### PR DESCRIPTION
### Problem
- `bun test --reporter=junit --reporter=dots --reporter-outfile=j.xml` printed dots and exited 0 with no `j.xml`. `--reporter` was a single-value option, so the last occurrence silently replaced `junit`. `--dots --reporter=junit` did give both.
- `bun test --reporter-outfile=x.xml` without `--reporter` was accepted, wrote nothing and exited 0, although the inverse (`--reporter=junit` without an outfile) is an error.
- Cause: `parse_test_command_options` (`src/runtime/cli/Arguments.rs`) read `--reporter` with `args.option()` (last value) and never checked an outfile that no reporter uses.

### Fix
- `--reporter <STR>...` is repeatable and every value enables its reporter, so `junit` and `dots` combine in either order.
- `--reporter-outfile` without an enabled JUnit reporter exits 1 with `error: --reporter-outfile is the path of the JUnit report and requires --reporter=junit`, next to the existing inverse check.
- Help text, `docs/test/reporters.mdx`, the CLI snippet and `completions/bun-cli.json` describe the repeatable flag.
- Verified: `test/js/junit-reporter/junit.test.js` (two new tests, stock bun fails both), plus the rest of that file and `test/cli/test/bun-test.test.ts`.

### Background
- `bun test` has two reporters besides the console: `dots` (compact console output) and `junit` (an XML file written at the end of the run to `--reporter-outfile`). They are independent, `--dots --reporter=junit --reporter-outfile=f` already enabled both.
- `bun_clap` distinguishes `<STR>` (one value, last wins) from `<STR>...` (all values, read with `args.options()`), as `--coverage-reporter` already uses.

<details><summary>Notes</summary>

- A CI job that asks for a JUnit file and gets exit 0 with no file uploads nothing and stays green, which is how this was found.
- With `[test.reporter] junit = "cfg.xml"` in bunfig.toml and only `--reporter-outfile=cli.xml` on the command line, main currently writes `cfg.xml` because bunfig is applied after the flags (#40348 fixes that order). Until #40348 lands this combination now errors instead of silently writing the other path; after it lands the bunfig reporter satisfies the check and `cli.xml` is written, which #40348 tests.
- `--parallel` workers receive `--reporter=junit` without an outfile and are unaffected: the check only fires when an outfile is set.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.3 (f42e98025)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [704.20ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [454.37ms]
[String: "/tmp/junit-comprehensive_pA4Fkl"]
(pass) junit reporter > more scenarios [1186.71ms]
(pass) junit reporter > should report only the final result for a retried test [397.58ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [350.33ms]
(pass) junit reporter > escapes the classname attribute exactly once [299.42ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [379.39ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [316.39ms]
(pass) junit reporter > prints a stack frame whose source is not a file path as-is in <failure> [562.88ms]
633 |       const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), pro
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [13.71ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [10.21ms]
[String: "/tmp/junit-comprehensive_OOx8Hb"]
(pass) junit reporter > more scenarios [16.16ms]
(pass) junit reporter > should report only the final result for a retried test [7.35ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [7.10ms]
(pass) junit reporter > escapes the classname attribute exactly once [7.60ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [6.97ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [7.45ms]
(pass) junit reporter > prints a stack frame whose source is not a file path as-is in <failure> [17.05ms]
633 |       const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
634 |       // dots: no per-test "(pass)" lines
635 |       expect(stderr).not.toContain("(pass)");
636 |       expect(stderr).toContain("2 pass");
637 |       // 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.3 (f42e98025)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [748.16ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [499.90ms]
[String: "/tmp/junit-comprehensive_7aIIkE"]
(pass) junit reporter > more scenarios [1040.96ms]
(pass) junit reporter > should report only the final result for a retried test [337.61ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [424.29ms]
(pass) junit reporter > escapes the classname attribute exactly once [413.00ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [319.82ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [378.91ms]
(pass) junit reporter > prints a stack frame whose source is not a file path as-is in <failure> [549.84ms]
(pass) junit reporter > applies every --reporter flag, so junit and dots can be combined in either orde
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
completions/bun-cli.json             |  6 ++--
 docs/snippets/cli/test.mdx           |  6 ++--
 docs/test/reporters.mdx              |  2 +-
 src/runtime/cli/Arguments.rs         | 13 ++++++--
 test/js/junit-reporter/junit.test.js | 59 ++++++++++++++++++++++++++++++++++++
 5 files changed, 76 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
completions/bun-cli.json                  1      1     19
docs/snippets/cli/test.mdx                1      1     19
docs/test/reporters.mdx                   1      1     19
src/runtime/cli/Arguments.rs              7      4     18
test/js/junit-reporter/junit.test.js      2      3     18
```

</details>

<!-- robobun:evidence:end -->