### PR TITLE
Fit the startup address-space reservations to RLIMIT_AS (WebKit + mimalloc bump)

### DIFF
--- a/docs/guides/ecosystem/systemd.mdx
+++ b/docs/guides/ecosystem/systemd.mdx
@@ -63,7 +63,7 @@ The command attaches the capability to the `bun` binary itself. Replacing the bi
 
 systemd's resource-control and sandboxing options work with Bun. Two of them need care:
 
-- To cap memory, use `MemoryMax=`. `LimitAS=` (the same limit as `ulimit -v`) caps address space instead, and Bun reserves far more address space than the memory it uses. Bun sizes its startup reservations to fit the limit, but a value below a few hundred megabytes can still stop it from starting.
+- To cap memory, use `MemoryMax=`. `LimitAS=` (the same limit as `ulimit -v`) caps address space instead, and Bun reserves far more address space than the memory it uses. Bun sizes its startup reservations to fit the limit, but a value below a few hundred megabytes can still stop it from starting. Bun 1.4.2 and earlier do not: there, set `BUN_JSC_jitMemoryReservationSize=67108864` and `MIMALLOC_ARENA_RESERVE=256MiB` in the unit's `Environment=` to keep the JIT under such a limit.
 - `MemoryDenyWriteExecute=yes` forbids memory mappings that are writable and executable at the same time, and forbids making a mapping executable later. A JIT needs one or the other, so JavaScriptCore's JIT is unavailable. JavaScript and WebAssembly still run, in the interpreter, which is several times slower for compute-heavy code.
 
 ---

--- a/docs/guides/ecosystem/systemd.mdx
+++ b/docs/guides/ecosystem/systemd.mdx
@@ -64,7 +64,7 @@ The command attaches the capability to the `bun` binary itself. Replacing the bi
 systemd's resource-control and sandboxing options work with Bun. Two of them need care:
 
 - To cap memory, use `MemoryMax=`. `LimitAS=` (the same limit as `ulimit -v`) caps address space instead, and Bun reserves far more address space than the memory it uses. Bun sizes its startup reservations to fit the limit, but a value below a few hundred megabytes can still stop it from starting.
-- `MemoryDenyWriteExecute=yes` forbids executable memory, so JavaScriptCore's JIT is unavailable. JavaScript and WebAssembly still run, in the interpreter, which is several times slower for compute-heavy code.
+- `MemoryDenyWriteExecute=yes` forbids memory mappings that are writable and executable at the same time, and forbids making a mapping executable later. A JIT needs one or the other, so JavaScriptCore's JIT is unavailable. JavaScript and WebAssembly still run, in the interpreter, which is several times slower for compute-heavy code.
 
 ---
 

--- a/docs/guides/ecosystem/systemd.mdx
+++ b/docs/guides/ecosystem/systemd.mdx
@@ -61,6 +61,13 @@ The command attaches the capability to the `bun` binary itself. Replacing the bi
 
 ---
 
+systemd's resource-control and sandboxing options work with Bun. Two of them need care:
+
+- To cap memory, use `MemoryMax=`. `LimitAS=` (the same limit as `ulimit -v`) caps address space instead, and Bun reserves far more address space than the memory it uses. Bun sizes its startup reservations to fit the limit, but a value below a few hundred megabytes can still stop it from starting.
+- `MemoryDenyWriteExecute=yes` forbids executable memory, so JavaScriptCore's JIT is unavailable. JavaScript and WebAssembly still run, in the interpreter, which is several times slower for compute-heavy code.
+
+---
+
 With the service file configured, _enable_ the service. Once enabled, it starts automatically on reboot. Enabling the service requires `sudo` permissions.
 
 ```bash terminal icon="terminal"

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "6a64e1ba7f5b2130d4efccb67ec87fd0003f0f6a";
+const MIMALLOC_COMMIT = "42e3c67de436f8434b8eb16243ef70db9c96f128";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-586-84eef7b0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-586-84eef7b0";
+export const WEBKIT_VERSION = "autobuild-preview-pr-586-4915c3bd";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/address-space-limit.test.ts
+++ b/test/js/bun/jsc/address-space-limit.test.ts
@@ -34,12 +34,13 @@ describe.skipIf(!isLinux || isASAN || isDebug)("RLIMIT_AS", () => {
     expect({ stdout, exitCode, signalCode }).toEqual({ stdout: `{"jit":true}`, exitCode: 0, signalCode: null });
   });
 
-  for (const limitMB of [768, 1024, 1200, 1536, 2048, 2250]) {
-    test.concurrent(`ulimit -v ${limitMB}M: bun starts and keeps the JIT`, async () => {
+  test.concurrent.each([768, 1024, 1200, 1536, 2048, 2250])(
+    "ulimit -v %dM: bun starts and keeps the JIT",
+    async limitMB => {
       const { stdout, stderr, exitCode, signalCode } = await run(limitMB);
       // stderr first: on failure it carries the crash banner or the allocation error.
       expect({ stderr, stdout }).toEqual({ stderr: expect.any(String), stdout: `{"jit":true}` });
       expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
-    });
-  }
+    },
+  );
 });

--- a/test/js/bun/jsc/address-space-limit.test.ts
+++ b/test/js/bun/jsc/address-space-limit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux } from "harness";
+
+// RLIMIT_AS (`ulimit -v`, systemd `LimitAS=`) caps the address space a process
+// may reserve, committed or not. At startup bun reserves a mimalloc arena, the
+// JSC structure heap and the JIT pool. Each used to have a fixed size (1 GiB,
+// up to 4 GiB, and 1 GiB on x64), so under a limit of a couple of GiB the JIT
+// pool did not fit and bun ran interpreter-only with no message, and at some
+// limits the structure heap did not fit either and bun aborted at startup.
+
+const script = /* js */ `
+  function hot(n) { let s = 0; for (let i = 0; i < n; i++) s = (s + i * 7) % 1000003; return s; }
+  for (let i = 0; i < 30; i++) hot(10000);
+  const { numberOfDFGCompiles } = require("bun:jsc");
+  // numberOfDFGCompiles() reports 1000000 for any function while the JIT tiers are unavailable.
+  process.stdout.write(JSON.stringify({ jit: numberOfDFGCompiles(hot) !== 1000000 }));
+`;
+
+async function run(limitMB: number | undefined) {
+  const cmd =
+    limitMB === undefined
+      ? [bunExe(), "-e", script]
+      : ["sh", "-c", `ulimit -v ${limitMB * 1024} && exec "$0" -e "$1"`, bunExe(), script];
+  await using proc = Bun.spawn({ cmd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+// An ASAN build reserves terabytes of shadow address space and a debug build
+// maps several hundred MB of unoptimized code, so neither fits these limits.
+describe.skipIf(!isLinux || isASAN || isDebug)("RLIMIT_AS", () => {
+  test("without a limit the JIT is available", async () => {
+    const { stdout, exitCode, signalCode } = await run(undefined);
+    expect({ stdout, exitCode, signalCode }).toEqual({ stdout: `{"jit":true}`, exitCode: 0, signalCode: null });
+  });
+
+  for (const limitMB of [768, 1024, 1200, 1536, 2048, 2250]) {
+    test.concurrent(`ulimit -v ${limitMB}M: bun starts and keeps the JIT`, async () => {
+      const { stdout, stderr, exitCode, signalCode } = await run(limitMB);
+      // stderr first: on failure it carries the crash banner or the allocation error.
+      expect({ stderr, stdout }).toEqual({ stderr: expect.any(String), stdout: `{"jit":true}` });
+      expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
+    });
+  }
+});

--- a/test/js/bun/jsc/address-space-limit.test.ts
+++ b/test/js/bun/jsc/address-space-limit.test.ts
@@ -8,7 +8,7 @@ import { bunEnv, bunExe, isASAN, isDebug, isLinux } from "harness";
 // pool did not fit and bun ran interpreter-only with no message, and at some
 // limits the structure heap did not fit either and bun aborted at startup.
 
-const script = /* js */ `
+const jitScript = /* js */ `
   function hot(n) { let s = 0; for (let i = 0; i < n; i++) s = (s + i * 7) % 1000003; return s; }
   for (let i = 0; i < 30; i++) hot(10000);
   const { numberOfDFGCompiles } = require("bun:jsc");
@@ -16,7 +16,25 @@ const script = /* js */ `
   process.stdout.write(JSON.stringify({ jit: numberOfDFGCompiles(hot) !== 1000000 }));
 `;
 
-async function run(limitMB: number | undefined) {
+// Allocates untouched 16 MB buffers until the address space runs out and reports how far it got.
+const heapScript = /* js */ `
+  const buffers = [];
+  let mb = 0;
+  try {
+    for (;;) { buffers.push(new Uint8Array(16 << 20)); mb += 16; }
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ error: e.constructor.name, mb }));
+  }
+`;
+
+// 200_000 objects with distinct shapes: each takes a Structure from the structure heap.
+const structureScript = /* js */ `
+  const objects = [];
+  for (let i = 0; i < 200_000; i++) objects.push({ ["k" + i]: i });
+  process.stdout.write(JSON.stringify({ structures: objects.length }));
+`;
+
+async function run(limitMB: number | undefined, script: string) {
   const cmd =
     limitMB === undefined
       ? [bunExe(), "-e", script]
@@ -30,17 +48,34 @@ async function run(limitMB: number | undefined) {
 // maps several hundred MB of unoptimized code, so neither fits these limits.
 describe.skipIf(!isLinux || isASAN || isDebug)("RLIMIT_AS", () => {
   test("without a limit the JIT is available", async () => {
-    const { stdout, exitCode, signalCode } = await run(undefined);
+    const { stdout, exitCode, signalCode } = await run(undefined, jitScript);
     expect({ stdout, exitCode, signalCode }).toEqual({ stdout: `{"jit":true}`, exitCode: 0, signalCode: null });
   });
 
   test.concurrent.each([768, 1024, 1200, 1536, 2048, 2250])(
     "ulimit -v %dM: bun starts and keeps the JIT",
     async limitMB => {
-      const { stdout, stderr, exitCode, signalCode } = await run(limitMB);
+      const { stdout, stderr, exitCode, signalCode } = await run(limitMB, jitScript);
       // stderr first: on failure it carries the crash banner or the allocation error.
       expect({ stderr, stdout }).toEqual({ stderr: expect.any(String), stdout: `{"jit":true}` });
       expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
     },
   );
+
+  // The startup reservations have to leave most of the limit to the program: under 1.5 GB it gets
+  // a catchable out-of-memory error, and not before it has allocated a third of the limit.
+  test.concurrent("ulimit -v 1536M: most of the limit is left for the heap", async () => {
+    const { stdout, stderr, exitCode, signalCode } = await run(1536, heapScript);
+    expect(stderr).toBe("");
+    const { error, mb } = JSON.parse(stdout);
+    expect(error).toBe("RangeError");
+    expect(mb).toBeGreaterThanOrEqual(512);
+    expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  });
+
+  test.concurrent("ulimit -v 512M: the structure heap still holds 200k shapes", async () => {
+    const { stdout, stderr, exitCode, signalCode } = await run(512, structureScript);
+    expect({ stderr, stdout }).toEqual({ stderr: expect.any(String), stdout: `{"structures":200000}` });
+    expect({ exitCode, signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  });
 });


### PR DESCRIPTION
### Problem
- Under `RLIMIT_AS` (`ulimit -v`, systemd `LimitAS=`) below about 2.3 GB, bun runs with no JIT and says nothing: `numberOfDFGCompiles()` reports the no-JIT sentinel and compute-heavy code is 3x to 17x slower. At some limits (about 1150 to 1200 MB and 2200 MB on x64, everything below 340 MB) `bun -e 1` aborts at startup with the crash banner and a bun.report link: `panic(main thread): abort() called` in `JSC::StructureMemoryManager::StructureMemoryManager()` (Sentry BUN-4NF7, also the subject of #39967). #3536 was closed saying bun sizes these reservations to the limit and starts down to 512 MB; it did not.
- The cause is three fixed-size startup reservations, which `RLIMIT_AS` charges whether or not they are committed: mimalloc's first 1 GiB arena (reserved before `main()`), JSC's 1 GiB JIT pool (`initializeJITPageReservation()`, which turns `useJIT` off when it fails), and JSC's Structure heap (4 GB halved until something fits, `RELEASE_ASSERT` when nothing does or when mimalloc rejects the 32 MB rung).

### Fix
- oven-sh/WebKit#586: `WTF::addressSpaceLimit()`; the default JIT pool is capped at `RLIMIT_AS / 16` (16 MiB floor) and halved on refusal instead of dropping the JIT; the Structure heap is capped at `RLIMIT_AS / 16` (128 MB floor) and falls back to its block bitmap when mimalloc rejects a small reservation (was oven-sh/WebKit#483). `BUN_JSC_jitMemoryReservationSize` still wins.
- oven-sh/mimalloc#35: each arena reservation is capped at `RLIMIT_AS / 4`. All of it is a no-op without a limit, and the parts only work together: a smaller JIT pool next to a 1 GiB arena and a greedy Structure heap just moves the abort window.
- Before this merges, both upstream PRs have to merge and `WEBKIT_VERSION` / `MIMALLOC_COMMIT` move to the merged shas (the WebKit pin is a preview tag, which also carries oven-sh/WebKit#566 and oven-sh/WebKit#568 from `main`). #39967 then only covers the floor below about 180 MB.
- Verified: `test/js/bun/jsc/address-space-limit.test.ts` (new; bun 1.4.3 fails 6 of 9, this build passes all). Also `bun-jsc.test.ts`, `test/js/bun/wasm`, and the sweep in Notes. Self-reviewed: 3 concerns raised (Structure heap not budgeted, heap headroom, docs escape hatch), 3 addressed.

### Background
- `RLIMIT_AS` limits a process's address space, not its memory. A `MAP_NORESERVE` or `PROT_NONE` reservation costs no RAM but counts in full, so software that reserves big regions up front (JSC, mimalloc, also V8: node cannot start below about 1.5 GB) hits the limit long before it uses that much memory.
- JSC allocates all JIT code from one pool reserved at startup so near jumps reach everywhere in it; without the pool every tier is off and JS and Wasm run in LLInt and IPInt. Structures (object shapes) live in their own aligned reservation so a StructureID is a 32-bit offset; running out of it is fatal, hence the 128 MB floor.

<details><summary>Notes</summary>

Sweep on x64 Linux, `prlimit --as=<MB>`, release builds. "stock" is 1.4.3-canary (f42e98025, same as 1.4.2 here); "fixed" is this branch built against the two upstream commits. Sizes in MB: mimalloc first arena / Structure heap / JIT pool.

| MB | stock | fixed |
| --- | --- | --- |
| 200 to 330 | abort | 66 / 16 to 64 / 16 to 25 |
| 400 | - / 64 / no JIT | 100 / 64 / 25 |
| 500 | - / 128 / no JIT | 128 / 128 / 31 |
| 1000 | - / 256 / no JIT | 252 / 128 / 63 |
| 1150, 1200 | abort | 288, 300 / 128 / 72, 75 |
| 1600 | 1024 / 128 / no JIT | 400 / 128 / 100 |
| 2000 | 1024 / 256 / no JIT | 500 / 128 / 125 |
| 2200 | abort | 552 / 128 / 137 |
| 2600 | 1024 / 128 / 1024 | 652 / 128 / 163 |
| 4000 | 1024 / 512 / 1024 | 1000 / 128 / 250 |
| unlimited | 1024 / 4096 / 1024 | 1024 / 4096 / 1024 |

Every 10 MB step from 180 MB to 2.6 GB starts and tiers up; stock starts nowhere below 340 MB and has no JIT below about 2.3 GB.

Usable heap (16 MB `Uint8Array`s until `RangeError: Out of memory`), stock vs fixed: 512 MB limit 160 / 136, 1 GB 448 / 488, 1.5 GB 928 / 848, 2 GB 1216 / 1216. The JIT pool costs address space the stock build did not spend; the Structure heap cap pays most of it back. `tsc` over `packages/bun-types` peaks at 5 MB of JIT code and a 3000-hot-function churn test at 39 MB, so the 64 MB pool under a 1 GB limit is not the bottleneck; both run at unlimited speed under 512 MB.

Not addressed here: under `MemoryDenyWriteExecute=yes` every executable reservation fails with `EACCES`, so the JIT is still off (now after six more `mmap` attempts); the docs note says so. Whether bun should print something in that case is a separate decision.

The gate that reverts `src/` cannot show a fail-before for this PR: the change is in `scripts/build/deps/*.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/jsc/address-space-limit.test.ts

<!-- robobun:evidence:end -->