### PR TITLE
fetch: close connections evicted from a full keep-alive pool with FIN, not RST

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -726,7 +726,9 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 return Some(pooled);
             };
             bun_core::scoped_log!(HTTPContext, "Keep-Alive pool full, evicting oldest");
-            Self::terminate_socket(pooled_socket_mut(oldest).http_socket);
+            // The evicted connection is healthy: retire it with a FIN
+            // (`close_socket`), not the RST `terminate_socket` sends.
+            Self::close_socket(pooled_socket_mut(oldest).http_socket);
         }
         let Some(slot) = pool.claim() else {
             return Some(pooled);

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -733,3 +733,77 @@ test.skipIf(isWindows)("a full keep-alive pool evicts the longest-idle connectio
     for (const s of servers) s.srv.close();
   }
 });
+
+// More concurrent requests to one origin than the pool holds (64). The origin
+// answers none of them until all have arrived, so each request gets its own
+// connection. When the responses complete, 64 connections are parked and the
+// rest are evicted. The origin must see each evicted one end with a clean EOF
+// ('end'), not ECONNRESET. Subprocess so the pool starts empty.
+test.concurrent.each(["http", "https"])(
+  "a full keep-alive pool closes the %s connections it evicts with FIN, not RST",
+  async scheme => {
+    const total = 80;
+    const evicted = total - 64;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+      import net from "node:net";
+      import tls from "node:tls";
+      const total = ${total};
+      const outcome = { connections: 0, ended: 0, reset: 0, other: [] };
+      const waiting = [];
+      const onConnection = sock => {
+        outcome.connections++;
+        let settled = false;
+        const settle = fn => { if (!settled) { settled = true; fn(); } };
+        sock.on("end", () => settle(() => outcome.ended++));
+        sock.on("error", err => settle(() => (err.code === "ECONNRESET" ? outcome.reset++ : outcome.other.push(String(err.code)))));
+        let buf = "";
+        sock.on("data", d => {
+          buf += d.toString("latin1");
+          let i;
+          while ((i = buf.indexOf("\\r\\n\\r\\n")) >= 0) {
+            buf = buf.slice(i + 4);
+            waiting.push(sock);
+            if (waiting.length === total) {
+              for (const s of waiting) s.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\n\\r\\nok");
+            }
+          }
+        });
+      };
+      const server = ${scheme === "https" ? `tls.createServer(${JSON.stringify(tls)}, onConnection)` : "net.createServer(onConnection)"};
+      server.listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+      const origin = "${scheme}://127.0.0.1:" + server.address().port;
+
+      const bodies = await Promise.all(
+        Array.from({ length: total }, (_, i) =>
+          fetch(origin + "/" + i, { tls: { rejectUnauthorized: false } }).then(r => r.text()),
+        ),
+      );
+      if (bodies.some(b => b !== "ok")) throw new Error("unexpected body");
+
+      // Every eviction has already issued its close by the time the last
+      // response resolved; wait for the origin side to observe each one.
+      while (outcome.ended + outcome.reset + outcome.other.length < ${evicted}) {
+        await new Promise(r => setImmediate(r));
+      }
+      console.log(JSON.stringify(outcome));
+      process.exit(0);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ result, exitCode }).toEqual({
+      result: { connections: total, ended: evicted, reset: 0, other: [] },
+      exitCode: 0,
+    });
+  },
+);


### PR DESCRIPTION
### Problem
- When more than 64 concurrent `fetch()` requests to one keep-alive origin complete, bun parks 64 connections and closes the rest with an RST. The origin's next read on each of them fails with `ECONNRESET` (100 concurrent fetches: 36 resets on bun, 0 on node). Load balancers count these as errors.
- The cause is the eviction in `HTTPContext::park` (`src/http/HTTPContext.rs:729`). #34079 taught a full pool to evict its longest-idle entry, and did it with `terminate_socket` (`CloseCode::failure`: `SO_LINGER {1,0}`, RST). Before #34079 the overflow socket went through `close_socket` (FIN).

### Fix
- Evict with `close_socket` (`CloseCode::normal`): a FIN for plain connections, `close_notify` then FIN for TLS. `terminate_socket` stays for sockets that are actually broken.
- Correct because the evicted connection is healthy and idle, so a graceful close loses nothing. The pool slot is still freed synchronously: `mark_socket_as_dead` runs before the close in both helpers. node's `http.Agent` and undici also retire surplus idle sockets with a FIN.
- Verified: `test/js/web/fetch/fetch-keepalive.test.ts`, new http and https cases. Stock bun reports `reset: 16, ended: 0`, the fix `reset: 0, ended: 16`, on Linux and Windows. Also ran `fetch.unix` and `fetch-tcp-keepalive`.

### Background
- bun's fetch keeps up to 64 idle connections per `HTTPContext` (`POOL_SIZE`). `release_socket` parks a finished connection. When the pool is full, `park` evicts the entry with the lowest `park_seq`.
- uSockets close codes (`src/uws_sys/us_socket_t.rs`): `normal` sends a FIN (TLS: `close_notify`, then closes once the peer answers). `failure` sets `SO_LINGER {1,0}`, so the kernel sends an RST and skips `TIME_WAIT`.
- An RST on an idle connection does not hurt the finished exchange, but the peer's pending `recv()` reports `ECONNRESET` instead of EOF.

<details><summary>Notes</summary>

- Kernel `Tcp: OutRsts` delta across the eviction window (80 concurrent fetches, 16 evictions, measured inside the process before exit): fixed build 0 for both http and https, stock bun 16 for both. So the deferred TLS close also ends in a FIN, not in the dead-socket `terminate_socket` fallback.
- Open fds settle to the same count with and without the fix (64 pooled client sockets plus the origin's 64). Right after the responses resolve, the https run briefly holds the 16 evicted client fds until the origin answers the `close_notify` (about 150 ms in a debug build on loopback). If a TLS peer never answers, the entry's remaining pool timer (at most 5 minutes) still force-closes it.
- Trade-off: a FIN from the client puts the client side of each evicted connection into `TIME_WAIT`, which the RST avoided. Evictions only happen when more than 64 connections to one origin go idle at once. This is the same `TIME_WAIT` cost bun had before #34079, and the one node, undici and Go accept for surplus idle connections.
- Left alone on purpose: the 5-minute idle timeout on a pooled socket (`on_long_timeout`) also closes with `terminate_socket`. Servers close idle connections long before 300 s in practice, and a graceful TLS close from the timeout handler would have no timer left to bound the wait for the peer's `close_notify`. That path is a separate decision.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch-keepalive.test.ts

<!-- robobun:evidence:end -->