### PR TITLE
fix(node:sqlite): preserve virtual-table statement ownership on close

### DIFF
--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -912,11 +912,11 @@ void JSDatabaseSync::closeInternal(FinalizeStatements finalizeStatements)
     // Statement cells are not tracked here: GC order between JSDatabaseSync
     // and its JSStatementSyncs is undefined during VM teardown, so holding
     // raw pointers back to them would dangle. FinalizeStatements::Yes
-    // instead finalizes the native handles through sqlite3_next_stmt and
-    // flags the shared NodeSqliteConnectionRecord so ~JSStatementSync()
-    // does not double-finalize. With No, close_v2 zombifies the connection
-    // and each statement finalizes itself on GC; statements observe
-    // closure via isFinalized().
+    // instead finalizes the native handles tracked in the shared
+    // NodeSqliteConnectionRecord, so ~JSStatementSync() does not
+    // double-finalize. With No, close_v2 zombifies the connection and each
+    // statement finalizes itself on GC; statements observe closure via
+    // isFinalized().
     if (!m_db) return;
 
     // A BusyScope is on the stack (re-entrant close from an option getter /
@@ -944,15 +944,16 @@ void JSDatabaseSync::closeInternal(FinalizeStatements finalizeStatements)
     m_db = nullptr;
     unregisterOpenDatabase(this);
     if (finalizeStatements == FinalizeStatements::Yes && record) {
-        // Finalize every outstanding statement so close_v2 really closes
-        // the file. The flag is set BEFORE the walk: an xFinal re-entry
-        // can trigger GC, and a wrapper swept mid-walk must not finalize a
-        // handle the walk already released. A wrapper that skips its own
-        // finalize early is still in the connection's list, and the walk
-        // re-fetches the head each iteration, so nothing is leaked.
+        // Finalize every StatementSync-owned handle so close_v2 really
+        // closes the file. sqlite3_next_stmt() also exposes private
+        // statements owned by virtual table extensions; finalizing those
+        // here leaves the extension with dangling pointers during teardown.
+        // The flag is set before the loop because sqlite3_finalize() can run
+        // an aggregate xFinal callback, which may trigger GC mid-loop.
         record->statementsFinalized = true;
+        auto statements = WTF::move(record->statements);
         ++m_closeWalkDepth;
-        while (sqlite3_stmt* stmt = sqlite3_next_stmt(handle, nullptr))
+        for (sqlite3_stmt* stmt : statements)
             sqlite3_finalize(stmt);
         --m_closeWalkDepth;
     }
@@ -2474,6 +2475,8 @@ void JSStatementSync::finishCreation(VM& vm, JSDatabaseSync* db, sqlite3_stmt* s
     m_stmt = stmt;
     m_originGeneration = db->openGeneration();
     m_connectionRecord = db->connectionRecord();
+    if (stmt)
+        m_connectionRecord->statements.add(stmt);
     m_database.set(vm, this, db);
     m_extraMemorySize = stmt ? static_cast<size_t>(sqlite3_stmt_status(stmt, SQLITE_STMTSTATUS_MEMUSED, 0)) : 0;
     if (m_extraMemorySize)
@@ -2483,12 +2486,18 @@ void JSStatementSync::finishCreation(VM& vm, JSDatabaseSync* db, sqlite3_stmt* s
 void JSStatementSync::finalizeStatement()
 {
     if (!m_stmt) return;
-    // After an explicit db.close() the shared record says the walk already
-    // finalized this handle; m_stmt dangles and must not be touched. The
-    // database cell itself may already be swept, hence the record.
-    if (!m_connectionRecord || !m_connectionRecord->statementsFinalized)
-        sqlite3_finalize(m_stmt);
+    sqlite3_stmt* stmt = m_stmt;
     m_stmt = nullptr;
+    // After an explicit db.close() the shared record says its tracked loop
+    // already finalized this handle. Otherwise remove this wrapper-owned
+    // handle before finalizing it so the connection never retains a stale
+    // pointer that an allocator may reuse.
+    if (m_connectionRecord && m_connectionRecord->statementsFinalized)
+        return;
+    if (m_connectionRecord) {
+        m_connectionRecord->statements.remove(stmt);
+    }
+    sqlite3_finalize(stmt);
 }
 
 JSStatementSync::~JSStatementSync()

--- a/src/jsc/bindings/sqlite/NodeSqlite.h
+++ b/src/jsc/bindings/sqlite/NodeSqlite.h
@@ -15,6 +15,7 @@
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/InternalFunction.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/StringHash.h>
@@ -73,14 +74,16 @@ struct NodeSqliteSessionRecord : public WTF::RefCounted<NodeSqliteSessionRecord>
 };
 
 // Shared bookkeeping between a DatabaseSync and every StatementSync prepared
-// on one open()ed connection. An explicit close() finalizes all outstanding
-// sqlite3_stmts (a sqlite3_next_stmt walk) so sqlite3_close_v2 really closes
-// the file; an unfinalized statement zombifies the connection and the open
-// OS handle locks the database file on Windows. Statement wrappers are GC
-// cells whose sweep order relative to the database is undefined, so they
-// learn "close() already finalized my handle" through this refcounted
-// record instead of reaching back into the database cell.
+// on one open()ed connection. Track native handles instead of JS cells so
+// explicit close() can finalize only statements owned by StatementSync.
+// sqlite3_next_stmt() cannot be used here: virtual table extensions may own
+// private statements on the same connection and must finalize those during
+// their own teardown. Statement wrappers are GC cells whose sweep order
+// relative to the database is undefined, so they learn "close() already
+// finalized my handle" through this refcounted record instead of reaching
+// back into the database cell.
 struct NodeSqliteConnectionRecord : public WTF::RefCounted<NodeSqliteConnectionRecord> {
+    WTF::HashSet<sqlite3_stmt*> statements;
     bool statementsFinalized { false };
 };
 

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -135,6 +135,19 @@ describe("DatabaseSync", () => {
     );
   });
 
+  test("close() leaves virtual-table-owned statements to the module", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("CREATE VIRTUAL TABLE docs USING fts5(body); INSERT INTO docs VALUES ('alpha beta')");
+    const statement = db.prepare("SELECT rowid FROM docs WHERE docs MATCH ?");
+    expect(statement.all("alpha")).toEqual([{ rowid: 1 }]);
+
+    db.close();
+
+    expect(() => statement.all("alpha")).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_STATE", message: "statement has been finalized" }),
+    );
+  });
+
   test("close() finalizes outstanding prepared statements and releases the file", () => {
     using dir = tempDir("node-sqlite-close-finalize", {});
     const dbPath = path.join(String(dir), "x.db");

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -106,6 +106,35 @@ describe("DatabaseSync", () => {
     db.close();
   });
 
+  test.each([
+    ["close", "unused"],
+    ["close", "get"],
+    ["close", "all"],
+    ["dispose", "unused"],
+    ["dispose", "get"],
+    ["dispose", "all"],
+  ] as const)("%s releases WAL sidecars with a retained %s statement", (closeMethod, method) => {
+    using dir = tempDir("node-sqlite-close-statement", {});
+    const file = path.join(String(dir), "db.sqlite");
+    using db = new DatabaseSync(file);
+    db.exec("PRAGMA journal_mode = WAL; CREATE TABLE t (n INTEGER); INSERT INTO t VALUES (1), (2)");
+    const stmt = db.prepare("SELECT n FROM t ORDER BY n");
+    if (method === "get") {
+      expect(stmt.get()).toEqual({ n: 1 });
+    } else if (method === "all") {
+      expect(stmt.all()).toEqual([{ n: 1 }, { n: 2 }]);
+    }
+    expect([existsSync(`${file}-wal`), existsSync(`${file}-shm`)]).toEqual([true, true]);
+
+    if (closeMethod === "close") db.close();
+    else db[Symbol.dispose]();
+
+    expect([existsSync(`${file}-wal`), existsSync(`${file}-shm`)]).toEqual([false, false]);
+    expect(() => stmt.get()).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_STATE", message: "statement has been finalized" }),
+    );
+  });
+
   test("close() finalizes outstanding prepared statements and releases the file", () => {
     using dir = tempDir("node-sqlite-close-finalize", {});
     const dbPath = path.join(String(dir), "x.db");


### PR DESCRIPTION
This PR remains stacked on #40005 and fixes a lifetime regression in that branch while retaining its immediate close behavior.

### Problem

The new explicit-close path used `sqlite3_next_stmt()` to find outstanding statements. That API returns every statement on the connection, including private statements prepared and owned by virtual-table modules. Finalizing those handles before the module tears down leaves dangling pointers. A completed FTS5 query and a completed sqlite-vec KNN query both reproduced a heap use-after-free during `DatabaseSync.close()`; stock Bun and Node completed the same cases.

### Fix

- Track only native handles created for JavaScript `StatementSync` wrappers in the per-connection record.
- Remove a handle from that set before ordinary wrapper finalization.
- On explicit close, mark the record finalized, move the owned handle set, and finalize only that snapshot before `sqlite3_close_v2()`.
- Keep the existing WAL cleanup tests and add a built-in FTS5 regression that exercises a completed virtual-table statement without an external fixture.

This preserves #40005's file-handle cleanup while leaving extension-private statements under their module's ownership. Empty SQL remains untracked, tag-store statements use the same wrapper path, and the finalized flag still protects reentrant GC during aggregate finalization.

### Validation

- Release-ASAN: full `test/js/node/sqlite/node-sqlite.test.ts`: 125 passed, 4 platform skips, 0 failed.
- Release: the same file: 125 passed, 4 platform skips, 0 failed.
- The formerly crashing built-in FTS5 close case passed under ASAN and release.
- sqlite-vec 0.1.9 close/reopen stress passed 10 cycles under ASAN and 100 cycles under release; the prior implementation failed on the first close.
- OpenClaw source `0053d7ab613bc9b04e4efed066bdb5d1346bc5fb`: the exact memory-index reopen case that previously segfaulted passed, as did the adjacent hybrid-ranking case, with the default Bun runtime and SQLite guards.
- Prettier, diff checks, and an independent P0-P2 review passed.

This contribution was developed and reviewed with AI assistance using Codex.
