### PR TITLE
Bun.write: detach and end the FileSink when a JS stream body settles without closing its controller

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1592,14 +1592,7 @@ impl BlobExt for Blob {
             assignment_result.ensure_still_alive();
             // it returns a Promise when it goes through ReadableStreamDefaultReader
             if let Some(promise) = assignment_result.as_any_promise() {
-                let status = promise.status();
-                if status != jsc::js_promise::Status::Pending {
-                    // The pump is over and `file_sink`'s reference goes away
-                    // when this function returns, so the controller cell must
-                    // not keep pointing at the sink.
-                    file_sink.detach_js_controller(global_this);
-                }
-                match status {
+                match promise.status() {
                     jsc::js_promise::Status::Pending => {
                         let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
                             promise: jsc::JSPromiseStrong::init(global_this),
@@ -1621,6 +1614,14 @@ impl BlobExt for Blob {
                         return Ok(promise_value);
                     }
                     jsc::js_promise::Status::Fulfilled => {
+                        // `file_sink`'s reference goes away when this returns.
+                        if let bun_sys::Result::Err(err) = file_sink.end_js_pump(global_this) {
+                            return Ok(JSPromise::rejected_promise(
+                                global_this,
+                                err.to_js(global_this),
+                            )
+                            .to_js());
+                        }
                         let written = file_sink.stream_bytes.get().unwrap_or(0);
                         readable_stream.done();
                         return Ok(JSPromise::resolved_promise_value(
@@ -1629,6 +1630,8 @@ impl BlobExt for Blob {
                         ));
                     }
                     jsc::js_promise::Status::Rejected => {
+                        // The pump's error is the one reported.
+                        let _ = file_sink.end_js_pump(global_this);
                         readable_stream.cancel(global_this)?;
                         promise.set_handled(global_this.vm());
                         return Ok(JSPromise::rejected_promise(
@@ -1639,12 +1642,14 @@ impl BlobExt for Blob {
                     }
                 }
             } else {
-                file_sink.detach_js_controller(global_this);
+                let _ = file_sink.end_js_pump(global_this);
                 readable_stream.cancel(global_this)?;
                 return Ok(JSPromise::rejected_promise(global_this, assignment_result).to_js());
             }
         }
-        file_sink.detach_js_controller(global_this);
+        if let bun_sys::Result::Err(err) = file_sink.end_js_pump(global_this) {
+            return Ok(JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js());
+        }
         let written = file_sink.stream_bytes.get().unwrap_or(0);
 
         Ok(JSPromise::resolved_promise_value(
@@ -5748,12 +5753,16 @@ pub(crate) fn on_file_stream_resolve_request_stream(
     let mut this: Box<FileStreamWrapper> = unsafe {
         bun_core::heap::take(args[args.len() - 1].as_number() as usize as *mut FileStreamWrapper)
     };
-    // This call owns the last reference the pump held; the controller cell must
-    // not outlive it still pointing at the sink.
-    this.sink.detach_js_controller(global_this);
+    // `this` holds the last reference the pump had on the sink.
+    let ended = this.sink.end_js_pump(global_this);
     let strong = core::mem::take(&mut this.readable_stream_ref);
     if let Some(stream) = strong.get() {
         stream.done();
+    }
+    if let bun_sys::Result::Err(err) = ended {
+        this.promise
+            .reject(global_this, Ok(err.to_js(global_this)))?;
+        return Ok(JSValue::UNDEFINED);
     }
     let written = this.sink.stream_bytes.get().unwrap_or(0);
     this.promise
@@ -5775,10 +5784,9 @@ pub(crate) fn on_file_stream_reject_request_stream(
     };
     let err = args[0];
 
-    // A direct stream's pump fails without an `end()`/`close()` on the
-    // controller, so the cell may still point at the sink whose last reference
-    // this call owns.
-    this.sink.detach_js_controller(global_this);
+    // `this` holds the last reference the pump had on the sink. The pump's
+    // error is the one reported.
+    let _ = this.sink.end_js_pump(global_this);
 
     let strong = core::mem::take(&mut this.readable_stream_ref);
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5775,8 +5775,9 @@ pub(crate) fn on_file_stream_reject_request_stream(
     };
     let err = args[0];
 
-    // The pump failed without an `end()`/`close()` on the controller, so the
-    // cell still points at the sink whose last reference this call owns.
+    // A direct stream's pump fails without an `end()`/`close()` on the
+    // controller, so the cell may still point at the sink whose last reference
+    // this call owns.
     this.sink.detach_js_controller(global_this);
 
     let strong = core::mem::take(&mut this.readable_stream_ref);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1592,7 +1592,14 @@ impl BlobExt for Blob {
             assignment_result.ensure_still_alive();
             // it returns a Promise when it goes through ReadableStreamDefaultReader
             if let Some(promise) = assignment_result.as_any_promise() {
-                match promise.status() {
+                let status = promise.status();
+                if status != jsc::js_promise::Status::Pending {
+                    // The pump is over and `file_sink`'s reference goes away
+                    // when this function returns, so the controller cell must
+                    // not keep pointing at the sink.
+                    file_sink.detach_js_controller(global_this);
+                }
+                match status {
                     jsc::js_promise::Status::Pending => {
                         let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
                             promise: jsc::JSPromiseStrong::init(global_this),
@@ -1632,10 +1639,12 @@ impl BlobExt for Blob {
                     }
                 }
             } else {
+                file_sink.detach_js_controller(global_this);
                 readable_stream.cancel(global_this)?;
                 return Ok(JSPromise::rejected_promise(global_this, assignment_result).to_js());
             }
         }
+        file_sink.detach_js_controller(global_this);
         let written = file_sink.stream_bytes.get().unwrap_or(0);
 
         Ok(JSPromise::resolved_promise_value(
@@ -5739,6 +5748,9 @@ pub(crate) fn on_file_stream_resolve_request_stream(
     let mut this: Box<FileStreamWrapper> = unsafe {
         bun_core::heap::take(args[args.len() - 1].as_number() as usize as *mut FileStreamWrapper)
     };
+    // This call owns the last reference the pump held; the controller cell must
+    // not outlive it still pointing at the sink.
+    this.sink.detach_js_controller(global_this);
     let strong = core::mem::take(&mut this.readable_stream_ref);
     if let Some(stream) = strong.get() {
         stream.done();
@@ -5762,6 +5774,10 @@ pub(crate) fn on_file_stream_reject_request_stream(
         bun_core::heap::take(args[args.len() - 1].as_number() as usize as *mut FileStreamWrapper)
     };
     let err = args[0];
+
+    // The pump failed without an `end()`/`close()` on the controller, so the
+    // cell still points at the sink whose last reference this call owns.
+    this.sink.detach_js_controller(global_this);
 
     let strong = core::mem::take(&mut this.readable_stream_ref);
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1017,26 +1017,30 @@ impl FileSink {
         }
     }
 
-    /// Take the JS pump controller's pointer to this sink away from it.
+    /// The JS pump that `JSSink::assign_to_stream` started into this sink has
+    /// settled. If it did so without `controller.end()`/`.close()` (a direct
+    /// stream whose `pull()` settled without closing it), do here what those
+    /// would have done: detach the controller cell and end the sink.
     ///
-    /// `JSSink::assign_to_stream` hands the `JSReadableFileSinkController` cell
-    /// a raw `*FileSink` and takes no refcount claim for it, while the cell's
-    /// destructor releases one (`FileSink__finalize`). A pump that closes the
-    /// controller (`controller.end()`/`.close()`) nulls the cell's sink
-    /// pointer first, so the destructor releases nothing and a later
-    /// `controller.write()` is a no-op. A direct stream whose `pull()` settles
-    /// without closing the controller never does. So the owner of the sink
-    /// detaches the cell here, on every path that gives up its own reference.
-    /// A no-op once the controller is detached.
-    pub(crate) fn detach_js_controller(&self, global_this: &JSGlobalObject) {
-        if !matches!(self.source.get(), streams::SourceHandle::JSController(_)) {
-            return;
-        }
-        // Take the handle out of the cell before the call: `detach_ptr` runs
-        // the controller's `onClose`, which reaches `js_controller_detached` on
-        // this sink and borrows `source` again.
-        let mut source = self.source.replace(streams::SourceHandle::default());
-        JSSink::detach(&mut source, global_this);
+    /// The cell holds a raw `*FileSink` with no refcount claim, and its
+    /// destructor releases one (`FileSink__finalize`) while it is attached.
+    /// Once detached, it neither finalizes nor writes to the sink. Ending the
+    /// sink flushes what it buffered and closes it, which releases the
+    /// keep-alive reference a pending write took. Returns the flush error, if
+    /// any. A no-op once the controller is detached.
+    pub(crate) fn end_js_pump(&self, global_this: &JSGlobalObject) -> sys::Result<()> {
+        let streams::SourceHandle::JSController(controller) = *self.source.get() else {
+            return sys::Result::Ok(());
+        };
+        // Cleared first: detaching runs the controller's `onClose`, which
+        // reaches `js_controller_detached` on this sink and borrows `source`.
+        self.source.take();
+        // `onClose` runs the direct stream's close steps, `underlyingSource.cancel()`
+        // included. A throw from that user hook is reported, not left pending.
+        crate::dispatch::fold(bun_jsc::call_check_slow(global_this, || {
+            streams::controller_abi::detach_ptr(controller)
+        }));
+        self.end(None)
     }
 
     /// Protect the JS wrapper object from GC collection while an async operation is pending.

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1017,6 +1017,28 @@ impl FileSink {
         }
     }
 
+    /// Take the JS pump controller's pointer to this sink away from it.
+    ///
+    /// `JSSink::assign_to_stream` hands the `JSReadableFileSinkController` cell
+    /// a raw `*FileSink` and takes no refcount claim for it, while the cell's
+    /// destructor releases one (`FileSink__finalize`). Every pump that reaches
+    /// its end calls `controller.end()`/`.close()` first, which nulls the
+    /// cell's sink pointer, so the destructor releases nothing and a later
+    /// `controller.write()` is a no-op. A pump that fails after it returned (a
+    /// direct stream whose `pull()` promise rejects) calls neither. So the
+    /// owner of the sink detaches the cell here, on every path that gives up
+    /// its own reference.
+    pub(crate) fn detach_js_controller(&self, global_this: &JSGlobalObject) {
+        if !matches!(self.source.get(), streams::SourceHandle::JSController(_)) {
+            return;
+        }
+        // Take the handle out of the cell before the call: `detach_ptr` runs
+        // the controller's `onClose`, which reaches `js_controller_detached` on
+        // this sink and borrows `source` again.
+        let mut source = self.source.replace(streams::SourceHandle::default());
+        JSSink::detach(&mut source, global_this);
+    }
+
     /// Protect the JS wrapper object from GC collection while an async operation is pending.
     /// This should be called when endFromJS returns a pending Promise.
     /// The reference is released when runPending() completes.

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1021,13 +1021,13 @@ impl FileSink {
     ///
     /// `JSSink::assign_to_stream` hands the `JSReadableFileSinkController` cell
     /// a raw `*FileSink` and takes no refcount claim for it, while the cell's
-    /// destructor releases one (`FileSink__finalize`). Every pump that reaches
-    /// its end calls `controller.end()`/`.close()` first, which nulls the
-    /// cell's sink pointer, so the destructor releases nothing and a later
-    /// `controller.write()` is a no-op. A pump that fails after it returned (a
-    /// direct stream whose `pull()` promise rejects) calls neither. So the
-    /// owner of the sink detaches the cell here, on every path that gives up
-    /// its own reference.
+    /// destructor releases one (`FileSink__finalize`). A pump that closes the
+    /// controller (`controller.end()`/`.close()`) nulls the cell's sink
+    /// pointer first, so the destructor releases nothing and a later
+    /// `controller.write()` is a no-op. A direct stream whose `pull()` settles
+    /// without closing the controller never does. So the owner of the sink
+    /// detaches the cell here, on every path that gives up its own reference.
+    /// A no-op once the controller is detached.
     pub(crate) fn detach_js_controller(&self, global_this: &JSGlobalObject) {
         if !matches!(self.source.get(), streams::SourceHandle::JSController(_)) {
             return;

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1141,6 +1141,69 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         Bun.write(join(String(dir), "missing", "c"), await fetch(server.url), { createPath: false }),
       ).rejects.toThrow(expect.objectContaining({ code: "ENOENT" }));
     });
+
+    // A direct stream whose pull() rejects after it returned calls neither controller.end()
+    // nor controller.close(), so the controller cell kept its pointer to the FileSink. The
+    // cell's destructor then released a reference it never took, which freed the sink while
+    // the flush task the sink had queued on the event loop still pointed at it.
+    describe.each([
+      ["an async generator that throws right after a yield", `yield "first"; throw new Error("boom");`],
+      ["an async generator that throws before the first yield", `throw new Error("boom");`],
+    ])("a body that fails: %s", (_label, generatorBody) => {
+      it("rejects, and the collected controller does not free the sink", async () => {
+        using dir = tempDir("bun-write-failed-generator", {});
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const dest = ${JSON.stringify(join(String(dir), "out.txt"))};
+             const body = async function* () { ${generatorBody} };
+             for (let i = 0; i < 5; i++) {
+               const reason = await Bun.write(dest, new Response(body())).then(() => "resolved", e => e.message);
+               if (reason !== "boom") { console.log("unexpected:", reason); process.exit(2); }
+               Bun.gc(true);
+             }
+             console.log("survived");`,
+          ],
+          env: bunEnv,
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr }).toEqual({ stdout: "survived\n", stderr: "" });
+        expect(exitCode).toBe(0);
+      });
+    });
+
+    it("a body that fails: a direct stream whose pull rejects", async () => {
+      using dir = tempDir("bun-write-failed-direct-stream", {});
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const dest = ${JSON.stringify(join(String(dir), "out.txt"))};
+           const body = () =>
+             new ReadableStream({
+               type: "direct",
+               async pull(controller) {
+                 controller.write("first");
+                 await Promise.resolve();
+                 throw new Error("boom");
+               },
+             });
+           for (let i = 0; i < 5; i++) {
+             const reason = await Bun.write(dest, new Response(body())).then(() => "resolved", e => e.message);
+             if (reason !== "boom") { console.log("unexpected:", reason); process.exit(2); }
+             Bun.gc(true);
+           }
+           console.log("survived");`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr }).toEqual({ stdout: "survived\n", stderr: "" });
+      expect(exitCode).toBe(0);
+    });
   });
 
   it("BunFile.name survives concurrent write() calls + GC", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1142,66 +1142,63 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       ).rejects.toThrow(expect.objectContaining({ code: "ENOENT" }));
     });
 
-    // A direct stream whose pull() rejects after it returned calls neither controller.end()
-    // nor controller.close(), so the controller cell kept its pointer to the FileSink. The
-    // cell's destructor then released a reference it never took, which freed the sink while
-    // the flush task the sink had queued on the event loop still pointed at it.
-    describe.each([
-      ["an async generator that throws right after a yield", `yield "first"; throw new Error("boom");`],
-      ["an async generator that throws before the first yield", `throw new Error("boom");`],
-    ])("a body that fails: %s", (_label, generatorBody) => {
-      it("rejects, and the collected controller does not free the sink", async () => {
-        using dir = tempDir("bun-write-failed-generator", {});
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "-e",
-            `const dest = ${JSON.stringify(join(String(dir), "out.txt"))};
-             const body = async function* () { ${generatorBody} };
-             for (let i = 0; i < 5; i++) {
-               const reason = await Bun.write(dest, new Response(body())).then(() => "resolved", e => e.message);
-               if (reason !== "boom") { console.log("unexpected:", reason); process.exit(2); }
-               Bun.gc(true);
-             }
-             console.log("survived");`,
-          ],
-          env: bunEnv,
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect({ stdout, stderr }).toEqual({ stdout: "survived\n", stderr: "" });
-        expect(exitCode).toBe(0);
-      });
-    });
-
-    it("a body that fails: a direct stream whose pull rejects", async () => {
-      using dir = tempDir("bun-write-failed-direct-stream", {});
+    // A direct stream whose pull() settles without a controller.end() or controller.close()
+    // left the controller cell pointing at the FileSink. When the cell was collected it
+    // released a reference it never took: that freed the sink under the flush task the sink
+    // had queued on the event loop, or under a later write through the same controller.
+    it.each([
+      [
+        "an async generator that throws right after a yield",
+        `async function* () { yield "first"; throw new Error("boom"); }`,
+        "rejected: boom",
+        "first",
+      ],
+      [
+        "an async generator that throws before its first yield",
+        `async function* () { throw new Error("boom"); }`,
+        "rejected: boom",
+        "",
+      ],
+      [
+        "a direct ReadableStream whose pull rejects",
+        `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await 1; throw new Error("boom"); } })`,
+        "rejected: boom",
+        "first",
+      ],
+      [
+        "a direct ReadableStream whose pull resolves without closing it",
+        `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await 1; } })`,
+        "resolved: 5",
+        "first",
+      ],
+    ])("the body's sink controller is collectable after %s", async (_label, body, settled, content) => {
+      using dir = tempDir("bun-write-settled-controller", {});
+      // A Windows file write completes on the libuv thread pool, so the bytes may land after
+      // Bun.write has settled; only the outcome is checked there.
+      const tail = isWindows ? `""` : `", " + JSON.stringify(readFileSync(dest, "utf8"))`;
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),
           "-e",
-          `const dest = ${JSON.stringify(join(String(dir), "out.txt"))};
-           const body = () =>
-             new ReadableStream({
-               type: "direct",
-               async pull(controller) {
-                 controller.write("first");
-                 await Promise.resolve();
-                 throw new Error("boom");
-               },
-             });
+          `const { readFileSync } = require("fs");
+           const dest = ${JSON.stringify(join(String(dir), "out.txt"))};
+           const body = ${body};
+           const outcomes = new Set();
            for (let i = 0; i < 5; i++) {
-             const reason = await Bun.write(dest, new Response(body())).then(() => "resolved", e => e.message);
-             if (reason !== "boom") { console.log("unexpected:", reason); process.exit(2); }
+             const settled = await Bun.write(dest, new Response(body())).then(n => "resolved: " + n, e => "rejected: " + e.message);
+             outcomes.add(settled + ${tail});
              Bun.gc(true);
            }
-           console.log("survived");`,
+           console.log([...outcomes].join(" | "));`,
         ],
         env: bunEnv,
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, stderr }).toEqual({ stdout: "survived\n", stderr: "" });
+      expect({ stdout: stdout.trim(), stderr }).toEqual({
+        stdout: isWindows ? settled : `${settled}, ${JSON.stringify(content)}`,
+        stderr: "",
+      });
       expect(exitCode).toBe(0);
     });
   });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1146,6 +1146,8 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     // left the controller cell pointing at the FileSink. When the cell was collected it
     // released a reference it never took: that freed the sink under the flush task the sink
     // had queued on the event loop, or under a later write through the same controller.
+    // `await 1` settles while Bun.write drains microtasks (the synchronous arms); `tick`
+    // settles on a later event-loop turn (the promise reaction handlers).
     it.each([
       [
         "an async generator that throws right after a yield",
@@ -1160,6 +1162,12 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         "",
       ],
       [
+        "an async generator that throws on a later tick",
+        `async function* () { yield "first"; await tick(); throw new Error("boom"); }`,
+        "rejected: boom",
+        "first",
+      ],
+      [
         "a direct ReadableStream whose pull rejects",
         `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await 1; throw new Error("boom"); } })`,
         "rejected: boom",
@@ -1168,6 +1176,12 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       [
         "a direct ReadableStream whose pull resolves without closing it",
         `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await 1; } })`,
+        "resolved: 5",
+        "first",
+      ],
+      [
+        "a direct ReadableStream whose pull resolves on a later tick without closing it",
+        `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await tick(); } })`,
         "resolved: 5",
         "first",
       ],
@@ -1182,6 +1196,7 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
           "-e",
           `const { readFileSync } = require("fs");
            const dest = ${JSON.stringify(join(String(dir), "out.txt"))};
+           const tick = () => new Promise(resolve => setImmediate(resolve));
            const body = ${body};
            const outcomes = new Set();
            for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
### Problem
- `Bun.write(dest, new Response(gen()))` crashes at the next GC when the async generator `gen` throws (or any direct stream's `pull()` settles without closing the controller). 1.4.2: `Segmentation fault at address 0xC0`. ASAN: `heap-use-after-free` in `FlushPendingTask::run_from_js_thread`, freed by `FileSink::finalize` in `~JSReadableFileSinkController`.
- `JSSink::assign_to_stream` (`src/runtime/webcore/Sink.rs:228`) gives the controller cell a raw `*FileSink` and takes no reference for it. The cell's destructor releases one unless `controller.end()`/`close()` detached it. `Blob::pipe_readable_stream_to_blob` relied on the pump to call those.

### Fix
- Add `FileSink::end_js_pump`: when the pump settled with the controller attached, detach it and `end()` the sink, as `controller.end()` would have. `pipe_readable_stream_to_blob` calls it on every settle path (three synchronous arms, the fall-through, both reaction handlers).
- A detached controller cannot write to or finalize the sink. That covers all three reported (use, free) pairs. `end()` also releases a pending write's keep-alive reference, so nothing leaks instead.
- Verified: 6 new cases in `test/js/bun/io/bun-write.test.js` fail on the unfixed debug build (ASAN) and on 1.4.3 canary (segfault), and pass with the fix. Plus the whole file and four related suites.

### Background
- `FileSink` is the refcounted native writer behind `Bun.write(dest, stream)`. A flush deferred to the event loop (`FlushPendingTask`) holds its own reference until it runs.
- For a JS-stream body, `assign_to_stream` creates a `JSReadableFileSinkController` (a C++ GC cell) that pumps chunks into the sink through `m_sinkPtr`. `end()`, `close()` and `detachPtr` null it. The destructor finalizes the sink only while it is set.
- An async-iterable body becomes a direct stream. `readDirectStream` (`BunStreamSource.cpp`) ties its result to the `pull()` promise and closes nothing.

<details><summary>Notes</summary>

Repro (crashes 1.4.2 and 1.4.3-canary every run):

```js
const body = async function* () { yield "first"; throw new Error("boom"); };
await Bun.write(`/tmp/out.txt`, new Response(body())).catch(e => console.log("rejected:", e.message));
Bun.gc(true); // controller cell swept -> FileSink__finalize -> deref -> freed; the queued FlushPendingTask then runs on it
```

Reference accounting on that path before the fix: `FileSink::init` +1 (held by the `RefPtr` in `pipe_readable_stream_to_blob`), `run_pending_later` +1 for the queued task. The function returns: 1. GC sweeps the controller: 0, freed. The task runs: use-after-free. With the controller detached, the task's reference is the last one and the sink is freed after the task has run.

The async-iterable source closes the controller on success only (`asyncIterFinishSuccess` in `BunAsyncIterableSource.cpp`), not in `asyncIterFinishWithError`, which is why the throwing generator is the common way to reach this. Other shapes of the same bug that the new test covers: a generator that throws before its first yield or on a later event-loop turn, a direct `ReadableStream` whose async `pull` rejects, and one whose async `pull` resolves without closing the controller, in the same turn or a later one (freed on the resolve path, then used by the destructor or a later `controller.write()`). The same-turn cases settle while `Bun.write` drains microtasks and take the synchronous arms. The later-turn cases take the `FileStreamWrapper` reaction handlers.

The other owners of a JS-pump sink detach the controller in their teardown already: `RequestContext.rs` (`Bun.serve`), `FetchTasklet::clear_sink`, `S3UploadStreamWrapper::detach_sink`. The `Bun.spawn` stdin path gets there through `writer.close()` -> `on_close` -> `source.close()` -> the controller's `onClose` -> `controller.end()`. `ReadableStream__cancel` (`WebStreamsExports.cpp`) documents the rule: a direct consumer's teardown "is owned by the controller close/detach path, never by readableStreamCancel". A pump that closed the controller itself has already cleared `source`, and `end_js_pump` is then a no-op.

Why `end()` and not only a detach: on a destination where writes complete later (every file on Windows, a FIFO or socket on POSIX) a pending write takes a keep-alive reference that only the writer's close releases. With the controller detached and nobody ending the sink, that reference would keep the sink and its fd alive forever. `end()` flushes, then closes, exactly what `controller.end()` -> `end_from_js` does. Its flush error, if any, becomes the rejection on the resolve paths. On the reject paths the pump's error wins.

Detaching runs the direct stream's close steps (`readDirectStreamCloseImpl`): the consumed stream ends up closed instead of staying locked and readable, and the source's `cancel` hook runs. For the async-iterable source that hook finds the iterator already finished and does nothing.

Other suites run with the fixed debug build: `test/js/bun/util/filesink.test.ts`, `test/js/web/streams/streams.test.js`, `test/js/bun/http/async-iterator-stream.test.ts`, `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`. No new failures (one pre-existing local timeout under the debug build that does not touch this path: the 256 MB `copyFileRange` fallback copy). No fd or `FileSink` leak over 200 iterations of the throwing generator and of the resolve-without-close stream (`fileSinkInternals.liveCount()` and `/proc/self/fd` stay flat).

Behavior is otherwise unchanged: a direct stream whose sync `pull` never closes still leaves `Bun.write` pending, as before.

Self-reviewed: 4 concerns raised, 4 addressed (end the sink so a pending write's keep-alive reference is released, report a throwing `cancel` hook instead of leaving the exception pending, cover the reaction-handler paths in the test, doc wording).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->