### PR TITLE
node:util: free MIMEType's type and subtype strings when the object is collected

### DIFF
--- a/src/jsc/bindings/webcore/JSMIMEType.h
+++ b/src/jsc/bindings/webcore/JSMIMEType.h
@@ -4,6 +4,7 @@
 #include "JSDOMWrapper.h" // For JSDOMObject
 #include "JSMIMEParams.h" // Need JSMIMEParams
 #include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/LazyClassStructure.h>
 #include <JavaScriptCore/JSGlobalObject.h>
@@ -11,10 +12,16 @@
 
 namespace WebCore {
 
-class JSMIMEType final : public JSC::JSNonFinalObject {
+// Destructible so that m_type and m_subtype are released when the cell is swept.
+class JSMIMEType final : public JSC::JSDestructibleObject {
 public:
-    using Base = JSC::JSNonFinalObject;
+    using Base = JSC::JSDestructibleObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static void destroy(JSC::JSCell* cell)
+    {
+        static_cast<JSMIMEType*>(cell)->JSMIMEType::~JSMIMEType();
+    }
 
     template<typename MyClassT, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunExe } from "harness";
+import { bunExe, expectRssDeltaBelow } from "harness";
 import { MIMEParams, MIMEType } from "util";
 
 describe("MIME API", () => {
@@ -435,4 +435,25 @@ test("ERR_INVALID_MIME_SYNTAX message matches Node.js", () => {
     "text/": 'The MIME syntax for a subtype in "text/" is invalid',
     "texthtml": 'The MIME syntax for a type in "texthtml" is invalid',
   });
+});
+
+test("MIMEType releases its type and subtype strings when garbage-collected", async () => {
+  // 128 KiB type + 128 KiB subtype, so each instance owns 256 KiB of lowercased copies.
+  // The count stays low because a debug ASAN build validates these at ~45 ns per byte.
+  const code = /* js */ `
+    const { MIMEType } = require("node:util");
+    const input = Buffer.alloc(128 * 1024, "a").toString() + "/" + Buffer.alloc(128 * 1024, "b").toString();
+    for (let i = 0; i < 20; i++) new MIMEType(input);
+    Bun.gc(true);
+    const before = process.memoryUsage.rss();
+    for (let i = 0; i < 160; i++) {
+      new MIMEType(input);
+      if (i % 20 === 19) Bun.gc(true);
+    }
+    Bun.gc(true);
+    console.log(JSON.stringify({ deltaMiB: (process.memoryUsage.rss() - before) / 1024 / 1024 }));
+  `;
+
+  // Unfixed: ~42 MiB (160 x 256 KiB). Fixed: 1 to 4 MiB of allocator slack.
+  await expectRssDeltaBelow(["--smol", "-e", code], { release: 20, debug: 25 });
 });


### PR DESCRIPTION
### Problem
- Every `new MIMEType(...)` (`node:util`) that the GC later collects leaks the storage of its `type` and `subtype` strings. RSS grows linearly with instance count (about 57 B per instance for `text/html;charset=utf-8`, about 160 B for a 100-char type/subtype) while the JSC object count stays flat. A server that does `new MIMEType(req.headers.get("content-type"))` per request grows for the life of the process.
- The cause is `class JSMIMEType final : public JSC::JSNonFinalObject` (`src/jsc/bindings/webcore/JSMIMEType.h:14`). It owns `WTF::String m_type` and `WTF::String m_subtype`, but a `JSNonFinalObject` is swept without its C++ destructor, so the two `StringImpl` refs are never dropped.

### Fix
- Derive `JSMIMEType` from `JSC::JSDestructibleObject` and add `destroy()`, which runs `~JSMIMEType()`.
- Correct because `subspaceForImpl` (`src/jsc/bindings/BunClientData.h:373`) selects `heap.destructibleObjectHeapCellType` for any `T` derived from `JSDestructibleObject`, so the existing `m_subspaceForJSMIMEType` IsoSubspace now calls `destroy()` on sweep. `JSMIMEParams` only holds a `WriteBarrier<JSMap>` and needs no change.
- Verified: `test/js/node/util/mime-api.test.ts` (new RSS test: 41 to 43 MiB unfixed, 1 to 4 MiB fixed, bound 20/25). Also `test/js/node/test/parallel/test-mime-api.js` and `test-mime-whatwg.js`.

### Background
- JSC only runs a cell's destructor when the cell type's `needsDestruction` is `NeedsDestruction` and its IsoSubspace uses a destructible `HeapCellType`. `JSNonFinalObject` inherits `DoesNotNeedDestruction` from `JSCell`, so members with non-trivial destructors (`WTF::String`, `Vector`, `RefPtr`) silently leak.
- `JSDestructibleObject` is the stock base for this: it sets `NeedsDestruction` and stores the `ClassInfo` so the sweeper can call the class's static `destroy(JSCell*)`.

<details><summary>Notes</summary>

- Ledger repro (`'a'.repeat(50) + '/' + 'b'.repeat(50)`, 1.5M instances, `Bun.gc(true)` every 40): bun 1.4.3 +227 MB, about 158 B per instance. With this change the same loop is flat after warm-up (+7 MB at 20k, +8 MB at 40k and 60k for a 1 KB type/subtype, vs +22/+49/+73 MB on 1.4.3).
- The test keeps the instance count at 160 x 256 KiB because a debug ASAN build validates and lowercases the input at about 45 ns per byte. The subprocess takes about 2.7 s there and about 0.1 s in release.
- The same defect exists in a few other cell classes (`Zig::ImportMetaObject::url`, the v8 shim `FunctionTemplate`/`ObjectTemplate` vectors, `v8::shim::GlobalInternals` containers). Those are tracked separately. `Bun::JSMockFunction` is covered by #40382.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/util/mime-api.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [12.14ms]
(pass) MIME API > basic properties and string conversion [26.01ms]
(pass) MIME API > type property manipulation [22.50ms]
(pass) MIME API > subtype property manipulation [20.67ms]
(pass) MIME API > parameters manipulation [22.73ms]
(pass) MIME API > invalid parameter names [14.91ms]
(pass) MIME API > invalid parameter values [7.60ms]
(pass) Exact match with node [591.96ms]
(pass) ERR_INVALID_MIME_SYNTAX message matches Node.js [7.80ms]
360 |     stderr: "pipe",
361 |   });
362 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
363 |   expect(stderr.trim()).toBe("");
364 |   const { deltaMiB } = JSON.parse(stdout.trim().split("\n").at(-1)!);
365 |   expect(deltaMiB).toBeLessThan(isASAN || isDebug ? bounds.debug : bounds.release);
                         ^
error: expect(received).toBeLessThan(expected)

Expected: < 25
Received
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [0.09ms]
(pass) MIME API > basic properties and string conversion [0.17ms]
(pass) MIME API > type property manipulation [0.27ms]
(pass) MIME API > subtype property manipulation [0.18ms]
(pass) MIME API > parameters manipulation [0.23ms]
(pass) MIME API > invalid parameter names [0.11ms]
(pass) MIME API > invalid parameter values [0.06ms]
(pass) Exact match with node [13.50ms]
(pass) ERR_INVALID_MIME_SYNTAX message matches Node.js [0.19ms]
360 |     stderr: "pipe",
361 |   });
362 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
363 |   expect(stderr.trim()).toBe("");
364 |   const { deltaMiB } = JSON.parse(stdout.trim().split("\n").at(-1)!);
365 |   expect(deltaMiB).toBeLessThan(isASAN || isDebug ? bounds.debug : bounds.release);
                         ^
error: expect(received).toBeLessThan(expected)

Expected: < 20
Received: 43

      at expectRssDeltaBelow (/workspace/bun/test/harness.ts:365:20)
      at async <anonymous> (/workspace/bun/test/js/node/util/mime-api.test.ts:458:9)
(fail
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/util/mime-api.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [18.43ms]
(pass) MIME API > basic properties and string conversion [32.01ms]
(pass) MIME API > type property manipulation [39.94ms]
(pass) MIME API > subtype property manipulation [22.15ms]
(pass) MIME API > parameters manipulation [23.88ms]
(pass) MIME API > invalid parameter names [16.56ms]
(pass) MIME API > invalid parameter values [8.33ms]
(pass) Exact match with node [597.77ms]
(pass) ERR_INVALID_MIME_SYNTAX message matches Node.js [11.15ms]
(pass) MIMEType releases its type and subtype strings when garbage-collected [2665.00ms]

 10 pass
 0 fail
 1 snapshots, 90 expect() calls
Ran 10 tests across 1 file. [5.99s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     197c76e54a
  features     baseline

23 deps, 131 codegen, 1172 objects in 682ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [16.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] fetch zlib
[zlib] up to date
[5/1244] gen bindgenv2
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[8/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen ProcessBinding
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSMIMEType.h | 11 +++++++++--
 test/js/node/util/mime-api.test.ts    | 23 ++++++++++++++++++++++-
 2 files changed, 31 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/webcore/JSMIMEType.h      1      2     10
test/js/node/util/mime-api.test.ts         2      3     10
```

</details>

<!-- robobun:evidence:end -->