### PR TITLE
pm view, pm diff, pm whoami, audit: reject a registry URL whose scheme is not http or https

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -35,6 +35,8 @@ pub enum WhoamiError {
     NeedAuth,
     #[error("probably invalid auth")]
     ProbablyInvalidAuth,
+    #[error("{0}")]
+    UnsupportedProtocol(registry::UnsupportedProtocol),
 }
 bun_core::oom_from_alloc!(WhoamiError);
 
@@ -54,6 +56,10 @@ pub fn whoami(manager: &mut PackageManager) -> Result<Vec<u8>, WhoamiError> {
     if registry.token.is_empty() {
         return Err(WhoamiError::NeedAuth);
     }
+
+    registry
+        .check_url_protocol()
+        .map_err(WhoamiError::UnsupportedProtocol)?;
 
     let auth_type: &[u8] = match &manager.options.publish_config.auth_type {
         Some(auth_type) => auth_type.as_str().as_bytes(),
@@ -317,9 +323,38 @@ pub mod registry {
         pub user: Box<[u8]>,
     }
 
+    /// `bun_http` negotiates TLS only for `https:` and dials every other
+    /// scheme as plaintext HTTP, so a request to a registry URL with any other
+    /// scheme (a typo such as `htps://`) would carry the credentials in
+    /// cleartext.
+    #[derive(Debug)]
+    pub struct UnsupportedProtocol {
+        href: Box<[u8]>,
+    }
+
+    impl core::fmt::Display for UnsupportedProtocol {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(
+                f,
+                "Registry URL must be http:// or https://\nReceived: \"{}\"",
+                bun_fmt::redacted_npm_url(&self.href),
+            )
+        }
+    }
+
     impl Scope {
         pub fn hash(str: &[u8]) -> u64 {
             bun_semver::semver_string::Builder::string_hash(str)
+        }
+
+        /// Call before building a request that sends `token`/`auth` to `url`.
+        pub fn check_url_protocol(&self) -> Result<(), UnsupportedProtocol> {
+            if self.url.url().has_http_like_protocol() {
+                return Ok(());
+            }
+            Err(UnsupportedProtocol {
+                href: Box::from(self.url.href()),
+            })
         }
 
         /// Stores the WHATWG serialization (the base `bun_url::join` resolves against) so same-origin checks, concatenated tarball URLs and `url_hash` agree with the requests; credentials must already be split off.

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -349,6 +349,10 @@ struct AuditRegistry {
 
 impl AuditRegistry {
     fn from_scope(scope: &bun_install::npm::registry::Scope, is_default: bool) -> AuditRegistry {
+        if let Err(err) = scope.check_url_protocol() {
+            Output::err_generic("{}", (err,));
+            Global::exit(1);
+        }
         AuditRegistry {
             href: Box::<[u8]>::from(strings::without_trailing_slash(scope.url.href())),
             url_hash: scope.url_hash,

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -338,6 +338,9 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                                 (bun_fmt::redacted_npm_url(pm.options.scope.url.href()),),
                             );
                         }
+                        Npm::WhoamiError::UnsupportedProtocol(err) => {
+                            Output::err_generic("{}", (err,));
+                        }
                     }
                     Global::crash();
                 }

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -702,6 +702,11 @@ fn fetch_registry_tree(
 ) -> Result<Tree, crate::Error> {
     let bump = Bump::new();
     let scope = pm.scope_for_package_name(name);
+    if let Err(err) = scope.check_url_protocol() {
+        Status::clear();
+        Output::err_generic("{}", (err,));
+        Global::exit(1);
+    }
 
     let mut url_buf = bun_paths::path_buffer_pool::get();
     let encoded_name = buf_print(

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -77,6 +77,10 @@ pub(crate) fn view(
     });
 
     let scope = manager.scope_for_package_name(name);
+    if let Err(err) = scope.check_url_protocol() {
+        Output::err_generic("{}", (err,));
+        Global::exit(1);
+    }
 
     let mut url_buf = bun_paths::path_buffer_pool::get();
     let encoded_name = buf_print(

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -634,7 +634,9 @@ describe("`bun audit`", () => {
         env: bunEnv,
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+      expect(stderr).toBe(
+        `error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`,
+      );
       expect(normalizeBunSnapshot(stdout)).toBe("bun audit <version> (<revision>)");
       expect(requests).toEqual([]);
       expect(exitCode).toBe(1);

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -599,6 +599,48 @@ describe("`bun audit`", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A scheme that is not http or https (a typo such as `htps://`) must not fall back to plaintext HTTP with the
+  // token attached. The mock is a plain HTTP listener, so a downgraded request shows up in `requests`.
+  test.each(["default", "scoped"] as const)(
+    "a %s registry whose url scheme is not http or https is rejected before any request",
+    async kind => {
+      const requests: string[] = [];
+      using mock = Bun.serve({
+        port: 0,
+        fetch(req) {
+          requests.push(`${req.method} ${new URL(req.url).pathname} ${req.headers.get("authorization")}`);
+          return Response.json({});
+        },
+      });
+      const bad = `{ url = "htps://localhost:${mock.port}/", token = "secret-token" }`;
+      using dir = tempDir("bun-test-audit-bad-scheme-" + kind, {
+        "package.json": JSON.stringify({ name: "test", version: "1.0.0", dependencies: { "@foo/bar": "1.0.0" } }),
+        "bun.lock": JSON.stringify({
+          lockfileVersion: 1,
+          workspaces: { "": { name: "test", dependencies: { "@foo/bar": "1.0.0" } } },
+          packages: { "@foo/bar": ["@foo/bar@1.0.0", "", {}, fakeIntegrity] },
+        }),
+        "bunfig.toml":
+          kind === "default"
+            ? `[install]\nregistry = ${bad}\n`
+            : `[install]\nregistry = "${mock.url.href}"\n[install.scopes]\nfoo = ${bad}\n`,
+      });
+
+      await using proc = spawn({
+        cmd: [bunExe(), "audit"],
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd: String(dir),
+        env: bunEnv,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+      expect(normalizeBunSnapshot(stdout)).toBe("bun audit <version> (<revision>)");
+      expect(requests).toEqual([]);
+      expect(exitCode).toBe(1);
+    },
+  );
+
   doAuditTest("workspaces print the path to the vulnerable package and include workspace:pkg in the name", {
     exitCode: 1,
     files: {

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -370,6 +370,29 @@ describe.concurrent("bun info", () => {
       `);
     });
   });
+
+  // A scheme that is not http or https (a typo such as `htps://`) must not fall back to plaintext HTTP with the
+  // token attached. The mock is a plain HTTP listener, so a downgraded request shows up in `requests`.
+  it.each(["info", "pm view"])("bun %s rejects a registry url scheme that is not http or https", async cmd => {
+    const requests: string[] = [];
+    using mock = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requests.push(`${req.method} ${new URL(req.url).pathname} ${req.headers.get("authorization")}`);
+        return Response.json({});
+      },
+    });
+    const testDir = tempDirWithFiles("view-bad-scheme", {
+      "package.json": JSON.stringify({ name: "pkg", version: "1.0.0" }),
+      "bunfig.toml": `[install]\nregistry = { url = "htps://localhost:${mock.port}/", token = "secret-token" }\n`,
+    });
+
+    const { output, error, code } = await runCommand([bunExe(), ...cmd.split(" "), "is-number"], testDir);
+    expect(error).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+    expect(output).toBe("");
+    expect(requests).toEqual([]);
+    expect(code).toBe(1);
+  });
 });
 
 // LSan's default conservative scan only flags the `send_sync` response-metadata

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -468,6 +468,34 @@ diffme@1.0.0 → diffme@2.0.0
     expect(hits.some(h => h.endsWith(" /@priv/diffme"))).toBe(true);
   });
 
+  // A scheme that is not http or https (a typo such as `htps://`) must not fall back to plaintext HTTP with the
+  // token attached. The mock is a plain HTTP listener, so a downgraded request shows up in `requests`.
+  test("a registry url scheme that is not http or https is rejected before any request", async () => {
+    const requests: string[] = [];
+    using mock = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requests.push(`${req.method} ${new URL(req.url).pathname} ${req.headers.get("authorization")}`);
+        return Response.json({});
+      },
+    });
+    using dir = tempDir("pm-diff-bad-scheme", {
+      "bunfig.toml": `[install]\nregistry = { url = "htps://localhost:${mock.port}/", token = "sekrit" }\n`,
+    });
+    await using p = Bun.spawn({
+      cmd: [bunExe(), "pm", "diff", "diffme@1.0.0", "2.0.0", "--name-only"],
+      cwd: String(dir),
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([p.stdout.text(), p.stderr.text(), p.exited]);
+    expect(stderr).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+    expect(stdout).toBe("");
+    expect(requests).toEqual([]);
+    expect(exitCode).toBe(1);
+  });
+
   test("errors: unknown package, no matching version; a third argument is a file filter", async () => {
     const unknown = await diff(["nope-nope@1.0.0", "2.0.0"]);
     expect(unknown.exitCode).toBe(1);

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -490,7 +490,9 @@ diffme@1.0.0 → diffme@2.0.0
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([p.stdout.text(), p.stderr.text(), p.exited]);
-    expect(stderr).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+    expect(stderr).toBe(
+      `error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`,
+    );
     expect(stdout).toBe("");
     expect(requests).toEqual([]);
     expect(exitCode).toBe(1);

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -866,6 +866,36 @@ test("bun pm whoami still works", async () => {
   expect(exitCode).toBe(1);
 });
 
+// A scheme that is not http or https (a typo such as `htps://`) must not fall back to plaintext HTTP with the
+// token attached. The mock is a plain HTTP listener, so a downgraded request shows up in `requests`.
+test("bun pm whoami rejects a registry url scheme that is not http or https", async () => {
+  const requests: string[] = [];
+  using mock = Bun.serve({
+    port: 0,
+    fetch(req) {
+      requests.push(`${req.method} ${new URL(req.url).pathname} ${req.headers.get("authorization")}`);
+      return Response.json({ username: "leaked" });
+    },
+  });
+  using dir = tempDir("whoami-bad-scheme", {
+    "package.json": JSON.stringify({ name: "whoami-bad-scheme", version: "1.0.0" }),
+    "bunfig.toml": `[install]\nregistry = { url = "htps://localhost:${mock.port}/", token = "secret-token" }\n`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "pm", "whoami"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe(`error: Registry URL must be http:// or https://\nReceived: "htps://localhost:${mock.port}/"\n`);
+  expect(stdout).toBe("");
+  expect(requests).toEqual([]);
+  expect(exitCode).toBe(1);
+});
+
 test.each([
   {
     name: "bun list executes pm ls",


### PR DESCRIPTION
### Problem
- `bun pm view` (`bun info`), `bun pm diff`, `bun pm whoami` and `bun audit` send the registry `Authorization` header over plaintext HTTP when the registry URL scheme is not `https`. A typo such as `registry = { url = "htps://npm.corp.example/", token = "..." }` leaks the token.
- The cause: the HTTP client uses TLS only for `https:` (`HTTPClient::is_https`, `src/http/lib.rs`) and dials every other scheme as plain HTTP. `bun install` rejects such a registry (`NetworkTask.rs`, "Registry URL must be http:// or https://"). These commands built requests from the scope URL with no check.

### Fix
- Add `Scope::check_url_protocol()` in `src/install/npm.rs`. It returns an `UnsupportedProtocol` error with the same text as `bun install`.
- Call it before each of those requests. On error, print it and exit 1. No request is sent.
- `bun publish` gets the same check in #41662. `bun install` keeps its own check.
- Verified: new tests in `test/cli/install/bun-info.test.ts`, `bun-pm-diff.test.ts`, `bun-pm.test.ts` and `bun-audit.test.ts` fail on stock bun (the plain HTTP mock receives `Bearer ...`) and pass on the debug build. Those files pass in full.
- Self-reviewed: no blocking concerns. No other request site that attaches registry credentials lacks the check.

### Background
- A registry `Scope` (`npm::registry::Scope`) holds the URL, token and basic-auth string of the default registry or one `@scope`, from bunfig.toml and .npmrc.
- The pm subcommands use the blocking `AsyncHTTP::init_sync` + `send_sync` path. It does no scheme validation itself: `fetch()` validates in its JS binding, `bun install` in `NetworkTask::for_manifest`.

<details><summary>Notes</summary>

- Repro on bun 1.4.3 against a plain `Bun.serve({ port: 0 })` that logs `authorization`, with `bunfig.toml` `registry = { url = "htps://localhost:PORT/", token = "SECRET-TOKEN" }`:
  - `bun pm view is-number` and `bun info is-number`: mock receives `GET /is-number` with `Bearer SECRET-TOKEN`.
  - `bun audit` (with a bun.lock): mock receives `POST /-/npm/v1/security/advisories/bulk` with `Bearer SECRET-TOKEN`.
  - `bun pm diff is-number@7.0.0 is-number@6.0.0`: mock receives `GET /is-number` with `Bearer SECRET-TOKEN`.
  - `bun pm whoami`: mock receives `GET /-/whoami` with `Bearer SECRET-TOKEN`.
  - `bun install`: no request, `error: Registry URL must be http:// or https://`.
- Call sites: `pm_view_command.rs` `view`, `pm_diff_command.rs` `fetch_registry_tree`, `npm.rs` `whoami` (new `WhoamiError::UnsupportedProtocol`), `audit_command.rs` `AuditRegistry::from_scope` (the one place where the default scope and each package scope enter the audit, before the first request. The default registry request is sent even for zero packages). The URL in the message goes through `redacted_npm_url`, like the existing whoami and audit messages.
- Config loading already splits URL credentials out of the stored registry URL (`NpmRegistry::from_url`, `Scope::from_api`), so the message does not print a token.
- `bun outdated` and `bun update -i` read manifests through the install network tasks, so they already get the `bun install` check. `bun create`, `bun upgrade` and `bun build --compile` use fixed `https://` URLs and no registry credentials.
- `bun pm whoami` still answers from a locally configured username (`.npmrc` `username`, URL userinfo) without a request, so the check sits after those early returns.
- In `bun audit` a bad scheme on a scoped registry is an error, not a "skipped registry" warning. It is a static configuration error, and `bun install` of the same project fails too.
- A schemeless registry such as `localhost:4873/` is now rejected by these commands too. `bun install` already fails on it ("Failed to join registry ... URLs").
- Also ran: the `whoami` tests in `bun-install-registry.test.ts`, the scoped-registry and secret-masking tests in `bun-audit.test.ts`, all of `bun-pm-diff.test.ts` and `bun-info.test.ts`, on Linux x64 ASAN debug and Windows x64 debug.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-pm-diff.test.ts

<!-- robobun:evidence:end -->