### PR TITLE
sql(mysql): set result.count and result.command for statements without a result set

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1410,6 +1410,8 @@ console.log(result.lastInsertRowid); // MySQL's LAST_INSERT_ID()
 // Handling affected rows
 const updated = await mysql`UPDATE users SET active = ${false} WHERE age < ${18}`;
 console.log(updated.affectedRows); // Number of rows updated
+console.log(updated.count); // Same number; `count` is the rows affected on every adapter
+console.log(updated.command); // "UPDATE"
 
 // Using MySQL-specific functions
 const now = await mysql`SELECT NOW() as current_time`;

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -18,6 +18,7 @@ const {
   createConnection: createMySQLConnection,
   createQuery: createMySQLQuery,
   init: initMySQL,
+  commands,
 } = $rust("mysql.rs", "createBinding") as MySQLDotZig;
 
 function wrapError(error: Error | MySQLErrorOptions) {
@@ -27,34 +28,14 @@ function wrapError(error: Error | MySQLErrorOptions) {
   return new MySQLError(error.message, error);
 }
 
-// MySQL replies carry no command tag, so the native side derives `command`
-// from the leading keyword of the statement and passes these as a 1-based
-// index. Keep in sync with KNOWN_KEYWORDS in src/sql_jsc/mysql/MySQLQuery.rs.
-const commands = [
-  null,
-  "SELECT",
-  "INSERT",
-  "UPDATE",
-  "DELETE",
-  "REPLACE",
-  "CALL",
-  "WITH",
-  "SHOW",
-  "SET",
-  "START",
-  "BEGIN",
-  "COMMIT",
-  "ROLLBACK",
-  "SAVEPOINT",
-  "RELEASE",
-  "USE",
-];
-
 initMySQL(
   function onResolveMySQLQuery(query, result, command, count, queries, is_last, last_insert_rowid, affected_rows) {
     $assert(result instanceof SQLResultArray, "Invalid result array");
 
     result.count = count || 0;
+    // MySQL replies carry no command tag; the native side derives this from
+    // the leading keyword of the statement, as an index into `commands` for
+    // the common ones.
     result.command = typeof command === "number" ? commands[command] : command;
     result.lastInsertRowid = last_insert_rowid;
     result.affectedRows = affected_rows || 0;
@@ -105,6 +86,8 @@ initMySQL(
 );
 
 export interface MySQLDotZig {
+  /** `result.command` strings that `onResolveQuery` receives as an index. */
+  commands: string[];
   init: (
     onResolveQuery: (
       query: Query<any, any>,

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -26,11 +26,36 @@ function wrapError(error: Error | MySQLErrorOptions) {
   }
   return new MySQLError(error.message, error);
 }
+
+// MySQL replies carry no command tag, so the native side derives `command`
+// from the leading keyword of the statement and passes these as a 1-based
+// index. Keep in sync with KNOWN_KEYWORDS in src/sql_jsc/mysql/MySQLQuery.rs.
+const commands = [
+  null,
+  "SELECT",
+  "INSERT",
+  "UPDATE",
+  "DELETE",
+  "REPLACE",
+  "CALL",
+  "WITH",
+  "SHOW",
+  "SET",
+  "START",
+  "BEGIN",
+  "COMMIT",
+  "ROLLBACK",
+  "SAVEPOINT",
+  "RELEASE",
+  "USE",
+];
+
 initMySQL(
-  function onResolveMySQLQuery(query, result, commandTag, count, queries, is_last, last_insert_rowid, affected_rows) {
+  function onResolveMySQLQuery(query, result, command, count, queries, is_last, last_insert_rowid, affected_rows) {
     $assert(result instanceof SQLResultArray, "Invalid result array");
 
     result.count = count || 0;
+    result.command = typeof command === "number" ? commands[command] : command;
     result.lastInsertRowid = last_insert_rowid;
     result.affectedRows = affected_rows || 0;
 
@@ -84,10 +109,12 @@ export interface MySQLDotZig {
     onResolveQuery: (
       query: Query<any, any>,
       result: SQLResultArray,
-      commandTag: string,
+      command: number | string | null,
       count: number,
       queries: any,
       is_last: boolean,
+      last_insert_rowid: number,
+      affected_rows: number,
     ) => void,
     onRejectQuery: (query: Query<any, any>, err: Error, queries) => void,
   ) => void;

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -33,9 +33,7 @@ initMySQL(
     $assert(result instanceof SQLResultArray, "Invalid result array");
 
     result.count = count || 0;
-    // MySQL replies carry no command tag; the native side derives this from
-    // the leading keyword of the statement, as an index into `commands` for
-    // the common ones.
+    // The statement's leading keyword; an index into `commands` when common.
     result.command = typeof command === "number" ? commands[command] : command;
     result.lastInsertRowid = last_insert_rowid;
     result.affectedRows = affected_rows || 0;

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -43,6 +43,8 @@ pub mod mysql {
     pub mod mysql_types;
     #[path = "SSLMode.rs"]
     pub mod ssl_mode;
+    #[path = "StatementKeyword.rs"]
+    pub mod statement_keyword;
     #[path = "StatusFlags.rs"]
     pub mod status_flags;
     #[path = "TLSStatus.rs"]

--- a/src/sql/mysql/MySQLQueryResult.rs
+++ b/src/sql/mysql/MySQLQueryResult.rs
@@ -4,6 +4,7 @@ pub struct MySQLQueryResult {
     pub last_insert_id: u64,
     pub affected_rows: u64,
     pub is_last_result: bool,
-    /// False when the session has `NO_BACKSLASH_ESCAPES` set.
+    /// Whether this result's statement was lexed with backslash escapes on
+    /// (`NO_BACKSLASH_ESCAPES` unset).
     pub backslash_escapes: bool,
 }

--- a/src/sql/mysql/MySQLQueryResult.rs
+++ b/src/sql/mysql/MySQLQueryResult.rs
@@ -1,6 +1,5 @@
 pub struct MySQLQueryResult {
-    /// Rows returned for a result set; rows affected for a reply with no
-    /// result set (the OK packet of an INSERT, UPDATE, DELETE or DDL).
+    /// Rows of a result set, or rows affected when there was none.
     pub count: u64,
     pub last_insert_id: u64,
     pub affected_rows: u64,

--- a/src/sql/mysql/MySQLQueryResult.rs
+++ b/src/sql/mysql/MySQLQueryResult.rs
@@ -5,4 +5,6 @@ pub struct MySQLQueryResult {
     pub last_insert_id: u64,
     pub affected_rows: u64,
     pub is_last_result: bool,
+    /// False when the session has `NO_BACKSLASH_ESCAPES` set.
+    pub backslash_escapes: bool,
 }

--- a/src/sql/mysql/MySQLQueryResult.rs
+++ b/src/sql/mysql/MySQLQueryResult.rs
@@ -1,5 +1,7 @@
 pub struct MySQLQueryResult {
-    pub result_count: u64,
+    /// Rows returned for a result set; rows affected for a reply with no
+    /// result set (the OK packet of an INSERT, UPDATE, DELETE or DDL).
+    pub count: u64,
     pub last_insert_id: u64,
     pub affected_rows: u64,
     pub is_last_result: bool,

--- a/src/sql/mysql/StatementKeyword.rs
+++ b/src/sql/mysql/StatementKeyword.rs
@@ -1,0 +1,117 @@
+//! MySQL replies carry no command tag (PostgreSQL sends `CommandComplete`
+//! with `INSERT 0 3`, `UPDATE 2`, ...), so `result.command` is derived from
+//! the query text: the leading keyword of the statement that produced the
+//! result.
+
+/// Returns the leading keyword of the `index`-th `;`-separated statement in
+/// `sql`. Whitespace, comments and opening parentheses before the keyword are
+/// skipped, and quoted strings, quoted identifiers and comments do not split
+/// statements. When `sql` has fewer statements than `index + 1` (a `CALL`
+/// produces one result per result set plus one), the last keyword found is
+/// returned. The slice is empty when there is no keyword.
+///
+/// Generic over the code unit so it runs on both Latin-1 and UTF-16 strings
+/// without transcoding.
+pub fn keyword_of_statement<T: Copy + Into<u32>>(sql: &[T], index: usize) -> &[T] {
+    let mut keyword: &[T] = &[];
+    let mut pos = 0usize;
+    let mut statement = 0usize;
+    loop {
+        pos = skip_to_keyword(sql, pos);
+        let start = pos;
+        while pos < sql.len() && is_alpha(sql[pos]) {
+            pos += 1;
+        }
+        if pos > start {
+            keyword = &sql[start..pos];
+        }
+        if statement == index {
+            return keyword;
+        }
+        match statement_end(sql, pos) {
+            Some(end) => pos = end + 1,
+            None => return keyword,
+        }
+        statement += 1;
+    }
+}
+
+#[inline]
+fn at<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> u32 {
+    if pos < sql.len() { sql[pos].into() } else { 0 }
+}
+
+#[inline]
+fn is_alpha<T: Copy + Into<u32>>(c: T) -> bool {
+    let c: u32 = c.into();
+    (c | 0x20) >= u32::from(b'a') && (c | 0x20) <= u32::from(b'z')
+}
+
+/// Skips whitespace, comments and `(` starting at `pos`.
+fn skip_to_keyword<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> usize {
+    while pos < sql.len() {
+        let c = at(sql, pos);
+        if c == u32::from(b' ') || (c >= u32::from(b'\t') && c <= u32::from(b'\r')) || c == u32::from(b'(') {
+            pos += 1;
+        } else if let Some(end) = comment_end(sql, pos) {
+            pos = end;
+        } else {
+            break;
+        }
+    }
+    pos
+}
+
+/// When a comment starts at `pos`, returns the position just past it.
+fn comment_end<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Option<usize> {
+    let c = at(sql, pos);
+    if c == u32::from(b'#') || (c == u32::from(b'-') && at(sql, pos + 1) == u32::from(b'-')) {
+        let mut end = pos;
+        while end < sql.len() && at(sql, end) != u32::from(b'\n') {
+            end += 1;
+        }
+        return Some(end);
+    }
+    if c == u32::from(b'/') && at(sql, pos + 1) == u32::from(b'*') {
+        let mut end = pos + 2;
+        while end < sql.len() && !(at(sql, end) == u32::from(b'*') && at(sql, end + 1) == u32::from(b'/')) {
+            end += 1;
+        }
+        return Some((end + 2).min(sql.len()));
+    }
+    None
+}
+
+/// Position of the `;` that ends the statement containing `pos`, if any.
+fn statement_end<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> Option<usize> {
+    while pos < sql.len() {
+        let c = at(sql, pos);
+        if c == u32::from(b';') {
+            return Some(pos);
+        }
+        if c == u32::from(b'\'') || c == u32::from(b'"') || c == u32::from(b'`') {
+            pos += 1;
+            while pos < sql.len() {
+                let q = at(sql, pos);
+                if q == u32::from(b'\\') && c != u32::from(b'`') {
+                    pos += 2;
+                } else if q == c {
+                    // A doubled quote is an escaped quote, not the end.
+                    if at(sql, pos + 1) == c {
+                        pos += 2;
+                    } else {
+                        break;
+                    }
+                } else {
+                    pos += 1;
+                }
+            }
+            pos += 1;
+        } else if let Some(end) = comment_end(sql, pos) {
+            pos = end;
+        } else {
+            pos += 1;
+        }
+    }
+    None
+}

--- a/src/sql/mysql/StatementKeyword.rs
+++ b/src/sql/mysql/StatementKeyword.rs
@@ -12,6 +12,8 @@ pub struct KeywordCursor {
     /// Just past the keyword last returned, inside that statement.
     pos: usize,
     started: bool,
+    /// How the statement at `pos` was lexed; its body is scanned on the next call.
+    backslash_escapes: bool,
     keyword: (usize, usize),
 }
 
@@ -19,6 +21,7 @@ impl KeywordCursor {
     /// Range of the next statement's leading keyword in `sql` (Latin-1 or
     /// UTF-16 units), empty when it has none. Past the last statement (a
     /// `CALL` yields several results) the previous keyword is returned again.
+    /// `backslash_escapes` is how the server lexed that next statement.
     pub fn next<T: Copy + Into<u32>>(
         &mut self,
         sql: &[T],
@@ -26,12 +29,13 @@ impl KeywordCursor {
     ) -> Range<usize> {
         let mut pos = self.pos;
         if self.started {
-            match statement_end(sql, pos, backslash_escapes) {
+            match statement_end(sql, pos, self.backslash_escapes) {
                 Some(end) => pos = end + 1,
                 None => return self.keyword.0..self.keyword.1,
             }
         }
         self.started = true;
+        self.backslash_escapes = backslash_escapes;
         pos = skip_to_keyword(sql, pos);
         let start = pos;
         while pos < sql.len() && is_alpha(sql[pos]) {

--- a/src/sql/mysql/StatementKeyword.rs
+++ b/src/sql/mysql/StatementKeyword.rs
@@ -7,10 +7,13 @@ use core::ops::Range;
 
 /// Walks the `;`-separated statements of a query, one per result, and yields
 /// the leading keyword of each. Whitespace, comments and opening parentheses
-/// before a keyword are skipped, and quoted strings, quoted identifiers and
-/// comments do not split statements. The text of a statement is only scanned
-/// when the result after it arrives, so a single-statement query costs a look
-/// at its first word.
+/// before a keyword are skipped, `/*! ... */` counts as code, and quoted
+/// strings, quoted identifiers and comments do not split statements. The text
+/// of a statement is only scanned when the result after it arrives, so a
+/// single-statement query costs a look at its first word.
+///
+/// Not modelled: `ANSI_QUOTES` (a `"` identifier is scanned like a string)
+/// and `DELIMITER`, which the server does not understand either.
 #[derive(Clone, Copy, Default)]
 pub struct KeywordCursor {
     /// Just past the keyword last returned, inside that statement.
@@ -23,14 +26,19 @@ impl KeywordCursor {
     /// Advances to the next statement and returns the range of its leading
     /// keyword in `sql` (empty when it has none). When no statement is left (a
     /// `CALL` produces one result per result set plus one), the previous
-    /// keyword is returned again.
+    /// keyword is returned again. `backslash_escapes` is false when the
+    /// session runs with `NO_BACKSLASH_ESCAPES`.
     ///
     /// Generic over the code unit so it runs on both Latin-1 and UTF-16
     /// strings without transcoding.
-    pub fn next<T: Copy + Into<u32>>(&mut self, sql: &[T]) -> Range<usize> {
+    pub fn next<T: Copy + Into<u32>>(
+        &mut self,
+        sql: &[T],
+        backslash_escapes: bool,
+    ) -> Range<usize> {
         let mut pos = self.pos;
         if self.started {
-            match statement_end(sql, pos) {
+            match statement_end(sql, pos, backslash_escapes) {
                 Some(end) => pos = end + 1,
                 None => return self.keyword.0..self.keyword.1,
             }
@@ -60,7 +68,33 @@ fn is_alpha<T: Copy + Into<u32>>(c: T) -> bool {
     (c | 0x20) >= u32::from(b'a') && (c | 0x20) <= u32::from(b'z')
 }
 
-/// Skips whitespace, comments and `(` starting at `pos`.
+#[inline]
+fn is_digit(c: u32) -> bool {
+    c >= u32::from(b'0') && c <= u32::from(b'9')
+}
+
+/// Length of the `/*!`, `/*!50701` or MariaDB `/*M!100504` prefix at `pos`
+/// that opens an executable comment, whose content the server runs as SQL.
+fn executable_comment_prefix<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Option<usize> {
+    if at(sql, pos) != u32::from(b'/') || at(sql, pos + 1) != u32::from(b'*') {
+        return None;
+    }
+    let mut end = pos + 2;
+    if at(sql, end) == u32::from(b'M') {
+        end += 1;
+    }
+    if at(sql, end) != u32::from(b'!') {
+        return None;
+    }
+    end += 1;
+    while is_digit(at(sql, end)) {
+        end += 1;
+    }
+    Some(end - pos)
+}
+
+/// Skips whitespace, comments, executable comment openers and `(` starting
+/// at `pos`.
 fn skip_to_keyword<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> usize {
     while pos < sql.len() {
         let c = at(sql, pos);
@@ -69,6 +103,8 @@ fn skip_to_keyword<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> usize {
             || c == u32::from(b'(')
         {
             pos += 1;
+        } else if let Some(len) = executable_comment_prefix(sql, pos) {
+            pos += len;
         } else if let Some(end) = comment_end(sql, pos) {
             pos = end;
         } else {
@@ -78,17 +114,26 @@ fn skip_to_keyword<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> usize {
     pos
 }
 
-/// When a comment starts at `pos`, returns the position just past it.
+/// When a comment starts at `pos`, returns the position just past it. `-- `
+/// needs whitespace or a control character after it (`1--1` is arithmetic),
+/// and `/*!` is not a comment.
 fn comment_end<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Option<usize> {
     let c = at(sql, pos);
-    if c == u32::from(b'#') || (c == u32::from(b'-') && at(sql, pos + 1) == u32::from(b'-')) {
+    if c == u32::from(b'#')
+        || (c == u32::from(b'-')
+            && at(sql, pos + 1) == u32::from(b'-')
+            && at(sql, pos + 2) <= u32::from(b' '))
+    {
         let mut end = pos;
         while end < sql.len() && at(sql, end) != u32::from(b'\n') {
             end += 1;
         }
         return Some(end);
     }
-    if c == u32::from(b'/') && at(sql, pos + 1) == u32::from(b'*') {
+    if c == u32::from(b'/')
+        && at(sql, pos + 1) == u32::from(b'*')
+        && executable_comment_prefix(sql, pos).is_none()
+    {
         let mut end = pos + 2;
         while end < sql.len()
             && !(at(sql, end) == u32::from(b'*') && at(sql, end + 1) == u32::from(b'/'))
@@ -101,7 +146,11 @@ fn comment_end<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Option<usize> {
 }
 
 /// Position of the `;` that ends the statement containing `pos`, if any.
-fn statement_end<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> Option<usize> {
+fn statement_end<T: Copy + Into<u32>>(
+    sql: &[T],
+    mut pos: usize,
+    backslash_escapes: bool,
+) -> Option<usize> {
     while pos < sql.len() {
         let c = at(sql, pos);
         if c == u32::from(b';') {
@@ -111,7 +160,7 @@ fn statement_end<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> Option<usize
             pos += 1;
             while pos < sql.len() {
                 let q = at(sql, pos);
-                if q == u32::from(b'\\') && c != u32::from(b'`') {
+                if q == u32::from(b'\\') && backslash_escapes && c != u32::from(b'`') {
                     pos += 2;
                 } else if q == c {
                     // A doubled quote is an escaped quote, not the end.

--- a/src/sql/mysql/StatementKeyword.rs
+++ b/src/sql/mysql/StatementKeyword.rs
@@ -3,36 +3,49 @@
 //! the query text: the leading keyword of the statement that produced the
 //! result.
 
-/// Returns the leading keyword of the `index`-th `;`-separated statement in
-/// `sql`. Whitespace, comments and opening parentheses before the keyword are
-/// skipped, and quoted strings, quoted identifiers and comments do not split
-/// statements. When `sql` has fewer statements than `index + 1` (a `CALL`
-/// produces one result per result set plus one), the last keyword found is
-/// returned. The slice is empty when there is no keyword.
-///
-/// Generic over the code unit so it runs on both Latin-1 and UTF-16 strings
-/// without transcoding.
-pub fn keyword_of_statement<T: Copy + Into<u32>>(sql: &[T], index: usize) -> &[T] {
-    let mut keyword: &[T] = &[];
-    let mut pos = 0usize;
-    let mut statement = 0usize;
-    loop {
+use core::ops::Range;
+
+/// Walks the `;`-separated statements of a query, one per result, and yields
+/// the leading keyword of each. Whitespace, comments and opening parentheses
+/// before a keyword are skipped, and quoted strings, quoted identifiers and
+/// comments do not split statements. The text of a statement is only scanned
+/// when the result after it arrives, so a single-statement query costs a look
+/// at its first word.
+#[derive(Clone, Copy, Default)]
+pub struct KeywordCursor {
+    /// Just past the keyword last returned, inside that statement.
+    pos: usize,
+    started: bool,
+    keyword: (usize, usize),
+}
+
+impl KeywordCursor {
+    /// Advances to the next statement and returns the range of its leading
+    /// keyword in `sql` (empty when it has none). When no statement is left (a
+    /// `CALL` produces one result per result set plus one), the previous
+    /// keyword is returned again.
+    ///
+    /// Generic over the code unit so it runs on both Latin-1 and UTF-16
+    /// strings without transcoding.
+    pub fn next<T: Copy + Into<u32>>(&mut self, sql: &[T]) -> Range<usize> {
+        let mut pos = self.pos;
+        if self.started {
+            match statement_end(sql, pos) {
+                Some(end) => pos = end + 1,
+                None => return self.keyword.0..self.keyword.1,
+            }
+        }
+        self.started = true;
         pos = skip_to_keyword(sql, pos);
         let start = pos;
         while pos < sql.len() && is_alpha(sql[pos]) {
             pos += 1;
         }
-        if pos > start {
-            keyword = &sql[start..pos];
+        self.pos = pos;
+        if pos > start || self.keyword.1 == 0 {
+            self.keyword = (start, pos);
         }
-        if statement == index {
-            return keyword;
-        }
-        match statement_end(sql, pos) {
-            Some(end) => pos = end + 1,
-            None => return keyword,
-        }
-        statement += 1;
+        self.keyword.0..self.keyword.1
     }
 }
 

--- a/src/sql/mysql/StatementKeyword.rs
+++ b/src/sql/mysql/StatementKeyword.rs
@@ -51,7 +51,10 @@ fn is_alpha<T: Copy + Into<u32>>(c: T) -> bool {
 fn skip_to_keyword<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> usize {
     while pos < sql.len() {
         let c = at(sql, pos);
-        if c == u32::from(b' ') || (c >= u32::from(b'\t') && c <= u32::from(b'\r')) || c == u32::from(b'(') {
+        if c == u32::from(b' ')
+            || (c >= u32::from(b'\t') && c <= u32::from(b'\r'))
+            || c == u32::from(b'(')
+        {
             pos += 1;
         } else if let Some(end) = comment_end(sql, pos) {
             pos = end;
@@ -74,7 +77,9 @@ fn comment_end<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Option<usize> {
     }
     if c == u32::from(b'/') && at(sql, pos + 1) == u32::from(b'*') {
         let mut end = pos + 2;
-        while end < sql.len() && !(at(sql, end) == u32::from(b'*') && at(sql, end + 1) == u32::from(b'/')) {
+        while end < sql.len()
+            && !(at(sql, end) == u32::from(b'*') && at(sql, end + 1) == u32::from(b'/'))
+        {
             end += 1;
         }
         return Some((end + 2).min(sql.len()));

--- a/src/sql/mysql/StatementKeyword.rs
+++ b/src/sql/mysql/StatementKeyword.rs
@@ -1,19 +1,12 @@
-//! MySQL replies carry no command tag (PostgreSQL sends `CommandComplete`
-//! with `INSERT 0 3`, `UPDATE 2`, ...), so `result.command` is derived from
-//! the query text: the leading keyword of the statement that produced the
-//! result.
+//! MySQL replies carry no command tag, so `result.command` is the leading
+//! keyword of the statement in the query text.
 
 use core::ops::Range;
 
-/// Walks the `;`-separated statements of a query, one per result, and yields
-/// the leading keyword of each. Whitespace, comments and opening parentheses
-/// before a keyword are skipped, `/*! ... */` counts as code, and quoted
-/// strings, quoted identifiers and comments do not split statements. The text
-/// of a statement is only scanned when the result after it arrives, so a
-/// single-statement query costs a look at its first word.
-///
-/// Not modelled: `ANSI_QUOTES` (a `"` identifier is scanned like a string)
-/// and `DELIMITER`, which the server does not understand either.
+/// Yields the leading keyword of each `;`-separated statement, one per
+/// result, skipping comments (but not `/*! ... */`) and ignoring `;` inside
+/// quotes and comments. A statement's text is scanned only when the next
+/// result arrives. `ANSI_QUOTES` is not modelled.
 #[derive(Clone, Copy, Default)]
 pub struct KeywordCursor {
     /// Just past the keyword last returned, inside that statement.
@@ -23,14 +16,9 @@ pub struct KeywordCursor {
 }
 
 impl KeywordCursor {
-    /// Advances to the next statement and returns the range of its leading
-    /// keyword in `sql` (empty when it has none). When no statement is left (a
-    /// `CALL` produces one result per result set plus one), the previous
-    /// keyword is returned again. `backslash_escapes` is false when the
-    /// session runs with `NO_BACKSLASH_ESCAPES`.
-    ///
-    /// Generic over the code unit so it runs on both Latin-1 and UTF-16
-    /// strings without transcoding.
+    /// Range of the next statement's leading keyword in `sql` (Latin-1 or
+    /// UTF-16 units), empty when it has none. Past the last statement (a
+    /// `CALL` yields several results) the previous keyword is returned again.
     pub fn next<T: Copy + Into<u32>>(
         &mut self,
         sql: &[T],
@@ -73,8 +61,8 @@ fn is_digit(c: u32) -> bool {
     c >= u32::from(b'0') && c <= u32::from(b'9')
 }
 
-/// Length of the `/*!`, `/*!50701` or MariaDB `/*M!100504` prefix at `pos`
-/// that opens an executable comment, whose content the server runs as SQL.
+/// Length of a `/*!`, `/*!50701` or `/*M!100504` opener at `pos`: the server
+/// runs what follows as SQL.
 fn executable_comment_prefix<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Option<usize> {
     if at(sql, pos) != u32::from(b'/') || at(sql, pos + 1) != u32::from(b'*') {
         return None;
@@ -93,8 +81,7 @@ fn executable_comment_prefix<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Opti
     Some(end - pos)
 }
 
-/// Skips whitespace, comments, executable comment openers and `(` starting
-/// at `pos`.
+/// Skips whitespace, comments, executable-comment openers and `(`.
 fn skip_to_keyword<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> usize {
     while pos < sql.len() {
         let c = at(sql, pos);
@@ -114,9 +101,7 @@ fn skip_to_keyword<T: Copy + Into<u32>>(sql: &[T], mut pos: usize) -> usize {
     pos
 }
 
-/// When a comment starts at `pos`, returns the position just past it. `-- `
-/// needs whitespace or a control character after it (`1--1` is arithmetic),
-/// and `/*!` is not a comment.
+/// End of the comment starting at `pos`, if one does (`1--1` is arithmetic).
 fn comment_end<T: Copy + Into<u32>>(sql: &[T], pos: usize) -> Option<usize> {
     let c = at(sql, pos);
     if c == u32::from(b'#')

--- a/src/sql/mysql/StatusFlags.rs
+++ b/src/sql/mysql/StatusFlags.rs
@@ -6,6 +6,8 @@ use core::fmt;
 pub enum StatusFlag {
     /// Indicates there are more result sets from this query
     SERVER_MORE_RESULTS_EXISTS = 8,
+    /// The session's sql_mode has NO_BACKSLASH_ESCAPES: `\` is literal in strings
+    SERVER_STATUS_NO_BACKSLASH_ESCAPES = 0x200,
 }
 
 #[derive(Copy, Clone, Default)]

--- a/src/sql_jsc/mysql.rs
+++ b/src/sql_jsc/mysql.rs
@@ -7,8 +7,7 @@ pub fn create_binding(global_object: &JSGlobalObject) -> JsResult<JSValue> {
         b"MySQLConnection",
         crate::jsc::codegen::JSMySQLConnection::get_constructor(global_object),
     );
-    // The strings behind the `result.command` indexes that
-    // `MySQLQuery::command_to_js` hands to JS.
+    // `result.command` strings, see `MySQLQuery::command_to_js`.
     binding.put(
         global_object,
         b"commands",

--- a/src/sql_jsc/mysql.rs
+++ b/src/sql_jsc/mysql.rs
@@ -1,13 +1,24 @@
-use crate::jsc::{JSGlobalObject, JSValue};
+use crate::jsc::{JSGlobalObject, JSValue, JsResult, bun_string_jsc};
 
-pub fn create_binding(global_object: &JSGlobalObject) -> JSValue {
+pub fn create_binding(global_object: &JSGlobalObject) -> JsResult<JSValue> {
     let binding = JSValue::create_empty_object_with_null_prototype(global_object);
     binding.put(
         global_object,
         b"MySQLConnection",
         crate::jsc::codegen::JSMySQLConnection::get_constructor(global_object),
     );
-    crate::put_host_functions!(
+    // The strings behind the `result.command` indexes that
+    // `MySQLQuery::command_to_js` hands to JS.
+    binding.put(
+        global_object,
+        b"commands",
+        JSValue::create_array_from_iter(
+            global_object,
+            my_sql_query::COMMON_KEYWORDS.iter(),
+            |keyword| bun_string_jsc::create_utf8_for_js(global_object, keyword),
+        )?,
+    );
+    Ok(crate::put_host_functions!(
         binding,
         global_object,
         [
@@ -23,7 +34,7 @@ pub fn create_binding(global_object: &JSGlobalObject) -> JSValue {
                 2
             ),
         ]
-    )
+    ))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -222,7 +222,9 @@ impl JSMySQLQuery {
         let global = self.global_object();
         // Computed before `result()` marks the query as answered, so that a
         // failure here can still reject it.
-        let keyword = self.query.with_mut(|q| q.advance_command());
+        let keyword = self
+            .query
+            .with_mut(|q| q.advance_command(result.backslash_escapes));
         let js_command = match self.query.get().command_to_js(global, keyword) {
             Ok(command) => command,
             Err(err) => {

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -11,12 +11,10 @@ use bun_jsc::JsCell;
 use bun_ptr::{AsCtxPtr, BackRef, ParentRef, RefPtr};
 use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::protocol::any_mysql_error::{self as AnyMySQLError};
-use bun_sql::postgres::command_tag::CommandTag;
 use bun_sql::shared::sql_query_result_mode::SQLQueryResultMode;
 
 use super::js_mysql_connection::MySQLConnection;
 use crate::mysql::protocol::any_mysql_error_jsc::mysql_error_to_js;
-use crate::postgres::command_tag_jsc::CommandTagJsc as _;
 // `my_sql_query` exports both the `MySQLQuery` *struct* and a
 // `declare_scope!`-generated `MySQLQuery` *static* (ScopedLogger). Importing
 // the name once pulls in both namespaces, so the `debug!` macro below resolves
@@ -221,6 +219,16 @@ impl JSMySQLQuery {
         // allocation outlives the closure body.
         let _guard = self.ref_guard();
         let is_last_result = result.is_last_result;
+        let global = self.global_object();
+        // Computed before `result()` marks the query as answered, so that a
+        // failure here can still reject it.
+        let js_command = match self.query.get().command(global) {
+            Ok(command) => command,
+            Err(err) => {
+                return self.reject_with_js_value(queries_array, global.take_exception(err));
+            }
+        };
+        js_command.ensure_still_alive();
         // R-2: `&Self` is `Copy`; the guard captures it by value and runs on
         // every exit path (defer). All mutation is `JsCell`-backed.
         let _downgrade = scopeguard::guard(self, move |s| {
@@ -240,12 +248,6 @@ impl JSMySQLQuery {
             return;
         };
         this_value.ensure_still_alive();
-        let tag = CommandTag::Select(result.result_count);
-        let Ok(js_tag) = tag.to_js_tag(self.global_object()) else {
-            debug_assert!(false, "in MySQLQuery Tag should always be a number");
-            return;
-        };
-        js_tag.ensure_still_alive();
 
         let Some(function) = self
             .vm_mut()
@@ -271,8 +273,8 @@ impl JSMySQLQuery {
             &[
                 target_value,
                 pending_value,
-                js_tag,
-                tag.to_js_number(),
+                js_command,
+                JSValue::js_number(result.count as f64),
                 if queries_array.is_empty() {
                     JSValue::UNDEFINED
                 } else {

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -220,8 +220,7 @@ impl JSMySQLQuery {
         let _guard = self.ref_guard();
         let is_last_result = result.is_last_result;
         let global = self.global_object();
-        // Computed before `result()` marks the query as answered, so that a
-        // failure here can still reject it.
+        // Before `result()`, so a throw here can still reject the query.
         let keyword = self
             .query
             .with_mut(|q| q.advance_command(result.backslash_escapes));

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -222,7 +222,8 @@ impl JSMySQLQuery {
         let global = self.global_object();
         // Computed before `result()` marks the query as answered, so that a
         // failure here can still reject it.
-        let js_command = match self.query.get().command(global) {
+        let keyword = self.query.with_mut(|q| q.advance_command());
+        let js_command = match self.query.get().command_to_js(global, keyword) {
             Ok(command) => command,
             Err(err) => {
                 return self.reject_with_js_value(queries_array, global.take_exception(err));

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1432,8 +1432,19 @@ impl MySQLConnection {
         }
 
         // Short-lived borrow via the audited accessor; dropped before the
-        // re-entrant `on_query_result` call below.
-        let result_count = request.get_statement().map_or(0, |s| s.result_count);
+        // re-entrant `on_query_result` call below. HEADER_RECEIVED means a
+        // result set preceded this OK/EOF, so `count` is its row count;
+        // otherwise the OK packet answers a statement with no result set and
+        // `count` is the rows it affected, matching PostgreSQL's command tag.
+        let count = request.get_statement().map_or(affected_rows, |s| {
+            if s.execution_flags
+                .contains(mysql_statement::ExecutionFlags::HEADER_RECEIVED)
+            {
+                s.result_count
+            } else {
+                affected_rows
+            }
+        });
         // R-2: `on_query_result` is `&self`; `js_connection_ref()` is the
         // audited container_of accessor. The `&JSMySQLConnection` lives only for
         // this call (same footprint as the prior `(*ptr).on_query_result()`
@@ -1443,7 +1454,7 @@ impl MySQLConnection {
         self.js_connection_ref().on_query_result(
             request,
             &MySQLQueryResult {
-                result_count,
+                count,
                 last_insert_id,
                 affected_rows,
                 is_last_result,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1433,10 +1433,8 @@ impl MySQLConnection {
         }
 
         // Short-lived borrow via the audited accessor; dropped before the
-        // re-entrant `on_query_result` call below. HEADER_RECEIVED means a
-        // result set preceded this OK/EOF, so `count` is its row count;
-        // otherwise the OK packet answers a statement with no result set and
-        // `count` is the rows it affected, matching PostgreSQL's command tag.
+        // re-entrant `on_query_result` call below. Without a result set
+        // (no HEADER_RECEIVED) the OK packet's affected rows are the count.
         let count = request.get_statement().map_or(affected_rows, |s| {
             if s.execution_flags
                 .contains(mysql_statement::ExecutionFlags::HEADER_RECEIVED)

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1418,6 +1418,7 @@ impl MySQLConnection {
     ) {
         self.status_flags = status_flags;
         let is_last_result = !status_flags.has(StatusFlag::SERVER_MORE_RESULTS_EXISTS);
+        let backslash_escapes = !status_flags.has(StatusFlag::SERVER_STATUS_NO_BACKSLASH_ESCAPES);
         debug!(
             "handleResultSetOK: {} {}",
             status_flags.to_int(),
@@ -1458,6 +1459,7 @@ impl MySQLConnection {
                 last_insert_id,
                 affected_rows,
                 is_last_result,
+                backslash_escapes,
             },
         );
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1416,9 +1416,13 @@ impl MySQLConnection {
         last_insert_id: u64,
         affected_rows: u64,
     ) {
+        // The mode this result's statement was lexed with is the one in
+        // effect before it ran, so read it before taking the new flags.
+        let backslash_escapes = !self
+            .status_flags
+            .has(StatusFlag::SERVER_STATUS_NO_BACKSLASH_ESCAPES);
         self.status_flags = status_flags;
         let is_last_result = !status_flags.has(StatusFlag::SERVER_MORE_RESULTS_EXISTS);
-        let backslash_escapes = !status_flags.has(StatusFlag::SERVER_STATUS_NO_BACKSLASH_ESCAPES);
         debug!(
             "handleResultSetOK: {} {}",
             status_flags.to_int(),

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -64,10 +64,7 @@ const KNOWN_KEYWORDS: [&[u8]; 16] = [
 /// Upper-cases an ASCII keyword and converts it to the value JS receives as
 /// the command: a number for `KNOWN_KEYWORDS`, a string otherwise, `null`
 /// when there is no keyword.
-fn keyword_to_js<T: Copy + Into<u32>>(
-    global: &JSGlobalObject,
-    keyword: &[T],
-) -> JsResult<JSValue> {
+fn keyword_to_js<T: Copy + Into<u32>>(global: &JSGlobalObject, keyword: &[T]) -> JsResult<JSValue> {
     if keyword.is_empty() {
         return Ok(JSValue::NULL);
     }

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -32,17 +32,14 @@ pub struct MySQLQuery {
     /// one ref).
     statement: Option<RefPtr<MySQLStatement>>,
     query: BunString,
-    /// Position in `query` of the statement whose result arrives next; its
-    /// leading keyword becomes `result.command`.
+    /// Where in `query` the next result's statement starts.
     command: KeywordCursor,
 
     status: Status,
     flags: Flags,
 }
 
-/// Statements common enough that `result.command` reaches JS as an index into
-/// this table (exposed to JS as `commands` on the binding) instead of a string
-/// allocated per query.
+/// `result.command` values passed to JS by index (the binding's `commands`).
 pub(crate) const COMMON_KEYWORDS: [&[u8]; 16] = [
     b"SELECT",
     b"INSERT",
@@ -62,9 +59,7 @@ pub(crate) const COMMON_KEYWORDS: [&[u8]; 16] = [
     b"USE",
 ];
 
-/// Upper-cases an ASCII keyword into what JS receives as the command: an
-/// index into `COMMON_KEYWORDS`, a string otherwise, `null` when there is no
-/// keyword.
+/// An index into `COMMON_KEYWORDS`, else the upper-cased keyword, else null.
 fn keyword_to_js<T: Copy + Into<u32>>(global: &JSGlobalObject, keyword: &[T]) -> JsResult<JSValue> {
     if keyword.is_empty() {
         return Ok(JSValue::NULL);
@@ -456,8 +451,7 @@ impl MySQLQuery {
         }
     }
 
-    /// Advances to the statement whose result arrives next and returns the
-    /// range of its leading keyword in the query text.
+    /// Range in `query` of the leading keyword of the next result's statement.
     pub(crate) fn advance_command(&mut self, backslash_escapes: bool) -> Range<usize> {
         if self.query.is_utf16() {
             self.command.next(self.query.utf16(), backslash_escapes)
@@ -466,8 +460,7 @@ impl MySQLQuery {
         }
     }
 
-    /// `result.command` for a keyword range from `advance_command` (see
-    /// `keyword_to_js`).
+    /// `result.command` for a range from `advance_command`.
     pub(crate) fn command_to_js(
         &self,
         global: &JSGlobalObject,

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -1,5 +1,5 @@
 use crate::error::ThrowSqlError;
-use crate::jsc::{JSGlobalObject, JSValue, MarkedArgumentBuffer};
+use crate::jsc::{JSGlobalObject, JSValue, JsResult, MarkedArgumentBuffer, bun_string_jsc};
 use bun_core::String as BunString;
 
 use super::my_sql_value::Value;
@@ -10,6 +10,7 @@ use bun_sql::mysql::protocol::column_definition41::ColumnFlags;
 use bun_sql::mysql::protocol::new_writer::{NewWriter, WriterContext};
 use bun_sql::mysql::protocol::prepared_statement;
 use bun_sql::mysql::query_status::Status;
+use bun_sql::mysql::statement_keyword::keyword_of_statement;
 use bun_sql::shared::sql_query_result_mode::SQLQueryResultMode;
 
 use crate::jsc::js_error_to_mysql;
@@ -29,9 +30,63 @@ pub struct MySQLQuery {
     /// one ref).
     statement: Option<RefPtr<MySQLStatement>>,
     query: BunString,
+    /// Results delivered so far. A multi-statement query gets one result per
+    /// statement, so this is also the index of the statement that the next
+    /// result belongs to.
+    results_received: u32,
 
     status: Status,
     flags: Flags,
+}
+
+/// `result.command` is passed to JS as an index into this table (offset by
+/// one) for the common statements, so they do not allocate a string per
+/// query. Keep in sync with `commands` in src/js/internal/sql/mysql.ts.
+const KNOWN_KEYWORDS: [&[u8]; 16] = [
+    b"SELECT",
+    b"INSERT",
+    b"UPDATE",
+    b"DELETE",
+    b"REPLACE",
+    b"CALL",
+    b"WITH",
+    b"SHOW",
+    b"SET",
+    b"START",
+    b"BEGIN",
+    b"COMMIT",
+    b"ROLLBACK",
+    b"SAVEPOINT",
+    b"RELEASE",
+    b"USE",
+];
+
+/// Upper-cases an ASCII keyword and converts it to the value JS receives as
+/// the command: a number for `KNOWN_KEYWORDS`, a string otherwise, `null`
+/// when there is no keyword.
+fn keyword_to_js<T: Copy + Into<u32>>(
+    global: &JSGlobalObject,
+    keyword: &[T],
+) -> JsResult<JSValue> {
+    if keyword.is_empty() {
+        return Ok(JSValue::NULL);
+    }
+    let mut stack = [0u8; 16];
+    let mut heap = Vec::new();
+    let upper: &mut [u8] = if keyword.len() <= stack.len() {
+        &mut stack[..keyword.len()]
+    } else {
+        heap.resize(keyword.len(), 0);
+        &mut heap
+    };
+    for (dst, &c) in upper.iter_mut().zip(keyword) {
+        // `keyword_of_statement` only yields ASCII letters.
+        *dst = (c.into() as u8).to_ascii_uppercase();
+    }
+    if let Some(i) = KNOWN_KEYWORDS.iter().position(|k| *k == &*upper) {
+        return Ok(JSValue::js_number((i + 1) as f64));
+    }
+    bun_string_jsc::create_utf8_for_js(global, upper)
 }
 
 /// Not all fields are `bool`, so per PORTING.md this is a transparent `u8` with shift accessors.
@@ -397,8 +452,20 @@ impl MySQLQuery {
         Self {
             statement: None,
             query,
+            results_received: 0,
             status: Status::Pending,
             flags: Flags::new(bigint, simple),
+        }
+    }
+
+    /// `result.command` for the result about to be delivered: the leading
+    /// keyword of its statement in the query text (see `keyword_to_js`).
+    pub(crate) fn command(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        let index = self.results_received as usize;
+        if self.query.is_utf16() {
+            keyword_to_js(global, keyword_of_statement(self.query.utf16(), index))
+        } else {
+            keyword_to_js(global, keyword_of_statement(self.query.latin1(), index))
         }
     }
 
@@ -445,6 +512,7 @@ impl MySQLQuery {
         } else {
             Status::PartialResponse
         };
+        self.results_received += 1;
 
         true
     }

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -1,3 +1,5 @@
+use core::ops::Range;
+
 use crate::error::ThrowSqlError;
 use crate::jsc::{JSGlobalObject, JSValue, JsResult, MarkedArgumentBuffer, bun_string_jsc};
 use bun_core::String as BunString;
@@ -10,7 +12,7 @@ use bun_sql::mysql::protocol::column_definition41::ColumnFlags;
 use bun_sql::mysql::protocol::new_writer::{NewWriter, WriterContext};
 use bun_sql::mysql::protocol::prepared_statement;
 use bun_sql::mysql::query_status::Status;
-use bun_sql::mysql::statement_keyword::keyword_of_statement;
+use bun_sql::mysql::statement_keyword::KeywordCursor;
 use bun_sql::shared::sql_query_result_mode::SQLQueryResultMode;
 
 use crate::jsc::js_error_to_mysql;
@@ -30,10 +32,9 @@ pub struct MySQLQuery {
     /// one ref).
     statement: Option<RefPtr<MySQLStatement>>,
     query: BunString,
-    /// Results delivered so far. A multi-statement query gets one result per
-    /// statement, so this is also the index of the statement that the next
-    /// result belongs to.
-    results_received: u32,
+    /// Position in `query` of the statement whose result arrives next; its
+    /// leading keyword becomes `result.command`.
+    command: KeywordCursor,
 
     status: Status,
     flags: Flags,
@@ -77,7 +78,7 @@ fn keyword_to_js<T: Copy + Into<u32>>(global: &JSGlobalObject, keyword: &[T]) ->
         &mut heap
     };
     for (dst, &c) in upper.iter_mut().zip(keyword) {
-        // `keyword_of_statement` only yields ASCII letters.
+        // `KeywordCursor` only yields ASCII letters.
         *dst = (c.into() as u8).to_ascii_uppercase();
     }
     if let Some(i) = KNOWN_KEYWORDS.iter().position(|k| *k == &*upper) {
@@ -449,20 +450,33 @@ impl MySQLQuery {
         Self {
             statement: None,
             query,
-            results_received: 0,
+            command: KeywordCursor::default(),
             status: Status::Pending,
             flags: Flags::new(bigint, simple),
         }
     }
 
-    /// `result.command` for the result about to be delivered: the leading
-    /// keyword of its statement in the query text (see `keyword_to_js`).
-    pub(crate) fn command(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        let index = self.results_received as usize;
+    /// Advances to the statement whose result arrives next and returns the
+    /// range of its leading keyword in the query text.
+    pub(crate) fn advance_command(&mut self) -> Range<usize> {
         if self.query.is_utf16() {
-            keyword_to_js(global, keyword_of_statement(self.query.utf16(), index))
+            self.command.next(self.query.utf16())
         } else {
-            keyword_to_js(global, keyword_of_statement(self.query.latin1(), index))
+            self.command.next(self.query.latin1())
+        }
+    }
+
+    /// `result.command` for a keyword range from `advance_command` (see
+    /// `keyword_to_js`).
+    pub(crate) fn command_to_js(
+        &self,
+        global: &JSGlobalObject,
+        keyword: Range<usize>,
+    ) -> JsResult<JSValue> {
+        if self.query.is_utf16() {
+            keyword_to_js(global, &self.query.utf16()[keyword])
+        } else {
+            keyword_to_js(global, &self.query.latin1()[keyword])
         }
     }
 
@@ -509,8 +523,6 @@ impl MySQLQuery {
         } else {
             Status::PartialResponse
         };
-        self.results_received += 1;
-
         true
     }
 

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -40,10 +40,10 @@ pub struct MySQLQuery {
     flags: Flags,
 }
 
-/// `result.command` is passed to JS as an index into this table (offset by
-/// one) for the common statements, so they do not allocate a string per
-/// query. Keep in sync with `commands` in src/js/internal/sql/mysql.ts.
-const KNOWN_KEYWORDS: [&[u8]; 16] = [
+/// Statements common enough that `result.command` reaches JS as an index into
+/// this table (exposed to JS as `commands` on the binding) instead of a string
+/// allocated per query.
+pub(crate) const COMMON_KEYWORDS: [&[u8]; 16] = [
     b"SELECT",
     b"INSERT",
     b"UPDATE",
@@ -62,9 +62,9 @@ const KNOWN_KEYWORDS: [&[u8]; 16] = [
     b"USE",
 ];
 
-/// Upper-cases an ASCII keyword and converts it to the value JS receives as
-/// the command: a number for `KNOWN_KEYWORDS`, a string otherwise, `null`
-/// when there is no keyword.
+/// Upper-cases an ASCII keyword into what JS receives as the command: an
+/// index into `COMMON_KEYWORDS`, a string otherwise, `null` when there is no
+/// keyword.
 fn keyword_to_js<T: Copy + Into<u32>>(global: &JSGlobalObject, keyword: &[T]) -> JsResult<JSValue> {
     if keyword.is_empty() {
         return Ok(JSValue::NULL);
@@ -81,8 +81,8 @@ fn keyword_to_js<T: Copy + Into<u32>>(global: &JSGlobalObject, keyword: &[T]) ->
         // `KeywordCursor` only yields ASCII letters.
         *dst = (c.into() as u8).to_ascii_uppercase();
     }
-    if let Some(i) = KNOWN_KEYWORDS.iter().position(|k| *k == &*upper) {
-        return Ok(JSValue::js_number((i + 1) as f64));
+    if let Some(i) = COMMON_KEYWORDS.iter().position(|k| *k == &*upper) {
+        return Ok(JSValue::js_number(i as f64));
     }
     bun_string_jsc::create_utf8_for_js(global, upper)
 }
@@ -458,11 +458,11 @@ impl MySQLQuery {
 
     /// Advances to the statement whose result arrives next and returns the
     /// range of its leading keyword in the query text.
-    pub(crate) fn advance_command(&mut self) -> Range<usize> {
+    pub(crate) fn advance_command(&mut self, backslash_escapes: bool) -> Range<usize> {
         if self.query.is_utf16() {
-            self.command.next(self.query.utf16())
+            self.command.next(self.query.utf16(), backslash_escapes)
         } else {
-            self.command.next(self.query.latin1())
+            self.command.next(self.query.latin1(), backslash_escapes)
         }
     }
 

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -212,16 +212,19 @@ if (isDockerEnabled()) {
           expect(rows).toEqual([{ a: 1 }, { a: 2 }]);
           expect(meta(rows)).toEqual({ count: 2, command: "SELECT", affectedRows: 0 });
           // Text protocol, one result per statement. Quotes and comments that
-          // contain `;` do not split statements.
+          // contain `;` do not split statements, `--` without a space after
+          // it is not a comment, and `/*! */` is code, not a comment.
           const results = await sql`
             insert into ${sql(t)} values (4, 'a;b'); -- not a DELETE;
             select b from ${sql(t)} where a = 4; # also ; ignored
-            (select 7 as n);
+            (select 7--1 as n);
+            /*!40101 update ${sql(t)} set b = 'w' */;
             delete from ${sql(t)}`.simple();
           expect(results.map(meta)).toEqual([
             { count: 1, command: "INSERT", affectedRows: 1 },
             { count: 1, command: "SELECT", affectedRows: 0 },
             { count: 1, command: "SELECT", affectedRows: 0 },
+            { count: 3, command: "UPDATE", affectedRows: 3 },
             { count: 3, command: "DELETE", affectedRows: 3 },
           ]);
           expect(meta(await sql.unsafe("replace into " + t + " values (1, 'r')"))).toEqual({

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -177,6 +177,64 @@ if (isDockerEnabled()) {
             await sql`UPDATE ${sql(random_name)} SET name = "test2" WHERE id = ${lastInsertRowid}`;
           expect(affectedRows).toBe(1);
         });
+        test("result count and command are set for statements without a result set", async () => {
+          // MySQL answers INSERT/UPDATE/DELETE/DDL with an OK packet and no
+          // command tag. `count` is the OK packet's affected rows and
+          // `command` is the statement's leading keyword, so both match what
+          // the PostgreSQL and SQLite adapters report for the same statement.
+          await using db = new SQL({ ...getOptions(), max: 1 });
+          using sql = await db.reserve();
+          const t = "cc_" + randomUUIDv7("hex").replaceAll("-", "");
+          const meta = (r: any) => ({ count: r.count, command: r.command, affectedRows: r.affectedRows });
+
+          expect(meta(await sql`CREATE TEMPORARY TABLE ${sql(t)} (a INT, b VARCHAR(9))`)).toEqual({
+            count: 0,
+            command: "CREATE",
+            affectedRows: 0,
+          });
+          // Prepared-statement path (binary protocol).
+          expect(meta(await sql`INSERT INTO ${sql(t)} (a, b) VALUES (1, ${"x"}), (2, ${"y"}), (3, ${"z"})`)).toEqual({
+            count: 3,
+            command: "INSERT",
+            affectedRows: 3,
+          });
+          expect(meta(await sql`update ${sql(t)} set b = ${"q"} where a < ${3}`)).toEqual({
+            count: 2,
+            command: "UPDATE",
+            affectedRows: 2,
+          });
+          expect(meta(await sql`  /* hint */ DELETE FROM ${sql(t)} WHERE a = ${3}`)).toEqual({
+            count: 1,
+            command: "DELETE",
+            affectedRows: 1,
+          });
+          const rows = await sql`SELECT a FROM ${sql(t)} ORDER BY a`;
+          expect(rows).toEqual([{ a: 1 }, { a: 2 }]);
+          expect(meta(rows)).toEqual({ count: 2, command: "SELECT", affectedRows: 0 });
+          // Text protocol, one result per statement. Quotes and comments that
+          // contain `;` do not split statements.
+          const results = await sql`
+            insert into ${sql(t)} values (4, 'a;b'); -- not a DELETE;
+            select b from ${sql(t)} where a = 4; # also ; ignored
+            (select 7 as n);
+            delete from ${sql(t)}`.simple();
+          expect(results.map(meta)).toEqual([
+            { count: 1, command: "INSERT", affectedRows: 1 },
+            { count: 1, command: "SELECT", affectedRows: 0 },
+            { count: 1, command: "SELECT", affectedRows: 0 },
+            { count: 3, command: "DELETE", affectedRows: 3 },
+          ]);
+          expect(meta(await sql.unsafe("replace into " + t + " values (1, 'r')"))).toEqual({
+            count: 1,
+            command: "REPLACE",
+            affectedRows: 1,
+          });
+          expect(meta(await sql.unsafe("truncate table " + t))).toEqual({
+            count: 0,
+            command: "TRUNCATE",
+            affectedRows: 0,
+          });
+        });
         test("MEDIUMINT not in the last column reads following columns correctly", async () => {
           // MySQL's binary protocol sends MYSQL_TYPE_INT24 as a fixed 4-byte
           // field. Reading only 3 left the cursor 1 byte behind, silently


### PR DESCRIPTION
### Problem
- On the MySQL adapter, the result of an `INSERT`, `UPDATE`, `DELETE` or DDL statement had `count = 0` and `command = null`. The PostgreSQL and SQLite adapters fill both (`count` = rows affected, `command` = `"INSERT"`/`"UPDATE"`/...), so `if (result.count === 0)` meant something else on MySQL. Only the MySQL-specific `affectedRows` carried the number.
- The cause: `JSMySQLQuery::resolve` (`src/sql_jsc/mysql/JSMySQLQuery.rs`) always built `CommandTag::Select(result_count)`, where `result_count` is the number of rows read (0 for a reply with no result set), and `onResolveMySQLQuery` (`src/js/internal/sql/mysql.ts`) ignored the tag and never set `result.command`.

### Fix
- `handle_result_set_ok` passes `count = affected_rows` when the OK packet answers a statement with no result set (no column-count header was received, `HEADER_RECEIVED` unset), and the row count when it terminates a result set. `affectedRows` and `lastInsertRowid` are unchanged.
- `command` is the leading keyword of the statement, upper-cased. The MySQL protocol sends no command tag, so it comes from the query text, as on the SQLite adapter: a small scanner (`src/sql/mysql/StatementKeyword.rs`, generic over Latin-1/UTF-16 so the query string is not transcoded) skips whitespace, comments and `(` (MySQL rules: `-- ` needs a following space, `/*! ... */` is code), and for a multi-statement query steps to the next `;`-separated statement per result, without splitting on `;` inside quotes or comments (`NO_BACKSLASH_ESCAPES` is read from the OK packet's status flags). Sixteen common keywords reach JS as an index into a table the binding exposes, the rest as a string.
- Refs #40432 (the same `UPDATE` gives `count: 2` on SQLite/PostgreSQL and `count: 0` on MySQL). Out of scope: whether `UPDATE` counts matched or changed rows (`CLIENT_FOUND_ROWS`, #30848). #40434 adds `affectedRows` to the other adapters plus docs and types for the metadata fields; its wording for the MySQL `count`/`command` cells needs to follow whichever of the two lands first.
- The `count` change (about 20 lines in `MySQLConnection.rs`, `JSMySQLQuery.rs`, `mysql.ts`) and the `command` scanner are separable. If only the first is wanted now, say so and I will split the scanner into a follow-up.
- Verified: `test/js/sql/sql-mysql.test.ts` "result count and command are set for statements without a result set" (prepared and text protocol, multi-statement with `;` in quotes and comments, `REPLACE`, `TRUNCATE`, `CREATE`); fails on bun 1.4.3-canary. Also ran the rest of `sql-mysql.test.ts`, `sql-mysql.transactions.test.ts` and `sql-mysql.helpers.test.ts` against MariaDB 11.8.

### Background
- A MySQL server answers a statement either with a result set (column definitions, rows, then an EOF/OK terminator) or with a bare OK packet that carries `affected_rows` and `last_insert_id`. PostgreSQL instead ends every statement with `CommandComplete "INSERT 0 3"`, which is where its `command` and `count` come from.
- `Bun.SQL` resolves every query to an `SQLResultArray` whose non-enumerable `count`, `command`, `lastInsertRowid` and `affectedRows` mirror postgres.js. The MySQL native side calls `onResolveMySQLQuery` once per result; a multi-statement or `CALL` query produces several results, accumulated until `SERVER_MORE_RESULTS_EXISTS` clears.

<details><summary>Notes</summary>

- Before (bun 1.4.3-canary, MariaDB 11.8): `INSERT 3` -> `count=0 command=null affectedRows=3`; `UPDATE 3` -> `count=0 command=null affectedRows=3`; `DELETE 1` -> `count=0 command=null affectedRows=1`. After: `count=3 command=INSERT`, `count=3 command=UPDATE`, `count=1 command=DELETE`; `SELECT` keeps `count = rows.length` and gets `command=SELECT`.
- `CALL p()` yields one result per result set plus a final OK; all of them report `command: "CALL"`. When a `CALL` is followed by more statements in the same text, the results after the procedure's first one are attributed one statement too early. The protocol gives no way to tell a procedure's extra result sets from the next statement's, and `command` is informational, so this is accepted.
- A statement whose text has no leading keyword (empty, comment only) reports `command: null`, as PostgreSQL does for an empty tag.
- Self-reviewed, and the first bot review's four findings (`--` rule, `/*!` executable comments, `NO_BACKSLASH_ESCAPES`, one keyword table) are all addressed in cc3ef7f0.
- The scanner only looks at the first word of a single-statement query; the rest of a statement is scanned only when a further result arrives, so large single `INSERT` texts cost nothing extra.

</details>
