### PR TITLE
Bun.serve: reject a Request that a different server received in timeout(), requestIP() and upgrade()

### DIFF
--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -384,6 +384,8 @@ Use this for development and hot reloading. You can update only `fetch`, `error`
 
 ## Per-Request Controls
 
+These methods act on a `Request` that this server received. When several servers share one handler, use the `server` argument that Bun passes to `fetch` and to route handlers: calling `timeout()`, `requestIP()`, or `upgrade()` on a different `Bun.serve()` instance with that request throws a `TypeError`.
+
 ### `server.timeout(Request, seconds)`
 
 Override the idle timeout for an individual request. Pass `0` to disable the timeout entirely for that request.

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -996,6 +996,7 @@ declare module "bun" {
      * @param options Pass headers or attach data to the {@link ServerWebSocket}
      *
      * @returns `true` if the upgrade was successful and `false` if it failed
+     * @throws {TypeError} If `request` was received by a different server
      *
      * @example
      * ```js
@@ -1125,6 +1126,8 @@ declare module "bun" {
     /**
      * Returns the client IP address and port of the given Request. If the request was closed or is a unix socket, returns null.
      *
+     * @throws {TypeError} If `request` was received by a different server
+     *
      * @example
      * ```js
      * export default {
@@ -1138,6 +1141,8 @@ declare module "bun" {
 
     /**
      * Reset the idle timeout of the given Request to the given number of seconds. `0` means no timeout.
+     *
+     * @throws {TypeError} If `request` was received by a different server
      *
      * @example
      * ```js

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -177,6 +177,16 @@ impl AnyRequestContext {
         dispatch!(self, false, |_T, ctx| ctx.set_timeout(seconds))
     }
 
+    /// Type-erased pointer to the `NewServer` that received this request;
+    /// null when there is no context or it already detached from its server.
+    pub(crate) fn server_ptr(self) -> *const () {
+        dispatch!(self, core::ptr::null(), |_T, ctx| {
+            ctx.server
+                .get()
+                .map_or(core::ptr::null(), |s| s.as_ptr().cast_const().cast())
+        })
+    }
+
     pub(crate) fn set_cookies(self, cookie_map: Option<*mut CookieMap>) {
         dispatch!(self, (), |_T, ctx| ctx.set_cookies(cookie_map))
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1526,10 +1526,30 @@ where
         self.timeout(global, callframe)
     }
 
+    /// A live `Request` (or node:http response) that another `Bun.serve()`
+    /// instance dispatched must not be acted on through this one. `owner` is
+    /// null once the request detached from its server; those calls keep their
+    /// no-op behavior.
+    fn check_request_owner(&self, owner: *const (), method: &str) -> JsResult<()> {
+        if owner.is_null() || core::ptr::eq(owner, core::ptr::from_ref(self).cast()) {
+            return Ok(());
+        }
+        Err(self
+            .global()
+            .err(
+                jsc::ErrorCode::INVALID_ARG_VALUE,
+                format_args!(
+                    "server.{method}() was called with a Request that a different server received. Use the server passed to fetch() as the second argument."
+                ),
+            )
+            .throw())
+    }
+
     pub(crate) fn request_ip(&self, request: &Request) -> JsResult<JSValue> {
         if matches!(self.config.address, server_config::Address::Unix(_)) {
             return Ok(JSValue::NULL);
         }
+        self.check_request_owner(request.request_context.server_ptr(), "requestIP")?;
         let Some(info) = request.request_context.get_remote_socket_info() else {
             return Ok(JSValue::NULL);
         };
@@ -1567,11 +1587,15 @@ where
 
         if let Some(request) = <Request as bun_jsc::JsClass>::from_js(arguments[0]) {
             // SAFETY: from_js returns a live *mut Request; shared access only.
-            let _ = unsafe { (*request).request_context.set_timeout(value) };
+            let request_context = unsafe { (*request).request_context };
+            self.check_request_owner(request_context.server_ptr(), "timeout")?;
+            let _ = request_context.set_timeout(value);
         } else if let Some(response) = <NodeHTTPResponse as bun_jsc::JsClass>::from_js(arguments[0])
         {
             // SAFETY: from_js returns a live *mut NodeHTTPResponse
-            unsafe { (*response).set_timeout((value % 255) as u8) };
+            let response = unsafe { &*response };
+            self.check_request_owner(response.server.ptr.cast_const(), "timeout")?;
+            response.set_timeout((value % 255) as u8);
         } else {
             return Err(self
                 .global()
@@ -1673,6 +1697,7 @@ where
             // SAFETY: from_js returns a live *mut NodeHTTPResponse; shared —
             // its mutable state is `Cell`/`JsCell` and `upgrade` takes `&self`.
             let node_http_response = unsafe { &*node_http_response };
+            self.check_request_owner(node_http_response.server.ptr.cast_const(), "upgrade")?;
             if node_http_response
                 .flags
                 .get()
@@ -1792,6 +1817,7 @@ where
         // argument). Shared, re-derived after each JS re-entry point below; the
         // one field write at the end goes through `request_ptr`.
         let request = unsafe { &*request_ptr };
+        self.check_request_owner(request.request_context.server_ptr(), "upgrade")?;
 
         let Some(upgrader_ptr) = request
             .request_context

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3160,6 +3160,59 @@ it.concurrent(
   20_000,
 );
 
+it.concurrent("timeout(), requestIP() and upgrade() throw for a Request that a different server received", async () => {
+  const calls: Record<string, unknown> = {};
+  const capture = (label: string, fn: () => unknown) => {
+    try {
+      calls[label] = { returned: fn() };
+    } catch (e: any) {
+      calls[label] = { threw: { name: e?.name, code: e?.code, message: e?.message } };
+    }
+  };
+  const opened = Promise.withResolvers<string>();
+  using other = Bun.serve({
+    port: 0,
+    websocket: { open: () => opened.resolve("other"), message() {} },
+    fetch: () => new Response("other"),
+  });
+  using server = Bun.serve({
+    port: 0,
+    websocket: { open: () => opened.resolve("server"), message() {} },
+    fetch(req, server) {
+      capture("other.timeout", () => other.timeout(req, 0));
+      capture("other.requestIP", () => other.requestIP(req));
+      capture("other.upgrade", () => other.upgrade(req));
+      capture("server.timeout", () => server.timeout(req, 0));
+      capture("server.requestIP", () => server.requestIP(req)?.family);
+      capture("server.upgrade", () => server.upgrade(req));
+      if ((calls["server.upgrade"] as any)?.returned === true) return;
+      return new Response("not upgraded", { status: 400 });
+    },
+  });
+  const ws = new WebSocket(server.url.href.replace(/^http/, "ws"));
+  const clientOpened = Promise.withResolvers<void>();
+  ws.onopen = () => clientOpened.resolve();
+  ws.onerror = () => clientOpened.reject(new Error("handshake failed: " + JSON.stringify(calls)));
+  ws.onclose = e => clientOpened.reject(new Error(`closed ${e.code} before open: ` + JSON.stringify(calls)));
+  await clientOpened.promise;
+  ws.close();
+  const foreign = (method: string) => ({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_VALUE",
+    message: `server.${method}() was called with a Request that a different server received. Use the server passed to fetch() as the second argument.`,
+  });
+  expect(calls).toEqual({
+    "other.timeout": { threw: foreign("timeout") },
+    "other.requestIP": { threw: foreign("requestIP") },
+    "other.upgrade": { threw: foreign("upgrade") },
+    "server.timeout": { returned: undefined },
+    "server.requestIP": { returned: expect.stringMatching(/^IPv[46]$/) },
+    "server.upgrade": { returned: true },
+  });
+  // The socket was upgraded onto the server that received it, not `other`.
+  expect(await opened.promise).toBe("server");
+});
+
 it.concurrent("#6462", async () => {
   let headers: string[] = [];
   using server = Bun.serve({


### PR DESCRIPTION
### Problem
- `server.timeout(req, s)`, `server.requestIP(req)` and `server.upgrade(req)` act on a `Request` that a different `Bun.serve()` instance received. `A.timeout(reqB, 0)` clears B's `idleTimeout` on that connection, and for a WebSocket handshake sent to B, `A.upgrade(reqB)` returns `true` and runs A's handlers on B's connection.
- Cause: `timeout()` (`server_body.rs:1568`), `request_ip()` (`:1533`) and `on_upgrade()` (`:1796`) use `request.request_context` without comparing its `server` backref with `self`. `on_upgrade()` only matched the ssl/debug type tag.

### Fix
- `AnyRequestContext::server_ptr()` returns the owning server. `check_request_owner()` compares it with `self` and throws `TypeError` (`ERR_INVALID_ARG_VALUE`) for a different live server. The `NodeHTTPResponse` arms compare `response.server` the same way.
- A request that already detached from its server keeps the current no-op / `null` / `false` results. The foreign case throws, because it is always a caller bug and the message names the fix: use the `server` that `fetch(req, server)` receives.
- Self-reviewed: `ctx.server` is the receiver's own address on every dispatch path, and no internal caller, doc example or existing test pairs a request with another server.
- Verified: `test/js/bun/http/serve.test.ts` (new test, fails on 1.4.3), plus the websocket-server and `first_party/ws` suites.

### Background
- Each in-flight request has a pooled `RequestContext` with a `server` backref to the `NewServer` that owns the pool. A JS `Request` reaches it through the tagged pointer `AnyRequestContext`.
- `server.upgrade()` builds a `ServerWebSocket` from the receiver's `websocket` handlers, then moves the socket into the WebSocket context of the request's own server. With a foreign receiver, the handlers and the socket belong to different servers.

<details><summary>Notes</summary>

- Found by a multi-instance isolation sweep. `requestIP()` on a foreign request was read-only and returned a correct value before this change. It now throws too, so the three per-request methods share one contract. Code that shares one handler between two servers and closes over the wrong `server` variable gets the error message instead of working by accident for `requestIP`/`timeout` and failing silently (or cross-wiring) for `upgrade`. If that tradeoff is not wanted for `requestIP`, dropping its check is a one-line change. A search of the issue tracker found no report that depends on cross-server calls.
- Unix-socket servers return `null` from `timeout()`/`requestIP()` before they look at the request, as before.
- `--hot`: a reload that keeps the same server id reuses the same `NewServer`, so in-flight requests still match. A reload that changes hostname/port creates a new server, and the old server's in-flight requests are foreign to it.
- node:http: `ws`'s `handleUpgrade()` path calls `server.upgrade(nodeHttpResponse)` with `socket.server[kBunInternals]`, which is the server that created the response, so it is unaffected (`first_party/ws` 78/78 pass).
- The `seconds > 255` clamp in `timeout()` is a separate item and is covered by #34958.
- Repro used for the report (bun 1.4.3, both directions, wall-clock controls): B with `idleTimeout: 8` answered at 13 s after `A.timeout(reqB, 0)`; A with `idleTimeout: 30` was reset at 3 s after `B.timeout(reqA, 2)`. `A.requestIP(reqB)` answered. A WebSocket client to B got A's handlers and `A.pendingWebSockets` became 1 while B's stayed 0.
- Suites run locally with the debug build: the `requestIP|timeout|upgrade` tests in `serve.test.ts`, `websocket-server.test.ts` + `websocket-server-upgrade-reentrant.test.ts` + `websocket-upgrade-signal-gc.test.ts`, `first_party/ws/ws.test.ts` + `ws-upgrade-events.test.ts`, `serve-http2-lifecycle.test.ts`, `bun-serve-routes.test.ts`, `bun-server.test.ts`, `bun-types.test.ts`.

</details>
