### PR TITLE
sql(postgres): declare text format for Bind parameters that have no binary encoder

### DIFF
--- a/src/sql/postgres/protocol/FieldDescription.rs
+++ b/src/sql/postgres/protocol/FieldDescription.rs
@@ -1,5 +1,5 @@
 use crate::postgres::any_postgres_error::AnyPostgresError;
-use crate::postgres::postgres_types::{self as types, Int4, Short};
+use crate::postgres::postgres_types::{self as types, Int4};
 use crate::postgres::protocol::new_reader::NewReader;
 use crate::shared::column_identifier::ColumnIdentifier;
 
@@ -13,9 +13,7 @@ pub struct FieldDescription {
 
 impl FieldDescription {
     pub fn type_tag(&self) -> types::Tag {
-        // `types::Tag` is a `#[repr(transparent)] struct(Short)` newtype over
-        // the OID, so wrap the truncated value directly.
-        types::Tag(self.type_oid as Short)
+        types::Tag::from_oid(self.type_oid)
     }
 
     pub(crate) fn decode_internal<Container: super::new_reader::ReaderContext>(

--- a/src/sql/postgres/types/Tag.rs
+++ b/src/sql/postgres/types/Tag.rs
@@ -179,6 +179,9 @@ pg_tags! {
 }
 
 impl Tag {
+    /// Types whose binary wire format `DataCell` can decode, so result columns
+    /// of these types are requested in binary. Bind parameters are encoded by
+    /// a shorter list, `ParamEncoding` in `bun_sql_jsc`.
     pub fn is_binary_format_supported(self) -> bool {
         match self {
             // TODO: .int2_array, .float8_array,

--- a/src/sql/postgres/types/Tag.rs
+++ b/src/sql/postgres/types/Tag.rs
@@ -56,7 +56,7 @@
 //  varbit                                |  1562 |     1563
 //  numeric                               |  1700 |     1231
 
-use super::int_types::short as Short;
+use super::int_types::{Int4, short as Short};
 
 // Non-exhaustive: any `short` value is a valid `Tag`. A `#[repr(i16)] enum`
 // cannot hold arbitrary values, so model as a transparent newtype with
@@ -179,6 +179,14 @@ pg_tags! {
 }
 
 impl Tag {
+    /// Maps a wire OID to a `Tag`. An OID outside the `Short` range is a
+    /// user-defined type and is handled as text. Every place that derives a
+    /// format code or picks a codec from an OID must go through this, so the
+    /// two sides agree.
+    pub fn from_oid(oid: Int4) -> Tag {
+        Short::try_from(oid).map_or(Tag::text, Tag)
+    }
+
     /// Types whose binary wire format `DataCell` can decode, so result columns
     /// of these types are requested in binary. Bind parameters are encoded by
     /// a shorter list, `ParamEncoding` in `bun_sql_jsc`.

--- a/src/sql/postgres/types/Tag.rs
+++ b/src/sql/postgres/types/Tag.rs
@@ -179,17 +179,12 @@ pg_tags! {
 }
 
 impl Tag {
-    /// Maps a wire OID to a `Tag`. An OID outside the `Short` range is a
-    /// user-defined type and is handled as text. Every place that derives a
-    /// format code or picks a codec from an OID must go through this, so the
-    /// two sides agree.
+    /// The one OID-to-`Tag` mapping. An OID above `Short::MAX` is a user-defined type: text.
     pub fn from_oid(oid: Int4) -> Tag {
         Short::try_from(oid).map_or(Tag::text, Tag)
     }
 
-    /// Types whose binary wire format `DataCell` can decode, so result columns
-    /// of these types are requested in binary. Bind parameters are encoded by
-    /// a shorter list, `ParamEncoding` in `bun_sql_jsc`.
+    /// Types `DataCell` decodes from binary (result columns). Bind parameters use `ParamEncoding`.
     pub fn is_binary_format_supported(self) -> bool {
         match self {
             // TODO: .int2_array, .float8_array,

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1268,13 +1268,7 @@ impl<'a> Putter<'a> {
         if IS_RAW {
             *cell = SQLDataCell::raw(optional_bytes);
         } else {
-            let tag = if (types::short::MAX as u32) < oid {
-                types::Tag::text
-            } else {
-                // types::Tag is `#[repr(transparent)] struct Tag(pub Short)` —
-                // construct directly, no transmute needed.
-                types::Tag(oid as types::short)
-            };
+            let tag = field.type_tag();
             *cell = if let Some(data) = optional_bytes {
                 from_bytes(
                     (field.binary || self.binary) && tag.is_binary_format_supported(),

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -49,6 +49,76 @@ pub enum MessageType {
 /// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
 const MAX_PARAMETERS: usize = u16::MAX as usize;
 
+/// How `write_bind` puts one parameter value on the wire. Both the
+/// format-code section and the value section of the Bind message are derived
+/// from this, so they cannot disagree.
+///
+/// This is the encode side only. `Tag::is_binary_format_supported` is the
+/// decode side (result columns) and is wider: `DataCell` decodes binary
+/// numeric, float4, time, int4[] and float4[], but nothing here encodes them.
+#[derive(Clone, Copy)]
+enum ParamEncoding {
+    /// `String(value)`, format 0. The server parses it as the parameter's type.
+    Text,
+    /// `JSON.stringify(value)`, format 0.
+    Json,
+    Bool,
+    Int4,
+    Float8,
+    /// int8 microseconds since 2000-01-01, for timestamp and timestamptz.
+    Timestamp,
+    Bytea,
+}
+
+impl ParamEncoding {
+    fn for_tag(tag: types::Tag) -> ParamEncoding {
+        match tag {
+            types::Tag::json | types::Tag::jsonb => ParamEncoding::Json,
+            types::Tag::bool => ParamEncoding::Bool,
+            types::Tag::int4 => ParamEncoding::Int4,
+            types::Tag::float8 => ParamEncoding::Float8,
+            types::Tag::timestamp | types::Tag::timestamptz => ParamEncoding::Timestamp,
+            types::Tag::bytea => ParamEncoding::Bytea,
+            _ => ParamEncoding::Text,
+        }
+    }
+
+    /// If they pass a value as a string, let's avoid attempting to convert it
+    /// to the binary representation. This minimizes the room for mistakes on
+    /// our end, such as stripping the timezone differently than what Postgres
+    /// does when given a timestamp with timezone.
+    fn for_value(self, value: JSValue) -> ParamEncoding {
+        if self.is_binary() && value.is_string() {
+            ParamEncoding::Text
+        } else {
+            self
+        }
+    }
+
+    fn is_binary(self) -> bool {
+        match self {
+            ParamEncoding::Text | ParamEncoding::Json => false,
+            ParamEncoding::Bool
+            | ParamEncoding::Int4
+            | ParamEncoding::Float8
+            | ParamEncoding::Timestamp
+            | ParamEncoding::Bytea => true,
+        }
+    }
+
+    fn format_code(self) -> Short {
+        if self.is_binary() { 1 } else { 0 }
+    }
+}
+
+fn param_tag(parameter_field: Int4) -> types::Tag {
+    match Short::try_from(parameter_field) {
+        Ok(oid) => types::Tag(oid),
+        // Outside the `Short` range: a user-defined type, bound as text.
+        Err(_) => types::Tag::text,
+    }
+}
+
 pub(crate) fn write_bind<Context: WriterContext>(
     name: &[u8],
     cursor_name: &BunString,
@@ -82,39 +152,17 @@ pub(crate) fn write_bind<Context: WriterContext>(
 
     let mut iter = QueryBindingIterator::init(values_array, columns_value, global)
         .map_err(js_error_to_postgres)?;
-    for i in 0..(len as usize) {
-        let parameter_field = parameter_fields[i];
-        let is_custom_type = (Short::MAX as Int4) < parameter_field;
-        let tag: types::Tag = if is_custom_type {
-            types::Tag::text
-        } else {
-            types::Tag(Short::try_from(parameter_field).unwrap())
-        };
-
-        let force_text = is_custom_type
-            || (tag.is_binary_format_supported()
-                && 'brk: {
-                    iter.to(i as u32);
-                    if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-                        break 'brk value.is_string();
-                    }
-                    if iter.any_failed() {
-                        return Err(AnyPostgresError::InvalidQueryBinding);
-                    }
-                    break 'brk false;
-                });
-
-        if force_text {
-            // If they pass a value as a string, let's avoid attempting to
-            // convert it to the binary representation. This minimizes the room
-            // for mistakes on our end, such as stripping the timezone
-            // differently than what Postgres does when given a timestamp with
-            // timezone.
-            writer.short(0)?;
-            continue;
+    for (i, &parameter_field) in parameter_fields.iter().enumerate() {
+        let mut encoding = ParamEncoding::for_tag(param_tag(parameter_field));
+        if encoding.is_binary() {
+            iter.to(i as u32);
+            if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
+                encoding = encoding.for_value(value);
+            } else if iter.any_failed() {
+                return Err(AnyPostgresError::InvalidQueryBinding);
+            }
         }
-
-        writer.short(tag.format_code())?;
+        writer.short(encoding.format_code())?;
     }
 
     // The number of parameter values that follow (possibly zero). This
@@ -125,24 +173,16 @@ pub(crate) fn write_bind<Context: WriterContext>(
     iter.to(0);
     let mut i: usize = 0;
     while let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-        let tag: types::Tag = 'brk: {
-            if i >= len as usize {
-                // parameter in array but not in parameter_fields
-                // this is probably a bug a bug in bun lets return .text here so the server will send a error 08P01
-                // with will describe better the error saying exactly how many parameters are missing and are expected
-                // Example:
-                // SQL error: PostgresError: bind message supplies 0 parameters, but prepared statement "PSELECT * FROM test_table WHERE id=$1 .in$0" requires 1
-                // errno: "08P01",
-                // code: "ERR_POSTGRES_SERVER_ERROR"
-                break 'brk types::Tag::text;
-            }
-            let parameter_field = parameter_fields[i];
-            let is_custom_type = (Short::MAX as Int4) < parameter_field;
-            break 'brk if is_custom_type {
-                types::Tag::text
-            } else {
-                types::Tag(Short::try_from(parameter_field).unwrap())
-            };
+        let tag: types::Tag = match parameter_fields.get(i) {
+            Some(&parameter_field) => param_tag(parameter_field),
+            // parameter in array but not in parameter_fields
+            // this is probably a bug a bug in bun lets return .text here so the server will send a error 08P01
+            // with will describe better the error saying exactly how many parameters are missing and are expected
+            // Example:
+            // SQL error: PostgresError: bind message supplies 0 parameters, but prepared statement "PSELECT * FROM test_table WHERE id=$1 .in$0" requires 1
+            // errno: "08P01",
+            // code: "ERR_POSTGRES_SERVER_ERROR"
+            None => types::Tag::text,
         };
         if value.is_empty_or_undefined_or_null() {
             bun_core::scoped_log!(Postgres, "  -> NULL");
@@ -154,18 +194,8 @@ pub(crate) fn write_bind<Context: WriterContext>(
         }
         bun_core::scoped_log!(Postgres, "  -> {}", tag.tag_name().unwrap_or("(unknown)"));
 
-        // If they pass a value as a string, let's avoid attempting to
-        // convert it to the binary representation. This minimizes the room
-        // for mistakes on our end, such as stripping the timezone
-        // differently than what Postgres does when given a timestamp with
-        // timezone.
-        let effective_tag = if tag.is_binary_format_supported() && value.is_string() {
-            types::Tag::text
-        } else {
-            tag
-        };
-        match effective_tag {
-            types::Tag::jsonb | types::Tag::json => {
+        match ParamEncoding::for_tag(tag).for_value(value) {
+            ParamEncoding::Json => {
                 // Use jsonStringifyFast for SIMD-optimized serialization
                 let str = value
                     .json_stringify_fast(global)
@@ -175,12 +205,12 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 writer.write(slice.slice())?;
                 l.write_excluding_self()?;
             }
-            types::Tag::bool => {
+            ParamEncoding::Bool => {
                 let l = writer.length()?;
                 writer.write(&[value.to_boolean() as u8])?;
                 l.write_excluding_self()?;
             }
-            types::Tag::timestamp | types::Tag::timestamptz => {
+            ParamEncoding::Timestamp => {
                 let l = writer.length()?;
                 writer.int8(
                     crate::postgres::types::date::from_js(global, value)
@@ -188,7 +218,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 )?;
                 l.write_excluding_self()?;
             }
-            types::Tag::bytea => {
+            ParamEncoding::Bytea => {
                 let Some(buf) = value.as_array_buffer(global) else {
                     let received = JSGlobalObject::determine_specific_type(global, value)
                         .map_err(js_error_to_postgres)?;
@@ -206,23 +236,17 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 writer.write(bytes)?;
                 l.write_excluding_self()?;
             }
-            types::Tag::int4 => {
+            ParamEncoding::Int4 => {
                 let l = writer.length()?;
                 writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
                 l.write_excluding_self()?;
             }
-            types::Tag::int4_array => {
-                let l = writer.length()?;
-                writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
-                l.write_excluding_self()?;
-            }
-            types::Tag::float8 => {
+            ParamEncoding::Float8 => {
                 let l = writer.length()?;
                 writer.f64(value.to_number(global).map_err(js_error_to_postgres)?)?;
                 l.write_excluding_self()?;
             }
-
-            _ => {
+            ParamEncoding::Text => {
                 let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
                 if str.tag() == bun_core::Tag::Dead {
                     return Err(AnyPostgresError::OutOfMemory);

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -49,14 +49,14 @@ pub enum MessageType {
 /// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
 const MAX_PARAMETERS: usize = u16::MAX as usize;
 
-/// How `write_bind` puts one parameter value on the wire. Both the
-/// format-code section and the value section of the Bind message are derived
-/// from this, so they cannot disagree.
+/// How `write_bind` puts one parameter value on the wire. It is decided once
+/// per parameter, and both the format-code section and the value section of
+/// the Bind message are written from it, so they cannot disagree.
 ///
 /// This is the encode side only. `Tag::is_binary_format_supported` is the
 /// decode side (result columns) and is wider: `DataCell` decodes binary
 /// numeric, float4, time, int4[] and float4[], but nothing here encodes them.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum ParamEncoding {
     /// `String(value)`, format 0. The server parses it as the parameter's type.
     Text,
@@ -111,14 +111,6 @@ impl ParamEncoding {
     }
 }
 
-fn param_tag(parameter_field: Int4) -> types::Tag {
-    match Short::try_from(parameter_field) {
-        Ok(oid) => types::Tag(oid),
-        // Outside the `Short` range: a user-defined type, bound as text.
-        Err(_) => types::Tag::text,
-    }
-}
-
 pub(crate) fn write_bind<Context: WriterContext>(
     name: &[u8],
     cursor_name: &BunString,
@@ -150,10 +142,14 @@ pub(crate) fn write_bind<Context: WriterContext>(
     // of parameters.
     writer.short(len)?;
 
+    // Decided once per parameter here and reused for the value section below,
+    // so a getter or `toString()` that runs in between cannot make the bytes
+    // disagree with the declared format code.
+    let mut encodings: Vec<ParamEncoding> = Vec::with_capacity(parameter_fields.len());
     let mut iter = QueryBindingIterator::init(values_array, columns_value, global)
         .map_err(js_error_to_postgres)?;
     for (i, &parameter_field) in parameter_fields.iter().enumerate() {
-        let mut encoding = ParamEncoding::for_tag(param_tag(parameter_field));
+        let mut encoding = ParamEncoding::for_tag(types::Tag::from_oid(parameter_field));
         if encoding.is_binary() {
             iter.to(i as u32);
             if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
@@ -163,6 +159,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
             }
         }
         writer.short(encoding.format_code())?;
+        encodings.push(encoding);
     }
 
     // The number of parameter values that follow (possibly zero). This
@@ -173,28 +170,34 @@ pub(crate) fn write_bind<Context: WriterContext>(
     iter.to(0);
     let mut i: usize = 0;
     while let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-        let tag: types::Tag = match parameter_fields.get(i) {
-            Some(&parameter_field) => param_tag(parameter_field),
-            // parameter in array but not in parameter_fields
-            // this is probably a bug a bug in bun lets return .text here so the server will send a error 08P01
-            // with will describe better the error saying exactly how many parameters are missing and are expected
-            // Example:
-            // SQL error: PostgresError: bind message supplies 0 parameters, but prepared statement "PSELECT * FROM test_table WHERE id=$1 .in$0" requires 1
-            // errno: "08P01",
-            // code: "ERR_POSTGRES_SERVER_ERROR"
-            None => types::Tag::text,
-        };
+        // parameter in array but not in parameter_fields
+        // this is probably a bug a bug in bun lets return .text here so the server will send a error 08P01
+        // with will describe better the error saying exactly how many parameters are missing and are expected
+        // Example:
+        // SQL error: PostgresError: bind message supplies 0 parameters, but prepared statement "PSELECT * FROM test_table WHERE id=$1 .in$0" requires 1
+        // errno: "08P01",
+        // code: "ERR_POSTGRES_SERVER_ERROR"
+        let index = i;
+        i += 1;
+        let encoding = encodings.get(index).copied().unwrap_or(ParamEncoding::Text);
         if value.is_empty_or_undefined_or_null() {
             bun_core::scoped_log!(Postgres, "  -> NULL");
             //  As a special case, -1 indicates a
             // NULL parameter value. No value bytes follow in the NULL case.
             writer.int4((-1i32) as u32)?;
-            i += 1;
             continue;
         }
-        bun_core::scoped_log!(Postgres, "  -> {}", tag.tag_name().unwrap_or("(unknown)"));
+        bun_core::scoped_log!(
+            Postgres,
+            "  -> {} as {:?}",
+            parameter_fields
+                .get(index)
+                .and_then(|&oid| types::Tag::from_oid(oid).tag_name())
+                .unwrap_or("(unknown)"),
+            encoding
+        );
 
-        match ParamEncoding::for_tag(tag).for_value(value) {
+        match encoding {
             ParamEncoding::Json => {
                 // Use jsonStringifyFast for SIMD-optimized serialization
                 let str = value
@@ -257,8 +260,6 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 l.write_excluding_self()?;
             }
         }
-
-        i += 1;
     }
 
     let mut any_non_text_fields: bool = false;

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -49,13 +49,7 @@ pub enum MessageType {
 /// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
 const MAX_PARAMETERS: usize = u16::MAX as usize;
 
-/// How `write_bind` puts one parameter value on the wire. It is decided once
-/// per parameter, and both the format-code section and the value section of
-/// the Bind message are written from it, so they cannot disagree.
-///
-/// This is the encode side only. `Tag::is_binary_format_supported` is the
-/// decode side (result columns) and is wider: `DataCell` decodes binary
-/// numeric, float4, time, int4[] and float4[], but nothing here encodes them.
+/// How `write_bind` encodes one parameter. Its format code and its value bytes both come from this.
 #[derive(Clone, Copy, Debug)]
 enum ParamEncoding {
     /// `String(value)`, format 0. The server parses it as the parameter's type.
@@ -79,14 +73,12 @@ impl ParamEncoding {
             types::Tag::float8 => ParamEncoding::Float8,
             types::Tag::timestamp | types::Tag::timestamptz => ParamEncoding::Timestamp,
             types::Tag::bytea => ParamEncoding::Bytea,
+            // No binary encoder for the rest (numeric, float4, time, int4[], ...), only a decoder.
             _ => ParamEncoding::Text,
         }
     }
 
-    /// If they pass a value as a string, let's avoid attempting to convert it
-    /// to the binary representation. This minimizes the room for mistakes on
-    /// our end, such as stripping the timezone differently than what Postgres
-    /// does when given a timestamp with timezone.
+    /// A string value is sent as text so that the server parses it (time zones and so on), not Bun.
     fn for_value(self, value: JSValue) -> ParamEncoding {
         if self.is_binary() && value.is_string() {
             ParamEncoding::Text
@@ -142,9 +134,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
     // of parameters.
     writer.short(len)?;
 
-    // Decided once per parameter here and reused for the value section below,
-    // so a getter or `toString()` that runs in between cannot make the bytes
-    // disagree with the declared format code.
+    // Reused by the value section so a `toString()` that runs in between cannot change a decision.
     let mut encodings: Vec<ParamEncoding> = Vec::with_capacity(parameter_fields.len());
     let mut iter = QueryBindingIterator::init(values_array, columns_value, global)
         .map_err(js_error_to_postgres)?;
@@ -170,15 +160,9 @@ pub(crate) fn write_bind<Context: WriterContext>(
     iter.to(0);
     let mut i: usize = 0;
     while let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-        // parameter in array but not in parameter_fields
-        // this is probably a bug a bug in bun lets return .text here so the server will send a error 08P01
-        // with will describe better the error saying exactly how many parameters are missing and are expected
-        // Example:
-        // SQL error: PostgresError: bind message supplies 0 parameters, but prepared statement "PSELECT * FROM test_table WHERE id=$1 .in$0" requires 1
-        // errno: "08P01",
-        // code: "ERR_POSTGRES_SERVER_ERROR"
         let index = i;
         i += 1;
+        // More values than parameters: the extras go out as text and the server reports 08P01.
         let encoding = encodings.get(index).copied().unwrap_or(ParamEncoding::Text);
         if value.is_empty_or_undefined_or_null() {
             bun_core::scoped_log!(Postgres, "  -> NULL");

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -212,7 +212,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                     return Err(js_error_to_postgres(global.throw_value(
                         global.ERR_INVALID_ARG_TYPE(format_args!(
                             "Query parameter ${} of type bytea must be a Buffer, TypedArray, ArrayBuffer or string. Received {}",
-                            i + 1,
+                            index + 1,
                             received,
                         )),
                     )));

--- a/test/js/sql/postgres-bind-param-format.test.ts
+++ b/test/js/sql/postgres-bind-param-format.test.ts
@@ -4,12 +4,26 @@
 // the server reports (numeric, real, time, int4[], real[], ...) is sent as
 // `String(value)` and must be declared as text so the server parses it.
 //
-// Runs against a real Postgres server with the default `prepare: true`, where
+// The mock-server tests pin the exact Bind bytes. The container tests run the
+// same cases against a real Postgres with the default `prepare: true`, where
 // Bun binds with the parameter types from the server's ParameterDescription.
 
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
+import {
+  type PgBind,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgDecodeBind,
+  pgMockServer,
+  pgNoData,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
 
 // Stand-in for a decimal.js / big.js style value: not a string, but its text
 // form is what should reach the server.
@@ -19,6 +33,110 @@ class Textual {
     return this.text;
   }
 }
+
+/**
+ * Mock backend for one prepared query. Describe is answered with the given
+ * parameter OIDs and result columns, Execute with one `row`. Resolves with
+ * every Bind the client sent and the rows it decoded.
+ */
+async function runAgainstMock(opts: {
+  paramOids: number[];
+  columns?: { name: string; typeOid: number }[];
+  row?: (Buffer | null)[];
+  query: (sql: SQL) => Promise<any>;
+}): Promise<{ binds: PgBind[]; rows: any }> {
+  const binds: PgBind[] = [];
+  const columns = opts.columns ?? [];
+  const { server, port } = await pgMockServer((type, body, socket) => {
+    switch (type) {
+      case "P":
+        return pgParseComplete();
+      case "D":
+        return [pgParameterDescription(opts.paramOids), columns.length ? pgRowDescription(columns) : pgNoData()];
+      case "B":
+        binds.push(pgDecodeBind(body));
+        return pgBindComplete();
+      case "E":
+        return opts.row ? [pgDataRow(opts.row), pgCommandComplete("SELECT 1")] : pgCommandComplete("SELECT 0");
+      case "S":
+        return pgReadyForQuery();
+      case "X":
+        socket.end();
+        break;
+    }
+  });
+  try {
+    await using sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1 });
+    const rows = await opts.query(sql);
+    return { binds, rows };
+  } finally {
+    server.close();
+  }
+}
+
+describe("Bind format codes (mock server)", () => {
+  test("parameters typed numeric, float4, time, int4[] and float4[] are declared and sent as text", async () => {
+    const { binds } = await runAgainstMock({
+      // numeric, float4, time, int4_array, float4_array
+      paramOids: [1700, 700, 1083, 1007, 1021],
+      query: sql =>
+        sql.unsafe("select $1, $2, $3, $4, $5", [
+          new Textual("19.99"),
+          new Textual("1234"),
+          new Textual("12:34:56"),
+          sql.array([1, 2], "INT4"),
+          sql.array([1.5], "REAL"),
+        ]),
+    });
+    expect(binds).toHaveLength(1);
+    expect({
+      paramFormats: binds[0].paramFormats,
+      params: binds[0].params.map(p => p?.toString("latin1")),
+    }).toEqual({
+      paramFormats: [0, 0, 0, 0, 0],
+      params: ["19.99", "1234", "12:34:56", `{"1","2"}`, "{1.5}"],
+    });
+  });
+
+  test("parameters with a binary encoder are declared binary, a string value stays text", async () => {
+    const date = new Date("2000-01-01T00:00:01.000Z"); // 1_000_000 us after the Postgres epoch
+    const { binds } = await runAgainstMock({
+      // bool, int4, float8, timestamptz, bytea, int4 (bound from a string)
+      paramOids: [16, 23, 701, 1184, 17, 23],
+      query: sql => sql.unsafe("select $1, $2, $3, $4, $5, $6", [true, 7, 1.5, date, Buffer.from([1, 2]), "8"]),
+    });
+    expect(binds).toHaveLength(1);
+    expect({ paramFormats: binds[0].paramFormats, params: binds[0].params }).toEqual({
+      paramFormats: [1, 1, 1, 1, 1, 0],
+      params: [
+        Buffer.from([1]),
+        Buffer.from([0, 0, 0, 7]),
+        Buffer.from("3ff8000000000000", "hex"),
+        Buffer.from("00000000000f4240", "hex"),
+        Buffer.from([1, 2]),
+        Buffer.from("8"),
+      ],
+    });
+  });
+
+  test("a result column whose OID is above 65535 is requested and decoded as text", async () => {
+    // 65552 = 65536 + 16: a user-defined type whose low 16 bits alias `bool`.
+    const { binds, rows } = await runAgainstMock({
+      paramOids: [23],
+      columns: [
+        { name: "custom", typeOid: 65552 },
+        { name: "n", typeOid: 23 },
+      ],
+      row: [Buffer.from("(42,t)"), Buffer.from([0, 0, 0, 9])],
+      query: sql => sql`select custom, n from t where n = ${9}`,
+    });
+    expect(binds).toHaveLength(1);
+    expect({ resultFormats: binds[0].resultFormats, row: rows[0] }).toEqual({
+      resultFormats: [0, 1],
+      row: { custom: "(42,t)", n: 9 },
+    });
+  });
+});
 
 describeWithContainer("postgres", { image: "postgres_plain" }, container => {
   const connect = () =>

--- a/test/js/sql/postgres-bind-param-format.test.ts
+++ b/test/js/sql/postgres-bind-param-format.test.ts
@@ -1,0 +1,96 @@
+// The Bind message declares a format code (0 = text, 1 = binary) for every
+// parameter and then carries the encoded values. Bun only has binary encoders
+// for bool, int4, float8, timestamp(tz) and bytea. Every other parameter type
+// the server reports (numeric, real, time, int4[], real[], ...) is sent as
+// `String(value)` and must be declared as text so the server parses it.
+//
+// Runs against a real Postgres server with the default `prepare: true`, where
+// Bun binds with the parameter types from the server's ParameterDescription.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+// Stand-in for a decimal.js / big.js style value: not a string, but its text
+// form is what should reach the server.
+class Textual {
+  constructor(public text: string) {}
+  toString() {
+    return this.text;
+  }
+}
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const connect = () =>
+    new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+
+  test("object bound to a numeric, real or time column is sent as its text form", async () => {
+    await container.ready;
+    await using sql = connect();
+    await sql`create temp table t (n numeric, r real, t time)`;
+
+    const rows = await sql`
+      insert into t (n, r, t)
+      values (${new Textual("19.99")}, ${new Textual("1234")}, ${new Textual("12:34:56")})
+      returning n::text as n, r::text as r, t::text as t`;
+    expect(rows[0]).toEqual({ n: "19.99", r: "1234", t: "12:34:56" });
+  });
+
+  test("object bound to a $1::numeric / $1::real cast is sent as its text form", async () => {
+    await container.ready;
+    await using sql = connect();
+    const rows = await sql`select ${new Textual("0.1")}::numeric::text as n, ${new Textual("2.5")}::real::text as r`;
+    expect(rows[0]).toEqual({ n: "0.1", r: "2.5" });
+  });
+
+  test("sql.array() in the sql(object) helper works for int4[] and real[] columns", async () => {
+    await container.ready;
+    await using sql = connect();
+    await sql`create temp table t (id int4, ia int4[], ra real[])`;
+
+    const inserted = await sql`
+      insert into t ${sql({ id: 1, ia: sql.array([1, 2, 3], "INT4"), ra: sql.array([1.5, 2.5], "REAL") })}
+      returning ia::text as ia, ra::text as ra`;
+    expect(inserted[0]).toEqual({ ia: "{1,2,3}", ra: "{1.5,2.5}" });
+
+    const updated = await sql`
+      update t set ${sql({ ia: sql.array([4], "INT4"), ra: sql.array([0.25], "REAL") })}
+      where id = 1
+      returning ia::text as ia, ra::text as ra`;
+    expect(updated[0]).toEqual({ ia: "{4}", ra: "{0.25}" });
+  });
+
+  test("sql.array() passed to sql.unsafe() works for int4[] and real[] parameters", async () => {
+    await container.ready;
+    await using sql = connect();
+    const rows = await sql.unsafe("select $1::int4[]::text as ia, $2::real[]::text as ra", [
+      sql.array([7, 8], "INT4"),
+      sql.array([1.5], "REAL"),
+    ]);
+    expect(rows[0]).toEqual({ ia: "{7,8}", ra: "{1.5}" });
+  });
+
+  test("parameters with a binary encoder still round-trip", async () => {
+    await container.ready;
+    await using sql = connect();
+    await sql`create temp table t (b bool, i int4, f float8, ts timestamptz, bin bytea, r real, n numeric)`;
+
+    const date = new Date("2024-01-02T03:04:05.678Z");
+    const rows = await sql`
+      insert into t (b, i, f, ts, bin, r, n)
+      values (${true}, ${-123456}, ${1.25}, ${date}, ${Buffer.from([0, 1, 254, 255])}, ${"2.5"}, ${"12345678901234567890.5"})
+      returning b, i, f, ts, bin, r::text as r, n::text as n`;
+    expect(rows[0]).toEqual({
+      b: true,
+      i: -123456,
+      f: 1.25,
+      ts: date,
+      bin: Buffer.from([0, 1, 254, 255]),
+      r: "2.5",
+      n: "12345678901234567890.5",
+    });
+  });
+});

--- a/test/js/sql/wire-frames.test.ts
+++ b/test/js/sql/wire-frames.test.ts
@@ -18,11 +18,43 @@ import {
   pgCopyDone,
   pgCopyOutResponse,
   pgDataRow,
+  pgDecodeBind,
   pgErrorResponse,
   pgMinimalReadyServer,
   pgReadyForQuery,
   pgRowDescription,
 } from "./wire-frames";
+
+test("pgDecodeBind decodes a §55.7 Bind body", () => {
+  // portal "", statement "S1", 2 format codes [1, 0], 2 params (4-byte int4 7, NULL), 1 result format [1]
+  const body = Buffer.from(
+    "\x00S1\x00" +
+      "\x00\x02\x00\x01\x00\x00" +
+      "\x00\x02" +
+      "\x00\x00\x00\x04\x00\x00\x00\x07" +
+      "\xff\xff\xff\xff" +
+      "\x00\x01\x00\x01",
+    "binary",
+  );
+  expect(pgDecodeBind(body)).toEqual({
+    portal: "",
+    statement: "S1",
+    paramFormats: [1, 0],
+    params: [Buffer.from([0, 0, 0, 7]), null],
+    resultFormats: [1],
+  });
+  // 0 format codes means "all text"; 1 code applies to every parameter.
+  const none = Buffer.from(
+    "\x00\x00" + "\x00\x00" + "\x00\x02" + "\x00\x00\x00\x01a\x00\x00\x00\x01b" + "\x00\x00",
+    "binary",
+  );
+  expect(pgDecodeBind(none).paramFormats).toEqual([0, 0]);
+  const one = Buffer.from(
+    "\x00\x00" + "\x00\x01\x00\x01" + "\x00\x02" + "\x00\x00\x00\x01a\x00\x00\x00\x01b" + "\x00\x00",
+    "binary",
+  );
+  expect(pgDecodeBind(one).paramFormats).toEqual([1, 1]);
+});
 
 test("mysqlLenencInt encodes per page_protocol_basic_dt_integers.html", () => {
   expect(mysqlLenencInt(0)).toEqual(Buffer.from([0x00]));

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -231,6 +231,59 @@ export function pgParameterDescription(typeOids: number[]): Buffer {
   return pgRaw("t", body);
 }
 
+// PostgreSQL FE/BE protocol §55.7 NoData: Byte1('n') Int32(4)
+export function pgNoData(): Buffer {
+  return pgRaw("n", Buffer.alloc(0));
+}
+
+export type PgBind = {
+  portal: string;
+  statement: string;
+  /** One per parameter (expanded if the client sent 0 or 1 codes). 0 = text, 1 = binary. */
+  paramFormats: number[];
+  params: (Buffer | null)[];
+  resultFormats: number[];
+};
+
+// PostgreSQL FE/BE protocol §55.7 Bind (frontend): String(portal) String(statement)
+//   Int16(nFormats) Int16[nFormats] Int16(nParams) per param: Int32(len | -1) Byte[len]
+//   Int16(nResultFormats) Int16[nResultFormats]
+// `body` is the message without the type byte and length, as pgReadFrontendMessages hands it out.
+export function pgDecodeBind(body: Buffer): PgBind {
+  let o = 0;
+  const cstring = () => {
+    const end = body.indexOf(0, o);
+    const s = body.toString("utf8", o, end);
+    o = end + 1;
+    return s;
+  };
+  const int16 = () => {
+    const v = body.readInt16BE(o);
+    o += 2;
+    return v;
+  };
+  const portal = cstring();
+  const statement = cstring();
+  const formats: number[] = [];
+  for (let n = int16(), i = 0; i < n; i++) formats.push(int16());
+  const params: (Buffer | null)[] = [];
+  for (let n = int16(), i = 0; i < n; i++) {
+    const len = body.readInt32BE(o);
+    o += 4;
+    if (len === -1) {
+      params.push(null);
+    } else {
+      params.push(Buffer.from(body.subarray(o, o + len)));
+      o += len;
+    }
+  }
+  const resultFormats: number[] = [];
+  for (let n = int16(), i = 0; i < n; i++) resultFormats.push(int16());
+  const paramFormats =
+    formats.length === params.length ? formats : params.map(() => (formats.length === 1 ? formats[0] : 0));
+  return { portal, statement, paramFormats, params, resultFormats };
+}
+
 /**
  * Drain complete PostgreSQL frontend messages from `buffered`, calling
  * onMessage(type, body) for each; returns the leftover bytes. The very first


### PR DESCRIPTION
### Problem
- `sql({ ids: sql.array([1, 2], "INT4") })` into an `int4[]` column fails with `08P01 insufficient data left in message`. A decimal.js style object bound to `numeric` fails with `08P01`, to `time` with `22008 time out of range`. Bound to `real`, `"1234"` stores `2.5931515e-09`.
- Cause: `write_bind` (`src/sql_jsc/postgres/PostgresRequest.rs`) took each parameter's format code from `Tag::is_binary_format_supported()`, the decode-side list. Binary encoders only exist for bool, int4, float8, timestamp(tz) and bytea. numeric, float4, time and float4[] were declared binary and written as `String(value)`. The `int4_array` arm wrote one int4.
- Result columns had the same split: `FieldDescription::type_tag()` truncated the OID to 16 bits for the format code, while `DataCell` mapped an OID above 65535 to text.

### Fix
- A `ParamEncoding` enum lists the encoders that exist. `write_bind` decides it once per parameter and writes the format code and the value bytes from it. Types without a binary encoder go out as text, as string values already do.
- `Tag::from_oid()` is now the only OID-to-`Tag` mapping, for parameters, result format codes and `DataCell`.
- Verified: `test/js/sql/postgres-bind-param-format.test.ts` (new, mock server plus PostgreSQL 17; 6 of 8 tests fail on bun 1.4.3). Also `sql.test.ts`, `sql-prepare-false.test.ts` and every `postgres-*.test.ts`.

### Background
- Parse carries a type OID per parameter (0 = server decides). Bind carries a format code per parameter (0 text, 1 binary), the value bytes, then a format code per result column. With the default `prepare: true`, Bun binds with the types the server reports.
- Bun declares an OID only for JS numbers, booleans and typed arrays. Objects, `Date` and `sql.array()` values get OID 0, so the server infers `numeric`, `real`, `time` or `int4[]` from the column or cast.
- `DataCell` decodes numeric, float4, time, int4[] and float4[] from binary. Nothing encodes them.

<details><summary>Notes</summary>

- Behavior for values that hit the affected parameter types, against PostgreSQL 17 (before / after):
  - `sql({ ia: sql.array([1,2], "INT4") })` into `int4[]`: `08P01` / `{1,2}`
  - `sql({ ra: sql.array([1.5,2.5], "REAL") })` into `real[]`: `54000` / `{1.5,2.5}`
  - `{ toString: () => "19.99" }` into `numeric`: `08P01` / `19.99`
  - `{ toString: () => "1234" }` into `real`: stores `2.5931515e-09` / `1234`
  - `{ toString: () => "12:34:56" }` into `time`: `22008` / `12:34:56`
  - `[1, 2]` into `int4[]`: `08P01` / `22P02 malformed array literal: "1,2"` (#33579 makes plain JS arrays work and builds on the text format)
  - a `Date` into `time`: `22008 time out of range` / `22007 invalid input syntax for type time: "Thu Jan 01 1970 ..."` (the `Date` text form is a separate issue, see #39452)
- `sql.array()` in a tagged template was not affected: `bindParam` pushes the serialized string and appends a `$1::TYPE[]` cast, and a string value was already sent as text. The `sql(object)` helper and `sql.unsafe()` bind the `SQLArrayParameter` object itself.
- Result columns: a user-defined type whose OID aliases a binary-decoded builtin modulo 65536 (for example 65552 = 65536 + 16, `bool`) was requested in binary and then read as text. The mock test `a result column whose OID is above 65535 is requested and decoded as text` covers it.
- The encoding is recorded while the format codes are written and reused for the value section. Before, both sections looked at the value separately, so a `toString()` or getter that changed another bound value in between could still produce a format/bytes mismatch. A probe with such a value now round-trips.
- #35508 (numeric precision for JS numbers) contains a similar format-code change as a side effect of a larger behavior change. This PR is the standalone fix and does not change how JS numbers are declared or encoded. #33579, #39452 and #40944 edit the same `match`; whichever lands second needs a small rebase. Rebased on top of #41889 (bytea type check), which already landed.
- `wire-frames.ts` gains `pgNoData()` and `pgDecodeBind()` for the mock tests, with a self-test in `wire-frames.test.ts`.
- The local `sql.test.ts` run has the same failures with and without this change. They come from the local server setup (SQL_ASCII encoding, no md5/scram roles, prepared transactions disabled, PG 17 `pg_database` shape) and debug-build timeouts, not from parameter binding or result decoding.
- Self-reviewed: 2 concerns raised, 2 addressed (the result-column OID mapping, and deciding the encoding once per parameter).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bind-param-format.test.ts test/js/sql/wire-frames.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/wire-frames.test.ts:
(pass) pgDecodeBind decodes a §55.7 Bind body [21.39ms]
(pass) mysqlLenencInt encodes per page_protocol_basic_dt_integers.html [9.69ms]
(pass) pgErrorResponse encodes per §55.7 [7.88ms]
(pass) postgres: pgAuthenticationOk + pgReadyForQuery are accepted by Bun's parser [406.29ms]
(pass) postgres: COPY OUT response frames are consumed and the following result set decodes [243.90ms]
(pass) postgres: pgMinimalReadyServer satisfies connect() [43.47ms]
(pass) mysql: mysqlHandshakeV10 + mysqlOkPacket are accepted by Bun's parser [74.89ms]

test/js/sql/postgres-bind-param-format.test.ts:
90 |     });
91 |     expect(binds).toHaveLength(1);
92 |     expect({
93 |       paramFormats: binds[0].paramFormats,
94 |       params: binds[0].params.map(p => p?.toString("latin1")),
95 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
    "paramFormats": [
-     0,
-     0,
-     0,
-  
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/sql/wire-frames.test.ts:
(pass) pgDecodeBind decodes a §55.7 Bind body [0.29ms]
(pass) mysqlLenencInt encodes per page_protocol_basic_dt_integers.html [0.11ms]
(pass) pgErrorResponse encodes per §55.7 [0.10ms]
(pass) postgres: pgAuthenticationOk + pgReadyForQuery are accepted by Bun's parser [6.29ms]
(pass) postgres: COPY OUT response frames are consumed and the following result set decodes [3.60ms]
(pass) postgres: pgMinimalReadyServer satisfies connect() [0.63ms]
(pass) mysql: mysqlHandshakeV10 + mysqlOkPacket are accepted by Bun's parser [1.50ms]

test/js/sql/postgres-bind-param-format.test.ts:
90 |     });
91 |     expect(binds).toHaveLength(1);
92 |     expect({
93 |       paramFormats: binds[0].paramFormats,
94 |       params: binds[0].params.map(p => p?.toString("latin1")),
95 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
    "paramFormats": [
-     0,
-     0,
-     0,
-     0,
-     0,
+     1,
+     1,
+     1,
+     1,
+     1,
    ],
    "params": [
      "19.99",
      "1234",
      "12:34:56",
-     "{"1","2"}",
+     "",
      "{1.5}",
    ],
  }

- Expected  - 6
+ R
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bind-param-format.test.ts test/js/sql/wire-frames.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/wire-frames.test.ts:
(pass) pgDecodeBind decodes a §55.7 Bind body [18.19ms]
(pass) mysqlLenencInt encodes per page_protocol_basic_dt_integers.html [11.13ms]
(pass) pgErrorResponse encodes per §55.7 [6.91ms]
(pass) postgres: pgAuthenticationOk + pgReadyForQuery are accepted by Bun's parser [410.90ms]
(pass) postgres: COPY OUT response frames are consumed and the following result set decodes [240.77ms]
(pass) postgres: pgMinimalReadyServer satisfies connect() [31.71ms]
(pass) mysql: mysqlHandshakeV10 + mysqlOkPacket are accepted by Bun's parser [80.37ms]

test/js/sql/postgres-bind-param-format.test.ts:
(pass) Bind format codes (mock server) > parameters typed numeric, float4, time, int4[] and float4[] are declared and sent as text [207.04ms]
(pass) Bind format codes (mock server) > parameters with a binary encoder are declared binary, a string value stays text [40.22ms]
(pass) Bind format codes (mock server) > a resul
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 609ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/postgres/protocol/FieldDescription.rs  |   6 +-
 src/sql/postgres/types/Tag.rs                  |   8 +-
 src/sql_jsc/postgres/DataCell.rs               |   8 +-
 src/sql_jsc/postgres/PostgresRequest.rs        | 171 ++++++++++----------
 test/js/sql/postgres-bind-param-format.test.ts | 214 +++++++++++++++++++++++++
 test/js/sql/wire-frames.test.ts                |  32 ++++
 test/js/sql/wire-frames.ts                     |  53 ++++++
 7 files changed, 399 insertions(+), 93 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/sql/postgres/protocol/FieldDescription.rs       1      1     28
src/sql/postgres/types/Tag.rs                       3      4     29
src/sql_jsc/postgres/DataCell.rs                    1      1     28
src/sql_jsc/postgres/PostgresRequest.rs             9     16     28
test/js/sql/postgres-bind-param-format.test.ts      0      4     24
test/js/sql/wire-frames.test.ts                     1      1      9
test/js/sql/wire-frames.ts                          2      1     29
```

</details>

<!-- robobun:evidence:end -->