### PR TITLE
fetch: stop using sendfile(2) for file request bodies on macOS

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -21,6 +21,7 @@
 [bun_http]
 "generic_body_not_generic:src/http/HTTPContext.rs" = 1
 "generic_body_not_generic:src/http/lib.rs" = 2
+"narrowed_two_ways:src/http/SendFile.rs" = 1
 
 [bun_http_jsc]
 "generic_body_not_generic:src/http_jsc/websocket_client.rs" = 2

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -230,9 +230,7 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER, "BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE, "BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE", {});
-    // fetch() streams a `Bun.file()` body over plain HTTP with sendfile(2) on
-    // Linux and FreeBSD. This makes it use the pread + send copy loop that macOS
-    // always uses (`SendFile::write_copy`), so that path has test coverage there.
+    // fetch() file bodies use the pread + send copy loop (always on for macOS) instead of sendfile(2).
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE, "BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE, "BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -230,6 +230,10 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER, "BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE, "BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE", {});
+    // fetch() streams a `Bun.file()` body over plain HTTP with sendfile(2) on
+    // Linux and FreeBSD. This makes it use the pread + send copy loop that macOS
+    // always uses (`SendFile::write_copy`), so that path has test coverage there.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE, "BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE, "BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO", {});
     // Force the event loop to use epoll_pwait(2) instead of epoll_pwait2(2).

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -23,9 +23,12 @@ impl SendFile {
         url.is_http() && url.href.len() > 0
     }
 
-    // Takes the resolved fd directly rather than the socket; callers pass
-    // `socket.fd()`.
-    pub(crate) fn write(&mut self, socket_fd: Fd) -> Status {
+    /// `socket_fd` feeds `sendfile(2)`; `send` is the socket's own write (the one a `Bytes` body uses) for the copy path.
+    pub(crate) fn write(
+        &mut self,
+        socket_fd: Fd,
+        send: impl FnMut(&[u8]) -> crate::Result<usize>,
+    ) -> Status {
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         if !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE
             .get()
@@ -35,11 +38,14 @@ impl SendFile {
         }
 
         #[cfg(unix)]
-        return self.write_copy(socket_fd);
+        {
+            let _ = socket_fd;
+            return self.write_copy(send);
+        }
 
         #[cfg(windows)]
         {
-            let _ = socket_fd;
+            let _ = (socket_fd, send);
             Status::Again
         }
     }
@@ -114,9 +120,9 @@ impl SendFile {
         Status::Again
     }
 
-    /// `pread` + non-blocking `send`, leaving `offset`/`remain` at the first byte the socket did not take.
+    /// `pread` + `send`, leaving `offset`/`remain` at the first byte the socket did not take.
     #[cfg(unix)]
-    fn write_copy(&mut self, socket_fd: Fd) -> Status {
+    fn write_copy(&mut self, mut send: impl FnMut(&[u8]) -> crate::Result<usize>) -> Status {
         bun_core::scoped_log!(
             crate::fetch,
             "copy file body offset={} remain={}",
@@ -137,13 +143,9 @@ impl SendFile {
                 Ok(n) => n,
                 Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
             };
-            let wrote = match bun_sys::send_non_block(socket_fd, &buf[..read]) {
+            let wrote = match send(&buf[..read]) {
                 Ok(n) => n,
-                // ENOBUFS (kernel buffer pool empty) is transient, as in us_socket_write.
-                Err(err) if matches!(err.get_errno(), bun_sys::E::EAGAIN | bun_sys::E::ENOBUFS) => {
-                    break;
-                }
-                Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
+                Err(err) => return Status::Err(err),
             };
             self.offset += wrote;
             self.remain -= wrote;

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -107,8 +107,13 @@ impl SendFile {
         {
             let _ = adjusted_count;
             let buf = crate::scratch::file_body_copy_buffer();
+            // A writable event can mean as little as the low-water mark of
+            // socket space. Start small and double while the socket keeps
+            // taking whole chunks, so a slow link does not pread 256 KiB to
+            // send 2 KiB on every wake.
+            let mut chunk: usize = 16 * 1024;
             loop {
-                let want = buf.len().min(self.remain);
+                let want = chunk.min(buf.len()).min(self.remain);
                 if want == 0 {
                     return Status::Done;
                 }
@@ -134,6 +139,7 @@ impl SendFile {
                 if wrote < read {
                     break;
                 }
+                chunk = chunk.saturating_mul(2);
             }
         }
 

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -5,14 +5,7 @@ use bun_core::feature_flags;
 use bun_sys::{self, Fd};
 use bun_url::URL;
 
-/// Streams a file request body from the HTTP thread. Linux and FreeBSD hand
-/// the copy to `sendfile(2)`. macOS copies through a userspace buffer instead:
-/// XNU's `sendfile` allocates its mbuf chain with an uninterruptible wait
-/// before it checks for socket space, so under mbuf pressure the HTTP thread
-/// sleeps in the kernel and the process cannot be killed (the server side
-/// avoids it for the same reason, see `can_sendfile` in FileResponseStream.rs).
-/// `BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE=1` selects the userspace copy on
-/// the other platforms too.
+/// A file request body streamed from the HTTP thread. Never `sendfile(2)` on macOS: XNU's sleeps uninterruptibly under mbuf pressure (see `can_sendfile` in FileResponseStream.rs).
 #[derive(Copy, Clone)]
 pub struct SendFile {
     pub fd: Fd,
@@ -121,9 +114,7 @@ impl SendFile {
         Status::Again
     }
 
-    /// `pread` into the HTTP thread's scratch buffer, non-blocking `send`, and
-    /// leave `offset`/`remain` at the first byte the socket did not take so the
-    /// next writable event resumes there.
+    /// `pread` + non-blocking `send`, leaving `offset`/`remain` at the first byte the socket did not take.
     #[cfg(unix)]
     fn write_copy(&mut self, socket_fd: Fd) -> Status {
         bun_core::scoped_log!(
@@ -133,9 +124,7 @@ impl SendFile {
             self.remain
         );
         let buf = crate::scratch::file_body_copy_buffer();
-        // A writable event can mean as little as the low-water mark of socket
-        // space. Start small and double while the socket keeps taking whole
-        // chunks, so a slow link does not pread 256 KiB to send 2 KiB per wake.
+        // Start small and double: a writable wake can mean as little as the low-water mark of space.
         let mut chunk: usize = 16 * 1024;
         loop {
             let want = chunk.min(buf.len()).min(self.remain);
@@ -150,8 +139,7 @@ impl SendFile {
             };
             let wrote = match bun_sys::send_non_block(socket_fd, &buf[..read]) {
                 Ok(n) => n,
-                // ENOBUFS is the kernel's network buffer pool running dry:
-                // transient, like the other usockets write paths treat it.
+                // ENOBUFS (kernel buffer pool empty) is transient, as in us_socket_write.
                 Err(err) if matches!(err.get_errno(), bun_sys::E::EAGAIN | bun_sys::E::ENOBUFS) => {
                     break;
                 }

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -1,10 +1,16 @@
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[cfg(target_os = "freebsd")]
 use core::ptr;
 
 use bun_core::feature_flags;
 use bun_sys::{self, Fd};
 use bun_url::URL;
 
+/// Streams a file request body from the HTTP thread. Linux and FreeBSD hand
+/// the copy to `sendfile(2)`. macOS copies through a userspace buffer instead:
+/// XNU's `sendfile` allocates its mbuf chain with an uninterruptible wait
+/// before it checks for socket space, so under mbuf pressure the HTTP thread
+/// sleeps in the kernel and the process cannot be killed (the server side
+/// avoids it for the same reason, see `can_sendfile` in FileResponseStream.rs).
 #[derive(Copy, Clone)]
 pub struct SendFile {
     pub fd: Fd,
@@ -99,29 +105,35 @@ impl SendFile {
             not(target_os = "freebsd")
         ))]
         {
-            let mut sbytes: i64 = i64::try_from(adjusted_count).expect("int cast"); // C off_t
-            // Same-width signedness flip; `as` is a bit-reinterpret here.
-            let signed_offset: i64 = self.offset as u64 as i64;
-            // SAFETY: fds valid; sbytes is a live stack local; hdtr is null (no headers).
-            let errcode = bun_sys::get_errno(unsafe {
-                bun_sys::c::sendfile(
-                    self.fd.native(),
-                    socket_fd.native(),
-                    signed_offset,
-                    &raw mut sbytes,
-                    ptr::null_mut(),
-                    0,
-                )
-            });
-            let wrote: u64 = u64::try_from(sbytes).expect("int cast");
-            self.offset = (self.offset as u64).saturating_add(wrote) as usize;
-            self.remain = (self.remain as u64).saturating_sub(wrote) as usize;
-            if errcode != bun_sys::E::EAGAIN || self.remain == 0 || sbytes == 0 {
-                if errcode == bun_sys::E::SUCCESS {
+            let _ = adjusted_count;
+            let buf = crate::scratch::file_body_copy_buffer();
+            loop {
+                let want = buf.len().min(self.remain);
+                if want == 0 {
                     return Status::Done;
                 }
-
-                return Status::Err(bun_errno::from_errno(errcode as i32).into());
+                let read = match bun_sys::pread(self.fd, &mut buf[..want], self.offset as i64) {
+                    // The file shrank after it was measured; nothing more to send.
+                    Ok(0) => return Status::Done,
+                    Ok(n) => n,
+                    Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
+                };
+                let wrote = match bun_sys::send_non_block(socket_fd, &buf[..read]) {
+                    Ok(n) => n,
+                    // ENOBUFS is the mbuf pool running dry: transient, like the
+                    // other usockets write paths treat it. Wait for writable.
+                    Err(err)
+                        if matches!(err.get_errno(), bun_sys::E::EAGAIN | bun_sys::E::ENOBUFS) =>
+                    {
+                        break;
+                    }
+                    Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
+                };
+                self.offset += wrote;
+                self.remain -= wrote;
+                if wrote < read {
+                    break;
+                }
             }
         }
 

--- a/src/http/SendFile.rs
+++ b/src/http/SendFile.rs
@@ -11,6 +11,8 @@ use bun_url::URL;
 /// before it checks for socket space, so under mbuf pressure the HTTP thread
 /// sleeps in the kernel and the process cannot be killed (the server side
 /// avoids it for the same reason, see `can_sendfile` in FileResponseStream.rs).
+/// `BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE=1` selects the userspace copy on
+/// the other platforms too.
 #[derive(Copy, Clone)]
 pub struct SendFile {
     pub fd: Fd,
@@ -31,15 +33,30 @@ impl SendFile {
     // Takes the resolved fd directly rather than the socket; callers pass
     // `socket.fd()`.
     pub(crate) fn write(&mut self, socket_fd: Fd) -> Status {
-        // Clamp `remain` so the signed sendfile count cannot overflow.
-        let adjusted_count_temporary: u64 = (self.remain as u64).min(i64::MAX as u64);
-        let adjusted_count: u64 = adjusted_count_temporary;
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        if !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE
+            .get()
+            .unwrap_or(false)
+        {
+            return self.write_sendfile(socket_fd);
+        }
 
+        #[cfg(unix)]
+        return self.write_copy(socket_fd);
+
+        #[cfg(windows)]
+        {
+            let _ = socket_fd;
+            Status::Again
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn write_sendfile(&mut self, socket_fd: Fd) -> Status {
         // Android: same kernel `sendfile(2)` ABI, dispatched via `bun_sys::linux`'s
         // raw-syscall thunk (no libc difference matters here).
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            let _ = adjusted_count; // unused on Linux path
             let mut signed_offset: i64 = i64::try_from(self.offset).expect("int cast");
             let begin = self.offset;
             // this does the syscall directly, without libc
@@ -72,6 +89,8 @@ impl SendFile {
 
         #[cfg(target_os = "freebsd")]
         {
+            // Clamp `remain` so the signed sendfile count cannot overflow.
+            let adjusted_count: u64 = (self.remain as u64).min(i64::MAX as u64);
             let mut sbytes: i64 = 0; // C off_t
             // Same-width signedness flip; `as` is a bit-reinterpret here.
             let signed_offset: i64 = self.offset as u64 as i64;
@@ -99,55 +118,52 @@ impl SendFile {
             }
         }
 
-        #[cfg(all(
-            unix,
-            not(any(target_os = "linux", target_os = "android")),
-            not(target_os = "freebsd")
-        ))]
-        {
-            let _ = adjusted_count;
-            let buf = crate::scratch::file_body_copy_buffer();
-            // A writable event can mean as little as the low-water mark of
-            // socket space. Start small and double while the socket keeps
-            // taking whole chunks, so a slow link does not pread 256 KiB to
-            // send 2 KiB on every wake.
-            let mut chunk: usize = 16 * 1024;
-            loop {
-                let want = chunk.min(buf.len()).min(self.remain);
-                if want == 0 {
-                    return Status::Done;
-                }
-                let read = match bun_sys::pread(self.fd, &mut buf[..want], self.offset as i64) {
-                    // The file shrank after it was measured; nothing more to send.
-                    Ok(0) => return Status::Done,
-                    Ok(n) => n,
-                    Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
-                };
-                let wrote = match bun_sys::send_non_block(socket_fd, &buf[..read]) {
-                    Ok(n) => n,
-                    // ENOBUFS is the mbuf pool running dry: transient, like the
-                    // other usockets write paths treat it. Wait for writable.
-                    Err(err)
-                        if matches!(err.get_errno(), bun_sys::E::EAGAIN | bun_sys::E::ENOBUFS) =>
-                    {
-                        break;
-                    }
-                    Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
-                };
-                self.offset += wrote;
-                self.remain -= wrote;
-                if wrote < read {
+        Status::Again
+    }
+
+    /// `pread` into the HTTP thread's scratch buffer, non-blocking `send`, and
+    /// leave `offset`/`remain` at the first byte the socket did not take so the
+    /// next writable event resumes there.
+    #[cfg(unix)]
+    fn write_copy(&mut self, socket_fd: Fd) -> Status {
+        bun_core::scoped_log!(
+            crate::fetch,
+            "copy file body offset={} remain={}",
+            self.offset,
+            self.remain
+        );
+        let buf = crate::scratch::file_body_copy_buffer();
+        // A writable event can mean as little as the low-water mark of socket
+        // space. Start small and double while the socket keeps taking whole
+        // chunks, so a slow link does not pread 256 KiB to send 2 KiB per wake.
+        let mut chunk: usize = 16 * 1024;
+        loop {
+            let want = chunk.min(buf.len()).min(self.remain);
+            if want == 0 {
+                return Status::Done;
+            }
+            let read = match bun_sys::pread(self.fd, &mut buf[..want], self.offset as i64) {
+                // The file shrank after it was measured; nothing more to send.
+                Ok(0) => return Status::Done,
+                Ok(n) => n,
+                Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
+            };
+            let wrote = match bun_sys::send_non_block(socket_fd, &buf[..read]) {
+                Ok(n) => n,
+                // ENOBUFS is the kernel's network buffer pool running dry:
+                // transient, like the other usockets write paths treat it.
+                Err(err) if matches!(err.get_errno(), bun_sys::E::EAGAIN | bun_sys::E::ENOBUFS) => {
                     break;
                 }
-                chunk = chunk.saturating_mul(2);
+                Err(err) => return Status::Err(bun_errno::SystemErrno::from(err).into()),
+            };
+            self.offset += wrote;
+            self.remain -= wrote;
+            if wrote < read {
+                break;
             }
+            chunk = chunk.saturating_mul(2);
         }
-
-        #[cfg(windows)]
-        {
-            let _ = (socket_fd, adjusted_count);
-        }
-
         Status::Again
     }
 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1067,18 +1067,12 @@ static SHARED_RESPONSE_HEADERS_BUF: bun_core::RacyCell<[picohttp::Header; 256]> 
 static SINGLE_PACKET_SMALL_BUFFER: bun_core::RacyCell<[u8; 16 * 1024]> =
     bun_core::RacyCell::new([0; 16 * 1024]);
 
-// macOS copies file request bodies through userspace instead of sendfile(2)
-// (see `SendFile`); each chunk is pread into this and written out before the
-// next pread, so one buffer serves every in-flight upload.
-#[cfg(all(
-    unix,
-    not(any(target_os = "linux", target_os = "android", target_os = "freebsd"))
-))]
+// `SendFile::write_copy` preads each chunk of a file request body into this and
+// writes it out before the next pread, so one buffer serves every in-flight
+// upload.
+#[cfg(unix)]
 const FILE_BODY_COPY_BUFFER_SIZE: usize = 256 * 1024;
-#[cfg(all(
-    unix,
-    not(any(target_os = "linux", target_os = "android", target_os = "freebsd"))
-))]
+#[cfg(unix)]
 static FILE_BODY_COPY_BUFFER: bun_core::RacyCell<[u8; FILE_BODY_COPY_BUFFER_SIZE]> =
     bun_core::RacyCell::new([0; FILE_BODY_COPY_BUFFER_SIZE]);
 
@@ -1111,10 +1105,7 @@ mod scratch {
         // SAFETY: see module-level INVARIANT.
         unsafe { &mut *TEMP_HOSTNAME.get() }
     }
-    #[cfg(all(
-        unix,
-        not(any(target_os = "linux", target_os = "android", target_os = "freebsd"))
-    ))]
+    #[cfg(unix)]
     #[inline]
     pub(crate) fn file_body_copy_buffer() -> &'static mut [u8; FILE_BODY_COPY_BUFFER_SIZE] {
         // SAFETY: see module-level INVARIANT.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1067,15 +1067,6 @@ static SHARED_RESPONSE_HEADERS_BUF: bun_core::RacyCell<[picohttp::Header; 256]> 
 static SINGLE_PACKET_SMALL_BUFFER: bun_core::RacyCell<[u8; 16 * 1024]> =
     bun_core::RacyCell::new([0; 16 * 1024]);
 
-// `SendFile::write_copy` preads each chunk of a file request body into this and
-// writes it out before the next pread, so one buffer serves every in-flight
-// upload.
-#[cfg(unix)]
-const FILE_BODY_COPY_BUFFER_SIZE: usize = 256 * 1024;
-#[cfg(unix)]
-static FILE_BODY_COPY_BUFFER: bun_core::RacyCell<[u8; FILE_BODY_COPY_BUFFER_SIZE]> =
-    bun_core::RacyCell::new([0; FILE_BODY_COPY_BUFFER_SIZE]);
-
 /// Accessors for the HTTP-thread-only `RacyCell` scratch buffers.
 ///
 /// INVARIANT: every caller is on the dedicated HTTP thread (the only thread
@@ -1106,8 +1097,14 @@ mod scratch {
         unsafe { &mut *TEMP_HOSTNAME.get() }
     }
     #[cfg(unix)]
-    #[inline]
+    pub(crate) const FILE_BODY_COPY_BUFFER_SIZE: usize = 256 * 1024;
+    /// `SendFile::write_copy` preads each chunk of a file request body into
+    /// this and writes it out before the next pread, so one buffer serves every
+    /// in-flight upload. Zero-initialised so it lands in .bss, not in the binary.
+    #[cfg(unix)]
     pub(crate) fn file_body_copy_buffer() -> &'static mut [u8; FILE_BODY_COPY_BUFFER_SIZE] {
+        static FILE_BODY_COPY_BUFFER: bun_core::RacyCell<[u8; FILE_BODY_COPY_BUFFER_SIZE]> =
+            bun_core::RacyCell::new([0; FILE_BODY_COPY_BUFFER_SIZE]);
         // SAFETY: see module-level INVARIANT.
         unsafe { &mut *FILE_BODY_COPY_BUFFER.get() }
     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1098,9 +1098,7 @@ mod scratch {
     }
     #[cfg(unix)]
     pub(crate) const FILE_BODY_COPY_BUFFER_SIZE: usize = 256 * 1024;
-    /// `SendFile::write_copy` preads each chunk of a file request body into
-    /// this and writes it out before the next pread, so one buffer serves every
-    /// in-flight upload. Zero-initialised so it lands in .bss, not in the binary.
+    /// Scratch for `SendFile::write_copy`, drained before the next `pread`. Zero-initialised so it stays in .bss.
     #[cfg(unix)]
     pub(crate) fn file_body_copy_buffer() -> &'static mut [u8; FILE_BODY_COPY_BUFFER_SIZE] {
         static FILE_BODY_COPY_BUFFER: bun_core::RacyCell<[u8; FILE_BODY_COPY_BUFFER_SIZE]> =

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1048,7 +1048,7 @@ bun_core::comptime_string_map! {
 }
 
 // ── shared per-thread buffers ───────────────────────────────────────────
-// All four are HTTP-thread-only scratch (single uws loop thread); `RacyCell`
+// All of these are HTTP-thread-only scratch (single uws loop thread); `RacyCell`
 // is the alias-safe static cell per docs/PORTING.md §Global mutable state.
 
 // we always rewrite the entire HTTP request when write() returns EAGAIN
@@ -1066,6 +1066,21 @@ static SHARED_RESPONSE_HEADERS_BUF: bun_core::RacyCell<[picohttp::Header; 256]> 
 // so we can avoid allocating a temporary buffer to copy the data in
 static SINGLE_PACKET_SMALL_BUFFER: bun_core::RacyCell<[u8; 16 * 1024]> =
     bun_core::RacyCell::new([0; 16 * 1024]);
+
+// macOS copies file request bodies through userspace instead of sendfile(2)
+// (see `SendFile`); each chunk is pread into this and written out before the
+// next pread, so one buffer serves every in-flight upload.
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android", target_os = "freebsd"))
+))]
+const FILE_BODY_COPY_BUFFER_SIZE: usize = 256 * 1024;
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android", target_os = "freebsd"))
+))]
+static FILE_BODY_COPY_BUFFER: bun_core::RacyCell<[u8; FILE_BODY_COPY_BUFFER_SIZE]> =
+    bun_core::RacyCell::new([0; FILE_BODY_COPY_BUFFER_SIZE]);
 
 /// Accessors for the HTTP-thread-only `RacyCell` scratch buffers.
 ///
@@ -1095,6 +1110,15 @@ mod scratch {
     pub(crate) fn temp_hostname() -> &'static mut [u8; 8192] {
         // SAFETY: see module-level INVARIANT.
         unsafe { &mut *TEMP_HOSTNAME.get() }
+    }
+    #[cfg(all(
+        unix,
+        not(any(target_os = "linux", target_os = "android", target_os = "freebsd"))
+    ))]
+    #[inline]
+    pub(crate) fn file_body_copy_buffer() -> &'static mut [u8; FILE_BODY_COPY_BUFFER_SIZE] {
+        // SAFETY: see module-level INVARIANT.
+        unsafe { &mut *FILE_BODY_COPY_BUFFER.get() }
     }
 }
 pub(crate) use scratch::temp_hostname;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3367,8 +3367,8 @@ impl<'a> HTTPClient<'a> {
                             );
                         }
 
-                        // sendfile.write() takes the raw fd, not the socket handle.
-                        match sendfile.write(socket.fd()) {
+                        let send = |chunk: &[u8]| write_to_socket::<IS_SSL>(socket, chunk);
+                        match sendfile.write(socket.fd(), send) {
                             #[cfg(not(windows))]
                             crate::send_file::Status::Done => {
                                 self.state.request_stage = RequestStage::Done;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1456,12 +1456,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         Err(_) => break 'use_sendfile,
                     };
 
-                    #[cfg(target_os = "macos")]
-                    {
-                        // macOS streams this with pread (`SendFile::write_copy`), which needs a regular file
-                        if !bun_sys::S::ISREG(stat.st_mode as u32) {
-                            break 'use_sendfile;
-                        }
+                    // sendfile(2) and the pread copy loop both need a regular file. Anything else takes the read path.
+                    if !bun_sys::S::ISREG(stat.st_mode as u32) {
+                        break 'use_sendfile;
                     }
 
                     // if it's < 32 KB, it's not worth it
@@ -1482,18 +1479,15 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         content_size: original_size.min(stat_size) as usize,
                     };
 
-                    if bun_sys::S::ISREG(stat.st_mode as u32) {
-                        let stat_size_usize = stat_size as usize;
-                        sf.offset = sf.offset.min(stat_size_usize);
-                        sf.remain = sf
-                            .remain
-                            .max(sf.offset)
-                            .min(stat_size_usize)
-                            .saturating_sub(sf.offset);
-                        // `remain` is now the exact byte count we will send (the slice
-                        // window clamped to the file); that is the Content-Length.
-                        sf.content_size = sf.remain;
-                    }
+                    let stat_size_usize = stat_size as usize;
+                    sf.offset = sf.offset.min(stat_size_usize);
+                    sf.remain = sf
+                        .remain
+                        .max(sf.offset)
+                        .min(stat_size_usize)
+                        .saturating_sub(sf.offset);
+                    // `remain` is now the exact byte count we send (the slice window clamped to the file): the Content-Length.
+                    sf.content_size = sf.remain;
                     body.detach();
                     body = HTTPRequestBody::Sendfile(sf);
 

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1458,7 +1458,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
                     #[cfg(target_os = "macos")]
                     {
-                        // macOS only supports regular files for sendfile()
+                        // macOS streams this with pread (`SendFile::write_copy`), which needs a regular file
                         if !bun_sys::S::ISREG(stat.st_mode as u32) {
                             break 'use_sendfile;
                         }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -5108,23 +5108,6 @@ pub mod c {
         dyld_get_image_header_raw(image_index).cast()
     }
 
-    /// Darwin `sendfile(fd, s, off, *len, *hdtr, flags)`.
-    /// NOTE: on `EINTR`/`EAGAIN` the kernel still writes the
-    /// bytes-sent count back through `*len` before returning -1 — callers MUST
-    /// advance their offset by `*len` even on error. This wrapper is raw (no
-    /// EINTR retry); the caller owns the offset bookkeeping.
-    #[cfg(target_os = "macos")]
-    pub unsafe fn sendfile(
-        fd: c_int,
-        s: c_int,
-        off: i64,
-        len: *mut i64,
-        hdtr: *mut c_void,
-        flags: c_int,
-    ) -> c_int {
-        // SAFETY: caller contract (`unsafe fn`) — all pointers forwarded verbatim.
-        unsafe { libc::sendfile(fd, s, off, len, hdtr.cast(), flags) }
-    }
     /// FreeBSD `sendfile(fd, s, off, nbytes, *hdtr, *sbytes, flags)`.
     #[cfg(target_os = "freebsd")]
     pub unsafe fn sendfile(

--- a/test/js/bun/http/fetch-file-upload-backpressure-fixture.ts
+++ b/test/js/bun/http/fetch-file-upload-backpressure-fixture.ts
@@ -1,0 +1,35 @@
+// Uploads an unaligned slice of a 16 MiB file to a server that reads slower
+// than the client writes, then prints what the server saw. The parent test runs
+// this with and without BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE so both the
+// sendfile(2) path and the userspace copy path get the same check.
+import { join } from "path";
+
+const size = 16 * 1024 * 1024;
+const start = 123_457;
+const bytes = Buffer.allocUnsafe(size);
+// Position-dependent pattern: a misplaced or repeated chunk changes the hash.
+for (let i = 0; i < size; i += 4) bytes.writeUInt32LE(i >>> 2, i);
+const path = join(process.cwd(), "big.bin");
+await Bun.write(path, bytes);
+const expected = Bun.CryptoHasher.hash("sha256", bytes.subarray(start), "hex");
+
+await using server = Bun.serve({
+  port: 0,
+  development: false,
+  maxRequestBodySize: size,
+  async fetch(req) {
+    const hasher = new Bun.CryptoHasher("sha256");
+    let received = 0;
+    for await (const chunk of req.body!) {
+      hasher.update(chunk);
+      received += chunk.length;
+      // Yield so the client outruns the reader and has to resume after partial writes.
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+    return Response.json({ contentLength: req.headers.get("content-length"), received, hash: hasher.digest("hex") });
+  },
+});
+
+const res = await fetch(server.url, { method: "PUT", body: Bun.file(path).slice(start) });
+const body = await res.json();
+console.log(JSON.stringify({ status: res.status, ...body, expected, expectedLength: size - start }));

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -222,6 +222,44 @@ describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
   });
 });
 
+// The streaming file body path (sendfile(2) on Linux, a pread + send loop on
+// macOS) resumes from its own offset after every partial write. A reader that
+// keeps falling behind forces many of those resumes; a position-dependent byte
+// pattern and an unaligned slice start make any misplaced or repeated chunk
+// change the hash.
+test("large Bun.file().slice() upload arrives intact when the server reads slower than the client writes", async () => {
+  const size = 16 * 1024 * 1024;
+  const bytes = Buffer.allocUnsafe(size);
+  for (let i = 0; i < size; i += 4) bytes.writeUInt32LE(i >>> 2, i);
+  using dir = tempDir("fetch-file-slice-backpressure", { "big.bin": bytes });
+  const start = 123_457;
+  const expected = Bun.CryptoHasher.hash("sha256", bytes.subarray(start), "hex");
+
+  await using server = Bun.serve({
+    port: 0,
+    development: false,
+    maxRequestBodySize: size,
+    async fetch(req) {
+      const hasher = new Bun.CryptoHasher("sha256");
+      let received = 0;
+      for await (const chunk of req.body!) {
+        hasher.update(chunk);
+        received += chunk.length;
+        await new Promise<void>(resolve => setImmediate(resolve));
+      }
+      return Response.json({
+        contentLength: req.headers.get("content-length"),
+        received,
+        hash: hasher.digest("hex"),
+      });
+    },
+  });
+
+  const res = await fetch(server.url, { method: "PUT", body: Bun.file(join(String(dir), "big.bin")).slice(start) });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ contentLength: String(size - start), received: size - start, hash: expected });
+});
+
 test("missing file throws the expected error", async () => {
   Bun.gc(true);
   // Run this 1000 times to check for GC bugs

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -222,43 +222,43 @@ describe("Bun.file().slice() upload sends the slice's Content-Length", () => {
   });
 });
 
-// The streaming file body path (sendfile(2) on Linux, a pread + send loop on
-// macOS) resumes from its own offset after every partial write. A reader that
-// keeps falling behind forces many of those resumes; a position-dependent byte
-// pattern and an unaligned slice start make any misplaced or repeated chunk
-// change the hash.
-test("large Bun.file().slice() upload arrives intact when the server reads slower than the client writes", async () => {
-  const size = 16 * 1024 * 1024;
-  const bytes = Buffer.allocUnsafe(size);
-  for (let i = 0; i < size; i += 4) bytes.writeUInt32LE(i >>> 2, i);
-  using dir = tempDir("fetch-file-slice-backpressure", { "big.bin": bytes });
-  const start = 123_457;
-  const expected = Bun.CryptoHasher.hash("sha256", bytes.subarray(start), "hex");
-
-  await using server = Bun.serve({
-    port: 0,
-    development: false,
-    maxRequestBodySize: size,
-    async fetch(req) {
-      const hasher = new Bun.CryptoHasher("sha256");
-      let received = 0;
-      for await (const chunk of req.body!) {
-        hasher.update(chunk);
-        received += chunk.length;
-        await new Promise<void>(resolve => setImmediate(resolve));
-      }
-      return Response.json({
-        contentLength: req.headers.get("content-length"),
-        received,
-        hash: hasher.digest("hex"),
+// The streaming file body path resumes from its own offset after every partial
+// write: sendfile(2) on Linux and FreeBSD, a pread + send copy loop on macOS.
+// BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE selects the copy loop everywhere, so
+// both get the same check on every POSIX lane. The fixture's reader keeps
+// falling behind to force many resumes from an unaligned slice start.
+describe.concurrent(
+  "large Bun.file().slice() upload arrives intact when the server reads slower than the client writes",
+  () => {
+    for (const [label, env] of [
+      ["sendfile(2) where available", {}],
+      ["userspace copy", { BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE: "1" }],
+    ] as const) {
+      test(label, async () => {
+        using dir = tempDir("fetch-file-slice-backpressure", {});
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), join(import.meta.dir, "fetch-file-upload-backpressure-fixture.ts")],
+          env: { ...bunEnv, ...env },
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        const lastLine = stdout.trim().split("\n").at(-1) || JSON.stringify({ stdout, stderr });
+        const result = JSON.parse(lastLine);
+        expect(result).toEqual({
+          status: 200,
+          contentLength: String(result.expectedLength),
+          received: result.expectedLength,
+          hash: result.expected,
+          expected: result.expected,
+          expectedLength: 16 * 1024 * 1024 - 123_457,
+        });
+        expect(exitCode).toBe(0);
       });
-    },
-  });
-
-  const res = await fetch(server.url, { method: "PUT", body: Bun.file(join(String(dir), "big.bin")).slice(start) });
-  expect(res.status).toBe(200);
-  expect(await res.json()).toEqual({ contentLength: String(size - start), received: size - start, hash: expected });
-});
+    }
+  },
+);
 
 test("missing file throws the expected error", async () => {
   Bun.gc(true);


### PR DESCRIPTION
### Problem
- The darwin CI hosts `biscuit` and `hardtack` die about 15 hours after each daily reboot. Every aarch64 `test-bun` job on them then fails with `buildkite-agent artifact download timed out after 120s for step 'darwin-aarch64-build-bun'`.
- On both, the last job before the collapse has `✗ uploads roundtrip with sendfile()` timing out (builds 111543, 111820). That test uploads a `Bun.file()` body over plain HTTP: the last macOS caller of `sendfile(2)` (`src/http/SendFile.rs:107`).
- XNU's `sendfile` waits uninterruptibly for mbufs. The process cannot be killed and keeps its socket buffers, so the host's network starves until reboot. #33728 removed the server-side call for this reason.

### Fix
- On macOS `SendFile::write` copies on the HTTP thread instead (`write_copy`): `pread` into a scratch buffer, write it with the socket's own `us_socket_write` (the call a `Bytes` body uses), resume from the file offset on the next writable event. Linux and FreeBSD keep `sendfile(2)`.
- `BUN_FEATURE_FLAG_DISABLE_FETCH_SENDFILE=1` selects the copy loop there too, so Linux CI covers it.
- Content-Length, streaming, and slices are unchanged. The read path (`fetch.rs:1512`) buffers the whole file on the JS thread, which #33728 rejected.
- Verified: `test/js/bun/http/fetch-file-upload.test.ts` runs a sliced 16 MiB upload against a slow reader both ways, in a Linux ASAN build.

### Background
- `SendFile` is the HTTP-thread state for one upload: fd, `offset`, `remain`. `RequestStage::Body` (`src/http/lib.rs`) calls `write` once per writable event.
- An mbuf is XNU's network buffer unit. The pool scales with RAM, so the two 16 GB hosts go first.
- #41494 moves a refused `sendfile` onto the `FileReader` stream path on Linux, as its review asked. macOS can take that path once it lands.

<details><summary>Notes</summary>

Evidence from the Buildkite API (job logs and `builds?include_retried_jobs=true`):

- biscuit (`darwin-aarch64-26.6.1-1`, agent connected 2026-09-06T05:28Z): jobs pass until build 111543 (18:10Z to 18:40Z), where `uploads roundtrip with sendfile()` times out in the parallel batch next to twelve `fetch-backpressure.test.ts` stalls. Build 111569 (18:40Z): `test/package.json` install 45.27 s (was 4.39 s), job times out at 45 min. Build 111626: install 83.73 s, times out. From 111690 (20:12Z) on, every job fails at the artifact download in 123 to 160 s, 60+ jobs. The host recovered at its 05:27Z reboot on 09-07 (build 112026 passed).
- hardtack (`darwin-aarch64-26.6.2-1`, connected 10:28Z): passes until build 111820 (21:47Z to 22:08Z), where the same test times out. Build 111836 (22:08Z): `1221 packages installed [69.03s]` (was 2.8 s), times out at 45 min. 111889 times out. From 111905 (02:16Z) on, every job fails at the download. git fetch in those jobs runs at 6 to 10 KiB/s. Still failing at 06:44Z.
- Healthy hosts in the same minutes (breadstick, crouton, the Tart guests) download the same 144 MiB of zips in 2 to 3 s.
- #40865 recorded the same two hosts doing this on 2026-08-27/28 (62 download timeouts, all on biscuit and hardtack, episodes starting 15 to 18 hours after the 06:27 reboot). The job header's `max user processes` is 1333 on these two and 2666 on the other minis, which marks them as the 16 GB boxes.
- #33728 has the kernel analysis (`bsd/kern/uipc_syscalls.c`: the `M_WAIT` allocation runs before the `SS_NBIO` / `sbspace()` check), a sample of a wedged `bun-profile` parked in `sendfile + 8`, and the note that the client upload path was left as-is because its only fallback was a synchronous whole-file read on the JS thread.
- I could not reach the hosts from this session, so there is no process sample from this episode. The inference rests on the test that timed out right before each collapse being the one remaining macOS `sendfile(2)` caller, on both hosts, and on the identical shape to #33116. A skeptic would want `netstat -mm` and a `sample` of a stuck `bun-profile` from one of these boxes late in the day. The `fetch-backpressure.test.ts` stalls in the same batch are the likely depleter. `sendfile` is what turns a depleted pool into an unkillable process.
- The copy loop writes through `write_to_socket` / `us_socket_write`, so errno handling is usockets': `EAGAIN`, `ENOBUFS`, and macOS's spurious `EPROTOTYPE` re-arm the writable poll, and a dead peer fails the request through the socket's close event, exactly as for a `Bytes` body. With free socket space and an empty mbuf pool that is a re-poll spin, not a sleep: the process stays killable and its buffers are freed when it exits, which is the property the hosts need. Checked with the flag on Linux: a peer that resets mid-upload rejects with `ECONNRESET` within milliseconds, a server that answers 413 before reading the body now resolves with that response (the `sendfile(2)` path rejects with `EPIPE` there, the `Bytes` path also resolves), and the 100 GB Content-Length case in `fetch.test.ts` passes.
- The copy starts at 16 KiB per `pread` and doubles while the socket takes whole chunks, up to the 256 KiB buffer, so a wake at the low-water mark does not read 256 KiB to send 2 KiB.
- Why not make macOS take the existing read path (`fetch.rs:1512`, what HTTPS and proxied uploads use): it reads the whole file into memory on the JS thread and copies it once more, so an upload larger than RAM fails. `sends the exact Content-Length for a file body of 100 GB` in `fetch.test.ts:3589` is skipped on Windows for that reason and would have to be skipped on macOS too.
- The review of #41494 asked for the `FileReader` stream path instead of a copy loop inside `SendFile`. Doing that for every macOS upload up front is larger than it looks: a stream body gets `Transfer-Encoding: chunked` unless a Content-Length is injected (`lib.rs` request header build, `FetchTasklet::skip_chunked_framing`), and a non-303 redirect with a stream body is a `RequestBodyNotReusable` error. This PR keeps the wire format identical and leaves that move to #41494.
- Fail-before cannot be shown on Linux or without exhausting a macOS kernel's mbuf pool, which is not safe on a shared runner. The new test is a correctness check for the copy loop (offset bookkeeping across partial writes from an unaligned slice start), not a reproduction of the hang.
- Until PR branches pick this up, a branch without it can still wedge these two hosts when its own test binary runs this file there.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/fetch-file-upload.test.ts

<!-- robobun:evidence:end -->
