### PR TITLE
js_parser: instantiate a TypeScript namespace whose body is only `;` or a directive

### DIFF
--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1486,7 +1486,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
-            let mut skip = matches!(stmt.data, js_ast::stmt::Data::SEmpty(_));
+            // TypeScript instantiates a namespace whose body has any non-type
+            // statement, even `;` or "use strict", so a namespace body keeps
+            // them for the emptiness check in parse_type_script_namespace_stmt.
+            let keep_trivia = opts.scope.is_namespace();
+            let mut skip = !keep_trivia && matches!(stmt.data, js_ast::stmt::Data::SEmpty(_));
             // Parse one or more directives at the beginning
             if is_directive_prologue {
                 is_directive_prologue = false;
@@ -1496,7 +1500,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             is_directive_prologue = true;
 
                             if str_.eql_comptime(b"use strict") {
-                                skip = true;
+                                skip = !keep_trivia;
                                 // Track "use strict" directives
                                 p.current_scope_mut().strict_mode =
                                     StrictModeKind::ExplicitStrictMode;
@@ -1507,7 +1511,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 // In the REPL the directive stays a string
                                 // statement so it evaluates as the result,
                                 // like node ('use asm' prints 'use asm').
-                                skip = true;
+                                skip = !keep_trivia;
                                 stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});
                             } else {
                                 let bytes = str_.string(p.arena).expect("OOM");

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1486,9 +1486,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
 
-            // TypeScript instantiates a namespace whose body has any non-type
-            // statement, even `;` or "use strict", so a namespace body keeps
-            // them for the emptiness check in parse_type_script_namespace_stmt.
+            // tsc instantiates `namespace N { ; }`, so the body must not look empty.
             let keep_trivia = opts.scope.is_namespace();
             let mut skip = !keep_trivia && matches!(stmt.data, js_ast::stmt::Data::SEmpty(_));
             // Parse one or more directives at the beginning

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: a TypeScript namespace whose body is only `;` or a directive is instantiated.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1152,6 +1152,21 @@ describe("Bun.Transpiler", () => {
       exp("namespace x { export const y = 1; } await 1;", "var x;\n((x) => {\n  x.y = 1;\n})(x ||= {});\nawait 1");
     });
 
+    it("instantiates a namespace whose body has only an empty statement or a directive", () => {
+      const exp = ts.expectPrinted_;
+
+      // tsc treats any non-type statement as instantiating, including `;` and
+      // "use strict". Only a body with no statements (or only types) is erased.
+      exp("namespace x {}", "");
+      exp("namespace x { interface I {} type T = I; }", "");
+      exp("namespace x { ; }", "var x;\n((x) => {\n  ;\n})(x ||= {})");
+      exp('namespace x { "use strict"; }', "var x;\n((x) => {})(x ||= {})");
+      exp('namespace x { "use asm"; }', "var x;\n((x) => {\n  ;\n})(x ||= {})");
+      exp("namespace x { ; interface I {} }", "var x;\n((x) => {\n  ;\n})(x ||= {})");
+      exp("namespace x.y { ; }", "var x;\n((x) => {\n  let y;\n  ((y) => {\n    ;\n  })(y = x.y ||= {});\n})(x ||= {})");
+      exp("declare namespace x { ; }", "");
+    });
+
     it("doesn't crash with functions assigned to enum values", () => {
       const exp = ts.expectPrinted_;
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1163,7 +1163,10 @@ describe("Bun.Transpiler", () => {
       exp('namespace x { "use strict"; }', "var x;\n((x) => {})(x ||= {})");
       exp('namespace x { "use asm"; }', "var x;\n((x) => {\n  ;\n})(x ||= {})");
       exp("namespace x { ; interface I {} }", "var x;\n((x) => {\n  ;\n})(x ||= {})");
-      exp("namespace x.y { ; }", "var x;\n((x) => {\n  let y;\n  ((y) => {\n    ;\n  })(y = x.y ||= {});\n})(x ||= {})");
+      exp(
+        "namespace x.y { ; }",
+        "var x;\n((x) => {\n  let y;\n  ((y) => {\n    ;\n  })(y = x.y ||= {});\n})(x ||= {})",
+      );
       exp("declare namespace x { ; }", "");
     });
 


### PR DESCRIPTION
### Problem
- `namespace N { ; }` and `namespace N { "use strict"; }` are valid TypeScript (no diagnostics under tsc 6.0). tsc instantiates both, so `typeof N` is `"object"`. esbuild agrees. bun erased the namespace and `typeof N` was `"undefined"`, in `bun run`, `bun build` (with and without `--minify`, `--no-bundle`) and `Bun.Transpiler` alike.
- The cause: `parse_stmts_up_to` (`src/js_parser/parse/mod.rs:1489`) drops `;`, `"use strict"` and `"use asm"` from the statement list at parse time. `parse_type_script_namespace_stmt` (`src/js_parser/parse/parse_typescript.rs:398`) then sees an empty body and treats the namespace as type-only.

### Fix
- When the statements being parsed are a namespace body (`opts.scope.is_namespace()`), keep those three statements in the list. The emptiness check then counts them, as tsc's `getModuleInstanceState` and esbuild's `len(stmts) == importEqualsCount` do.
- Output for every other scope is unchanged. Inside an instantiated namespace the kept `;` prints as `;` (same as esbuild) and the `"use strict"` expression statement is dropped by the visitor as before.
- Bumps the runtime transpiler cache version, since the output for these inputs changes.
- Verified: `test/bundler/transpiler/transpiler.test.js` (new block, fails on stock bun, passes with this change). Also ran all of `transpiler.test.js`, `test/bundler/esbuild/ts.test.ts` and `test/bundler/bundler_edgecase.test.ts`.

### Background
- TypeScript erases a namespace that contains only types (interfaces, type aliases, non-instantiated nested namespaces, unexported `import x =` aliases). Any other statement makes it "instantiated": tsc emits `var N; (function (N) { ... })(N || (N = {}));` and `N` is a real object at runtime.
- bun's parser follows esbuild here: parse the body, then erase the namespace if every remaining statement is an unexported import alias. esbuild keeps empty statements and directives in the parsed list, so they count. bun drops them early as a size optimization, which is where the two diverged.

<details><summary>Notes</summary>

Found by a TypeScript enum/namespace lowering fuzz run against tsc 6.0.3. The other census items in that run (enum initialisers that tsc rejects with TS1061 / TS18033 / TS2651 / TS2452, and `enum E {}` followed by `var E`) are invalid TypeScript and are not touched here.

Checked variants, all `typeof === "object"` under tsc and now under bun: `{ ; }`, `{ "use strict"; }`, `{ "use asm"; }`, `{ debugger; }` (already worked), `{ {} }` (already worked), `{ ; interface I {} }`, `namespace a.b { ; }`. `declare namespace N { ; }` stays erased.

</details>
