### PR TITLE
bun-types test: expect the Blob.textStream() diagnostic under lib.dom with @types/node 26.5

### DIFF
--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -860,11 +860,12 @@ describe("@types/bun integration test", () => {
         "WebGLVertexArrayObjectOES",
       ]),
       diagnostics: [
+        // lib.dom's Blob has no textStream(); node:buffer's Blob declares it
+        // since @types/node 26.5.0 (added to Node.js in v24.19.0 / v26.5.0).
         {
-          code: 2322,
+          code: 2741,
           line: "24154.ts:11:3",
-          message:
-            "Type 'Blob' is not assignable to type 'import(\"node:buffer\").Blob'.\nThe types returned by 'stream()' are incompatible between these types.\nType 'ReadableStream<Uint8Array<ArrayBuffer>>' is missing the following properties from type 'ReadableStream<NonSharedUint8Array>': blob, text, bytes, json",
+          message: "Property 'textStream' is missing in type 'Blob' but required in type 'import(\"node:buffer\").Blob'.",
         },
         {
           code: 2769,

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -865,7 +865,8 @@ describe("@types/bun integration test", () => {
         {
           code: 2741,
           line: "24154.ts:11:3",
-          message: "Property 'textStream' is missing in type 'Blob' but required in type 'import(\"node:buffer\").Blob'.",
+          message:
+            "Property 'textStream' is missing in type 'Blob' but required in type 'import(\"node:buffer\").Blob'.",
         },
         {
           code: 2769,


### PR DESCRIPTION
Test expectation only. No types or runtime change.

### Problem
- The `bun-types` workflow ("TypeScript types") fails on every PR since 2026-09-07 14:07 UTC. The case `lib configuration > checks with lib.dom.d.ts` expects TS2322 at `24154.ts:11:3` (the `stream()` return types differ). It now gets TS2741: `Property 'textStream' is missing in type 'Blob' but required in type 'import("node:buffer").Blob'.`
- The fixture resolves `@types/node` to `latest`. `@types/node@26.5.0`, published at that time, added `textStream()` to `node:buffer`'s `Blob` (Node.js v24.19.0 / v26.5.0). lib.dom's `Blob` has no `textStream`, so TypeScript reports the missing property first.

### Fix
- Update the expected diagnostic for `24154.ts:11:3` in the lib.dom case to the TS2741 message.
- bun-types stays as it is. Bun's `Blob` has no `textStream()` at runtime (only `Request` and `Response` do, `fetch.d.ts:81,93`), so declaring it on the global `Blob` would be wrong. The no-lib.dom cases still pass: there `Response#blob()` already returns `node:buffer`'s `Blob`.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts`, 21/21 with `@types/node@26.5.0`. On main the lib.dom case fails with the diff above.

### Background
- `fixture/24154.ts` returns `await response.blob()` from a function typed `Promise<import("node:buffer").Blob>`. Under lib.dom, `Response#blob()` yields lib.dom's `Blob`, which is not assignable to node's. The test pins the exact text of that one expected diagnostic.
- BuildKite excludes `integration/bun-types`. Only `.github/workflows/bun-types.yml` runs this file, on PRs that touch `packages/bun-types` or `test/integration/bun-types`.

<details><summary>Notes</summary>

- `@types/node` publish times: 26.4.1 at 2026-09-01 (no `textStream`), 26.5.0 at 2026-09-07T14:07:47Z (adds it at `buffer.d.ts:1779`). Every `bun-types.yml` run after that is red across unrelated branches, for example #41809, #41818, #41708.
- Node.js documents `blob.textStream()` as added in v26.5.0 and v24.19.0. Implementing it on Bun's `Blob` is a separate runtime change. It would not alter this lib.dom diagnostic unless bun-types also declared it on the global `Blob`.
- The type-checking cases in this file are `test.skipIf(isDebug)`, so a debug build skips them. CLAUDE.md says to run this file with the system bun, which is what the verification above did.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/integration/bun-types/bun-types.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/integration/bun-types/bun-types.test.ts
bun test v1.4.3 (f42e98025)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [4.75ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [10.62ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > TypeScript latest > checks without lib.dom.d.ts
(skip) @types/bun integration test > TypeScript 7.1 > checks the fixture and import attributes through ts7.1/index.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [754.01ms]
(pass) @types/bun integration test > TextDecoder > accepts the encoding labels the runtime supports [773.13ms]
(pass) @types/bun integration test > TextDecoder > the fixture label table matches the runtime [40.96ms]
(pass) @types/bun integration test > Event and EventTarget > lib.dom's composedPath() declaration wins when lib.dom is loaded [910.82ms]
(pass) @types/bun integration test > Event and EventTarget > the Node-style composedPath() tuple applies without lib.dom [824.53ms]
(pass) @types/bun integration test > process event methods with @types/node@24 > removeListener and off accept other event names [2035.99ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation produces type errors for invalid flags
(skip) @types/bun integration test > bun:bundle feature() > without Registry augmentation, feature() accepts any string

... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/integration/bun-types/bun-types.test.ts | 6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
test/integration/bun-types/bun-types.test.ts      2      1      6
```

</details>

<!-- robobun:evidence:end -->