### PR TITLE
Bun.serve: write one chunked last-chunk when a direct stream close()s with a buffered tail after streaming began

### DIFF
--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1208,13 +1208,15 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         self.has_backpressure && self.end_len > 0
     }
 
-    /// `res.end()` or a completed `res.try_end()` just wrote the last chunk
-    /// (or the whole Content-Length body) and `markDone()`d the response. The
-    /// one place `ended_response` is set, so every path that reaches uWS's end
-    /// through `send`/`send_readable` (endFromJS, auto-flush, on_writable,
-    /// `finalize()`'s flush) agrees the response is over and nothing ends it a
-    /// second time. Also the last point `res` is known live on HTTP/1 (see
-    /// `ended_response`), so release any request-body pause here.
+    /// `res.end()` or a completed `res.try_end()` just handed uWS the end of
+    /// the response: on HTTP/1 the last chunk (or the whole Content-Length
+    /// body) is written and the response `markDone()`d; H2/H3 may still be
+    /// draining but own the END from here. The one place `ended_response` is
+    /// set, so every path that reaches uWS's end through `send`/`send_readable`
+    /// (endFromJS, auto-flush, on_writable, `finalize()`'s flush) agrees the
+    /// response is over and nothing ends it a second time. Also the last point
+    /// `res` is known live on HTTP/1 (see `ended_response`), so release any
+    /// request-body pause here.
     fn mark_response_ended(&mut self, res: uws::AnyResponse) {
         self.has_backpressure = false;
         self.ended_response = true;
@@ -1970,7 +1972,8 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
                 res.clear_on_writable();
             }
             // After `end()` parked buffered bytes (`requested_end`), this flush
-            // is itself the `res.end()` that writes them plus the last chunk.
+            // is normally the `res.end()` that writes them plus the last chunk
+            // (and sets `ended_response`).
             let _ = self.flush_no_wait();
             self.set_done();
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1208,6 +1208,19 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         self.has_backpressure && self.end_len > 0
     }
 
+    /// `res.end()` or a completed `res.try_end()` just wrote the last chunk
+    /// (or the whole Content-Length body) and `markDone()`d the response. The
+    /// one place `ended_response` is set, so every path that reaches uWS's end
+    /// through `send`/`send_readable` (endFromJS, auto-flush, on_writable,
+    /// `finalize()`'s flush) agrees the response is over and nothing ends it a
+    /// second time. Also the last point `res` is known live on HTTP/1 (see
+    /// `ended_response`), so release any request-body pause here.
+    fn mark_response_ended(&mut self, res: uws::AnyResponse) {
+        self.has_backpressure = false;
+        self.ended_response = true;
+        res.resume();
+    }
+
     /// `len` bytes were accepted by `send`/`send_readable`. When uWS reports
     /// the socket is now backed up, return a pending Promise for JS-controller
     /// sources (direct-stream `pull` can `await controller.write()`; the
@@ -1254,7 +1267,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
             self.handle_first_write_if_necessary();
             let success = res.try_end(buf, self.end_len, false);
             if success {
-                self.has_backpressure = false;
+                self.mark_response_ended(res);
                 self.handle_wrote(self.end_len);
             } else if self.res.is_some() {
                 self.has_backpressure = true;
@@ -1277,7 +1290,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         // `on_writable()` below.
         if self.requested_end {
             res.end(buf, false);
-            self.has_backpressure = false;
+            self.mark_response_ended(res);
         } else {
             self.has_backpressure = matches!(res.write(buf), uws::WriteResult::Backpressure(_));
         }
@@ -1329,7 +1342,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
             let end_len = self.end_len;
             let success = res.try_end(&self.buffer[base..], end_len, false);
             if success {
-                self.has_backpressure = false;
+                self.mark_response_ended(res);
                 self.handle_wrote(end_len);
             } else if self.res.is_some() {
                 self.has_backpressure = true;
@@ -1349,7 +1362,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         // See `send_without_auto_flusher`.
         if self.requested_end {
             res.end(&self.buffer[base..], false);
-            self.has_backpressure = false;
+            self.mark_response_ended(res);
         } else {
             self.has_backpressure = matches!(
                 res.write(&self.buffer[base..]),
@@ -1451,14 +1464,12 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
             total_written = chunk_len as u64;
 
             if self.requested_end {
+                // `send_readable` drained the parked `try_end`/`end` and marked
+                // the response ended.
+                debug_assert!(self.ended_response);
                 if let Some(res) = self.any_res() {
                     res.clear_on_writable();
-                    // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-                    res.resume();
                 }
-                // `send_readable` drained the parked `try_end`, so uWS has
-                // `markDone()`d the response and dropped its `onAborted`.
-                self.ended_response = true;
                 self.source.close(None);
                 self.flush_promise();
                 self.finalize();
@@ -1822,19 +1833,12 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
                 value.protect();
                 return bun_sys::Result::Ok(value);
             }
-        } else {
-            if let Some(res) = self.any_res() {
-                res.end(b"", false);
-            }
+        } else if let Some(res) = self.any_res() {
+            res.end(b"", false);
+            self.mark_response_ended(res);
         }
 
-        if let Some(res) = self.any_res() {
-            // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-            res.resume();
-        }
-        // Both branches above fully ended the response through uWS, which
-        // `markDone()`s it and drops its `onAborted`.
-        self.ended_response = true;
+        debug_assert!(self.ended_response);
         self.mark_done();
         self.flush_promise();
         self.source.close(None);
@@ -1912,14 +1916,12 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         self.auto_flusher.registered.set(false);
 
         if self.requested_end {
+            // `send_readable` drained the parked `try_end`/`end` and marked the
+            // response ended.
+            debug_assert!(self.ended_response);
             if let Some(res) = self.any_res() {
                 res.clear_on_writable();
-                // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-                res.resume();
             }
-            // `send_readable` drained the parked `try_end`/`end`, so uWS has
-            // `markDone()`d the response and dropped its `onAborted`.
-            self.ended_response = true;
             self.source.close(None);
             self.flush_promise();
             self.finalize();
@@ -1967,6 +1969,8 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
                 // stream is freed after FIN, leave it dangling).
                 res.clear_on_writable();
             }
+            // After `end()` parked buffered bytes (`requested_end`), this flush
+            // is itself the `res.end()` that writes them plus the last chunk.
             let _ = self.flush_no_wait();
             self.set_done();
 

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -1033,64 +1033,164 @@ test("sync pull() under AsyncLocalStorage releases the request on end()", async 
 });
 
 // https://github.com/oven-sh/bun/issues/36940
-// close() while the sink still holds unflushed bytes deferred the final send
-// to the auto-flusher, which ended the response through uWS (writing the
-// terminating 0\r\n\r\n chunk) and then finalize() ended the stream a second
-// time, writing another terminator. On a keep-alive connection the stray
-// terminator is parsed as the start of the next response.
-test("close() with unflushed data writes the chunked terminator exactly once", async () => {
-  using server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      if (new URL(req.url).pathname === "/plain") {
-        return new Response("ok");
-      }
-      return new Response(
-        new ReadableStream({
-          type: "direct",
-          async pull(c) {
-            // Write enough for chunked encoding, in pieces small enough that
-            // bytes are still buffered below the high-water mark when close()
-            // runs.
-            for (let i = 0; i < 8; i++) {
-              await c.write(new Uint8Array(100).fill(0x78));
-            }
-            c.close();
-          },
-        }),
-        { headers: { "content-type": "text/plain" } },
-      );
+// close() while the sink still holds unflushed bytes must put exactly one
+// chunked last-chunk (0\r\n\r\n) on the wire, whichever path performs the
+// final send: the auto-flusher (pull() settles in the same task it started
+// in) or finalize() (pull() resumed from a later task, so its settle reaction
+// runs before the auto-flusher). Both end the response through uWS `end()`,
+// which already writes the terminator; a second `end_stream()` after that
+// wrote another one. On a keep-alive connection the stray terminator is
+// parsed as the start of the next response (node: HPE_INVALID_CONSTANT,
+// curl: "Leftovers after chunking").
+describe("close() with unflushed data writes the chunked terminator exactly once", () => {
+  // An event-loop turn, so pull() settles from a later task than the one that
+  // attached the stream. Not a time wait.
+  const nextTask = () => new Promise<void>(resolve => setImmediate(() => resolve()));
+  const x800 = Buffer.alloc(800, "x").toString();
+
+  const shapes: Record<string, { body: string; pull: (c: any) => unknown }> = {
+    // #36940: every await is a microtask, so pull() settles inside the
+    // attach-time drain and the auto-flusher performs the end.
+    "await write() x8, close()": {
+      body: x800,
+      async pull(c) {
+        for (let i = 0; i < 8; i++) {
+          await c.write(new Uint8Array(100).fill(0x78));
+        }
+        c.close();
+      },
     },
-  });
+    // The rest settle pull() from a later task with an earlier chunk already
+    // on the wire, so finalize()'s flush performs the end.
+    "write, await flush(), task, write, close()": {
+      body: "hello-world",
+      async pull(c) {
+        c.write("hello");
+        await c.flush();
+        await nextTask();
+        c.write("-world");
+        c.close();
+      },
+    },
+    "write, task, write, close() (no flush)": {
+      body: "hello-world",
+      async pull(c) {
+        c.write("hello");
+        await nextTask();
+        c.write("-world");
+        c.close();
+      },
+    },
+    "write, flush() not awaited, task, write, close()": {
+      body: "hello-world",
+      async pull(c) {
+        c.write("hello");
+        c.flush();
+        await nextTask();
+        c.write("-world");
+        c.close();
+      },
+    },
+    "write, await flush(), task, write, microtask, close()": {
+      body: "hello-world",
+      async pull(c) {
+        c.write("hello");
+        await c.flush();
+        await nextTask();
+        c.write("-world");
+        await Promise.resolve();
+        c.close();
+      },
+    },
+    "SSE loop: (write, await flush(), task) x3, write, close()": {
+      body: "ev0\nev1\nev2\nbye",
+      async pull(c) {
+        for (let i = 0; i < 3; i++) {
+          c.write("ev" + i + "\n");
+          await c.flush();
+          await nextTask();
+        }
+        c.write("bye");
+        c.close();
+      },
+    },
+    "sync pull(), then write + close() from a later task": {
+      body: "hello-late",
+      pull(c) {
+        c.write("hello");
+        setImmediate(() => {
+          c.write("-late");
+          c.close();
+        });
+      },
+    },
+  };
 
-  const { promise, resolve, reject } = Promise.withResolvers<string>();
-  const sock = net.connect(server.port, "127.0.0.1");
-  let raw = "";
-  let sentSecond = false;
-  sock.setNoDelay(true);
-  sock.on("connect", () => {
-    sock.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n");
-  });
-  sock.on("data", d => {
-    raw += d.toString("latin1");
-    // Once the first (chunked) response has terminated, reuse the connection.
-    // The stray terminator was flushed together with the real one, so it is
-    // already in `raw` by the time the second response arrives.
-    if (!sentSecond && raw.includes("0\r\n\r\n")) {
-      sentSecond = true;
-      sock.write("GET /plain HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+  test.concurrent.each(Object.keys(shapes))("%s", async name => {
+    const { body, pull } = shapes[name];
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname === "/plain") {
+          return new Response("ok");
+        }
+        return new Response(new ReadableStream({ type: "direct", pull } as any), {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const sock = net.connect(server.port, "127.0.0.1");
+    let raw = "";
+    let sentSecond = false;
+    sock.setNoDelay(true);
+    sock.on("connect", () => {
+      sock.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n");
+    });
+    sock.on("data", d => {
+      raw += d.toString("latin1");
+      // Once the first (chunked) response has terminated, reuse the connection.
+      if (!sentSecond && raw.includes("\r\n0\r\n\r\n")) {
+        sentSecond = true;
+        sock.write("GET /plain HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+      }
+    });
+    sock.on("close", () => resolve(raw));
+    sock.on("error", reject);
+    const data = await promise;
+
+    const headerEnd = data.indexOf("\r\n\r\n");
+    expect(data.slice(0, headerEnd).toLowerCase()).toContain("transfer-encoding: chunked");
+
+    // Decode the first response's chunked body strictly (RFC 9112 §7.1): the
+    // body ends at the first last-chunk, and whatever follows belongs to the
+    // next message.
+    let offset = headerEnd + 4;
+    let decoded = "";
+    while (true) {
+      const lineEnd = data.indexOf("\r\n", offset);
+      expect(lineEnd).toBeGreaterThan(-1);
+      const size = parseInt(data.slice(offset, lineEnd), 16);
+      expect(size).not.toBeNaN();
+      offset = lineEnd + 2;
+      if (size === 0) {
+        // No trailer section: the last-chunk is followed by the final CRLF.
+        expect(data.slice(offset, offset + 2)).toBe("\r\n");
+        offset += 2;
+        break;
+      }
+      decoded += data.slice(offset, offset + size);
+      expect(data.slice(offset + size, offset + size + 2)).toBe("\r\n");
+      offset += size + 2;
     }
-  });
-  sock.on("close", () => resolve(raw));
-  sock.on("error", reject);
-  const data = await promise;
+    expect(decoded).toBe(body);
 
-  // The chunked body is all "x"; the second response is framed by
-  // Content-Length. Exactly one terminating chunk must appear in the stream.
-  expect(data.split("0\r\n\r\n").length - 1).toBe(1);
-  // The bytes right after the terminator are the next response, not another
-  // terminator.
-  const afterTerminator = data.slice(data.indexOf("0\r\n\r\n") + 5);
-  expect(afterTerminator.slice(0, 12)).toBe("HTTP/1.1 200");
-  expect(afterTerminator).toEndWith("ok");
+    // The very next bytes are the second response, framed by Content-Length,
+    // and nothing else is on the connection.
+    const second = data.slice(offset);
+    expect(second.slice(0, 15)).toBe("HTTP/1.1 200 OK");
+    expect(second).toEndWith("\r\n\r\nok");
+    expect(second.split("\r\n0\r\n\r\n").length - 1).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- A `Bun.serve` body from a `type: "direct"` stream ends with two chunked last-chunks (`...\r\n0\r\n\r\n0\r\n\r\n`) when `controller.close()` runs with bytes still buffered, an earlier chunk already on the wire, and `pull()` settling from a later task. On keep-alive the 5 stray bytes break the next response (node: `HPE_INVALID_CONSTANT`, curl: `Leftovers after chunking`).
- Cause: `close()` parks the tail (`requested_end`). The settle reaction runs before the auto-flusher and calls `HTTPServerWritable::finalize()` (`src/runtime/webcore/streams.rs`). Its `flush_no_wait()` takes the `res.end(buf)` branch, which writes the terminator, without recording `ended_response`. So `finalize()` calls `res.end_stream()` too.

### Fix
- Set `ended_response` (and release the request-body pause) inside `send`/`send_readable`, where uWS `end()` or a completed `try_end()` happens. `on_writable`, `endFromJS` and the auto-flusher assert the flag instead of setting it.
- Correct because every path that ends the response through the sink shares one bookkeeping point, so `finalize()`'s `!ended_response` guard holds for any ordering. #36943 covered the auto-flusher ordering. This covers `finalize()`.
- Verified: `test/js/bun/http/serve-direct-readable-stream.test.ts` (6 new orderings fail on 1.4.3, all 30 pass), plus the suites listed in Notes.
- Self-reviewed: 3 concerns raised, 2 addressed (comment wording), 1 pre-existing and tracked separately (see Notes).

### Background
- A direct stream's `pull()` writes into `HTTPServerWritable`, the sink that is the HTTP response. Small writes stay buffered until `flush()`, the auto-flusher (a deferred task, after microtasks), or the end.
- In chunked mode uWS `end(data)` writes `data` plus `0\r\n\r\n`, and `sendTerminatingChunk` writes another unconditionally.
- `ended_response` records that the sink ended the uWS response, so nothing ends it again or touches a recycled HTTP/1 `resp`.

<details><summary>Notes</summary>

- The trigger is a state, not one sequence: buffer non-empty at `close()`, `HTTP_WRITE_CALLED` already set, and the pull promise still pending when `do_render_stream` inspected it (any macrotask boundary inside `pull()`): SSE loops, `write; await timer; write; close()` with no flush at all, a sync `pull()` that closes from a timer. When `pull()` settles within the attach-time `drain_microtasks()`, the deferred auto-flush runs in that same drain before the promise state is read, `on_auto_flush` performs the `res.end()` and (since #36943) sets the flag, so those shapes were already clean. `end()` instead of `close()` sends the tail itself (`end_from_js`) and was always clean.
- `RequestContext::handle_resolve_stream` reads `sink.ended_response` before it calls `finalize()`, so for this ordering it still takes its normal `end_stream()` path afterwards. That path is guarded by `resp.state().is_response_pending()` and runs in the same tick as the end, while `resp` is still valid, so it writes nothing further. Only `finalize()` itself was unguarded. This sequence is the same as before the change, minus one uWS call.
- `mark_response_ended` also calls `res.resume()`. The three former setters each paired the flag with that call ("release any request-body pause while `res` is live"), because `RequestContext::live_resp()` stops handing out `resp` once the flag is set. Keeping the pair together preserves that invariant on the `finalize()` path too. `us_socket_resume` is idempotent and the uWS wrappers no-op on a closed socket.
- uWS HTTP/1 `try_end` success implies `markDone()`: the sink only reaches `try_end` before any `write()`, with `end_len` equal to the whole buffered body, so `offset == totalSize` exactly when the write fully succeeded. On H2/H3 `end()` under window backpressure defers the END frame, which the transport then owns; the flag only has HTTP/1 consumers in `RequestContext` (`!MUX` checks).
- Not addressed here (pre-existing, tracked separately): if an earlier `res.write()` reported backpressure that has not drained when `close()` parks a tail, `flush_no_wait()` bails on `has_backpressure && end_len > 0` and the tail can be dropped. #37696 (open, conflicting with main) reworks `close()` to send the tail immediately and park a pending flush, which is the natural home for that.
- Transport independent: one `HTTPServerWritable` instantiation serves TCP, TLS and unix listeners through `uws::AnyResponse`, so the test stays TCP-only.
- Suites run locally with the debug ASAN build: `serve-direct-readable-stream` (30/30), `serve.test.ts` (295 pass; the 2 failures are the root-port and `/bun:info` loopback cases that fail identically on the stock binary in this container), `bun-server.test.ts` (IPv6 case environmental), `serve-body-leak`, `body-stream` (9086), `test/js/bun/stream/direct-readable-stream`, `serve-stream-body-error`, `serve-async-stream-client-abort`, `serve-response-stream-sink-leak`, `serve-stream-reject-flush-leak`, `async-iterator-stream`, `serve-error-handler-stream`, `serve-http2`, `serve-http2-lifecycle`, `serve-http3`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [62.92ms]
(pass) controller.end() after pull() resolved does not use the sink after free [450.84ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1335.33ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1267.18ms]
(pass) direct stream whose pull() runs while its Response is being attached > closing the connection after the request was released does not reach the request [1216.51ms]
(pass) pull() rejecting after the client aborted releases the request without reporting the error [1253.90ms]
(pass) direct stream whose pull() runs while its Response is being attached > server.stop(true) from inside pull() (fetch(), directly) aborts the stream before the socket is freed [1239.51ms]
(pass) direct stream whose pull() runs while its R
... (truncated)

release without fix: 6 failed, 4 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [14.50ms]
(skip) controller.end() after pull() resolved does not use the sink after free
(skip) client disconnect after controller.end() with a parked pull() does not use the socket after free
(skip) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free
(pass) direct stream whose pull() runs while its Response is being attached > closing the connection after the request was released does not reach the request [22.04ms]
(pass) direct stream whose pull() runs while its Response is being attached > server.stop(true) from inside pull() (fetch(), directly) aborts the stream before the socket is freed [20.89ms]
(pass) direct stream whose pull() runs while its Response is being attached > server.stop(true) from inside pull() (async fetch(), directly) aborts the stream before the socket is freed [20.79ms]
(pass) pull() rejecting after the client aborted releases the request without reporting the error [24.50ms]
(pass) direct stream whose pull() runs while its Response is being attac
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [57.78ms]
(pass) controller.end() after pull() resolved does not use the sink after free [436.21ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1474.16ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1308.58ms]
(pass) direct stream whose pull() runs while its Response is being attached > closing the connection after the request was released does not reach the request [1377.23ms]
(pass) pull() rejecting after the client aborted releases the request without reporting the error [1412.94ms]
(pass) direct stream whose pull() runs while its Response is being attached > server.stop(true) from inside pull() (fetch(), directly) aborts the stream before the socket is freed [1361.15ms]
(pass) direct stream whose pull() runs while its R
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     56c1395e24
  features     baseline

23 deps, 131 codegen, 1172 objects in 681ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [10.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] gen bindgenv2
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen ProcessBindingC
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/streams.rs                     |  57 +++---
 .../bun/http/serve-direct-readable-stream.test.ts  | 212 +++++++++++++++------
 2 files changed, 188 insertions(+), 81 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/webcore/streams.rs                             7     16     11
test/js/bun/http/serve-direct-readable-stream.test.ts      3      1     11
```

</details>

**root cause** · written by the author bot

The HTTP response sink tracked whether the chunked terminator had already been written with a flag that `close()` failed to consult: when `close()` ran with bytes still pending after chunked streaming had begun, it drained the buffer through the final-chunk-plus-terminator write path and then the end path emitted a second `0\r\n\r\n`, so the response carried two last-chunks and the five surplus bytes desynchronized the next message on a keep-alive connection. The fix funnels every termination path through a single helper that writes the terminator only if it has not already been written and…

<!-- robobun:evidence:end -->