### PR TITLE
renamer: reserve NaN, Infinity and undefined so inlined constants reach the globals

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1350,6 +1350,9 @@ pub struct Options<'a> {
     pub print_dce_annotations: bool,
 
     pub inline_require_and_import_errors: bool,
+    /// A bundler renamer named every symbol. Those renamers reserve `NaN`,
+    /// `Infinity` and `undefined`, so the printer may emit those globals as
+    /// bare identifiers without a user binding shadowing them.
     pub has_run_symbol_renamer: bool,
 
     pub require_or_import_meta_for_source_callback: RequireOrImportMetaCallback,

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1426,7 +1426,11 @@ pub fn compute_initial_reserved_names(
 
     let mut names = StringHashMap::<u32>::default();
 
-    const EXTRAS: [&[u8]; 2] = [b"Promise", b"Require"];
+    /// Globals the linker or printer reference by name in generated code. A
+    /// user binding with one of these names is renamed so the reference
+    /// reaches the global: the printer emits `ENumber` NaN/±Infinity and
+    /// `EUndefined` as the bare identifiers when the renamer has run.
+    const EXTRAS: [&[u8]; 5] = [b"Promise", b"Require", b"NaN", b"Infinity", b"undefined"];
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
 

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -521,10 +521,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode lodash/lodash.js": {
-          "js": "54d4179e9e85d931490846667d2101e01d42f31c70d455c42f2e59b6fc77bf6a",
+          "js": "9951d06da1bf94c69dece1b23f304c1cbf4018b894e398ac5ea10f35b5600187",
           "jsc": {
-            "bytes": 347200,
-            "sha256": "a1b09047322d27494939aa6bf2bd58cad3716d45daeb32072b6ddd18c8b5f2e8",
+            "bytes": 347208,
+            "sha256": "4cfc176092f6908342769b3fe32c38b70f55970236120e30f0bc817fd4619944",
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3318,6 +3318,46 @@ describe("bundler", () => {
     target: "bun",
     run: { stdout: '[true,true,null,"{\\"__proto__\\":{\\"x\\":1},\\"a\\":2}"]' },
   });
+  // A macro result or a folded constant that is NaN, ±Infinity or undefined
+  // prints as the bare global name. The renamer reserves those names, so a
+  // user binding called NaN, Infinity or undefined is renamed instead of
+  // capturing the printed value.
+  for (const minify of [false, true]) {
+    itBundled(`edgecase/MacroNaNInfinityUndefinedShadowed${minify ? "Minified" : ""}`, {
+      files: {
+        "/entry.ts": /* js */ `
+          import { nan, inf, ninf, undef } from "./macro.ts" with { type: "macro" };
+          import * as top from "./top-level.ts";
+          function f(NaN, Infinity, undefined) {
+            return [
+              typeof nan(), typeof undef(),
+              String(nan()), String(inf()), String(ninf()), String(undef()),
+              String(+"x"), String(void 0),
+              NaN, Infinity, undefined,
+            ];
+          }
+          console.write(JSON.stringify([f("n", "i", "u"), top.NaN, top.Infinity, top.undefined, String(nan()), String(inf())]));
+        `,
+        "/macro.ts": /* js */ `
+          export function nan() { return NaN; }
+          export function inf() { return Infinity; }
+          export function ninf() { return -Infinity; }
+          export function undef() { return undefined; }
+        `,
+        "/top-level.ts": /* js */ `
+          export const NaN = "N", Infinity = "I";
+          export var undefined = "U";
+        `,
+      },
+      target: "bun",
+      minifySyntax: minify,
+      minifyIdentifiers: minify,
+      run: {
+        stdout:
+          '[["number","undefined","NaN","Infinity","-Infinity","undefined","NaN","undefined","n","i","u"],"N","I","U","NaN","Infinity"]',
+      },
+    });
+  }
   // The macro module is transpiled by the macro VM, not by the bundler. That
   // VM has to be created from the build's transform options, or the macro
   // module does not see `--define` and `--loader`. The `Bun.build()` variant


### PR DESCRIPTION
### Problem
- A macro that returns `NaN`, `±Infinity` or `undefined` is inlined as an `ENumber`/`EUndefined` node, which non-minified bundles print as the bare identifiers `NaN`, `Infinity`, `undefined`. A binding with that name in scope captures the value: with `const NaN = "x"` in the function, `String(nan())` is `"x"` in the bundle and `"NaN"` under `bun run`. It also happens across files, since a bundle shares one top-level scope.
- The cause: `compute_initial_reserved_names` (`src/js_printer/renamer.rs`) does not reserve these names, so the bundler's renamers keep user bindings called `NaN`/`Infinity`/`undefined`, while `print_number`/`print_undefined` (`src/js_printer/lib.rs`) assume the bare names reach the globals.

### Fix
- Reserve `NaN`, `Infinity` and `undefined` next to `Promise` and `Require`. Both bundler renamers then rename such a user binding (`NaN` becomes `NaN2`), in nested scopes too, and never hand those names out.
- This is what the printer comment already assumed ("If we are not running the symbol renamer, we must not print `Infinity`"), and how the `Temporal` global used by TOML dates is protected.
- Verified: `test/bundler/bundler_edgecase.test.ts` (`edgecase/MacroNaNInfinityUndefinedShadowed`, fails on 1.4.2; the minified variant already passed). Also ran the esbuild default/dce/splitting ports, `bundler_minify` and `bundler_cjs2esm`.

- `test/bundler/bundler_bytecode_portable.test.ts`: the `lodash` hash moves on every platform, because lodash declares a local `undefined` that is now renamed; snapshot updated.

### Background
- The parser turns unbound `undefined`, `NaN`, `Infinity` into `EUndefined`/`ENumber`; a shadowed use stays a bound identifier. Synthesized nodes (macro results, `--define X=undefined`, folded `+"a"`, `void 0`) have nothing to bind, so the printer must name the global.
- With `--minify-syntax` the printer writes `1/0` and `void 0`, hence the three behaviours in the report.
- The bundler renamer names every symbol in a chunk around a reserved set. `bun run` and `--no-bundle` do not run it.

<details><summary>Notes</summary>

- `--define X=NaN` / `X=Infinity` still produce an identifier that binds like one written at the use site (a local `NaN` wins), which matches esbuild. `--define X=undefined` produces `EUndefined` and is covered by this change.
- `typeof nan()` folding to `"number"` was already right; it only looked inconsistent because the printed `NaN` then read the local.
- Not changed here: without the renamer (`bun run`, `--no-bundle`, `Bun.Transpiler`) `NaN` is still printed bare, so `function f(NaN) { return +"a" }` can read the parameter there. `Infinity` (`1 / 0`) and, under `bun run`, `undefined` (`void 0`) are already safe in that path.
</details>
