### PR TITLE
bundler: an empty data file is {} under "type": "module", and an empty .json is a build error

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2682,7 +2682,11 @@ pub mod parse_worker {
                 )
             } else if loader.is_css() {
                 get_empty_css_ast(log, transpiler, opts, bump, source)
-            } else if module_type == options::ModuleType::Esm {
+            } else if loader == Loader::Json {
+                // `JSON.parse("")` throws, and so does the runtime's `.json` loader.
+                let _ = log.add_error(Some(source), Loc::EMPTY, b"Unexpected end of file in JSON");
+                Err(AnyError::ParserError)
+            } else if loader.is_javascript_like() && module_type == options::ModuleType::Esm {
                 get_empty_ast::<E::Undefined>(log, transpiler, opts, bump, source)
             } else {
                 get_empty_ast::<E::Object>(log, transpiler, opts, bump, source)

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -542,6 +542,63 @@ describe("bundler", async () => {
         },
       });
     }
+
+    // An empty data file is `{}`, as it is under `bun run`. The enclosing
+    // package.json "type" only applies to JavaScript files; it used to turn
+    // these into `export default undefined`.
+    for (const type of ["module", "commonjs"] as const) {
+      itBundled(`bun/loader-empty-data-files-type-${type}`, {
+        target: "bun",
+        files: {
+          "/entry.ts": /* js */ `
+            import toml from "./empty.toml";
+            import yaml from "./empty.yaml";
+            import jsonc from "./empty.jsonc";
+            import json5 from "./empty.json5";
+            import spaces from "./spaces.toml";
+            const dynamic = await import("./empty.yaml");
+            console.write(JSON.stringify([toml, yaml, jsonc, json5, spaces, dynamic.default]));
+          `,
+          "/package.json": JSON.stringify({ type }),
+          "/empty.toml": "",
+          "/empty.yaml": "",
+          "/empty.jsonc": "",
+          "/empty.json5": "",
+          "/spaces.toml": "  \n\n",
+        },
+        run: { stdout: "[{},{},{},{},{},{}]" },
+      });
+    }
+
+    // `JSON.parse("")` throws, and `bun run` rejects an empty `.json` import.
+    // The bundler used to emit `{}` (or `undefined` under "type": "module").
+    itBundled("bun/loader-empty-json-file-is-an-error", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          import data from "./empty.json";
+          console.write(JSON.stringify(data));
+        `,
+        "/empty.json": "",
+      },
+      bundleErrors: {
+        "/empty.json": ["Unexpected end of file in JSON"],
+      },
+    });
+    itBundled("bun/loader-whitespace-json-file-is-an-error", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          const { default: data } = await import("./spaces.json");
+          console.write(JSON.stringify(data));
+        `,
+        "/package.json": JSON.stringify({ type: "module" }),
+        "/spaces.json": " \n\t\n",
+      },
+      bundleErrors: {
+        "/spaces.json": ["Unexpected end of file in JSON"],
+      },
+    });
   });
 
   // Lazy-export modules (JSON, TOML, CSS modules, ...) used to crash the

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -42,7 +42,9 @@ const many_baz = ["baz","baz","baz","baz","baz","baz","baz"]
 console.log(JSON.stringify(json));
 values;`,
       "stuff.ts": `export default { foo: "bar", baz: "baz" }`,
-      "lmao.json": ``,
+      // Tests that register an onLoad plugin for this file replace its contents.
+      // The rest bundle it as is, so it must be valid JSON.
+      "lmao.json": `{}`,
       "binding.gyp": /* gyp */ `{
         "targets": [
           {


### PR DESCRIPTION
### Problem
- `bun build` gives an empty data file a value that depends on the nearest package.json. Under `"type": "module"`, an empty `.toml`, `.yaml`, `.jsonc`, `.json5` or `.json` bundles to `module.exports = undefined`. Elsewhere it is `{}`. `bun run` gives `{}` for all but `.json`.
- An empty `.json` bundles with no diagnostic. `bun run` throws `JSON Parse error: Unexpected EOF`, node throws, and esbuild fails with `Unexpected end of file in JSON`.
- Cause: the empty-file short-circuit in `src/bundler/ParseTask.rs:2685` picks `E::Undefined` over `E::Object` whenever the resolver reports `ModuleType::Esm`. That rule models an empty JavaScript module, not a data file.

### Fix
- The `E::Undefined` arm now also requires `loader.is_javascript_like()`. Other loaders get `{}` in every package.
- An empty or whitespace-only file with the `json` loader is a build error, `Unexpected end of file in JSON`, like the runtime, node and esbuild. `.jsonc`, `.json5`, `.toml`, `.yaml` stay `{}` as under `bun run` (package.json and tsconfig.json use `jsonc`).
- Verified: `test/bundler/bundler_loader.test.ts` (4 new tests, 3 fail on 1.4.2). Also `esbuild/loader`, `esbuild/importstar` (empty `.js`/`.mjs`/`.cjs`) and the `Empty*` edgecase tests.

### Background
- Data loaders produce a lazy-export AST: one expression that the linker turns into `export default` plus per-key exports, or `module.exports = ...` when required.
- For a whitespace-only file whose loader is not in `handles_empty_file()`, ParseTask skips the loader and builds that expression from a default: `{}` for an empty CommonJS module, `undefined` for an empty ES module.
- `task.module_type` comes from the extension or the enclosing package.json `"type"`, for every file in the package.

<details><summary>Notes</summary>

Repro on 1.4.2 / canary, from the report:

```sh
for p in none module; do mkdir $p; : > $p/empty.json; printf 'import s from "./empty.json"; const m = await import("./empty.json"); console.log(JSON.stringify(s), typeof s, JSON.stringify(m.default));\n' > $p/t.mjs; done
echo '{"type":"module"}' > module/package.json
(cd none   && bun ./t.mjs; bun build ./t.mjs --outdir o && bun o/t.js)   # run: SyntaxError ... | build: {} object {}
(cd module && bun ./t.mjs; bun build ./t.mjs --outdir o && bun o/t.js)   # run: SyntaxError ... | build: undefined undefined undefined
```

The same `undefined` appeared for empty `.toml`, `.yaml` and `.jsonc` under `"type": "module"` (`bun run` prints `{}` for each).

After this change:

```
$ bun build ./t.mjs --outdir o
error: Unexpected end of file in JSON
    at /tmp/none/empty.json
```

Why an error and not `{}` for `.json`: the bundler's `.json` path is otherwise strict JSON (it rejects trailing commas and comments), the runtime hands `.json` to JSC's `JSON.parse`, and node and esbuild both reject the file. Keeping `{}` would leave `bun build --target=bun` output that behaves differently from running the same source. If `{}` is preferred instead, the change is to drop the `Loader::Json` arm; the tests name the expectation either way.

Not changed here, noted while probing: at runtime a whitespace-only `.jsonc`/`.json5` file of 33 bytes or more is an error (`Unexpected end of file` / `Unexpected end of input`) while a shorter one is `{}`, because of the `< 33` length check in `src/bundler/transpiler.rs:1537`. An empty `.md` diverges too (`bun run`: `Missing 'default' export`, `bun build`: `{}`); that one is tracked separately.

`export * from "./d.json"` dropping the JSON keys in `bun build` (the other item from the same report) is already addressed by #40826, which records lazy-export aliases in `named_exports`.

`test/bundler/native-plugin.test.ts`: its `beforeAll` fixture had an empty `lmao.json` placeholder. Tests that register an `onLoad` plugin for it replace the contents, but the `works with <loader> loader` tests bundle the fixture entry as is, so the placeholder is now `{}`. Verified with `bun bd test test/bundler/native-plugin.test.ts` (19 pass, 1 skip).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/native-plugin.test.ts

<!-- robobun:evidence:end -->