### PR TITLE
Bun.write: end the FileSink a JS stream was piped into when the pump settles

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -1041,6 +1041,29 @@ ${classes
   .join("\n")}
 }
 
+// Stop the controller pointing at its native sink, and nothing else. The owner
+// of a sink calls this when it gives up the last reference it holds: the
+// controller cell can outlive the sink, and both a late controller.write() and
+// ~controller (which calls finalize, releasing a reference the controller never
+// took) would then read freed memory. This is the same native-pointer pair the
+// end() and close() host fns run before they touch JS, so it cannot throw, run
+// user code, or change the piped stream's state. detach() is the variant that
+// also tells the stream the sink closed.
+extern "C" void JSSinkController__detachSinkPtr(JSC::EncodedJSValue controllerValue)
+{
+    JSC::JSValue value = JSC::JSValue::decode(controllerValue);
+${classes
+  .map(
+    name =>
+      `    if (auto* controller = dynamicDowncast<WebCore::${names(name).controller}>(value)) {
+        if (void* ptr = std::exchange(controller->m_sinkPtr, nullptr))
+            WebCore::${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
+        return;
+    }`,
+  )
+  .join("\n")}
+}
+
 namespace WebCore {
 
 void closeSinkControllerWithError(JSC::JSGlobalObject* globalObject, JSReadableSinkControllerBase* controller, JSC::JSValue error)

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -1041,14 +1041,7 @@ ${classes
   .join("\n")}
 }
 
-// Stop the controller pointing at its native sink, and nothing else. The owner
-// of a sink calls this when it gives up the last reference it holds: the
-// controller cell can outlive the sink, and both a late controller.write() and
-// ~controller (which calls finalize, releasing a reference the controller never
-// took) would then read freed memory. This is the same native-pointer pair the
-// end() and close() host fns run before they touch JS, so it cannot throw, run
-// user code, or change the piped stream's state. detach() is the variant that
-// also tells the stream the sink closed.
+// detach() minus the onClose callback: for a sink owner about to free the sink while the controller cell may outlive it. Runs no JS.
 extern "C" void JSSinkController__detachSinkPtr(JSC::EncodedJSValue controllerValue)
 {
     JSC::JSValue value = JSC::JSValue::decode(controllerValue);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1640,7 +1640,7 @@ impl BlobExt for Blob {
                         break 'piped Err(err);
                     }
                     break 'piped Ok(
-                        JSPromise::rejected_promise(global_this, assignment_result).to_js(),
+                        JSPromise::rejected_promise(global_this, assignment_result).to_js()
                     );
                 }
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1582,11 +1582,7 @@ impl BlobExt for Blob {
 
         assignment_result.ensure_still_alive();
 
-        // Every way out of this block is a settled pump: the sink is ended in
-        // there (`end_js_pump`), and `file_sink`, the last reference on it,
-        // drops after the block, behind `detach_js_controller`. Only a pump
-        // that is still pending returns early: it hands all of that over to
-        // `FileStreamWrapper`.
+        // A settled pump ends the sink and breaks out to the detach below; only a pending one returns, handing both to `FileStreamWrapper`.
         let outcome: JsResult<JSValue> = 'piped: {
             if let Some(err) = assignment_result.to_error() {
                 file_sink.end_js_pump(None);
@@ -1645,8 +1641,7 @@ impl BlobExt for Blob {
                 }
             }
 
-            // The pump already finished. The promise settles with the byte
-            // count once the file is closed: now, unless a flush is draining.
+            // The pump already finished; the promise carries the byte count once the file is closed.
             readable_stream.done();
             let promise = jsc::JSPromiseStrong::init(global_this);
             let promise_value = promise.value();
@@ -5741,8 +5736,7 @@ impl Drop for S3BlobDownloadTask {
 struct FileStreamWrapper {
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) readable_stream_ref: webcore::readable_stream::ReadableStreamStrong,
-    /// The reference `pipe_readable_stream_to_blob` handed over, and the last
-    /// one on the sink. `Drop` releases it, behind `detach_js_controller`.
+    /// The last reference on the sink; `Drop` detaches the JS controller before releasing it.
     pub sink: RefPtr<webcore::FileSink>,
 }
 
@@ -5787,8 +5781,7 @@ pub(crate) fn on_file_stream_reject_request_stream(
 
     let strong = core::mem::take(&mut this.readable_stream_ref);
 
-    // What arrived is written out and the file is closed, as when a piped
-    // reader fails (`js_close`).
+    // Writes out what arrived and closes the file, as `js_close` does when a piped reader fails.
     this.sink.end_js_pump(None);
 
     this.promise.reject(global_this, Ok(err))?;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1582,66 +1582,80 @@ impl BlobExt for Blob {
 
         assignment_result.ensure_still_alive();
 
-        if let Some(err) = assignment_result.to_error() {
-            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
-        }
-
-        if !assignment_result.is_empty_or_undefined_or_null() {
-            global_this.bun_vm().as_mut().drain_microtasks();
-
-            assignment_result.ensure_still_alive();
-            // it returns a Promise when it goes through ReadableStreamDefaultReader
-            if let Some(promise) = assignment_result.as_any_promise() {
-                match promise.status() {
-                    jsc::js_promise::Status::Pending => {
-                        let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
-                            promise: jsc::JSPromiseStrong::init(global_this),
-                            readable_stream_ref:
-                                webcore::readable_stream::ReadableStreamStrong::init(
-                                    readable_stream,
-                                    global_this,
-                                ),
-                            sink: file_sink,
-                        }));
-                        // SAFETY: wrapper was just produced by heap::alloc; sole owner here.
-                        let promise_value = unsafe { (*wrapper).promise.value() };
-                        assignment_result.then(
-                            global_this,
-                            wrapper.cast::<c_void>(),
-                            on_file_stream_resolve_request_stream_shim,
-                            on_file_stream_reject_request_stream_shim,
-                        );
-                        return Ok(promise_value);
-                    }
-                    jsc::js_promise::Status::Fulfilled => {
-                        let written = file_sink.stream_bytes.get().unwrap_or(0);
-                        readable_stream.done();
-                        return Ok(JSPromise::resolved_promise_value(
-                            global_this,
-                            JSValue::js_number(written as f64),
-                        ));
-                    }
-                    jsc::js_promise::Status::Rejected => {
-                        readable_stream.cancel(global_this)?;
-                        promise.set_handled(global_this.vm());
-                        return Ok(JSPromise::rejected_promise(
-                            global_this,
-                            promise.result(global_this.vm()),
-                        )
-                        .to_js());
-                    }
-                }
-            } else {
-                readable_stream.cancel(global_this)?;
-                return Ok(JSPromise::rejected_promise(global_this, assignment_result).to_js());
+        // Every way out of this block is a settled pump: the sink is ended in
+        // there (`end_js_pump`), and `file_sink`, the last reference on it,
+        // drops after the block, behind `detach_js_controller`. Only a pump
+        // that is still pending returns early: it hands all of that over to
+        // `FileStreamWrapper`.
+        let outcome: JsResult<JSValue> = 'piped: {
+            if let Some(err) = assignment_result.to_error() {
+                file_sink.end_js_pump(None);
+                break 'piped Ok(JSPromise::rejected_promise(global_this, err).to_js());
             }
-        }
-        let written = file_sink.stream_bytes.get().unwrap_or(0);
 
-        Ok(JSPromise::resolved_promise_value(
-            global_this,
-            JSValue::js_number(written as f64),
-        ))
+            if !assignment_result.is_empty_or_undefined_or_null() {
+                global_this.bun_vm().as_mut().drain_microtasks();
+
+                assignment_result.ensure_still_alive();
+                // it returns a Promise when it goes through ReadableStreamDefaultReader
+                if let Some(promise) = assignment_result.as_any_promise() {
+                    match promise.status() {
+                        jsc::js_promise::Status::Pending => {
+                            let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
+                                promise: jsc::JSPromiseStrong::init(global_this),
+                                readable_stream_ref:
+                                    webcore::readable_stream::ReadableStreamStrong::init(
+                                        readable_stream,
+                                        global_this,
+                                    ),
+                                sink: file_sink,
+                            }));
+                            // SAFETY: wrapper was just produced by heap::alloc; sole owner here.
+                            let promise_value = unsafe { (*wrapper).promise.value() };
+                            assignment_result.then(
+                                global_this,
+                                wrapper.cast::<c_void>(),
+                                on_file_stream_resolve_request_stream_shim,
+                                on_file_stream_reject_request_stream_shim,
+                            );
+                            return Ok(promise_value);
+                        }
+                        jsc::js_promise::Status::Fulfilled => {}
+                        jsc::js_promise::Status::Rejected => {
+                            file_sink.end_js_pump(None);
+                            if let Err(err) = readable_stream.cancel(global_this) {
+                                break 'piped Err(err);
+                            }
+                            promise.set_handled(global_this.vm());
+                            break 'piped Ok(JSPromise::rejected_promise(
+                                global_this,
+                                promise.result(global_this.vm()),
+                            )
+                            .to_js());
+                        }
+                    }
+                } else {
+                    file_sink.end_js_pump(None);
+                    if let Err(err) = readable_stream.cancel(global_this) {
+                        break 'piped Err(err);
+                    }
+                    break 'piped Ok(
+                        JSPromise::rejected_promise(global_this, assignment_result).to_js(),
+                    );
+                }
+            }
+
+            // The pump already finished. The promise settles with the byte
+            // count once the file is closed: now, unless a flush is draining.
+            readable_stream.done();
+            let promise = jsc::JSPromiseStrong::init(global_this);
+            let promise_value = promise.value();
+            file_sink.end_js_pump(Some(promise));
+            Ok(promise_value)
+        };
+
+        file_sink.detach_js_controller();
+        outcome
     }
 
     fn get_writer(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
@@ -5727,11 +5741,19 @@ impl Drop for S3BlobDownloadTask {
 struct FileStreamWrapper {
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) readable_stream_ref: webcore::readable_stream::ReadableStreamStrong,
+    /// The reference `pipe_readable_stream_to_blob` handed over, and the last
+    /// one on the sink. `Drop` releases it, behind `detach_js_controller`.
     pub sink: RefPtr<webcore::FileSink>,
 }
 
+impl Drop for FileStreamWrapper {
+    fn drop(&mut self) {
+        self.sink.detach_js_controller();
+    }
+}
+
 pub(crate) fn on_file_stream_resolve_request_stream(
-    global_this: &JSGlobalObject,
+    _global_this: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     let args = callframe.arguments();
@@ -5743,9 +5765,9 @@ pub(crate) fn on_file_stream_resolve_request_stream(
     if let Some(stream) = strong.get() {
         stream.done();
     }
-    let written = this.sink.stream_bytes.get().unwrap_or(0);
-    this.promise
-        .resolve(global_this, JSValue::js_number(written as f64))?;
+    // Settled with the byte count once the file is closed.
+    let promise = this.promise.take();
+    this.sink.end_js_pump(Some(promise));
     Ok(JSValue::UNDEFINED)
 }
 
@@ -5764,6 +5786,10 @@ pub(crate) fn on_file_stream_reject_request_stream(
     let err = args[0];
 
     let strong = core::mem::take(&mut this.readable_stream_ref);
+
+    // What arrived is written out and the file is closed, as when a piped
+    // reader fails (`js_close`).
+    this.sink.end_js_pump(None);
 
     this.promise.reject(global_this, Ok(err))?;
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1582,75 +1582,63 @@ impl BlobExt for Blob {
 
         assignment_result.ensure_still_alive();
 
-        // A settled pump ends the sink and breaks out to the detach below; only a pending one returns, handing both to `FileStreamWrapper`.
-        let outcome: JsResult<JSValue> = 'piped: {
-            if let Some(err) = assignment_result.to_error() {
-                file_sink.end_js_pump(None);
-                break 'piped Ok(JSPromise::rejected_promise(global_this, err).to_js());
-            }
+        if let Some(err) = assignment_result.to_error() {
+            file_sink.end_js_pump(None);
+            return Ok(JSPromise::rejected_promise(global_this, err).to_js());
+        }
 
-            if !assignment_result.is_empty_or_undefined_or_null() {
-                global_this.bun_vm().as_mut().drain_microtasks();
+        if !assignment_result.is_empty_or_undefined_or_null() {
+            global_this.bun_vm().as_mut().drain_microtasks();
 
-                assignment_result.ensure_still_alive();
-                // it returns a Promise when it goes through ReadableStreamDefaultReader
-                if let Some(promise) = assignment_result.as_any_promise() {
-                    match promise.status() {
-                        jsc::js_promise::Status::Pending => {
-                            let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
-                                promise: jsc::JSPromiseStrong::init(global_this),
-                                readable_stream_ref:
-                                    webcore::readable_stream::ReadableStreamStrong::init(
-                                        readable_stream,
-                                        global_this,
-                                    ),
-                                sink: file_sink,
-                            }));
-                            // SAFETY: wrapper was just produced by heap::alloc; sole owner here.
-                            let promise_value = unsafe { (*wrapper).promise.value() };
-                            assignment_result.then(
-                                global_this,
-                                wrapper.cast::<c_void>(),
-                                on_file_stream_resolve_request_stream_shim,
-                                on_file_stream_reject_request_stream_shim,
-                            );
-                            return Ok(promise_value);
-                        }
-                        jsc::js_promise::Status::Fulfilled => {}
-                        jsc::js_promise::Status::Rejected => {
-                            file_sink.end_js_pump(None);
-                            if let Err(err) = readable_stream.cancel(global_this) {
-                                break 'piped Err(err);
-                            }
-                            promise.set_handled(global_this.vm());
-                            break 'piped Ok(JSPromise::rejected_promise(
-                                global_this,
-                                promise.result(global_this.vm()),
-                            )
-                            .to_js());
-                        }
+            assignment_result.ensure_still_alive();
+            // it returns a Promise when it goes through ReadableStreamDefaultReader
+            if let Some(promise) = assignment_result.as_any_promise() {
+                match promise.status() {
+                    jsc::js_promise::Status::Pending => {
+                        let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
+                            promise: jsc::JSPromiseStrong::init(global_this),
+                            readable_stream_ref:
+                                webcore::readable_stream::ReadableStreamStrong::init(
+                                    readable_stream,
+                                    global_this,
+                                ),
+                            sink: file_sink,
+                        }));
+                        // SAFETY: wrapper was just produced by heap::alloc; sole owner here.
+                        let promise_value = unsafe { (*wrapper).promise.value() };
+                        assignment_result.then(
+                            global_this,
+                            wrapper.cast::<c_void>(),
+                            on_file_stream_resolve_request_stream_shim,
+                            on_file_stream_reject_request_stream_shim,
+                        );
+                        return Ok(promise_value);
                     }
-                } else {
-                    file_sink.end_js_pump(None);
-                    if let Err(err) = readable_stream.cancel(global_this) {
-                        break 'piped Err(err);
+                    jsc::js_promise::Status::Fulfilled => {}
+                    jsc::js_promise::Status::Rejected => {
+                        file_sink.end_js_pump(None);
+                        readable_stream.cancel(global_this)?;
+                        promise.set_handled(global_this.vm());
+                        return Ok(JSPromise::rejected_promise(
+                            global_this,
+                            promise.result(global_this.vm()),
+                        )
+                        .to_js());
                     }
-                    break 'piped Ok(
-                        JSPromise::rejected_promise(global_this, assignment_result).to_js()
-                    );
                 }
+            } else {
+                file_sink.end_js_pump(None);
+                readable_stream.cancel(global_this)?;
+                return Ok(JSPromise::rejected_promise(global_this, assignment_result).to_js());
             }
+        }
 
-            // The pump already finished; the promise carries the byte count once the file is closed.
-            readable_stream.done();
-            let promise = jsc::JSPromiseStrong::init(global_this);
-            let promise_value = promise.value();
-            file_sink.end_js_pump(Some(promise));
-            Ok(promise_value)
-        };
-
-        file_sink.detach_js_controller();
-        outcome
+        // The pump already finished; the promise carries the byte count once the file is closed.
+        readable_stream.done();
+        let promise = jsc::JSPromiseStrong::init(global_this);
+        let promise_value = promise.value();
+        file_sink.end_js_pump(Some(promise));
+        Ok(promise_value)
     }
 
     fn get_writer(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
@@ -5736,14 +5724,8 @@ impl Drop for S3BlobDownloadTask {
 struct FileStreamWrapper {
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) readable_stream_ref: webcore::readable_stream::ReadableStreamStrong,
-    /// The last reference on the sink; `Drop` detaches the JS controller before releasing it.
+    /// The last reference on the sink: `end_js_pump` it before the drop.
     pub sink: RefPtr<webcore::FileSink>,
-}
-
-impl Drop for FileStreamWrapper {
-    fn drop(&mut self) {
-        self.sink.detach_js_controller();
-    }
 }
 
 pub(crate) fn on_file_stream_resolve_request_stream(

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -563,8 +563,8 @@ impl FileSink {
         }
         if let Some(promise) = promise {
             self.stream_done.set(promise);
-            // Otherwise a flush is still draining: it holds the keep-alive ref and its `on_close` settles.
-            if !self.must_be_kept_alive_until_eof.get() {
+            // Otherwise `end()` left a flush draining (`done` is set): its `on_write` reaches `end_writer`, which settles.
+            if !self.writer.get().has_pending_data() {
                 self.settle_stream_done();
             }
         }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -540,25 +540,33 @@ impl FileSink {
         self.writer.with_mut(|w| w.end());
     }
 
-    /// `Bun.write(file, body)`'s JS pump settled: end the writer (flush, close; `on_close` ends an attached controller) and settle `promise` once it closed.
+    /// `Bun.write(file, body)`'s JS pump settled: end the writer, close a still-attached sink controller, then settle `promise` once the file is closed.
     pub(crate) fn end_js_pump(&self, promise: Option<bun_jsc::JSPromiseStrong>) {
+        // Closed after the writer below, not from `on_close`, which runs under the writer borrow.
+        let mut controller = match *self.source.get() {
+            streams::SourceHandle::JSController(_) => {
+                self.source.replace(streams::SourceHandle::None)
+            }
+            _ => streams::SourceHandle::None,
+        };
+        // A flush error is recorded and still closes the writer; the controller and the promise get it below.
+        let _ = self.end(None);
+        if let streams::SourceHandle::JSController(cell) = controller {
+            let err = match self.stream_error.get() {
+                Some(streams::StreamError::Error(err)) => Some(err.clone()),
+                _ => None,
+            };
+            // `onClose`: closes the stream, whose `end()` detaches the controller, then runs the source's `cancel()`.
+            controller.close(err);
+            // `onClose` does not run over a pending exception or a terminating worker; `m_sinkPtr` must go either way.
+            streams::controller_abi::detach_sink_ptr(cell);
+        }
         if let Some(promise) = promise {
             self.stream_done.set(promise);
-        }
-        // A flush error is recorded and still closes the writer; `settle_stream_done` rejects with it.
-        let _ = self.end(None);
-        // Otherwise a flush is still draining: it holds the keep-alive ref and its `on_close` settles.
-        if !self.must_be_kept_alive_until_eof.get() {
-            self.settle_stream_done();
-        }
-    }
-
-    /// The owner is dropping the last reference: null a still-attached controller's `m_sinkPtr` (its late writes and destructor use it). No JS runs.
-    pub(crate) fn detach_js_controller(&self) {
-        if let streams::SourceHandle::JSController(controller) =
-            self.source.replace(streams::SourceHandle::None)
-        {
-            streams::controller_abi::detach_sink_ptr(controller);
+            // Otherwise a flush is still draining: it holds the keep-alive ref and its `on_close` settles.
+            if !self.must_be_kept_alive_until_eof.get() {
+                self.settle_stream_done();
+            }
         }
     }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -540,6 +540,53 @@ impl FileSink {
         self.writer.with_mut(|w| w.end());
     }
 
+    /// `Bun.write(file, body)`: the JS pump that fed this sink has settled.
+    /// End the writer, so bytes it still buffers reach the file and the file
+    /// is closed. That close is also what reaches a sink controller still
+    /// attached as `source` (a direct stream whose `pull()` returned without
+    /// ending it): `on_close` closes the stream through the controller, and
+    /// the controller detaches itself from this sink.
+    ///
+    /// `promise` (the pump succeeded) settles once the writer has closed: with
+    /// the piped byte count, or with the write error if one happened.
+    pub(crate) fn end_js_pump(&self, promise: Option<bun_jsc::JSPromiseStrong>) {
+        if let Some(promise) = promise {
+            self.stream_done.set(promise);
+        }
+        // A failed flush is recorded and closes the writer too; `on_close`
+        // delivers the error.
+        let _ = self.end(None);
+        // The writer closed inside `end()` and `on_close` settled the promise,
+        // unless a flush is still draining. That drain holds the keep-alive
+        // ref and closes the writer when it completes.
+        if !self.must_be_kept_alive_until_eof.get() {
+            self.settle_stream_done();
+        }
+    }
+
+    /// The owner that piped a JS stream into this sink is dropping the last
+    /// reference on it, so the sink may be freed as soon as this returns.
+    ///
+    /// The pump writes through a JS sink controller cell that holds the sink as
+    /// a raw `m_sinkPtr` and calls back into it: from a late
+    /// `controller.write()`, and from the cell's own destructor
+    /// (`controllerDetached`, plus `finalize`, which releases a reference the
+    /// controller never took). The controller normally detached itself by now,
+    /// when the pump or `on_close` ended it, and cleared `source`. When it did
+    /// not (the close never reached it: a worker that is terminating, an
+    /// `onClose` that threw first, an fd the writer does not close), stop the
+    /// cell pointing here while the sink is still alive. Each of those calls
+    /// then finds a detached controller instead of freed memory.
+    ///
+    /// Runs no JS and cannot throw.
+    pub(crate) fn detach_js_controller(&self) {
+        if let streams::SourceHandle::JSController(controller) =
+            self.source.replace(streams::SourceHandle::None)
+        {
+            streams::controller_abi::detach_sink_ptr(controller);
+        }
+    }
+
     fn settle_stream_done(&self) {
         let mut promise = self.stream_done.replace(bun_jsc::JSPromiseStrong::empty());
         if !promise.has_value() {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -540,45 +540,20 @@ impl FileSink {
         self.writer.with_mut(|w| w.end());
     }
 
-    /// `Bun.write(file, body)`: the JS pump that fed this sink has settled.
-    /// End the writer, so bytes it still buffers reach the file and the file
-    /// is closed. That close is also what reaches a sink controller still
-    /// attached as `source` (a direct stream whose `pull()` returned without
-    /// ending it): `on_close` closes the stream through the controller, and
-    /// the controller detaches itself from this sink.
-    ///
-    /// `promise` (the pump succeeded) settles once the writer has closed: with
-    /// the piped byte count, or with the write error if one happened.
+    /// `Bun.write(file, body)`'s JS pump settled: end the writer (flush, close; `on_close` ends an attached controller) and settle `promise` once it closed.
     pub(crate) fn end_js_pump(&self, promise: Option<bun_jsc::JSPromiseStrong>) {
         if let Some(promise) = promise {
             self.stream_done.set(promise);
         }
-        // A failed flush is recorded and closes the writer too; `on_close`
-        // delivers the error.
+        // A flush error is recorded and still closes the writer; `settle_stream_done` rejects with it.
         let _ = self.end(None);
-        // The writer closed inside `end()` and `on_close` settled the promise,
-        // unless a flush is still draining. That drain holds the keep-alive
-        // ref and closes the writer when it completes.
+        // Otherwise a flush is still draining: it holds the keep-alive ref and its `on_close` settles.
         if !self.must_be_kept_alive_until_eof.get() {
             self.settle_stream_done();
         }
     }
 
-    /// The owner that piped a JS stream into this sink is dropping the last
-    /// reference on it, so the sink may be freed as soon as this returns.
-    ///
-    /// The pump writes through a JS sink controller cell that holds the sink as
-    /// a raw `m_sinkPtr` and calls back into it: from a late
-    /// `controller.write()`, and from the cell's own destructor
-    /// (`controllerDetached`, plus `finalize`, which releases a reference the
-    /// controller never took). The controller normally detached itself by now,
-    /// when the pump or `on_close` ended it, and cleared `source`. When it did
-    /// not (the close never reached it: a worker that is terminating, an
-    /// `onClose` that threw first, an fd the writer does not close), stop the
-    /// cell pointing here while the sink is still alive. Each of those calls
-    /// then finds a detached controller instead of freed memory.
-    ///
-    /// Runs no JS and cannot throw.
+    /// The owner is dropping the last reference: null a still-attached controller's `m_sinkPtr` (its late writes and destructor use it). No JS runs.
     pub(crate) fn detach_js_controller(&self) {
         if let streams::SourceHandle::JSController(controller) =
             self.source.replace(streams::SourceHandle::None)

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -777,9 +777,7 @@ pub(crate) mod controller_abi {
         pub(crate) safe fn on_close(c: ::bun_jsc::JSValue, reason: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__detachPtr"]
         pub(crate) safe fn detach_ptr(c: ::bun_jsc::JSValue);
-        /// Nulls the controller's `m_sinkPtr` without telling the stream that
-        /// the sink closed. No JS runs, so a caller on an error path, or with
-        /// an exception already pending, can still use it.
+        /// `detach_ptr` without the `onClose` callback: only nulls `m_sinkPtr`, runs no JS.
         #[link_name = "JSSinkController__detachSinkPtr"]
         pub(crate) safe fn detach_sink_ptr(c: ::bun_jsc::JSValue);
         /// Returns undefined (drained inline), the pump promise, or the thrown Exception cell.

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -777,6 +777,11 @@ pub(crate) mod controller_abi {
         pub(crate) safe fn on_close(c: ::bun_jsc::JSValue, reason: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__detachPtr"]
         pub(crate) safe fn detach_ptr(c: ::bun_jsc::JSValue);
+        /// Nulls the controller's `m_sinkPtr` without telling the stream that
+        /// the sink closed. No JS runs, so a caller on an error path, or with
+        /// an exception already pending, can still use it.
+        #[link_name = "JSSinkController__detachSinkPtr"]
+        pub(crate) safe fn detach_sink_ptr(c: ::bun_jsc::JSValue);
         /// Returns undefined (drained inline), the pump promise, or the thrown Exception cell.
         #[link_name = "JSSinkController__assignToStream"]
         pub(crate) safe fn assign_to_stream(

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1141,6 +1141,106 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         Bun.write(join(String(dir), "missing", "c"), await fetch(server.url), { createPath: false }),
       ).rejects.toThrow(expect.objectContaining({ code: "ENOENT" }));
     });
+
+    // A `type: "direct"` stream with an async `pull` is the one pump shape
+    // that never ends the sink controller itself. When `pull()` returns, the
+    // write has to end the sink: flush what the controller still buffers,
+    // close the file, close the stream, and detach the controller, which
+    // otherwise keeps pointing at a released FileSink.
+    it("ends a direct stream's sink when its pull() returns", async () => {
+      using dir = tempDir("bun-write-direct-pull-returns", {});
+      const dest = join(String(dir), "out.txt");
+      let ctrl;
+      const cancelled = [];
+      const stream = new ReadableStream({
+        type: "direct",
+        async pull(c) {
+          ctrl = c;
+          c.write("first ");
+          await c.flush();
+          // Buffered in the sink, never flushed by the stream itself.
+          c.write("second");
+        },
+        cancel(reason) {
+          cancelled.push(reason);
+        },
+      });
+      expect(await Bun.write(dest, new Response(stream))).toBe(12);
+      expect(await Bun.file(dest).text()).toBe("first second");
+      expect(cancelled).toEqual([undefined]);
+      expect(() => ctrl.write("late event")).toThrow(/already been closed/);
+      expect(() => ctrl.flush()).toThrow(/already been closed/);
+      expect(ctrl.end()).toBeUndefined();
+      Bun.gc(true);
+    });
+
+    // The same controller on the paths where the body fails. The sink is
+    // released when the pipe rejects, and the controller's own destructor
+    // reaches for it at the next GC. A subprocess, because that GC can be
+    // the one at process exit.
+    it("survives a GC after a direct stream or a generator body fails", async () => {
+      using dir = tempDir("bun-write-body-fails-gc", {});
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const dir = process.env.BUN_WRITE_DEST_DIR;
+            const lines = [];
+            const boom = () => new Error("boom");
+            try {
+              await Bun.write(
+                dir + "/gen.txt",
+                new Response(
+                  (async function* () {
+                    yield "a";
+                    throw boom();
+                  })(),
+                ),
+              );
+            } catch (e) {
+              lines.push("gen:" + e.message);
+            }
+            let ctrl;
+            try {
+              await Bun.write(
+                dir + "/direct.txt",
+                new Response(
+                  new ReadableStream({
+                    type: "direct",
+                    async pull(c) {
+                      ctrl = c;
+                      c.write("a");
+                      await c.flush();
+                      c.write("b");
+                      throw boom();
+                    },
+                  }),
+                ),
+              );
+            } catch (e) {
+              lines.push("direct:" + e.message);
+            }
+            lines.push("direct.txt:" + await Bun.file(dir + "/direct.txt").text());
+            try {
+              ctrl.write("late event");
+              lines.push("late:wrote");
+            } catch (e) {
+              lines.push("late:threw");
+            }
+            Bun.gc(true);
+            console.log(lines.join("\\n"));
+          `,
+        ],
+        env: { ...bunEnv, BUN_WRITE_DEST_DIR: String(dir) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim().split("\n")).toEqual(["gen:boom", "direct:boom", "direct.txt:ab", "late:threw"]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
   });
 
   it("BunFile.name survives concurrent write() calls + GC", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1158,7 +1158,9 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
           ctrl = c;
           c.write("first ");
           await c.flush();
-          // Buffered in the sink, never flushed by the stream itself.
+          // A later event loop turn, so that the pipe is pending when pull()
+          // returns, and "second" is still buffered in the sink then.
+          await new Promise(resolve => setImmediate(resolve));
           c.write("second");
         },
         cancel(reason) {


### PR DESCRIPTION
### Problem
- `Bun.write(file, new Response(stream))` with a `type: "direct"` stream whose async `pull()` returns: a later `controller.write()` is a heap-use-after-free in `FileSink::write_latin1` (release: `Segmentation fault at address 0x118`). Without a late write the next GC crashes instead: `~JSReadableFileSinkController` runs `FileSink__controllerDetached` and `FileSink__finalize` on the freed sink (`Segmentation fault at address 0xB0`, also after `pull()` or an async generator body throws). 3/3 on 1.4.2 and canary.
- The cause is `pipe_readable_stream_to_blob` and `on_file_stream_{resolve,reject}_request_stream` (`src/runtime/webcore/Blob.rs`): when the JS pump settled they only dropped the last reference on the `FileSink`. A direct stream with an async `pull()` never ends its sink controller, so the controller kept a raw `m_sinkPtr`, and its destructor released a reference it never took.
- The same drop lost data: bytes `pull()` wrote after its last flush were counted in the result but never reached the file.

### Fix
- Every settle path now calls `FileSink::end_js_pump` first. It takes a still-attached controller off `source`, `end()`s the writer (flush, close the file), then closes the controller through `SourceHandle::close`: the stream closes, the controller `end()`s and detaches itself, the source's `cancel()` runs. `Bun.serve`, `fetch()` bodies and `Bun.spawn` stdin already do this when a direct `pull()` returns.
- `onClose` does not run over a pending exception or in a terminating worker, so a new `JSSinkController__detachSinkPtr` (no JS) nulls `m_sinkPtr` after it either way.
- The promise settles last, through the native pipe's `stream_done` / `settle_stream_done`: the byte count once the file is closed, or the write error.
- Verified: `test/js/bun/io/bun-write.test.js` (two new tests fail on 1.4.3-canary, pass on the ASAN build), plus the suites and stress runs in Notes.

### Background
- A JS `ReadableStream` reaches a native sink through a generated `JSReadable*SinkController` cell (`generate-jssink.ts`) that stores the sink as a raw `m_sinkPtr`. `controller.end()` / `close()` null it. A cell that dies with it set also calls `${name}__finalize`, a `deref()` for `FileSink`.
- For a `type: "direct"` stream, `readDirectStream` calls `pull(controller)` once and writes go straight into the sink. Nothing in the pump ends the controller when an async `pull()` settles. The sink's owner has to.
- `FileSink` is refcounted. Its `StreamingWriter` buffers small writes and flushes them from a deferred task, `flush()`, or `end()`. `on_close` is the writer's callback once the fd is closed.

<details><summary>Notes</summary>

- Reproductions (all from the fuzz report, re-run here on 1.4.3-canary `f42e98025`):
  - late write after `await Bun.write(path, new Response(direct))`: `ctrl.write()` returned `true` from freed memory, the 300-iteration storm SEGVs at `0x118`.
  - `new Response(async function* () { yield "a"; throw e }())`: rejects, then SEGV at exit, 3/3.
  - direct `pull()` that writes, flushes, then throws: SEGV, 3/3.
  - `pull(c) { c.write("abc"); await tick; c.write("def") }`: resolved 6, file held 3 bytes.
- After the change the four cases give: `"This FileSink has already been closed"` on the late write, clean rejections, and a 6-byte file. `fileSinkInternals.liveCount()` returns to its baseline after 40 iterations of each shape.
- `cancel(undefined)` now runs on the direct source when the write completes, as it does for the same stream given to `Bun.serve`, `fetch()` or `Bun.spawn`.
- Also ran under the ASAN debug build: `streams.test.js`, `spawn-stdin-readable-stream`, `serve-direct-readable-stream`, `serve-body-leak`, `fetch-abort-stream-body`, the rest of `bun-write.test.js`, a worker-termination stress over the pipe, and the 300-iteration storm.
- Not changed: a direct stream whose synchronous `pull()` neither closes nor returns a promise still never settles (same on 1.4.3). `Bun.spawn` stdin drops the same trailing bytes on `pull()` return (`handle_resolve_stream` closes without a flush); that is a separate path.
- The reader pump (`readStreamIntoSink`) already ends the controller itself on both outcomes, so for default-controller streams `end_js_pump` finds `source` empty and the writer ended, and only settles the promise.
- The controller is closed after `end()` returns rather than from the writer's `on_close`, because `on_close` runs inside `writer.end()`: closing the controller from there re-entered `end_from_js` under the writer borrow (review note on the first revision).
- While stress-testing worker termination I hit a debug `assertNoException` in the unchanged `Pending` branch (`.then()` right after `drain_microtasks()` with a termination pending). It reproduces on main and is tracked separately.
- Pre-existing failures in this environment, with or without the change: `bun-write.test.js` "copyFileRange ... on large files" (5 s timeout under ASAN), `bun-write-leak.test.ts` and the pipe case of `streams-leak.test.ts` (RSS bounds and timeouts under the debug build).

</details>
