### PR TITLE
Keep the input Request's body when init.body is null

### DIFF
--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1198,8 +1198,11 @@ impl Request {
             }
 
             if !fields.contains(Fields::Body) {
+                // fetch spec: "Let inputOrInitBody be initBody if it is non-null;
+                // otherwise inputBody." A `body: null` member does not claim the
+                // field, so a later input Request/Response still supplies its body.
                 match value.fast_get(global_this, bun_jsc::BuiltinName::Body) {
-                    Ok(Some(body_)) => {
+                    Ok(Some(body_)) if !body_.is_null() => {
                         fields.insert(Fields::Body);
                         // fetch spec Request(init): `keepalive: true` with a ReadableStream
                         // body throws before body extraction (Node's message is "keepalive").
@@ -1221,7 +1224,7 @@ impl Request {
                             Err(e) => bail!(Err(e)),
                         }
                     }
-                    Ok(None) => {}
+                    Ok(_) => {}
                     Err(e) => bail!(Err(e)),
                 }
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1000,7 +1000,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     let mut body = 'extract_body: {
         if let Some(options) = options_object {
             if let Some(body__) = options.fast_get(global_this, jsc::BuiltinName::Body)? {
-                if !body__.is_undefined() {
+                // A null `init.body` falls through to the Request's body, as in
+                // `new Request(input, init)` (fetch spec: inputOrInitBody).
+                if !body__.is_undefined_or_null() {
                     break 'extract_body Some(HTTPRequestBody::from_js(ctx, body__)?);
                 }
             }

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -76,6 +76,76 @@ test("clone() does not lock original body when body was accessed before clone", 
   expect(clonedText).toBe("Hello, world!");
 });
 
+describe("RequestInit body: null", () => {
+  // Fetch spec Request constructor: "Let inputOrInitBody be initBody if it is non-null;
+  // otherwise inputBody." A present-but-null `init.body` keeps the input Request's body,
+  // the same as an absent or undefined one. (Contrast with `signal: null` below, which
+  // is `AbortSignal?` in WebIDL and does detach.)
+  test.each([
+    ["{ body: null }", { body: null }],
+    ["{ body: undefined }", { body: undefined }],
+    ["{}", {}],
+  ])("new Request(request, %s) keeps the input's body", async (_label, init) => {
+    const input = new Request("http://example.com/", { method: "POST", body: "keep-me" });
+    const derived = new Request(input, init as RequestInit);
+    expect(derived.method).toBe("POST");
+    expect(derived.body).not.toBeNull();
+    expect(await derived.text()).toBe("keep-me");
+  });
+
+  test("new Request(request, { body: null }) keeps a ReadableStream body", async () => {
+    const input = new Request("http://example.com/", {
+      method: "POST",
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("streamed"));
+          controller.close();
+        },
+      }),
+      // @ts-ignore
+      duplex: "half",
+    });
+    const derived = new Request(input, { body: null });
+    expect(derived.body).not.toBeNull();
+    expect(await derived.text()).toBe("streamed");
+  });
+
+  test("a non-null init.body still replaces the input's body", async () => {
+    const input = new Request("http://example.com/", { method: "POST", body: "original" });
+    expect(await new Request(input, { body: "replaced" }).text()).toBe("replaced");
+    expect(await new Request(input, { body: "" }).text()).toBe("");
+  });
+
+  test("new Request(url, { body: null }) has a null body", async () => {
+    const req = new Request("http://example.com/", { method: "POST", body: null });
+    expect(req.body).toBeNull();
+    expect(await req.text()).toBe("");
+  });
+
+  test("fetch(request, { body: null }) sends the request's body", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: async req => Response.json({ method: req.method, body: await req.text() }),
+    });
+    const results: Record<string, unknown> = {};
+    for (const [label, init] of [
+      ["null", { body: null }],
+      ["undefined", { body: undefined }],
+      ["absent", {}],
+      ["replaced", { body: "replaced" }],
+    ] as const) {
+      const res = await fetch(new Request(server.url, { method: "POST", body: "keep-me" }), init as RequestInit);
+      results[label] = await res.json();
+    }
+    expect(results).toEqual({
+      null: { method: "POST", body: "keep-me" },
+      undefined: { method: "POST", body: "keep-me" },
+      absent: { method: "POST", body: "keep-me" },
+      replaced: { method: "POST", body: "replaced" },
+    });
+  });
+});
+
 describe("RequestInit signal presence", () => {
   // Fetch spec step 27: "If init['signal'] exists, then set signal to it."
   // A present `signal: null` must replace (detach from) the input Request's signal.


### PR DESCRIPTION
### Problem
- `new Request(input, { body: null })` drops `input`'s body, and `fetch(request, { body: null })` sends an empty POST/PUT. `{}` and `{ body: undefined }` keep the body. undici keeps it in all three cases.
- The fetch spec's Request constructor says: "Let inputOrInitBody be initBody if it is non-null; otherwise inputBody." Bun instead treated the presence of a `body` key as "replace the body": `src/runtime/webcore/Request.rs:1200` claimed the body field for any present `init.body`, and `src/runtime/webcore/fetch.rs:1003` only skipped `undefined`.

```js
const a = new Request("http://h.example/", { method: "POST", body: "keep-me" });
await new Request(a, { body: null }).text(); // bun: ""   node: "keep-me"
```

### Fix
- Request constructor: a null `init.body` no longer claims the body field, so the input Request (or Response) still supplies its body on the next pass of the init loop.
- `fetch()`: a null `init.body` falls through to the Request's body, the same as `undefined`.
- `new Request(url, { body: null })` and `fetch(url, { body: null })` are unchanged: with no input body the result is still a null/empty body.
- Verified: `test/js/web/request/request.test.ts` (new `RequestInit body: null` block, 3 of 7 cases fail on stock bun). Also ran `test/js/web/fetch/{body-clone,body,body-mixin-errors,fetch-args,fetch}.test.ts`.

### Background
- `Request::construct_into` walks `[init, input]` in that order and records which fields it has filled in an `EnumSet<Fields>`. A field that `init` claims is not read from `input`. The bug was that `body: null` claimed `Fields::Body`.
- This is the opposite of `signal`: WebIDL types it `AbortSignal?`, so a present `signal: null` does detach from the input's signal (covered by the neighbouring `RequestInit signal presence` tests). `body` is `BodyInit?` too, but the constructor algorithm explicitly falls back to the input body when it is null.

<details><summary>Notes</summary>

- Option-normalising wrappers hit this: `new Request(req, { ...defaults, body: opts.body ?? null })` or `fetch(req, { body: opts.body ?? null })` silently sent empty bodies.
- Out of scope, unchanged here: Bun tees the input body (`input.bodyUsed` stays `false`) where the spec and undici make the input unusable. #35858 proposes that change and also contains the constructor half of this fix; #37033 overlaps too. Neither touches the `fetch()` path. This PR is the narrow fix for the `body: null` divergence only and does not conflict semantically with either.
- `fetch(url, { body: null })` previously went through `HTTPRequestBody::from_js(null)` (`BodyValue::Null.use_as_any_blob()`), now through `HTTPRequestBody::default()`. Both are `AnyBlob::Blob(Blob::default())`.
- Local `fetch.test.ts` failures (`ipv6 localhost`, external HTTPS, `bad permissions` as root, `(with gc)` timeouts, redirect-to-denied-host) reproduce on stock bun in this container and are environmental.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/request/request.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [10.44ms]
(pass) request can receive undefined signal [18.37ms]
(pass) request can receive null signal [13.48ms]
(pass) clone() does not lock original body when body was accessed before clone [27.77ms]
87 |     ["{}", {}],
88 |   ])("new Request(request, %s) keeps the input's body", async (_label, init) => {
89 |     const input = new Request("http://example.com/", { method: "POST", body: "keep-me" });
90 |     const derived = new Request(input, init as RequestInit);
91 |     expect(derived.method).toBe("POST");
92 |     expect(derived.body).not.toBeNull();
                                  ^
error: expect(received).not.toBeNull()

Received: null

      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:92:30)
      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:88:64)
(fail) RequestInit body: null > new Request(request, { body: null }) keeps the input's body [16.90ms
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [0.14ms]
(pass) request can receive undefined signal [0.29ms]
(pass) request can receive null signal [0.16ms]
(pass) clone() does not lock original body when body was accessed before clone [0.46ms]
87 |     ["{}", {}],
88 |   ])("new Request(request, %s) keeps the input's body", async (_label, init) => {
89 |     const input = new Request("http://example.com/", { method: "POST", body: "keep-me" });
90 |     const derived = new Request(input, init as RequestInit);
91 |     expect(derived.method).toBe("POST");
92 |     expect(derived.body).not.toBeNull();
                                  ^
error: expect(received).not.toBeNull()

Received: null

      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:92:30)
(fail) RequestInit body: null > new Request(request, { body: null }) keeps the input's body [0.38ms]
(pass) RequestInit body: null > new Request(request, { body: undefined }) keeps the input's body [0.07ms]
(pass) RequestInit body: null > new Request(request, {}) keeps the input's body [0.02ms]
104 |       }),
105 |       // @ts-ignore
106 |
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/request/request.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [15.09ms]
(pass) request can receive undefined signal [12.24ms]
(pass) request can receive null signal [6.97ms]
(pass) clone() does not lock original body when body was accessed before clone [14.73ms]
(pass) RequestInit body: null > new Request(request, { body: null }) keeps the input's body [7.09ms]
(pass) RequestInit body: null > new Request(request, { body: undefined }) keeps the input's body [1.85ms]
(pass) RequestInit body: null > new Request(request, {}) keeps the input's body [1.45ms]
(pass) RequestInit body: null > new Request(request, { body: null }) keeps a ReadableStream body [8.35ms]
(pass) RequestInit body: null > a non-null init.body still replaces the input's body [7.20ms]
(pass) RequestInit body: null > new Request(url, { body: null }) has a null body [4.71ms]
(pass) RequestInit body: null > fetch(request, { body: null }) sends the request's body [50.35ms]
(pass) RequestInit signal prese
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 711ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 16s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+b3e925fda
[build] done
bun test v1.4.3-canary.1 (b3e925fda)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [0.09ms]
(pass) request can receive undefined signal [0.17ms]
(pass) request can receive null signal [0.10ms]
(pass) clone() does not lock original body when body was accessed before clone [0.32ms]
(pass) RequestInit body: null > new Request(request, { body: null }) keeps the input's body [0.11ms]
(pass) RequestInit body: null > new Request(request, { body: undefined }) keeps the input's body [0.01ms]
(pass) RequestInit body: null > new Request(request
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Request.rs      |  7 ++--
 src/runtime/webcore/fetch.rs        |  4 ++-
 test/js/web/request/request.test.ts | 70 +++++++++++++++++++++++++++++++++++++
 3 files changed, 78 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/webcore/Request.rs           1      2      5
src/runtime/webcore/fetch.rs             2      1      5
test/js/web/request/request.test.ts      1      1      5
```

</details>

<!-- robobun:evidence:end -->