### PR TITLE
bun-types: declare reusePort and ipv6Only on Bun.listen's options, not Bun.connect's

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7087,6 +7087,22 @@ declare module "bun" {
      */
     exclusive?: boolean;
     /**
+     * Whether the `SO_REUSEPORT` flag should be set.
+     *
+     * This allows multiple processes to bind to the same port, which is useful for load balancing.
+     * Ignored when {@link exclusive} is `true`.
+     *
+     * @default false
+     */
+    reusePort?: boolean;
+    /**
+     * Whether the `IPV6_V6ONLY` flag should be set, so that a socket bound to an IPv6
+     * address does not also accept IPv4 connections.
+     *
+     * @default false
+     */
+    ipv6Only?: boolean;
+    /**
      * Whether to allow half-open connections.
      *
      * A half-open connection occurs when one end of the connection has called `close()`
@@ -7118,18 +7134,16 @@ declare module "bun" {
      */
     tls?: TLSOptions | boolean;
     /**
-     * Whether to use exclusive mode.
-     *
-     * When set to `true`, the socket binds exclusively to the specified address:port
-     * combination, preventing other processes from binding to the same port.
-     *
-     * When `false` (default), other sockets may be able to bind to the same port
-     * depending on the operating system's socket sharing capabilities and settings.
-     *
-     * @default false
+     * @deprecated Has no effect on a client socket. These are bind options for {@link Bun.listen} (see {@link TCPSocketListenOptions}).
      */
     exclusive?: boolean;
+    /**
+     * @deprecated Has no effect on a client socket. These are bind options for {@link Bun.listen} (see {@link TCPSocketListenOptions}).
+     */
     reusePort?: boolean;
+    /**
+     * @deprecated Has no effect on a client socket. These are bind options for {@link Bun.listen} (see {@link TCPSocketListenOptions}).
+     */
     ipv6Only?: boolean;
   }
 

--- a/test/integration/bun-types/fixture/tcp.ts
+++ b/test/integration/bun-types/fixture/tcp.ts
@@ -69,6 +69,17 @@ Bun.listen({
 });
 
 Bun.listen({
+  socket: {
+    data() {},
+  },
+  hostname: "::",
+  port: 0,
+  reusePort: true,
+  ipv6Only: true,
+  allowHalfOpen: true,
+});
+
+Bun.listen({
   data: { arg: "asdf" },
   socket: {
     data(socket) {


### PR DESCRIPTION
### Problem
- `TCPSocketConnectOptions` (`Bun.connect`) declares `exclusive`, `reusePort` and `ipv6Only`. `TCPSocketListenOptions` (`Bun.listen`) declares only `exclusive`. The runtime does the opposite: `Bun.listen({ reusePort: true })` lets two listeners bind one port and `ipv6Only` is applied, while `Bun.connect` parses the three keys and ignores them.
- Cause: both APIs parse one shared dictionary (`src/runtime/socket/SocketConfig.bindv2.ts`), but only the listen path turns `exclusive` / `reuse_port` / `ipv6_only` into socket flags (`SocketConfig::socket_flags`, `src/runtime/socket/Handlers.rs:462`, called only from `Listener::listen`). The connect path reads `allow_half_open` and `pause_on_connect` alone. #18962 added the two declarations to the connect interface instead of the listen one.

### Fix
- Declare `reusePort` and `ipv6Only` on `TCPSocketListenOptions`, with the same wording `Bun.serve` uses for them.
- Keep the three members on `TCPSocketConnectOptions` but mark them `@deprecated` ("has no effect on a client socket"), so existing code that passes them still type-checks and editors flag them.
- Verified: `test/integration/bun-types/fixture/tcp.ts` now passes `reusePort`, `ipv6Only` and `allowHalfOpen` to `Bun.listen`. `bun test test/integration/bun-types/bun-types.test.ts` fails on that fixture without the `.d.ts` change and passes with it (the `lib.dom.d.ts` case fails the same way on main, unrelated).

### Background
- `Bun.listen` and `Bun.connect` take their options through the same generated `SocketConfig` parser, so every key is accepted (and type-validated as a boolean) by both. Which keys do anything is decided later, per path.
- `reusePort` maps to `LIBUS_LISTEN_REUSE_PORT | LIBUS_LISTEN_REUSE_ADDR` and `ipv6Only` to `LIBUS_SOCKET_IPV6_ONLY`, both consumed by the usockets listen call. `exclusive` takes precedence over `reusePort`.

<details><summary>Notes</summary>

This is item (a) of an audit of declared-versus-honoured options. The other items of that batch are already covered by open PRs and are not repeated here: the `Bun.build` loader-name table and its error message (#38247), `json5` / `md` in the `Loader` union (#38267), and the `bun:test` declarations for `toHaveBeenCalledOnce`, the return-matcher aliases and `jest.now()` (#32333, #32335, #32455). The `Bun.SQL` `tls: "bogus"` message already lists `verify-ca` / `verify-full` on current canary.

</details>
