### PR TITLE
html entry, inspector: key banner styling on the fd the banner is written to

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -45,6 +45,7 @@ const sourceFiles = readdirRecursiveWithExclusionsAndExtensionsSync(
 // requires adding its entry below.
 const rustIdentifierPaths: Record<string, string> = {
   "bun.rs": "bun.rs",
+  "BunObject.rs": "runtime/api/BunObject.rs",
   "ipc.rs": "runtime/ipc_host.rs",
   "Counters.rs": "jsc/Counters.rs",
   "FrameworkRouter.rs": "runtime/bake/FrameworkRouter.rs",

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -859,7 +859,8 @@ function randomId() {
   return crypto.randomUUID();
 }
 
-const { enableANSIColors } = Bun;
+// The banner these helpers style is written to stderr only.
+const enableANSIColors = $rust("BunObject.rs", "enableANSIColorsStderr") as boolean;
 
 function dim(string: string): string {
   if (enableANSIColors) {

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -281,7 +281,9 @@ yourself with Bun.serve().
     }
   }
   const elapsed = (performance.now() - initial).toFixed(2);
-  const enableANSIColors = Bun.enableANSIColors;
+  // Everything below goes to stdout via console.log, so key styling on stdout
+  // alone. `Bun.enableANSIColors` is stdout OR stderr.
+  const enableANSIColors = $rust("BunObject.rs", "enableANSIColorsStdout") as boolean;
   function printInitialMessage(isFirst: boolean) {
     let pathnameToPrint;
     if (servePaths.length === 1) {
@@ -399,10 +401,17 @@ yourself with Bun.serve().
         case "h\n":
           console.clear();
           printInitialMessage(false);
-          console.log("\n  Shortcuts\x1b[2m:\x1b[0m\n");
-          console.log("  \x1b[2m→\x1b[0m   \x1b[36mc + Enter\x1b[0m   clear screen");
-          console.log("  \x1b[2m→\x1b[0m   \x1b[36mo + Enter\x1b[0m   open in browser");
-          console.log("  \x1b[2m→\x1b[0m   \x1b[36mq + Enter\x1b[0m   quit (or Ctrl+C)\n");
+          if (enableANSIColors) {
+            console.log("\n  Shortcuts\x1b[2m:\x1b[0m\n");
+            console.log("  \x1b[2m→\x1b[0m   \x1b[36mc + Enter\x1b[0m   clear screen");
+            console.log("  \x1b[2m→\x1b[0m   \x1b[36mo + Enter\x1b[0m   open in browser");
+            console.log("  \x1b[2m→\x1b[0m   \x1b[36mq + Enter\x1b[0m   quit (or Ctrl+C)\n");
+          } else {
+            console.log("\n  Shortcuts:\n");
+            console.log("  →   c + Enter   clear screen");
+            console.log("  →   o + Enter   open in browser");
+            console.log("  →   q + Enter   quit (or Ctrl+C)\n");
+          }
           break;
       }
     });

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -281,8 +281,7 @@ yourself with Bun.serve().
     }
   }
   const elapsed = (performance.now() - initial).toFixed(2);
-  // Everything below goes to stdout via console.log, so key styling on stdout
-  // alone. `Bun.enableANSIColors` is stdout OR stderr.
+  // The banner goes to stdout. `Bun.enableANSIColors` would also count stderr.
   const enableANSIColors = $rust("BunObject.rs", "enableANSIColorsStdout") as boolean;
   function printInitialMessage(isFirst: boolean) {
     let pathnameToPrint;

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -772,9 +772,7 @@ fn enable_ansi_colors(_global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
     JSValue::from(Output::enable_ansi_colors_stdout() || Output::enable_ansi_colors_stderr())
 }
 
-/// `$rust("BunObject.rs", "enableANSIColorsStdout")`. `Bun.enableANSIColors`
-/// is the OR of both streams; built-in JS that writes to one known fd keys its
-/// styling on that fd alone.
+/// `$rust("BunObject.rs", "enableANSIColorsStdout")`: the per-stream half of `Bun.enableANSIColors`.
 pub(crate) fn enable_ansi_colors_stdout(_global_this: &JSGlobalObject) -> JSValue {
     JSValue::from(Output::enable_ansi_colors_stdout())
 }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -772,6 +772,18 @@ fn enable_ansi_colors(_global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
     JSValue::from(Output::enable_ansi_colors_stdout() || Output::enable_ansi_colors_stderr())
 }
 
+/// `$rust("BunObject.rs", "enableANSIColorsStdout")`. `Bun.enableANSIColors`
+/// is the OR of both streams; built-in JS that writes to one known fd keys its
+/// styling on that fd alone.
+pub(crate) fn enable_ansi_colors_stdout(_global_this: &JSGlobalObject) -> JSValue {
+    JSValue::from(Output::enable_ansi_colors_stdout())
+}
+
+/// `$rust("BunObject.rs", "enableANSIColorsStderr")`.
+pub(crate) fn enable_ansi_colors_stderr(_global_this: &JSGlobalObject) -> JSValue {
+    JSValue::from(Output::enable_ansi_colors_stderr())
+}
+
 // callconv(jsc.conv) — `SYSV_ABI` on win-x64 (BunObject.cpp:1103). Returns
 // plain `JSValue` so the generated thunk is a bare deref+call (no
 // `ExceptionValidationScope`).

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isPosix, randomPort, tempDir } from "harness";
+import { bunEnv, bunExe, isPosix, isWindows, openPty, randomPort, tempDir } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -375,6 +375,37 @@ describe("http metadata endpoint", () => {
     expect(await web.text()).toBe("");
     expect(web.status).toBe(403);
   });
+});
+
+// The "Bun Inspector" banner goes to stderr, so its styling must follow stderr
+// alone. `bun --inspect app.js 2>inspector.log` from an interactive shell
+// (stdout still the terminal) used to put SGR and OSC 8 sequences in the file,
+// because the banner followed `Bun.enableANSIColors` (stdout OR stderr).
+test.skipIf(isWindows)("banner on a piped stderr is plain when stdout is a TTY", async () => {
+  using pty = openPty();
+  await using inspectee = spawn({
+    cwd: import.meta.dir,
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "inspectee.js"],
+    env: { ...bunEnv, FORCE_COLOR: undefined, NO_COLOR: undefined, TERM: "xterm-256color" },
+    stdin: pty.slave,
+    stdout: pty.slave,
+    stderr: "pipe",
+  });
+  pty.closeSlave();
+
+  let stderr = "";
+  const decoder = new TextDecoder();
+  for await (const chunk of inspectee.stderr as ReadableStream<Uint8Array>) {
+    stderr += decoder.decode(chunk, { stream: true });
+    // The banner opens and closes with the same rule line.
+    if (stderr.split("Bun Inspector").length > 2 && stderr.endsWith("\n")) break;
+  }
+  inspectee.kill();
+
+  expect(stderr).not.toContain("\x1b");
+  expect(stderr).toMatch(
+    /^-+ Bun Inspector -+\nListening:\n  ws:\/\/127\.0\.0\.1:\d+\/[\w-]+\nInspect in browser:\n  https:\/\/debug\.bun\.sh\/#127\.0\.0\.1:\d+\/[\w-]+\n-+ Bun Inspector -+\n$/,
+  );
 });
 
 describe("unix domain socket without websocket", () => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1892,8 +1892,8 @@ export function libcPathForDlopen() {
  *
  * To read what the child writes to the TTY, call `closeSlave()` after the
  * spawn (the child keeps its own copy) and read `takeMaster()` with
- * `fs.createReadStream("", { fd })`. The stream then ends (macOS) or errors
- * with EIO (Linux) once the child exits, instead of blocking forever.
+ * `fs.createReadStream("", { fd })`. Once the child exits the stream then
+ * ends (macOS) or errors with EIO (Linux) instead of blocking forever.
  *
  * `close()` / `using` closes whichever of the two fds this object still owns.
  */

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1911,15 +1911,17 @@ export function openPty(): {
     throw new Error("openPty: unsupported on Windows, use Bun.Terminal");
   }
   const { dlopen, FFIType } = require("bun:ffi") as typeof import("bun:ffi");
-  // glibc keeps openpty(3) in libutil; musl and macOS have it in libc.
+  // glibc keeps openpty(3) in libutil; musl, Bionic and macOS have it in libc.
   const lib = dlopen(
     isMacOS
       ? "libc.dylib"
-      : isMusl
-        ? process.arch === "arm64"
-          ? "libc.musl-aarch64.so.1"
-          : "libc.musl-x86_64.so.1"
-        : "libutil.so.1",
+      : isAndroid
+        ? "libc.so"
+        : isMusl
+          ? process.arch === "arm64"
+            ? "libc.musl-aarch64.so.1"
+            : "libc.musl-x86_64.so.1"
+          : "libutil.so.1",
     {
       openpty: {
         args: [FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr],

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1883,6 +1883,85 @@ export function libcPathForDlopen() {
   }
 }
 
+/**
+ * Open a pseudo-terminal pair with openpty(3). POSIX only.
+ *
+ * Use this when a spawned process needs a real TTY on some stdio fds and a
+ * pipe on others (e.g. `stdout: "pipe", stderr: pty.slave`), which
+ * `Bun.Terminal` cannot express. Pass `slave` as a stdio fd to `Bun.spawn`.
+ *
+ * To read what the child writes to the TTY, call `closeSlave()` after the
+ * spawn (the child keeps its own copy) and read `takeMaster()` with
+ * `fs.createReadStream("", { fd })`. The stream then ends (macOS) or errors
+ * with EIO (Linux) once the child exits, instead of blocking forever.
+ *
+ * `close()` / `using` closes whichever of the two fds this object still owns.
+ */
+export function openPty(): {
+  readonly master: number;
+  readonly slave: number;
+  /** Close the parent's slave fd. */
+  closeSlave(): void;
+  /** Take ownership of the master fd; `close()` will no longer close it. */
+  takeMaster(): number;
+  close(): void;
+  [Symbol.dispose](): void;
+} {
+  if (isWindows) {
+    throw new Error("openPty: unsupported on Windows, use Bun.Terminal");
+  }
+  const { dlopen, FFIType } = require("bun:ffi") as typeof import("bun:ffi");
+  // glibc keeps openpty(3) in libutil; musl and macOS have it in libc.
+  const lib = dlopen(
+    isMacOS
+      ? "libc.dylib"
+      : isMusl
+        ? process.arch === "arm64"
+          ? "libc.musl-aarch64.so.1"
+          : "libc.musl-x86_64.so.1"
+        : "libutil.so.1",
+    {
+      openpty: {
+        args: [FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr],
+        returns: FFIType.i32,
+      },
+    },
+  );
+  const masterBuf = new Int32Array(1);
+  const slaveBuf = new Int32Array(1);
+  if (lib.symbols.openpty(masterBuf, slaveBuf, null, null, null) !== 0) {
+    throw new Error("openpty failed");
+  }
+  lib.close();
+
+  let master = masterBuf[0];
+  let slave = slaveBuf[0];
+  const close = () => {
+    if (slave !== -1) closeSync(slave);
+    if (master !== -1) closeSync(master);
+    slave = master = -1;
+  };
+  return {
+    get master() {
+      return master;
+    },
+    get slave() {
+      return slave;
+    },
+    closeSlave() {
+      if (slave !== -1) closeSync(slave);
+      slave = -1;
+    },
+    takeMaster() {
+      const fd = master;
+      master = -1;
+      return fd;
+    },
+    close,
+    [Symbol.dispose]: close,
+  };
+}
+
 export function cwdScope(cwd: string) {
   const original = process.cwd();
   process.chdir(cwd);

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -773,8 +773,9 @@ test.concurrent.skipIf(isWindows)(
 );
 
 // The other direction: a TTY stdout keeps the styled banner when stderr is
-// not a terminal (`bun ./index.html 2>err.log`).
-test.concurrent.skipIf(isWindows)("startup banner on a TTY stdout is styled when stderr is piped", async () => {
+// not a terminal (`bun ./index.html 2>err.log`). "ignore" is /dev/null, which
+// is not a TTY either and, unlike an unread pipe, cannot fill up.
+test.concurrent.skipIf(isWindows)("startup banner on a TTY stdout is styled when stderr is not a TTY", async () => {
   using dir = tempDir("html-entry-banner-tty", bannerFixture);
   using pty = openPty();
   await using proc = Bun.spawn({
@@ -783,7 +784,7 @@ test.concurrent.skipIf(isWindows)("startup banner on a TTY stdout is styled when
     cwd: String(dir),
     stdin: "ignore",
     stdout: pty.slave,
-    stderr: "pipe",
+    stderr: "ignore",
   });
   // The child holds its own copy. Dropping ours lets the master read end when
   // the child exits instead of blocking.

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -786,21 +786,22 @@ test.concurrent.skipIf(isWindows)("startup banner on a TTY stdout is styled when
     stdout: pty.slave,
     stderr: "ignore",
   });
-  // The child holds its own copy. Dropping ours lets the master read end when
-  // the child exits instead of blocking.
+  // The child holds its own copy. Dropping ours makes the master read fail
+  // (Linux: EIO) or end (macOS) if the child dies early, instead of blocking.
   pty.closeSlave();
 
   let text = "";
-  const { promise: done, resolve } = Promise.withResolvers<void>();
+  const { promise: bannerDone, resolve } = Promise.withResolvers<void>();
   const master = fs.createReadStream("", { fd: pty.takeMaster() });
   master.on("data", (chunk: Buffer) => {
     text += chunk.toString("utf8");
     // The URL line is the last line of the banner when stdin is not a TTY.
-    if (/http:\/\/\S+\n/.test(Bun.stripANSI(text).replaceAll("\r\n", "\n"))) proc.kill();
+    if (/http:\/\/\S+\n/.test(Bun.stripANSI(text).replaceAll("\r\n", "\n"))) resolve();
   });
-  // Linux reports the hangup after the child exits as EIO, macOS as EOF.
   master.on("error", () => resolve()).on("close", resolve);
-  await done;
+  await bannerDone;
+  proc.kill();
+  master.destroy();
 
   expect(Bun.stripANSI(text).replaceAll("\r\n", "\n")).toMatch(
     /^ DEV  Bun v\S+ ready in \S+ ms\n\n➜ http:\/\/127\.0\.0\.1:\d+\/\n$/,

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,7 +1,17 @@
 import type { Subprocess } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, openPty, tempDir } from "harness";
+import fs from "node:fs";
 import { join } from "node:path";
+
+const bannerFixture = {
+  "index.html": `<!DOCTYPE html><html><head><script type="module" src="./a.ts"></script></head><body></body></html>`,
+  "a.ts": `console.log(1);`,
+};
+
+// No color override either way, so the banner style depends only on which
+// stdio fds are terminals.
+const ttyColorEnv = { ...bunEnv, FORCE_COLOR: undefined, NO_COLOR: undefined, TERM: "xterm-256color" };
 
 async function getServerUrl(process: Subprocess) {
   // Read the port number from stdout
@@ -714,4 +724,85 @@ test.concurrent("subdirectory routes use forward slashes on Windows", async () =
   const buttons = await fetch(new URL("/components/buttons", serverUrl));
   expect(buttons.status).toBe(200);
   expect(await buttons.text()).toContain("<title>Buttons</title>");
+});
+
+// `bun ./index.html > dev.log` from an interactive shell: stdout is a file or
+// pipe while stdin and stderr are still the terminal. The banner goes to
+// stdout, so it must be the plain variant. It used to follow
+// `Bun.enableANSIColors` (stdout OR stderr) and wrote SGR codes into the file.
+test.concurrent.skipIf(isWindows)(
+  "startup banner on a piped stdout is plain when stdin and stderr are a TTY",
+  async () => {
+    using dir = tempDir("html-entry-banner-tty", bannerFixture);
+    using pty = openPty();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.html", "--port=0", "--hostname=127.0.0.1"],
+      env: ttyColorEnv,
+      cwd: String(dir),
+      stdin: pty.slave,
+      stdout: "pipe",
+      stderr: pty.slave,
+    });
+    pty.closeSlave();
+
+    const decoder = new TextDecoder();
+    let text = "";
+    let askedForHelp = false;
+    for await (const chunk of proc.stdout as ReadableStream<Uint8Array>) {
+      text += decoder.decode(chunk, { stream: true });
+      const plain = Bun.stripANSI(text);
+      // Last line of the banner. Only printed when stdin is a TTY, so reaching
+      // it also proves the child saw the pty. Then type the `h` shortcut on
+      // that TTY: the help it prints goes to the piped stdout too.
+      if (!askedForHelp && plain.includes("to show shortcuts\n")) {
+        askedForHelp = true;
+        fs.writeSync(pty.master, "h\n");
+      }
+      if (plain.includes("quit (or Ctrl+C)\n")) break;
+    }
+    proc.kill();
+
+    expect(text).not.toContain("\x1b");
+    expect(text).toMatch(
+      /^Bun v\S+ dev server ready in \S+ ms\n\nurl: http:\/\/127\.0\.0\.1:\d+\/\n\nPress h \+ Enter to show shortcuts\n/,
+    );
+    expect(text).toMatch(
+      /\nBun v\S+\n\nurl: http:\/\/127\.0\.0\.1:\d+\/\n\n  Shortcuts:\n\n  →   c \+ Enter   clear screen\n  →   o \+ Enter   open in browser\n  →   q \+ Enter   quit \(or Ctrl\+C\)\n\n?$/,
+    );
+  },
+);
+
+// The other direction: a TTY stdout keeps the styled banner when stderr is
+// not a terminal (`bun ./index.html 2>err.log`).
+test.concurrent.skipIf(isWindows)("startup banner on a TTY stdout is styled when stderr is piped", async () => {
+  using dir = tempDir("html-entry-banner-tty", bannerFixture);
+  using pty = openPty();
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.html", "--port=0", "--hostname=127.0.0.1"],
+    env: ttyColorEnv,
+    cwd: String(dir),
+    stdin: "ignore",
+    stdout: pty.slave,
+    stderr: "pipe",
+  });
+  // The child holds its own copy. Dropping ours lets the master read end when
+  // the child exits instead of blocking.
+  pty.closeSlave();
+
+  let text = "";
+  const { promise: done, resolve } = Promise.withResolvers<void>();
+  const master = fs.createReadStream("", { fd: pty.takeMaster() });
+  master.on("data", (chunk: Buffer) => {
+    text += chunk.toString("utf8");
+    // The URL line is the last line of the banner when stdin is not a TTY.
+    if (/http:\/\/\S+\n/.test(Bun.stripANSI(text).replaceAll("\r\n", "\n"))) proc.kill();
+  });
+  // Linux reports the hangup after the child exits as EIO, macOS as EOF.
+  master.on("error", () => resolve()).on("close", resolve);
+  await done;
+
+  expect(Bun.stripANSI(text).replaceAll("\r\n", "\n")).toMatch(
+    /^ DEV  Bun v\S+ ready in \S+ ms\n\n➜ http:\/\/127\.0\.0\.1:\d+\/\n$/,
+  );
+  expect(text).toContain("\x1b[");
 });


### PR DESCRIPTION
### Problem
- `bun ./index.html > dev.log` (or `| tee dev.log`) from an interactive shell writes the styled banner into the file: `\x1b[34;7m DEV \x1b[0m \x1b[1;34m\x1b[5mBun\x1b[0m ...` (19 SGR sequences, including blink). The banner goes to stdout, but stdout is not a terminal here. `bun --inspect app.js 2> log` has the mirror problem: the "Bun Inspector" banner goes to stderr and the log gets SGR and OSC 8 sequences while stdout is the terminal.
- The cause: `src/js/internal/html.ts:284` and `src/js/internal/debugger.ts:862` choose the styled variant from `Bun.enableANSIColors`, which is `enable_ansi_colors_stdout || enable_ansi_colors_stderr` (`src/runtime/api/BunObject.rs:772`). Built-in JS had no per-stream flag.

### Fix
- Expose the two per-stream flags to built-in JS as `$rust("BunObject.rs", "enableANSIColorsStdout" / "enableANSIColorsStderr")`. The dev server banner (and its `h` shortcut help) keys on the stdout flag. The inspector banner keys on the stderr flag.
- `Bun.enableANSIColors` itself is public API and is unchanged.
- Correct because each flag is what the rest of the CLI already uses for that fd since #39765: `FORCE_COLOR` / `NO_COLOR` override, otherwise `isatty` of that fd.
- Verified: `test/js/bun/http/bun-serve-html-entry.test.ts` (two new tests, stock bun fails the piped-stdout one) and `test/cli/inspect/inspect.test.ts` (one new test, fails on stock bun). Both files pass in full on the debug build.

### Background
- `bun ./index.html` runs `src/js/internal/html.ts`, a built-in module that wraps `Bun.serve()` and prints a "ready in" banner with `console.log` (stdout). `bun --inspect` loads `src/js/internal/debugger.ts`, which prints its banner with `Bun.write(Bun.stderr, ...)`.
- `Output::set_init` (`src/bun_core/output.rs`) computes `ENABLE_ANSI_COLORS_STDOUT` and `ENABLE_ANSI_COLORS_STDERR` once at startup. Rust-side printing picks the flag for the fd it writes to. JS only had the OR of the two through `Bun.enableANSIColors`.
- `$rust("File.rs", "symbol")` is the built-in-JS macro that calls a Rust function through a generated thunk (`src/codegen/generate-js2native.ts`). The file id must be listed in `rustIdentifierPaths`, so `BunObject.rs` is added there.

<details><summary>Notes</summary>

Reproduction on 1.4.2 and canary, stdout piped, stdin and stderr on a pty:

```py
import os, subprocess, time, signal, select
m, s = os.openpty(); r, w = os.pipe()
p = subprocess.Popen(["bun", "./index.html", "--port=0", "--hostname=127.0.0.1"], stdin=s, stdout=w, stderr=s, preexec_fn=os.setsid); os.close(w)
time.sleep(2); os.kill(p.pid, signal.SIGINT); p.wait(); out = b""
while select.select([r], [], [], 0.3)[0]:
    d = os.read(r, 65536); out += d
    if not d: break
print(out)
```

Before: `b'\x1b[34;7m DEV \x1b[0m \x1b[1;34m\x1b[5mBun\x1b[0m \x1b[1;34mv1.4.3\x1b[0m ...'`. After: `b'Bun v1.4.3-debug dev server ready in 169.18 ms\n\nurl: http://127.0.0.1:32903/\n\nPress h + Enter to show shortcuts\n'`.

The all-TTY case still gets the styled banner, `FORCE_COLOR=1` with all pipes still gets it, and `NO_COLOR=1` on a TTY still gets the plain one (checked by hand and by the second new html test).

The tests need a real TTY on some stdio fds and a pipe on others, which `Bun.Terminal` cannot express, so `test/harness.ts` gains an `openPty()` helper (openpty(3) through `bun:ffi`, the same approach `test/cli/bun.test.ts` already uses inline).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-html-entry.test.ts, test/cli/inspect/inspect.test.ts

<!-- robobun:evidence:end -->