### PR TITLE
Fix Bun file loader paths from another cwd

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1392,13 +1392,54 @@ pub mod parse_worker {
                     .expect("unreachable");
                     buf.into_bump_str().as_bytes()
                 };
-                let root = Expr::init(
-                    E::String {
-                        data: unique_key.into(),
-                        ..Default::default()
-                    },
-                    Loc { start: 0 },
-                );
+                let root = if topts.target.is_bun() {
+                    let import_meta_dir = Expr::init(
+                        E::Dot {
+                            target: Expr::init(E::ImportMeta {}, Loc { start: 0 }),
+                            name_loc: Loc::EMPTY,
+                            name: b"dir".into(),
+                            ..Default::default()
+                        },
+                        Loc { start: 0 },
+                    );
+                    let separator = Expr::init(
+                        E::String {
+                            data: b"/".into(),
+                            ..Default::default()
+                        },
+                        Loc { start: 0 },
+                    );
+                    let asset_path = Expr::init(
+                        E::String {
+                            data: unique_key.into(),
+                            ..Default::default()
+                        },
+                        Loc { start: 0 },
+                    );
+                    Expr::init(
+                        E::Binary {
+                            op: bun_ast::OpCode::BinAdd,
+                            left: Expr::init(
+                                E::Binary {
+                                    op: bun_ast::OpCode::BinAdd,
+                                    left: import_meta_dir,
+                                    right: separator,
+                                },
+                                Loc { start: 0 },
+                            ),
+                            right: asset_path,
+                        },
+                        Loc { start: 0 },
+                    )
+                } else {
+                    Expr::init(
+                        E::String {
+                            data: unique_key.into(),
+                            ..Default::default()
+                        },
+                        Loc { start: 0 },
+                    )
+                };
                 *unique_key_for_additional_file = FileLoaderHash {
                     key: ast::StoreStr::new(unique_key),
                     content_hash,

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -32,6 +32,22 @@ describe("bundler", async () => {
         },
         run: { stdout: "Hello, world!" },
       });
+      if (target === "bun") {
+        itBundled("bun/loader-file-path-from-other-cwd", {
+          target,
+          outfile: "",
+          outdir: "/out",
+          files: {
+            "/entry.ts": /* js */ `
+        import { readFile } from "node:fs/promises";
+        import asset from './asset.txt' with {type: "file"};
+        console.write(await readFile(asset, "utf8"));
+      `,
+            "/asset.txt": "Hello from an asset",
+          },
+          run: { stdout: "Hello from an asset" },
+        });
+      }
       itBundled("bun/loader-json-file", {
         target,
         files: {


### PR DESCRIPTION
## Summary

Fixes #41780.

- Fix `with { type: "file" }` imports in Bun-target bundles when the bundle is executed from a different working directory.
- Anchor generated asset paths to `import.meta.dir`.
- Add a regression test covering file-loader imports from another cwd.

## Test plan

- `bun bd test test/bundler/bundler_loader.test.ts` attempted locally.
- Local Windows validation is currently blocked during the native Bun build before the test executes.
- The regression test should be verified by CI.
- Thanks for reviewing this, hope you like it :)