### PR TITLE
Request: never read a url from the RequestInit dictionary

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2354,7 +2354,7 @@ where
         {
             // SAFETY: JsClass::from_js returns a live *mut Request.
             // NOTE: `Request::clone()` (Request.rs:1627) seeds a fully-initialized
-            // sentinel and calls `clone_into(.., preserve_url=false)`.
+            // sentinel and calls `clone_into`.
             unsafe { (*request_).clone(ctx)? }
         } else {
             let fetch_error = Fetch::fetch_type_error_string(first_arg);

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1079,8 +1079,7 @@ impl Request {
 
         for (i, &value) in values_to_try.iter().enumerate() {
             let value_type = value.js_type();
-            // `input` is always last; everything before it is the `RequestInit`
-            // dictionary, which has no `url` member.
+            // The last candidate is `input`; the rest is the `RequestInit` dictionary (no `url` member).
             let is_input = !is_first_argument_a_url && i == values_to_try.len() - 1;
             let explicit_check = values_to_try.len() == 2
                 && value_type == bun_jsc::JSType::FinalObject

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1077,8 +1077,11 @@ impl Request {
         let values_to_try = &values_to_try_[0..((!is_first_argument_a_url) as usize
             + (arguments.len() > 1 && arguments[1].is_object()) as usize)];
 
-        for &value in values_to_try {
+        for (i, &value) in values_to_try.iter().enumerate() {
             let value_type = value.js_type();
+            // `input` is always last; everything before it is the `RequestInit`
+            // dictionary, which has no `url` member.
+            let is_input = !is_first_argument_a_url && i == values_to_try.len() - 1;
             let explicit_check = values_to_try.len() == 2
                 && value_type == bun_jsc::JSType::FinalObject
                 && values_to_try[1].js_type() == bun_jsc::JSType::DOMWrapper;
@@ -1172,7 +1175,7 @@ impl Request {
                         }
                     }
 
-                    if !fields.contains(Fields::Url) {
+                    if is_input && !fields.contains(Fields::Url) {
                         let url = response.url();
                         if !url.is_empty() {
                             req.url.set(url.clone());
@@ -1231,7 +1234,7 @@ impl Request {
                 }
             }
 
-            if !fields.contains(Fields::Url) {
+            if is_input && !fields.contains(Fields::Url) {
                 match value.fast_get(global_this, bun_jsc::BuiltinName::Url) {
                     Ok(Some(url)) => {
                         match BunString::from_js(url, global_this) {
@@ -1241,30 +1244,20 @@ impl Request {
                         if !req.url.get().is_empty() {
                             fields.insert(Fields::Url);
                         }
-
-                        // first value
                     }
                     Ok(None) => {
-                        // Short-circuit ordering: only probe
-                        // `implementsToString` (which performs JS property
-                        // lookup with observable side effects) when the first
-                        // two guards already hold.
-                        if value == values_to_try[values_to_try.len() - 1]
-                            && !is_first_argument_a_url
-                        {
-                            let implements = match value.implements_to_string(global_this) {
-                                Ok(b) => b,
+                        let implements = match value.implements_to_string(global_this) {
+                            Ok(b) => b,
+                            Err(e) => bail!(Err(e)),
+                        };
+                        if implements {
+                            let str = match BunString::from_js(value, global_this) {
+                                Ok(s) => s,
                                 Err(e) => bail!(Err(e)),
                             };
-                            if implements {
-                                let str = match BunString::from_js(value, global_this) {
-                                    Ok(s) => s,
-                                    Err(e) => bail!(Err(e)),
-                                };
-                                req.url.set(str);
-                                if !req.url.get().is_empty() {
-                                    fields.insert(Fields::Url);
-                                }
+                            req.url.set(str);
+                            if !req.url.get().is_empty() {
+                                fields.insert(Fields::Url);
                             }
                         }
                     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1088,13 +1088,9 @@ impl Request {
                 if let Some(request) = value.as_direct::<Request>() {
                     // SAFETY: as_direct returns a live *mut Request payload (m_ctx)
                     let request = unsafe { &*request };
-                    if values_to_try.len() == 1 {
-                        match Request::clone_into(
-                            request,
-                            &mut req,
-                            global_this,
-                            fields.contains(Fields::Url),
-                        ) {
+                    // Wholesale clone for `new Request(request)` only; a Request `init` takes the per-field path.
+                    if is_input && values_to_try.len() == 1 {
+                        match Request::clone_into(request, &mut req, global_this) {
                             Ok(()) => {}
                             Err(e) => bail!(Err(e)),
                         }
@@ -1454,7 +1450,6 @@ impl Request {
         &self,
         req: &mut Request,
         global_this: &JSGlobalObject,
-        preserve_url: bool,
     ) -> JsResult<()> {
         // allocator param dropped (global mimalloc)
         let _ = self.ensure_url();
@@ -1464,11 +1459,7 @@ impl Request {
         // Last fallible call; an early return here leaves `req.url` untouched.
         // `body` (a `BodyHiveHandle`) drops on the `?` error path, releasing its +1.
         let headers = self.clone_headers(global_this)?;
-        let url = if preserve_url {
-            req.url.take()
-        } else {
-            self.url.get().clone()
-        };
+        debug_assert!(req.url.get().is_empty());
 
         // `ptr::write` is a raw bit-overwrite — no destructors run on the old
         // `*req`, so the Drop impl on `JsRef` doesn't fire on the caller's
@@ -1476,15 +1467,14 @@ impl Request {
         // The old `req.body` hive ref is intentionally NOT unref'd here:
         // `clone()` seeds it with a dangling sentinel, and `construct_into`
         // releases its seed via the ptr-equality arm of its `cleanup`.
-        // `url` was taken above (preserve_url) or is the empty
-        // sentinel; remaining incoming fields are None/weak/Copy by contract.
+        // `req.url` is empty (asserted above); the other incoming fields are None/weak/Copy by contract.
         // SAFETY: `req` is a valid &mut, fully initialized by the caller;
         // nothing between here and the write can panic.
         unsafe {
             core::ptr::write(
                 req,
                 Request {
-                    url: JsCell::new(url),
+                    url: JsCell::new(self.url.get().clone()),
                     headers: JsCell::new(headers),
                     signal: JsCell::new(None),
                     body: ManuallyDrop::new(body),
@@ -1528,7 +1518,7 @@ impl Request {
             reported_estimated_size: Cell::new(0),
         });
         // Box<Request> drops on the error path automatically
-        self.clone_into(&mut req, global_this, false)?;
+        self.clone_into(&mut req, global_this)?;
         Ok(req)
     }
 }

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -76,6 +76,75 @@ test("clone() does not lock original body when body was accessed before clone", 
   expect(clonedText).toBe("Hello, world!");
 });
 
+// WHATWG `RequestInit` has no `url` member. The URL comes from `input` only.
+describe("RequestInit has no url member", () => {
+  test("new Request(request, { url }) keeps the input Request's url", () => {
+    const base = new Request("http://a.example/x", { method: "DELETE" });
+    const r = new Request(base, { url: "http://b.example/y" } as RequestInit);
+    expect(r.url).toBe("http://a.example/x");
+    expect(r.method).toBe("DELETE");
+  });
+
+  test("new Request(request, { url: <invalid> }) does not throw", () => {
+    const base = new Request("http://a.example/x");
+    expect(new Request(base, { url: "/relative" } as RequestInit).url).toBe("http://a.example/x");
+    expect(new Request(base, { url: 123 } as RequestInit).url).toBe("http://a.example/x");
+  });
+
+  test("init.url getter is never read", () => {
+    const base = new Request("http://a.example/x");
+    let called = false;
+    const init = {
+      method: "POST",
+      get url() {
+        called = true;
+        return "http://b.example/y";
+      },
+    };
+    const r = new Request(base, init);
+    expect(r.url).toBe("http://a.example/x");
+    expect(r.method).toBe("POST");
+    expect(called).toBe(false);
+  });
+
+  test("new Request(string, { url }) keeps the string url", () => {
+    expect(new Request("http://a.example/x", { url: "http://b.example/y" } as RequestInit).url).toBe(
+      "http://a.example/x",
+    );
+    // An empty-string input does not fall back to init.url.
+    expect(() => new Request("", { url: "http://b.example/y" } as RequestInit)).toThrow();
+  });
+
+  test("new Request({ url }, { url }) takes the url from input only", () => {
+    // A plain object with a `url` as *input* is a Bun extension and keeps working.
+    // @ts-expect-error
+    const r = new Request({ url: "http://a.example/x" }, { url: "http://b.example/y", method: "PATCH" });
+    expect(r.url).toBe("http://a.example/x");
+    expect(r.method).toBe("PATCH");
+  });
+
+  test("a Response passed as init does not contribute its url", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("hi"),
+    });
+    const res = await fetch(server.url);
+    expect(res.url).toBe(server.url.href);
+    const base = new Request("http://a.example/x");
+    // @ts-expect-error
+    expect(new Request(base, res).url).toBe("http://a.example/x");
+  });
+
+  test("fetch(new Request(request, { url })) goes to the input Request's url", async () => {
+    await using a = Bun.serve({ port: 0, fetch: () => new Response("a") });
+    await using b = Bun.serve({ port: 0, fetch: () => new Response("b") });
+    const req = new Request(new Request(a.url), { url: b.url.href } as RequestInit);
+    expect(req.url).toBe(a.url.href);
+    const res = await fetch(req);
+    expect(await res.text()).toBe("a");
+  });
+});
+
 describe("RequestInit signal presence", () => {
   // Fetch spec step 27: "If init['signal'] exists, then set signal to it."
   // A present `signal: null` must replace (detach from) the input Request's signal.

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -112,7 +112,7 @@ describe("RequestInit has no url member", () => {
       "http://a.example/x",
     );
     // An empty-string input does not fall back to init.url.
-    expect(() => new Request("", { url: "http://b.example/y" } as RequestInit)).toThrow();
+    expect(() => new Request("", { url: "http://b.example/y" } as RequestInit)).toThrow("url is required");
   });
 
   test("new Request({ url }, { url }) takes the url from input only", () => {

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -135,6 +135,18 @@ describe("RequestInit has no url member", () => {
     expect(new Request(base, res).url).toBe("http://a.example/x");
   });
 
+  test("a Request passed as init does not contribute its url", async () => {
+    const other = new Request("http://b.example/y", { method: "DELETE", headers: { foo: "bar" }, body: "hi" });
+    // The string input is still parsed and validated, and init's other fields still apply.
+    const r = new Request("http://A.example/a/../x", other);
+    expect(r.url).toBe("http://a.example/x");
+    expect(r.method).toBe("DELETE");
+    expect(r.headers.get("foo")).toBe("bar");
+    expect(await r.text()).toBe("hi");
+    expect(() => new Request("", other)).toThrow("url is required");
+    expect(() => new Request("not a url", other)).toThrow('Invalid URL "not a url"');
+  });
+
   test("fetch(new Request(request, { url })) goes to the input Request's url", async () => {
     await using a = Bun.serve({ port: 0, fetch: () => new Response("a") });
     await using b = Bun.serve({ port: 0, fetch: () => new Response("b") });


### PR DESCRIPTION
### Problem
- `new Request(request, init)` honours a non-standard `init.url` and retargets the request. `new Request(base, { url: "http://b.example/y" }).url` is `http://b.example/y` (undici: `base.url`), and `new Request(base, { url: "/relative" })` throws `TypeError Failed to construct 'Request': Invalid URL "/relative"` (undici: no throw). WHATWG `RequestInit` has no `url` member.
- The cause is the candidate loop in `Request::construct_into` (`src/runtime/webcore/Request.rs:1080`). It visits `init` before `input` and reads a URL from every candidate: `fast_get(Url)`, `response.url()` for a `Response`, and the wholesale `clone_into` for a `Request`. The first non-empty one wins, so a URL from `init` beats the one from `input`.

### Fix
- Compute `is_input` per candidate (the input object is always the last entry) and take a URL only when `is_input`. This covers a plain `init` dictionary, a `Response` passed as `init`, and a `Request` passed as `init`.
- For the `Request` case, the `clone_into` fast path now runs for `new Request(request)` only. `new Request(string, request)` takes the per-field path that `new Request(request, init)` already uses, so the string is parsed and validated like any other input. `clone_into` loses its now-unused `preserve_url` parameter.
- The Bun extension `new Request({ url, ... })` (a plain object as `input`) keeps working, since that object is the input.
- Verified: `test/js/web/request/request.test.ts` (8 new tests, all fail on stock bun 1.4.2). Also ran `test/js/web/request/`, the Request tests in `test/js/web/fetch/fetch.test.ts`, `fetch-args`, `body-clone`, `body-mixin-errors`, `FormData`, `filesystem_router`, `globals`, `streams -t Request`, `deno/fetch/request`.

### Background
- The constructor builds `values_to_try = [init?, input?]`: `init` when it is an object, then `input` when it is not a string or `URL`. Each field (`method`, `headers`, `body`, `url`, `signal`, ...) is taken from the first candidate that has it, tracked in the `fields` set.
- Per the Fetch spec, the request URL comes from `input` only: the parsed string, or the input `Request`'s URL. `init` is a `RequestInit` dictionary, so an extra `url` key on it (axios/ky-style configs, `{...requestLike}` spreads) must be ignored.
- `clone_into` is the helper behind `request.clone()`. It copies URL, method, flags, headers, body, and signal from one `Request` into another in one step.

<details><summary>Notes</summary>

Repro from the fuzz ledger (bun 1.4.2 vs node v26.3.0/undici):

```js
const base = new Request("http://a.example/x", { method: "DELETE" });
const r = new Request(base, { url: "http://b.example/y" });
console.log(r.url, r.method);
try { new Request(base, { url: "/relative" }); console.log("ok"); } catch (e) { console.log(e.constructor.name, e.message); }
console.log(new Request("http://a.example/x", { url: "http://b.example/y" }).url);
```

- bun before: `http://b.example/y DELETE` / `TypeError ... Invalid URL "/relative"` / `http://a.example/x`
- bun after, and undici: `http://a.example/x DELETE` / `ok` / `http://a.example/x`

Other faces fixed by the same change:
- `new Request("", { url })` no longer falls back to `init.url` (it throws "url is required", undici throws "Failed to parse URL").
- A `url` getter on `init` is no longer invoked.
- `new Request(request, fetchedResponse)` no longer takes the Response's URL.
- `new Request("", otherRequest)` no longer takes `otherRequest.url` (it throws "url is required").
- `new Request("http://A.example/a/../x", otherRequest).url` is now `http://a.example/x` (was returned unparsed), and `new Request("not a url", otherRequest)` now throws `Invalid URL` (was accepted). Both come from the fast path returning before the input URL was parsed.
- `new Request("http://a.example/y", usedRequest)` now throws `Body object should not be disturbed or locked`, the same as `new Request(usedRequest, {})` already did and as undici does.

Not changed here: a `Response` passed as `init` still contributes its method (GET) and headers through the direct-copy branch. The ledger tracks that as a separate family. `new Request(usedRequest)` with no init still clones (that is #37033's subject).

#37033 also introduces an `is_input` flag in this loop, for a different purpose (copying the input Request's internal state instead of calling getters). It does not stop `init.url` from being read.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/request/request.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [4.66ms]
(pass) request can receive undefined signal [29.19ms]
(pass) request can receive null signal [9.18ms]
(pass) clone() does not lock original body when body was accessed before clone [18.61ms]
79 | // WHATWG `RequestInit` has no `url` member. The URL comes from `input` only.
80 | describe("RequestInit has no url member", () => {
81 |   test("new Request(request, { url }) keeps the input Request's url", () => {
82 |     const base = new Request("http://a.example/x", { method: "DELETE" });
83 |     const r = new Request(base, { url: "http://b.example/y" } as RequestInit);
84 |     expect(r.url).toBe("http://a.example/x");
                       ^
error: expect(received).toBe(expected)

Expected: "http://a.example/x"
Received: "http://b.example/y"

      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:84:19)
(fail) RequestInit has no url member > new Request(request, { url }) keep
... (truncated)

release without fix: 8 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [0.07ms]
(pass) request can receive undefined signal [0.18ms]
(pass) request can receive null signal [0.09ms]
(pass) clone() does not lock original body when body was accessed before clone [0.31ms]
79 | // WHATWG `RequestInit` has no `url` member. The URL comes from `input` only.
80 | describe("RequestInit has no url member", () => {
81 |   test("new Request(request, { url }) keeps the input Request's url", () => {
82 |     const base = new Request("http://a.example/x", { method: "DELETE" });
83 |     const r = new Request(base, { url: "http://b.example/y" } as RequestInit);
84 |     expect(r.url).toBe("http://a.example/x");
                       ^
error: expect(received).toBe(expected)

Expected: "http://a.example/x"
Received: "http://b.example/y"

      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:84:19)
(fail) RequestInit has no url member > new Request(request, { url }) keeps the input Request's url [0.23ms]
85 |     expect(r.method).toBe("DELETE");
86 |   });
87 | 
88 |   test("new Request(request, { url: <invalid> }) does not thro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/request/request.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [3.99ms]
(pass) request can receive undefined signal [23.86ms]
(pass) request can receive null signal [9.81ms]
(pass) clone() does not lock original body when body was accessed before clone [16.26ms]
(pass) RequestInit has no url member > new Request(request, { url }) keeps the input Request's url [3.28ms]
(pass) RequestInit has no url member > new Request(request, { url: <invalid> }) does not throw [2.72ms]
(pass) RequestInit has no url member > init.url getter is never read [3.38ms]
(pass) RequestInit has no url member > new Request(string, { url }) keeps the string url [4.59ms]
(pass) RequestInit has no url member > new Request({ url }, { url }) takes the url from input only [2.24ms]
(pass) RequestInit has no url member > a Response passed as init does not contribute its url [40.21ms]
(pass) RequestInit has no url member > a Request passed as init does not contribute its url [11.27ms]
(pass) RequestI
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     35f104d5df
  features     baseline

23 deps, 131 codegen, 1172 objects in 750ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 KB  (entry point)

[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] gen .bind.ts → GeneratedBindings.cpp
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/server_body.rs   |  2 +-
 src/runtime/webcore/Request.rs      | 62 ++++++++++------------------
 test/js/web/request/request.test.ts | 81 +++++++++++++++++++++++++++++++++++++
 3 files changed, 104 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/server/server_body.rs        1      1     14
src/runtime/webcore/Request.rs           8      8     14
test/js/web/request/request.test.ts      3      3     14
```

</details>

<!-- robobun:evidence:end -->