### PR TITLE
shell: hand mkdir/touch/cp operands to the kernel as written

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -414,7 +414,7 @@ pub struct ShellCpTask {
 /// What `lstat` (file attributes on Windows) says about a `cp` operand.
 struct PathInfo {
     is_dir: bool,
-    /// `(st_dev, st_ino)`: the same-file check compares files, not spellings of their paths.
+    /// `(st_dev, st_ino)` of the file the operand leads to (through a symlink if it is one), for the same-file check.
     #[cfg(not(windows))]
     id: (u64, u64),
 }
@@ -610,9 +610,16 @@ impl ShellCpTask {
         #[cfg(not(windows))]
         {
             let st = bun_sys::lstat(path)?;
+            let id_of = |st: &bun_sys::Stat| (st.st_dev as u64, st.st_ino as u64);
+            // A symlink operand is the file it points at, as far as "same file" goes; a dangling one is itself.
+            let id = if bun_sys::S::ISLNK(st.st_mode as _) {
+                bun_sys::stat(path).map_or(id_of(&st), |target| id_of(&target))
+            } else {
+                id_of(&st)
+            };
             Ok(PathInfo {
                 is_dir: bun_sys::S::ISDIR(st.st_mode as _),
-                id: (st.st_dev as u64, st.st_ino as u64),
+                id,
             })
         }
     }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -4,7 +4,7 @@ use crate::node::PathLike;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, shell_join_cwd, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -411,6 +411,14 @@ pub struct ShellCpTask {
     pub task: ShellTask,
 }
 
+/// What `lstat` (file attributes on Windows) says about a `cp` operand.
+struct PathInfo {
+    is_dir: bool,
+    /// `(st_dev, st_ino)`: the same-file check compares files, not spellings of their paths.
+    #[cfg(not(windows))]
+    id: (u64, u64),
+}
+
 impl ShellCpTask {
     fn create(
         cmd: NodeId,
@@ -579,11 +587,20 @@ impl ShellCpTask {
             .is_some_and(|&c| resolve_path::Platform::AUTO.is_separator(c))
     }
 
-    fn is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
+    /// `dir` + separator + `name`, with `dir` kept byte for byte.
+    fn entry_in_dir(dir: &bun_core::ZStr, name: &[u8]) -> bun_core::ZBox {
+        bun_core::ZBox::from_vec_with_nul(
+            bun_paths::join_sep_maybe_z::<true>(&[dir.as_bytes(), name]).into_vec(),
+        )
+    }
+
+    fn classify(path: &bun_core::ZStr) -> bun_sys::Maybe<PathInfo> {
         #[cfg(windows)]
         {
             match bun_sys::get_file_attributes(path) {
-                Some(attrs) => Ok(attrs.is_directory),
+                Some(attrs) => Ok(PathInfo {
+                    is_dir: attrs.is_directory,
+                }),
                 None => Err(
                     bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::copyfile)
                         .with_path(path.as_bytes()),
@@ -593,7 +610,29 @@ impl ShellCpTask {
         #[cfg(not(windows))]
         {
             let st = bun_sys::lstat(path)?;
-            Ok(bun_sys::S::ISDIR(st.st_mode as _))
+            Ok(PathInfo {
+                is_dir: bun_sys::S::ISDIR(st.st_mode as _),
+                id: (st.st_dev as u64, st.st_ino as u64),
+            })
+        }
+    }
+
+    /// Whether `a` and `b` are one file; Windows has no inode here, but its paths are normalized.
+    fn same_file(
+        a: &bun_core::ZStr,
+        a_info: &PathInfo,
+        b: &bun_core::ZStr,
+        b_info: &PathInfo,
+    ) -> bool {
+        #[cfg(windows)]
+        {
+            let _ = (a_info, b_info);
+            a.as_bytes() == b.as_bytes()
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = (a, b);
+            a_info.id == b_info.id
         }
     }
 
@@ -605,27 +644,10 @@ impl ShellCpTask {
         &mut self,
         poster: &bun_jsc::ConcurrentPoster,
     ) -> Option<ShellErr> {
-        use resolve_path::{Platform, platform};
-
-        let mut buf2 = bun_paths::path_buffer_pool::get();
-        let mut buf3 = bun_paths::path_buffer_pool::get();
-        // We have to give an absolute path to our cp implementation for it to
-        // work with cwd.
-        let src: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.src) {
-            // `self.src` is the bare argv bytes (no NUL); re-terminate via
-            // the thread-local join buffer.
-            resolve_path::join_z::<platform::Auto>(&[&self.src])
-        } else {
-            resolve_path::join_z::<platform::Auto>(&[&self.cwd_path, &self.src])
-        };
-        let mut tgt: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.tgt) {
-            resolve_path::join_z_buf::<platform::Auto>(buf2.as_mut_slice(), &[&self.tgt])
-        } else {
-            resolve_path::join_z_buf::<platform::Auto>(
-                buf2.as_mut_slice(),
-                &[&self.cwd_path, &self.tgt],
-            )
-        };
+        // node:fs cp resolves relative paths against the process cwd, not the shell's.
+        let src = shell_join_cwd(&self.cwd_path, &self.src);
+        let src = src.as_zstr();
+        let mut tgt = shell_join_cwd(&self.cwd_path, &self.tgt);
 
         // Cases:
         //   SRC       DEST
@@ -635,10 +657,11 @@ impl ShellCpTask {
         //   folder -> folder
         // We need to check dest to see what it is; if it doesn't exist we
         // need to create it.
-        let src_is_dir = match Self::is_dir(src) {
-            Ok(x) => x,
+        let src_info = match Self::classify(src) {
+            Ok(info) => info,
             Err(e) => return Some(ShellErr::new_sys(&e)),
         };
+        let src_is_dir = src_info.is_dir;
 
         // Any source directory without -R is an error.
         if src_is_dir && !self.opts.recursive {
@@ -649,25 +672,17 @@ impl ShellCpTask {
             ));
         }
 
-        if !src_is_dir && src.as_bytes() == tgt.as_bytes() {
-            return Some(ShellErr::Custom(
-                format!(
-                    "{0} and {0} are identical (not copied)",
-                    bstr::BStr::new(&self.src)
-                )
-                .into_bytes()
-                .into_boxed_slice(),
-            ));
-        }
-
-        let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt) {
-            Ok(is_dir) => (is_dir, true),
-            Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
-                // If it has a trailing directory separator, it's a directory.
-                (Self::has_trailing_sep(tgt.as_bytes()), false)
-            }
+        let mut tgt_info = match Self::classify(&tgt) {
+            Ok(info) => Some(info),
+            Err(e) if e.get_errno() == bun_sys::E::ENOENT => None,
             Err(e) => return Some(ShellErr::new_sys(&e)),
         };
+        let (tgt_is_dir, tgt_exists) = match &tgt_info {
+            Some(info) => (info.is_dir, true),
+            // If it has a trailing directory separator, it's a directory.
+            None => (Self::has_trailing_sep(tgt.as_bytes()), false),
+        };
+        let mut tgt_in_dir = false;
 
         let mut _copying_many = false;
 
@@ -677,11 +692,8 @@ impl ShellCpTask {
         } else if self.opts.recursive {
             // 2nd synopsis: -R source_files... -> target.
             if tgt_exists {
-                let basename = resolve_path::basename(src.as_bytes());
-                tgt = resolve_path::join_z_buf::<platform::Auto>(
-                    buf3.as_mut_slice(),
-                    &[tgt.as_bytes(), basename],
-                );
+                tgt = Self::entry_in_dir(&tgt, resolve_path::basename(src.as_bytes()));
+                tgt_in_dir = true;
             } else if self.operands == 2 {
                 // source_dir -> new_target_dir.
             } else {
@@ -708,12 +720,36 @@ impl ShellCpTask {
                         .into_boxed_slice(),
                 ));
             }
-            let basename = resolve_path::basename(src.as_bytes());
-            tgt = resolve_path::join_z_buf::<platform::Auto>(
-                buf3.as_mut_slice(),
-                &[tgt.as_bytes(), basename],
-            );
+            tgt = Self::entry_in_dir(&tgt, resolve_path::basename(src.as_bytes()));
+            tgt_in_dir = true;
             _copying_many = true;
+        }
+
+        if tgt_in_dir {
+            tgt_info = Self::classify(&tgt).ok();
+        }
+        if let Some(tgt_info) = &tgt_info {
+            if !src_is_dir && Self::same_file(src, &src_info, &tgt, tgt_info) {
+                let shown: std::borrow::Cow<'_, [u8]> = if tgt_in_dir {
+                    bun_paths::join_sep_maybe_z::<false>(&[
+                        &self.tgt,
+                        resolve_path::basename(&self.src),
+                    ])
+                    .into_vec()
+                    .into()
+                } else {
+                    self.tgt.as_slice().into()
+                };
+                return Some(ShellErr::Custom(
+                    format!(
+                        "{} and {} are identical (not copied)",
+                        bstr::BStr::new(&shown),
+                        bstr::BStr::new(&self.src)
+                    )
+                    .into_bytes()
+                    .into_boxed_slice(),
+                ));
+            }
         }
 
         let args = crate::node::fs::args::Cp::owned(

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -4,7 +4,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, shell_join_cwd, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -295,22 +295,8 @@ impl ShellMkdirTask {
     }
 
     fn run_from_thread_pool(this: &mut ShellMkdirTask) {
-        use bun_paths::{Platform, platform, resolve_path};
-        // We have to give an absolute path to our mkdir implementation for it
-        // to work with cwd.
-        let mut spill = Vec::new();
-        let filepath: &bun_core::ZStr = if Platform::AUTO.is_absolute(&this.filepath) {
-            // Owned `Vec<u8>`; ensure NUL-terminated.
-            if this.filepath.last() != Some(&0) {
-                this.filepath.push(0);
-            }
-            bun_core::ZStr::from_buf(&this.filepath, this.filepath.len() - 1)
-        } else {
-            resolve_path::join_z_spill::<platform::Auto>(
-                &mut spill,
-                &[&this.cwd_path, &this.filepath],
-            )
-        };
+        // `NodeFS` mkdir resolves relative paths against the process cwd, not the shell's.
+        let filepath = shell_join_cwd(&this.cwd_path, &this.filepath);
 
         // `NodeFS` expects the `Valid::path_too_long` bound its JS callers
         // enforce; past it, `PathLike::slice_z` yields "" and mkdir reports ENOENT.

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -2,7 +2,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, shell_join_cwd, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -263,22 +263,10 @@ impl ShellTouchTask {
     /// utimes() the path; on ENOENT
     /// fall back to `open(O_CREAT|O_WRONLY, 0o664)`.
     pub(crate) fn run_from_thread_pool(this: &mut ShellTouchTask) {
-        use bun_paths::resolve_path::{self, Platform, platform};
         use bun_sys::FdExt as _;
-        // We have to give an absolute path. An operand that does not fit the
-        // path buffer is still passed on whole, so the OS reports ENAMETOOLONG
-        // for it like for any other operand.
-        let mut spill = Vec::new();
-        let filepath: &bun_core::ZStr = if Platform::AUTO.is_absolute(&this.filepath) {
-            // Re-terminate (`filepath` is the bare argv bytes without the
-            // trailing NUL).
-            resolve_path::join_z_spill::<platform::Auto>(&mut spill, &[&this.filepath])
-        } else {
-            resolve_path::join_z_spill::<platform::Auto>(
-                &mut spill,
-                &[&this.cwd_path, &this.filepath],
-            )
-        };
+        // `utimens`/`open` resolve relative paths against the process cwd, not the shell's.
+        let filepath = shell_join_cwd(&this.cwd_path, &this.filepath);
+        let filepath = filepath.as_zstr();
 
         // Call the bun_sys layer directly (uv_fs_utime on Windows) to avoid
         // the heavyweight NodeFS state.

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2293,6 +2293,29 @@ fn shell_get_path<'a>(
     >(&mut buf[..], &[&dirpath, to.as_bytes()]))
 }
 
+/// Operand `path` for a path-only syscall: prefixed with the shell `cwd` when relative, never normalized (`a/link/../b` is not `a/b` to the kernel).
+pub(crate) fn shell_join_cwd(cwd: &[u8], path: &[u8]) -> bun_core::ZBox {
+    if path.is_empty() || bun_paths::Platform::AUTO.is_absolute(path) {
+        return bun_core::ZBox::from_bytes(path);
+    }
+    #[cfg(windows)]
+    {
+        // Win32 resolves `.`/`..` textually itself, and the NT calls below it reject them.
+        let mut spill = Vec::new();
+        let joined = bun_paths::resolve_path::join_z_spill::<bun_paths::platform::Auto>(
+            &mut spill,
+            &[cwd, path],
+        );
+        bun_core::ZBox::from_bytes(joined.as_bytes())
+    }
+    #[cfg(not(windows))]
+    {
+        bun_core::ZBox::from_vec_with_nul(
+            bun_paths::join_sep_maybe_z::<true>(&[cwd, path]).into_vec(),
+        )
+    }
+}
+
 /// Windows: rewrite the path via `shell_get_path` then `bun_sys::stat`, tagging
 /// the error with the *original* `path_` (not the rewritten one). POSIX: plain
 /// `bun_sys::fstatat(dir, path_)`.

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2293,19 +2293,20 @@ fn shell_get_path<'a>(
     >(&mut buf[..], &[&dirpath, to.as_bytes()]))
 }
 
-/// Operand `path` for a path-only syscall: prefixed with the shell `cwd` when relative, never normalized (`a/link/../b` is not `a/b` to the kernel).
+/// Operand `path` for a path-only syscall: prefixed with the shell `cwd` when relative, not normalized on POSIX (`a/link/../b` is not `a/b` to the kernel).
 pub(crate) fn shell_join_cwd(cwd: &[u8], path: &[u8]) -> bun_core::ZBox {
-    if path.is_empty() || bun_paths::Platform::AUTO.is_absolute(path) {
+    let absolute = bun_paths::Platform::AUTO.is_absolute(path);
+    if path.is_empty() || (absolute && cfg!(not(windows))) {
         return bun_core::ZBox::from_bytes(path);
     }
     #[cfg(windows)]
     {
-        // Win32 resolves `.`/`..` textually itself, and the NT calls below it reject them.
+        // Win32 resolves `.`/`..` textually itself, and the NT calls below it reject them, so normalize here.
+        let (with_cwd, alone) = ([cwd, path], [path]);
+        let parts: &[&[u8]] = if absolute { &alone } else { &with_cwd };
         let mut spill = Vec::new();
-        let joined = bun_paths::resolve_path::join_z_spill::<bun_paths::platform::Auto>(
-            &mut spill,
-            &[cwd, path],
-        );
+        let joined =
+            bun_paths::resolve_path::join_z_spill::<bun_paths::platform::Auto>(&mut spill, parts);
         bun_core::ZBox::from_bytes(joined.as_bytes())
     }
     #[cfg(not(windows))]

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { linkSync, readFileSync, readdirSync, realpathSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -171,6 +173,120 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
   });
+});
+
+// The cp builtin hands both operands to the node:fs copy as paths from the
+// shell cwd. They reach the kernel as written: folding `link/..` out of the
+// string first copied from (or into) a different directory than the one every
+// other program sees. POSIX needs the builtin enabled explicitly; Windows
+// resolves `..` in the path string itself, before any symlink, so it has only
+// one view.
+test.skipIf(isWindows)("operands are copied from and to where the kernel resolves them", async () => {
+  using dir = tempDir("cp-kernel-path", {
+    "d/c.txt": "in d",
+    "other/c.txt": "in other",
+    "other/sub/.keep": "",
+  });
+  const base = String(dir);
+  // d/link/.. is other/, not d/
+  symlinkSync("../other/sub", join(base, "d", "link"));
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    $.nothrow();
+    const run = async (...args: string[]) => {
+      const { exitCode, stderr } = await $\`cp \${args}\`.quiet();
+      return { exitCode, stderr: stderr.toString() };
+    };
+    console.log(JSON.stringify({
+      from: await run("d/link/../c.txt", "out.txt"),
+      into: await run("d/c.txt", "d/link/.."),
+      intoRenamed: await run("d/c.txt", "d/link/../renamed.txt"),
+    }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+    cwd: base,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const ok = { exitCode: 0, stderr: "" };
+  expect(JSON.parse(stdout)).toEqual({ from: ok, into: ok, intoRenamed: ok });
+  expect({
+    out: readFileSync(join(base, "out.txt"), "utf8"),
+    d: readdirSync(join(base, "d")).sort(),
+    other: readdirSync(join(base, "other")).sort(),
+    otherC: readFileSync(join(base, "other", "c.txt"), "utf8"),
+    renamed: readFileSync(join(base, "other", "renamed.txt"), "utf8"),
+  }).toEqual({
+    out: "in other",
+    d: ["c.txt", "link"],
+    other: ["c.txt", "renamed.txt", "sub"],
+    otherC: "in d",
+    renamed: "in d",
+  });
+  expect(exitCode).toBe(0);
+});
+
+// The builtin refuses to copy a file onto itself. With operands no longer
+// normalized, two spellings of one path differ as strings, so the check
+// compares the files (device and inode) the way BSD and GNU cp do, which also
+// covers hard links and a directory reached through a symlink.
+test.skipIf(isWindows)("a file is not copied onto itself however the operands spell it", async () => {
+  using dir = tempDir("cp-same-file", {
+    "d/c.txt": "content",
+    "other/sub/s.txt": "sub content",
+    // past the size where the macOS copy path unlinks the destination first
+    "big.bin": Buffer.alloc(200 * 1024, "x").toString(),
+  });
+  const base = String(dir);
+  symlinkSync("../other/sub", join(base, "d", "link"));
+  linkSync(join(base, "d", "c.txt"), join(base, "hard.txt"));
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    $.nothrow();
+    const run = async (...args: string[]) => {
+      const { exitCode, stderr } = await $\`cp \${args}\`.quiet();
+      return { exitCode, stderr: stderr.toString() };
+    };
+    console.log(JSON.stringify({
+      dotSlash: await run("d/c.txt", "./d/c.txt"),
+      intoOwnDir: await run("d/c.txt", "d"),
+      throughLink: await run("other/sub/s.txt", "d/link/s.txt"),
+      hardLink: await run("d/c.txt", "hard.txt"),
+      big: await run("big.bin", "./big.bin"),
+      absolute: await run("big.bin", process.cwd() + "/big.bin"),
+    }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+    cwd: base,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const refused = (tgt: string, src: string) => ({
+    exitCode: 1,
+    stderr: `cp: ${tgt} and ${src} are identical (not copied)\n`,
+  });
+  expect(JSON.parse(stdout)).toEqual({
+    dotSlash: refused("./d/c.txt", "d/c.txt"),
+    intoOwnDir: refused("d/c.txt", "d/c.txt"),
+    throughLink: refused("d/link/s.txt", "other/sub/s.txt"),
+    hardLink: refused("hard.txt", "d/c.txt"),
+    big: refused("./big.bin", "big.bin"),
+    absolute: refused(`${realpathSync(base)}/big.bin`, "big.bin"),
+  });
+  expect({
+    c: readFileSync(join(base, "d", "c.txt"), "utf8"),
+    s: readFileSync(join(base, "other", "sub", "s.txt"), "utf8"),
+    big: readFileSync(join(base, "big.bin"), "utf8").length,
+  }).toEqual({ c: "content", s: "sub content", big: 200 * 1024 });
+  expect(exitCode).toBe(0);
 });
 
 function expectSortedOutput(expected: string) {

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
-import { linkSync, readFileSync, readdirSync, realpathSync, symlinkSync } from "node:fs";
+import { linkSync, readFileSync, readdirSync, readlinkSync, realpathSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
@@ -233,7 +233,8 @@ test.skipIf(isWindows)("operands are copied from and to where the kernel resolve
 // The builtin refuses to copy a file onto itself. With operands no longer
 // normalized, two spellings of one path differ as strings, so the check
 // compares the files (device and inode) the way BSD and GNU cp do, which also
-// covers hard links and a directory reached through a symlink.
+// covers hard links, a symlink to the file as either operand, and a directory
+// reached through a symlink.
 test.skipIf(isWindows)("a file is not copied onto itself however the operands spell it", async () => {
   using dir = tempDir("cp-same-file", {
     "d/c.txt": "content",
@@ -243,6 +244,7 @@ test.skipIf(isWindows)("a file is not copied onto itself however the operands sp
   });
   const base = String(dir);
   symlinkSync("../other/sub", join(base, "d", "link"));
+  symlinkSync("d/c.txt", join(base, "soft.txt"));
   linkSync(join(base, "d", "c.txt"), join(base, "hard.txt"));
   const fixture = /* ts */ `
     import { $ } from "bun";
@@ -256,6 +258,8 @@ test.skipIf(isWindows)("a file is not copied onto itself however the operands sp
       intoOwnDir: await run("d/c.txt", "d"),
       throughLink: await run("other/sub/s.txt", "d/link/s.txt"),
       hardLink: await run("d/c.txt", "hard.txt"),
+      ontoSymlink: await run("d/c.txt", "soft.txt"),
+      fromSymlink: await run("soft.txt", "d/c.txt"),
       big: await run("big.bin", "./big.bin"),
       absolute: await run("big.bin", process.cwd() + "/big.bin"),
     }));
@@ -278,14 +282,17 @@ test.skipIf(isWindows)("a file is not copied onto itself however the operands sp
     intoOwnDir: refused("d/c.txt", "d/c.txt"),
     throughLink: refused("d/link/s.txt", "other/sub/s.txt"),
     hardLink: refused("hard.txt", "d/c.txt"),
+    ontoSymlink: refused("soft.txt", "d/c.txt"),
+    fromSymlink: refused("d/c.txt", "soft.txt"),
     big: refused("./big.bin", "big.bin"),
     absolute: refused(`${realpathSync(base)}/big.bin`, "big.bin"),
   });
   expect({
     c: readFileSync(join(base, "d", "c.txt"), "utf8"),
+    soft: readlinkSync(join(base, "soft.txt")),
     s: readFileSync(join(base, "other", "sub", "s.txt"), "utf8"),
     big: readFileSync(join(base, "big.bin"), "utf8").length,
-  }).toEqual({ c: "content", s: "sub content", big: 200 * 1024 });
+  }).toEqual({ c: "content", soft: "d/c.txt", s: "sub content", big: 200 * 1024 });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/shell/commands/mkdir.test.ts
+++ b/test/js/bun/shell/commands/mkdir.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { readdirSync, realpathSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
 // A relative operand was joined onto the cwd in a fixed 4096-byte buffer, so an
@@ -17,7 +18,7 @@ test("operands longer than the path buffers are reported, not a crash", async ()
     const long = Buffer.alloc(5000, "a").toString();
     // Past the path buffer on every platform, Windows included.
     const huge = Buffer.alloc(100_000, "h").toString();
-    // Longer than the buffers as written, but normalizes down to one component.
+    // Longer than PATH_MAX as written, a single component once normalized.
     const dotSlashes = Buffer.alloc(6000, "./").toString();
     const run = async (...args: string[]) => {
       const { exitCode, stderr } = await $\`mkdir \${args}\`.quiet();
@@ -64,14 +65,73 @@ test("operands longer than the path buffers are reported, not a crash", async ()
     parents: failed(join(cwd, long)),
     huge: { exitCode: 1, stderr: tooLong(join(cwd, huge)) },
     mixed: { ...failed(join(cwd, long)), shortCreated: true },
-    dotSlashes: { exitCode: 0, stderr: "", created: true },
-    // An absolute operand is not normalized (`..` through a symlink means
-    // something else to the kernel), so like the kernel and coreutils, mkdir
-    // bounds it as written. On Windows it fits the much larger buffer and the
-    // fs layer normalizes it while converting it to a wide path, so it works.
+    // An operand is not normalized (`..` through a symlink means something
+    // else to the kernel), so like the kernel and coreutils, mkdir bounds it
+    // as written. Windows resolves `.`/`..` in the path string itself, and
+    // there the operand fits the much larger buffer, so it works.
+    dotSlashes: isWindows
+      ? { exitCode: 0, stderr: "", created: true }
+      : { ...failed(`${cwd}/${dotSlashes}normalized`), created: false },
     absoluteDotSlashes: isWindows
       ? { exitCode: 0, stderr: "", created: true }
       : { ...failed(`${dir}/${dotSlashes}as-written`), created: false },
   });
+  expect(exitCode).toBe(0);
+});
+
+// The operand reaches the kernel as written (prefixed with the shell cwd when
+// relative). Folding `link/..` or `missing/..` out of the string first named a
+// different directory than the one every other program sees. Windows resolves
+// `..` in the path string itself, before any symlink, so it has only one view.
+test.skipIf(isWindows)("operands are created where the kernel resolves them", async () => {
+  using dir = tempDir("mkdir-kernel-path", {
+    "d/c.txt": "",
+    "other/sub/.keep": "",
+  });
+  symlinkSync("../other/sub", join(String(dir), "d", "link"));
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    $.nothrow();
+    const run = async (...args: string[]) => {
+      const { exitCode, stdout, stderr } = await $\`mkdir \${args}\`.quiet();
+      return { exitCode, stdout: stdout.toString().split("\\n").sort(), stderr: stderr.toString() };
+    };
+    console.log(JSON.stringify({
+      // d/link/.. is other/, not d/
+      throughLink: await run("d/link/../made"),
+      throughLinkParents: await run("-p", "d/link/../deep/er"),
+      // coreutils creates the missing component, then follows the real ".."
+      missingParent: await run("-pv", "d/missing/../beside"),
+      missing: await run("d/nothere/../x"),
+      notDir: await run("d/c.txt/../y"),
+      empty: await run(""),
+    }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const cwd = realpathSync(String(dir));
+  const ok = { exitCode: 0, stdout: [""], stderr: "" };
+  expect(JSON.parse(stdout)).toEqual({
+    throughLink: ok,
+    throughLinkParents: ok,
+    missingParent: {
+      exitCode: 0,
+      stdout: ["", `${cwd}/d/missing`, `${cwd}/d/missing/../beside`],
+      stderr: "",
+    },
+    missing: { exitCode: 1, stdout: [""], stderr: `mkdir: ${cwd}/d/nothere/../x: No such file or directory\n` },
+    notDir: { exitCode: 1, stdout: [""], stderr: `mkdir: ${cwd}/d/c.txt/../y: Not a directory\n` },
+    empty: { exitCode: 1, stdout: [""], stderr: "mkdir: No such file or directory\n" },
+  });
+  expect(readdirSync(join(String(dir), "d")).sort()).toEqual(["beside", "c.txt", "link", "missing"]);
+  expect(readdirSync(join(String(dir), "other")).sort()).toEqual(["deep", "made", "sub"]);
+  expect(readdirSync(join(String(dir), "other", "deep"))).toEqual(["er"]);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/shell/commands/touch.test.ts
+++ b/test/js/bun/shell/commands/touch.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { readdirSync, realpathSync, statSync, symlinkSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 
 // Every operand, absolute or not, was joined into a fixed-size path buffer, so
@@ -16,7 +17,7 @@ test("operands longer than the path buffer are reported, not a crash", async () 
     const long = Buffer.alloc(5000, "a").toString();
     // Past the path buffer on every platform, Windows included.
     const huge = Buffer.alloc(100_000, "h").toString();
-    // Longer than the buffer as written, but normalizes down to one component.
+    // Longer than PATH_MAX as written, a single component once normalized.
     const dotSlashes = Buffer.alloc(6000, "./").toString() + "normalized";
     const run = async (...args: string[]) => {
       const { exitCode, stderr } = await $\`touch \${args}\`.quiet();
@@ -44,10 +45,12 @@ test("operands longer than the path buffer are reported, not a crash", async () 
 
   const long = Buffer.alloc(5000, "a").toString();
   const huge = Buffer.alloc(100_000, "h").toString();
-  // The over-long path is passed to the OS whole, and touch reports the path
-  // it operated on: a relative operand joined onto the cwd. Which errno
-  // Windows picks for it is up to the OS; what matters is that each operand
-  // fails on its own.
+  const dotSlashes = Buffer.alloc(6000, "./").toString() + "normalized";
+  // The over-long path is passed to the OS whole and as written, and touch
+  // reports the path it operated on: a relative operand joined onto the cwd.
+  // Which errno Windows picks for it is up to the OS; what matters is that
+  // each operand fails on its own. Windows also resolves `.`/`..` in the path
+  // string itself, so there the dotted operand names a short path and works.
   const failed = (path: string) =>
     isWindows
       ? { exitCode: 1, stderr: expect.stringMatching(/^touch: /) }
@@ -57,7 +60,70 @@ test("operands longer than the path buffer are reported, not a crash", async () 
     absolute: failed(`${dir}/${long}`),
     huge: failed(join(cwd, huge)),
     mixed: { ...failed(join(cwd, long)), shortCreated: true },
-    dotSlashes: { exitCode: 0, stderr: "", created: true },
+    dotSlashes: isWindows
+      ? { exitCode: 0, stderr: "", created: true }
+      : { ...failed(`${cwd}/${dotSlashes}`), created: false },
+  });
+  expect(exitCode).toBe(0);
+});
+
+// The operand reaches the kernel as written (prefixed with the shell cwd when
+// relative). Folding `link/..` or `missing/..` out of the string first touched
+// or created a different file than the one every other program sees. Windows
+// resolves `..` in the path string itself, before any symlink, so it has only
+// one view.
+test.skipIf(isWindows)("operands are touched where the kernel resolves them", async () => {
+  using dir = tempDir("touch-kernel-path", {
+    "d/c.txt": "",
+    "other/c.txt": "",
+    "other/sub/.keep": "",
+  });
+  const base = String(dir);
+  symlinkSync("../other/sub", join(base, "d", "link"));
+  const past = new Date("2001-02-03T04:05:06Z");
+  for (const file of ["d/c.txt", "other/c.txt"]) utimesSync(join(base, file), past, past);
+
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    $.nothrow();
+    const run = async (...args: string[]) => {
+      const { exitCode, stderr } = await $\`touch \${args}\`.quiet();
+      return { exitCode, stderr: stderr.toString() };
+    };
+    console.log(JSON.stringify({
+      // d/link/.. is other/, not d/
+      existing: await run("d/link/../c.txt"),
+      created: await run("d/link/../new.txt"),
+      missing: await run("d/nothere/../x"),
+      empty: await run(""),
+    }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    cwd: base,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const cwd = realpathSync(base);
+  expect(JSON.parse(stdout)).toEqual({
+    existing: { exitCode: 0, stderr: "" },
+    created: { exitCode: 0, stderr: "" },
+    missing: { exitCode: 1, stderr: `touch: ${cwd}/d/nothere/../x: No such file or directory\n` },
+    empty: { exitCode: 1, stderr: "touch: No such file or directory\n" },
+  });
+  expect({
+    d: readdirSync(join(base, "d")).sort(),
+    other: readdirSync(join(base, "other")).sort(),
+    dTouched: statSync(join(base, "d", "c.txt")).mtime > past,
+    otherTouched: statSync(join(base, "other", "c.txt")).mtime > past,
+  }).toEqual({
+    d: ["c.txt", "link"],
+    other: ["c.txt", "new.txt", "sub"],
+    dTouched: false,
+    otherTouched: true,
   });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- The `mkdir`, `touch` and `cp` shell builtins folded `.` and `..` out of each operand, `path.join` style, before any syscall. `mkdir -p d/link/../nd` created `d/nd` where coreutils (and `ls`, `cat`, `mv`, redirects in the same shell) see `other/nd`, and `touch d/missing/../t` created `d/t` instead of failing with ENOENT.
- Cause: `mkdir.rs`, `touch.rs` and `cp.rs` joined the operand onto the shell cwd with `resolve_path::join_z*`, which normalizes like Node's `path.join`.

### Fix
- New `shell_join_cwd` (`interpreter.rs`): a relative operand gets the shell cwd prefixed and nothing else changes. Windows keeps the normalizing join, because Win32 resolves `..` textually itself.
- `cp` refused to copy a file onto itself by comparing the two joined strings. Two spellings of one path no longer compare equal, so the check now compares device and inode once the target has its final `dir/basename` form, as BSD and GNU cp do.
- Verified: `test/js/bun/shell/commands/{mkdir,touch,cp}.test.ts`, new cases fail on 1.4.3 and pass here. Also the `ls`, `mv`, `rm` and `bunshell` suites.

### Background
- The shell keeps its own cwd as a string and an fd. `mkdir`, `touch` and `cp` sit on path-only APIs (node:fs mkdir and cp, `utimens`), so they spell the operand from the cwd string.
- To the kernel, `a/link/..` is the parent of the link target and `missing/..` does not exist. Only a textual resolver (Node's `path`, Win32) reads them as `a` and `.`.
- `cp` is a builtin by default only on Windows; on POSIX the new cp tests enable it with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`.

<details><summary>Notes</summary>

- Scope. The report this answers (forwarded by @Jarred-Sumner) also covers `rm`: `rm -r` listed a directory through the kernel path but unlinked each entry under the lexically joined parent, so `rm -rf d/link/..` deleted same-named files in `d/`. An earlier revision of this PR fixed that too (file entries unlinked relative to the listed directory's fd, plus a `.`/`..` operand refusal). That part is dropped here because #41842 reworks the whole `rm` walk to resolve every entry, directories included, relative to a held parent fd, which fixes the same bug and the directory-level re-resolution race, and the two conflicted throughout `rm.rs`. The `rm` regression cases from that revision are posted on #41842. The POSIX `.`/`..` operand refusal (`rm -rf .` empties the cwd today) is #34906's subject and is not included here either.
- Side effects: a relative `mkdir`/`touch` operand longer than `PATH_MAX` now fails with `ENAMETOOLONG` instead of being normalized short, as coreutils does (the existing long-operand tests change accordingly); `mkdir ''` and `touch ''` fail with ENOENT instead of acting on the cwd (#38002 covers empty operands more broadly, including the Windows fd-relative builtins).
- `mkdir -pv d/missing/../x` creates `d/missing` and then `d/x`, printing both, exactly as GNU does; `mkdir d/file/../x` is `ENOTDIR`.
- The same-file check also covers hard links, a symlink to the file as either operand (its identity is the file it points at), and a directory reached through a symlink. On Windows there is no inode at hand, so the check stays a string compare and `shell_join_cwd` keeps normalizing both relative and absolute operands there. The macOS copy path unlinks the destination before `clonefile` for files over 128 KB, so a same-file copy that slipped past the builtin's check would not be harmless there; the new cp test includes a 200 KB file copied onto `./itself` and through an absolute spelling.
- An earlier revision (with the `rm` part) also passed its tests on Windows x64; `cargo check` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` passes on this one.
- GNU control, for reference: `mkdir -p d/link/../nd` creates `other/nd`; `touch d/nodir/../t` is `ENOENT`; `cp a ./a` is refused ("are the same file"); `touch ''` and `mkdir ''` fail.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/commands/touch.test.ts, test/js/bun/shell/commands/mkdir.test.ts, test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->