### PR TITLE
bundler: emit --footer inside the @bun-cjs wrapper so --target=bun --format=cjs output loads

### DIFF
--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -748,16 +748,18 @@ pub(crate) fn post_process_js_chunk(
                 line_offset.advance(str);
             }
         }
-        options::OutputFormat::Cjs => {
-            if is_bun {
-                j.push_static(b"})\n");
-                line_offset.advance(b"})\n");
-            }
-        }
         _ => {}
     }
 
-    j.ensure_newline_at_end();
+    // Bun's loader evaluates a `@bun-cjs` file and takes its completion value as
+    // the module function, so the wrapper's `})` has to come last. That puts the
+    // footer inside the wrapper, the same as the banner.
+    let close_bun_cjs_wrapper = is_bun && output_format == options::OutputFormat::Cjs;
+
+    // With no footer, minified output keeps `})` right after the last statement.
+    if !close_bun_cjs_wrapper || !c.options.footer.is_empty() {
+        j.ensure_newline_at_end();
+    }
     // TODO: maybeAppendLegalComments
 
     if !c.options.footer.is_empty() {
@@ -769,6 +771,11 @@ pub(crate) fn post_process_js_chunk(
         line_offset.advance(c.options.footer);
         j.push_static(b"\n");
         line_offset.advance(b"\n");
+    }
+
+    if close_bun_cjs_wrapper {
+        j.push_static(b"})\n");
+        line_offset.advance(b"})\n");
     }
 
     // SAFETY: every borrowed node in `j` points into `chunk.compile_results_for_chunk`

--- a/test/bundler/bundler_footer.test.ts
+++ b/test/bundler/bundler_footer.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -26,6 +26,84 @@ describe("bundler", () => {
  * This is copyright of [...] ${new Date().getFullYear()}
  * do not redistribute without consent of [...]
 */\"\n`);
+    },
+  });
+
+  // With --target=bun --format=cjs the output is wrapped in
+  // `(function(exports, require, module, __filename, __dirname) { ... })` and
+  // Bun's loader takes the program's completion value as that function. The
+  // footer has to go inside the wrapper (like the banner). A footer statement
+  // after `})` makes the completion value `undefined` and the file fails to
+  // load with "Expected CommonJS module to have a function wrapper".
+  itBundled("footer/CommentFooterWithCJSAndTargetBun", {
+    footer: "// developed with love in SF",
+    format: "cjs",
+    target: "bun",
+    backend: "api",
+    outdir: "/out",
+    minifyWhitespace: true,
+    files: {
+      "/a.js": `module.exports = 1;`,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out/a.js")).toMatchInlineSnapshot(`
+        "// @bun @bun-cjs
+        (function(exports, require, module, __filename, __dirname) {module.exports=1;
+
+        // developed with love in SF
+        })
+        "
+      `);
+    },
+  });
+
+  itBundled("footer/CodeFooterWithCJSAndTargetBun", {
+    banner: `console.log("banner ran");`,
+    footer: `console.log("footer ran");`,
+    format: "cjs",
+    target: "bun",
+    backend: "api",
+    outdir: "/out",
+    files: {
+      "/entry.ts": `console.log("main ran");\nexport const x = 1;`,
+    },
+    onAfterBundle(api) {
+      const content = api.readFile("/out/entry.js");
+      expect(content).toStartWith(
+        `// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {console.log("banner ran");\n`,
+      );
+      expect(content).toEndWith(`\nconsole.log("footer ran");\n})\n`);
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "banner ran\nmain ran\nfooter ran",
+    },
+  });
+
+  itBundled("footer/CodeFooterWithBytecodeAndCJSTargetBun", {
+    footer: `console.log("footer ran");`,
+    format: "cjs",
+    target: "bun",
+    bytecode: true,
+    backend: "api",
+    outdir: "/out",
+    minifyWhitespace: true,
+    files: {
+      "/a.js": `module.exports = 1;\nconsole.log("main ran");`,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out/a.js")).toMatchInlineSnapshot(`
+        "// @bun @bytecode @bun-cjs
+        (function(exports, require, module, __filename, __dirname) {module.exports=1;console.log("main ran");
+
+        console.log("footer ran");
+        })
+        "
+      `);
+    },
+    run: {
+      file: "/out/a.js",
+      stdout: "main ran\nfooter ran",
     },
   });
 });


### PR DESCRIPTION
### Problem
- `bun build --target=bun --format=cjs --footer='console.log("footer ran");'` produces a file that bun itself refuses: `TypeError: Expected CommonJS module to have a function wrapper`. The footer runs, the module body never does. Same through `Bun.build()`, with or without `bytecode`. Reproduces on 1.3.14 through 1.4.3-canary, so it is not a regression.
- `post_process_js_chunk` (`src/bundler/linker_context/postProcessJSChunk.rs:751`) closed the wrapper with `})` and pushed the footer after it. A comment footer happened to work. A statement footer changed the program's completion value from the wrapper function to `undefined`.

### Fix
- Emit the footer first, then close the `@bun-cjs` wrapper. This mirrors #22641, which moved the banner to just inside the wrapper.
- Output without a footer is byte-identical to before (minified output still ends `;})`). ESM, IIFE, and `--target=node|browser --format=cjs` have no wrapper and do not change.
- Verified: `test/bundler/bundler_footer.test.ts`, three new cases (comment footer snapshot, code banner plus code footer that must print in order, the `--bytecode` variant). Stock bun fails all three. `bundler_banner`, `bundler_cjs`, `bundler_minify` and `bun-build-api` pass.

### Background
- With `--target=bun --format=cjs` the bundler emits `// @bun @bun-cjs` and wraps the chunk in `(function(exports, require, module, __filename, __dirname) { ... })`. The pragma tells the runtime that the file is already transpiled.
- `evaluateCommonJSModuleOnce` (`src/jsc/bindings/JSCommonJSModule.cpp:194`) evaluates such a file as a program and takes its completion value as the module function. Anything after `})` that is not a comment replaces that value.
- `--banner` and `--footer` are esbuild-style options: text placed at the start and end of each output file, usually a license comment, sometimes code.

<details><summary>Notes</summary>

Repro (from the report):

```sh
printf 'console.log("main ran");\nexport {};\n' > e.ts
bun build --target=bun --format=cjs --footer='console.log("footer ran");' ./e.ts --outfile o.js
tail -c 40 o.js     #   …console.log("main ran");\n})\nconsole.log("footer ran");
bun ./o.js
# footer ran
# TypeError: Expected CommonJS module to have a function wrapper. If you weren't messing around with Bun's internals, this is a bug in Bun
```

After this change the tail of `o.js` is:

```js
console.log("main ran");

console.log("footer ran");
})
```

and `bun ./o.js` prints `main ran` then `footer ran`.

The blank line before the footer is the existing footer formatting (ESM output has it too), not something this change adds.

The alternative was to make the loader tolerate trailing statements after the wrapper. That means special-casing source text in the loader for a shape that only `bun build` produces. The banner precedent already puts user text inside the wrapper, so the bundler side is the smaller and more consistent fix.

</details>
