### PR TITLE
bundler: export every top-level key of a JSON/TOML/YAML module, not only identifier keys

### DIFF
--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -16,7 +16,6 @@ use crate::{Chunk, Index, LinkerContext, Part, PartRange, WrapKind};
 use bun_ast::StoreRef;
 use bun_ast::binding::ToExprWrapper;
 use bun_ast::{B, Binding, E, Expr, G, Ref, S, Stmt};
-use bun_js_parser::lexer as js_lexer;
 
 use super::convert_stmts_for_chunk::convert_stmts_for_chunk;
 use super::convert_stmts_for_chunk_for_dev_server::convert_stmts_for_chunk_for_dev_server;
@@ -439,8 +438,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                         }
                         _ => unreachable!(),
                     };
-                    if name == b"default" || name == b"__esModule" || !js_lexer::is_identifier(name)
-                    {
+                    if name == b"default" || name == b"__esModule" {
                         continue;
                     }
 

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -430,16 +430,20 @@ pub(crate) fn generate_code_for_lazy_export(
                     }
 
                     // SAFETY: `LinkerContext::arena()` returns a stable `&Arena` valid for the
-                    // link pass; detach via raw-pointer round-trip so `name` doesn't borrow `this`
+                    // link pass; detach via raw-pointer round-trip so `alias` doesn't borrow `this`
                     // across the `&mut self` call to `generate_named_export_in_file` below.
                     let alloc: &bun_alloc::Arena =
                         unsafe { bun_ptr::detach_lifetime_ref::<bun_alloc::Arena>(this.arena()) };
-                    let name: &[u8] = bun_core::handle_oom(key_str.flattened(alloc).string(alloc));
+                    let alias: &[u8] = bun_core::handle_oom(key_str.flattened(alloc).string(alloc));
 
-                    // TODO: support non-identifier names
-                    if !js_lexer::is_identifier(name) {
-                        continue;
-                    }
+                    // The export alias can be any string, but the variable needs an identifier.
+                    let name: &[u8] = if js_lexer::is_identifier(alias) {
+                        alias
+                    } else {
+                        alloc.alloc_slice_copy(&bun_core::MutableString::ensure_valid_identifier(
+                            alias,
+                        )?)
+                    };
 
                     // This initializes the generated variable with a copy of the property
                     // value, which is INCORRECT for values that are objects/arrays because
@@ -453,7 +457,7 @@ pub(crate) fn generate_code_for_lazy_export(
                     // end up actually being used at this point (since import binding hasn't
                     // happened yet). So we need to wait until after tree shaking happens.
                     let generated =
-                        this.generate_named_export_in_file(source_index, module_ref, name, name)?;
+                        this.generate_named_export_in_file(source_index, module_ref, name, alias)?;
                     let new_stmts: &mut [Stmt] =
                         alloc.alloc_slice_fill_iter(core::iter::once(Stmt::alloc(
                             S::Local {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath, Loader } from "bun";
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import fs, { readdirSync } from "node:fs";
 import { join } from "path";
 import { itBundled } from "./expectBundled";
@@ -150,6 +151,162 @@ describe("bundler", async () => {
       });
     });
   }
+
+  // The runtime exposes every top-level string key of a JSON/TOML/YAML module as
+  // a named export, so a bundle must too: `import * as ns` and
+  // `import { "a b" as x }` see the same keys after `bun build` as under `bun run`.
+  describe("every top-level key of a data file is a named export", () => {
+    // Keys that are not identifiers, plus keywords, `default`, and a key that
+    // collides with the mangled name of another (`a b` becomes `a_b`).
+    const keysJson = `{
+      "a b": 1, "foo-bar": 2, "café": 3, "日本": 4, "🔥": 5, "": 6, "123": 7, "1e3": 8,
+      "let": 9, "class": 10, "if": 11, "default": 12, "a_b": 13
+    }`;
+    const keysEntry = /* js */ `
+      import * as ns from "./data.json";
+      import def from "./data.json";
+      import {
+        "a b" as ab, "foo-bar" as fooBar, "café" as cafe, "日本" as jp, "🔥" as fire, "" as empty,
+        "123" as n123, "1e3" as n1e3, "let" as let_, "class" as class_, "if" as if_, a_b,
+      } from "./data.json";
+      console.log(JSON.stringify([ab, fooBar, cafe, jp, fire, empty, n123, n1e3, let_, class_, if_, a_b]));
+      console.log(JSON.stringify([
+        ns["a b"], ns["foo-bar"], ns["café"], ns["日本"], ns["🔥"], ns[""], ns["123"], ns["1e3"],
+        ns.let, ns.class, ns.if, ns.a_b,
+      ]));
+      console.log(JSON.stringify(Object.keys(ns).sort()));
+      console.log(JSON.stringify(def), def.default, ns.default === def);
+    `;
+    const keysStdout = [
+      "[1,2,3,4,5,6,7,8,9,10,11,13]",
+      "[1,2,3,4,5,6,7,8,9,10,11,13]",
+      '["","123","1e3","a b","a_b","café","class","default","foo-bar","if","let","日本","🔥"]',
+      '{"123":7,"a b":1,"foo-bar":2,"café":3,"日本":4,"🔥":5,"":6,"1e3":8,"let":9,"class":10,"if":11,"default":12,"a_b":13} 12 true',
+    ].join("\n");
+
+    for (const format of ["esm", "cjs", "iife"] as const) {
+      for (const minify of [false, true]) {
+        itBundled(`bun/loader-json-non-identifier-keys-${format}${minify ? "-minify" : ""}`, {
+          target: "bun",
+          format,
+          minifyIdentifiers: minify,
+          minifySyntax: minify,
+          minifyWhitespace: minify,
+          files: {
+            "/entry.js": keysEntry,
+            "/data.json": keysJson,
+          },
+          run: { stdout: keysStdout },
+        });
+      }
+    }
+
+    // YAML plain keys and TOML quoted keys work like JSON keys, and a named
+    // export is the same object as the property of the default export.
+    for (const minify of [false, true]) {
+      itBundled(`bun/loader-yaml-toml-non-identifier-keys${minify ? "-minify" : ""}`, {
+        target: "bun",
+        minifyIdentifiers: minify,
+        minifySyntax: minify,
+        minifyWhitespace: minify,
+        files: {
+          "/entry.ts": /* js */ `
+            import * as j from './data.json';
+            import { "a b" as ab } from './data.json';
+            import * as y from './data.yaml';
+            import { "x y" as yxy } from './data.yaml';
+            import * as t from './data.toml';
+            import { "x-y" as txy } from './data.toml';
+            console.write(JSON.stringify([
+              ab === j["a b"], j["a b"] === j.default["a b"], j.obj === j.default.obj,
+              Object.keys(y).sort(), y["x y"], yxy, y.nested === y.default.nested,
+              Object.keys(t).sort(), t["a b"], txy, t.tbl === t.default.tbl,
+            ]));
+          `,
+          "/data.json": JSON.stringify({ "a b": { n: 1 }, obj: {}, ok: 7 }),
+          "/data.yaml": `x y: xy\nnested:\n  k: v\n`,
+          "/data.toml": `"a b" = 1\n"x-y" = 2\n[tbl]\nk = "v"\n`,
+        },
+        run: {
+          stdout: '[true,true,true,["default","nested","x y"],"xy","xy",true,["a b","default","tbl","x-y"],1,2,true]',
+        },
+      });
+    }
+
+    // A JSON entry point exports every key, with a string alias where the key
+    // is not an identifier.
+    itBundled("bun/loader-json-non-identifier-keys-entry-point", {
+      target: "bun",
+      format: "esm",
+      entryPoints: ["/data.json"],
+      files: {
+        "/data.json": keysJson,
+      },
+      onAfterBundle(api) {
+        const code = api.readFile("/out.js");
+        expect(code).toContain('as "a b"');
+        expect(code).toContain('as "foo-bar"');
+        expect(code).toContain('as ""');
+        expect(code).toContain('as "123"');
+        // The emoji is written as escapes in ASCII-only output.
+        expect(code).toMatch(/as "(🔥|\\uD83D\\uDD25)"/);
+        expect(code).toContain("as if");
+        expect(code).toContain("as default");
+      },
+    });
+
+    // A named re-export from a barrel sees the same keys.
+    itBundled("bun/loader-json-non-identifier-keys-re-export", {
+      target: "bun",
+      files: {
+        "/entry.js": /* js */ `
+          import * as barrel from "./barrel.js";
+          import { renamed, "" as empty, "日本" as jp } from "./barrel.js";
+          console.log(JSON.stringify([barrel.renamed, barrel[""], barrel["日本"], barrel.if, renamed, empty, jp]));
+          console.log(JSON.stringify(Object.keys(barrel).sort()));
+        `,
+        "/barrel.js": /* js */ `
+          export { "a b" as renamed, "" as "", "日本", if } from "./data.json";
+        `,
+        "/data.json": keysJson,
+      },
+      run: {
+        stdout: ["[1,6,4,11,1,6,4]", '["","if","renamed","日本"]'].join("\n"),
+      },
+    });
+
+    // The same source prints the same values under `bun run` and after `bun build`.
+    test("bun run and bun build agree on a JSON module", async () => {
+      using dir = tempDir("json-loader-runtime", {
+        "data.json": keysJson,
+        "entry.js": keysEntry,
+      });
+      const run = async (...args: string[]) => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), ...args],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { stdout, stderr, exitCode };
+      };
+
+      const runtime = await run("entry.js");
+      expect(runtime.stderr).toBe("");
+      expect(runtime.stdout).toBe(keysStdout + "\n");
+      expect(runtime.exitCode).toBe(0);
+
+      const build = await run("build", "entry.js", "--outfile=out.js");
+      expect(build.stderr).toBe("");
+      expect(build.exitCode).toBe(0);
+      const bundled = await run("out.js");
+      expect(bundled.stderr).toBe("");
+      expect(bundled.stdout).toBe(runtime.stdout);
+      expect(bundled.exitCode).toBe(0);
+    });
+  });
 
   itBundled("bun/loader-text-file", {
     target: "bun",

--- a/test/bundler/esbuild/loader.test.ts
+++ b/test/bundler/esbuild/loader.test.ts
@@ -240,7 +240,6 @@ describe("bundler", () => {
     },
   });
   itBundled("loader/JSONInvalidIdentifierES6", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         import * as ns from './test.json'
@@ -251,7 +250,7 @@ describe("bundler", () => {
       "/test2.json": `{"invalid-identifier": true}`,
     },
     run: {
-      stdout: 'true {"invalid-identifier":true}',
+      stdout: 'true {"default":{"invalid-identifier":true},"invalid-identifier":true}',
     },
   });
   itBundled("loader/JSONMissingES6", {


### PR DESCRIPTION
### Problem
- In a bundle, `import * as ns from "./k.json"` exposes only identifier-safe top-level keys. `ns["a b"]` is `undefined`, and `import { "a b" as x } from "./k.json"` fails with `No matching export in "k.json" for import "a b"`. `bun run`, `bun build --no-bundle` and esbuild export every key. No issue reports this: the gap is a `TODO: support non-identifier names` in the linker.
- The cause: `generate_code_for_lazy_export` (`src/bundler/linker_context/generateCodeForLazyExport.rs:439`) skips every string key that fails `js_lexer::is_identifier`, and the default-object fix-up in `generateCodeForFileInChunkJS.rs:442` repeats the filter.

### Fix
- Export every top-level string key. The export alias is the key. The local gets a valid identifier from `ensure_valid_identifier`: `var a_b = 1; export { a_b as "a b" }`. A JSON entry point now prints the same export clause as esbuild.
- `generateCodeForFileInChunkJS.rs` drops its `is_identifier` check, so the default object references the live local and `ns["a b"] === ns.default["a b"]`.
- This PR and #40826 made the same change here. #40826 now keeps only its `.json` number grammar. Its key tests and the `loader/JSONInvalidIdentifierES6` flip moved here.
- Verified: `test/bundler/bundler_loader.test.ts` (11 new tests) and `loader/JSONInvalidIdentifierES6` in `test/bundler/esbuild/loader.test.ts`, all 12 fail on 1.4.2. Self-reviewed: 3 concerns raised, 3 addressed (see Notes).

### Background
- A data module (JSON, TOML, YAML, JSONC, JSON5) parses to one expression in an `S.LazyExport`. At link time an object becomes one `export var` part per key plus `export default {...}`, so unused keys tree-shake.
- An export name can be any string (`export { x as "a b" }`, ES2022). A local name cannot, so `generate_named_export_in_file` takes the two as separate arguments. The renamer makes the local unique and safe (`if` becomes `if2`).
- After tree shaking, `generateCodeForFileInChunkJS` points the default object's properties at the live per-key locals. Both sides must agree on the key set.

<details><summary>Notes</summary>

Repro on 1.4.2:

```
// k.json: {"a b":1,"if":2,"ok":3,"a_b":4}
// entry.js
import * as ns from "./k.json";
console.log(JSON.stringify(Object.keys(ns)), ns["a b"], ns.if, ns.ok);
// bun entry.js                          -> ["a b","a_b","default","if","ok"] 1 2 3
// bun build entry.js --outfile=out.js   -> ["a_b","default","if","ok"] undefined 2 3
```

esbuild 0.25.1 prints the JSON entry point as `var a_b = 1; var if2 = 2; var ok = 3; var a_b2 = 4; ... export { a_b as "a b", a_b2 as a_b, k_default as default, if2 as if, ok }`. This branch prints the same.

Also run: the esbuild importstar, splitting, default, dce and css ports, `bundler_edgecase`, `bundler_minify`, `bundler_barrel`, `css/css-modules`. Checked by hand with the debug build: `--splitting` with two entries that share `k.json` (the shared chunk exports `a_b`, `ok`), `--format=cjs --target=node`, `--minify`.

Self-review, three concerns, all addressed by trimming:
- An earlier revision also exported YAML `true:`, `null:` and integer keys by stringifying them in the linker. That re-derives in the linker what the parser owns, and more weakly than the runtime (`1.5:` was still skipped). #41824 stringifies non-string YAML keys once in the parser, after which they are ordinary string keys here. Dropped.
- An earlier revision also recorded each lazy export in the AST `named_exports`, so `export * from "./data.json"` forwards every key like `bun run` does. esbuild and current `bun build` forward none, and a barrel with `export * from "./data.json"; export * from "./lib.js"` and an overlapping name changes from "lib wins" to "ambiguous". That is a policy choice for the bundler owner, not a rider. Dropped here. It is an 8-line addition to `generate_named_export_in_file` if wanted.
- The PR body predated the consolidation. Rewritten.

Not changed here:
- A YAML `true:` key with `--minify-syntax` prints as `!0:` in the default object, before and after this change (#41827, #41824).
- A top-level array or scalar has a synthetic `__esModule` export at runtime (`ObjectModule.cpp`) that the bundle does not have.
- #34617 covers reserved-word keys in the `Bun.Transpiler` / `--no-bundle` path, which prints without the renamer. The bundled path goes through the renamer, so `"if"`, `"let"`, `"class"` keys already get safe locals (in the test matrix).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 7 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 failed, 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_loader.test.ts test/bundler/esbuild/loader.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_loader.test.ts:
(pass) bundler > bun loader > bun/loader-yaml-file [798.61ms]
(pass) bundler > bun loader > bun/loader-text-file [451.05ms]
(pass) bundler > bun loader > bun/loader-json-file [369.23ms]
(pass) bundler > bun loader > bun/loader-toml-file [396.40ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-shadowed-temporal-global [458.91ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-imported-temporal-binding [607.77ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-no-bundle [403.96ms]
(pass) bundler > bun loader > bun/loader-toml-datetime [415.33ms]
(pass) bundler > bun loader > bun/loader-text-file [501.86ms]
(pass) bundler > bun loader > bun/loader-xml-file [411.36ms]
(pass) bundler > node loader > bun/loader-yaml-file [375.19ms]
(pass) bundler > node loader > bun/loader-text-file [464.89ms]
(pass) bundler > node loader > bun/loader-json-file [379.53ms]
(pass) bundler > node loader 
... (truncated)

release without fix: 12 failed, 7 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_loader.test.ts:
(pass) bundler > bun loader > bun/loader-yaml-file [108.64ms]
(pass) bundler > bun loader > bun/loader-text-file [24.18ms]
(pass) bundler > bun loader > bun/loader-json-file [11.60ms]
(pass) bundler > bun loader > bun/loader-toml-file [13.02ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-shadowed-temporal-global [11.03ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-imported-temporal-binding [10.71ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-no-bundle [11.00ms]
(pass) bundler > bun loader > bun/loader-toml-datetime [10.82ms]
(pass) bundler > bun loader > bun/loader-text-file [10.68ms]
(pass) bundler > bun loader > bun/loader-xml-file [11.48ms]
(pass) bundler > node loader > bun/loader-yaml-file [14.11ms]
(pass) bundler > node loader > bun/loader-text-file [12.02ms]
(pass) bundler > node loader > bun/loader-json-file [10.52ms]
(pass) bundler > node loader > bun/loader-toml-file [9.67ms]
(pass) bundler > node loader > bun/loader-toml-datetime-shadowed-temporal-global [10.53ms]
(pass) bundler > node loader > bun/loader-toml-datetime-imported-temporal-binding [1
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_loader.test.ts test/bundler/esbuild/loader.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_loader.test.ts:
(pass) bundler > bun loader > bun/loader-yaml-file [821.55ms]
(pass) bundler > bun loader > bun/loader-text-file [449.12ms]
(pass) bundler > bun loader > bun/loader-json-file [494.89ms]
(pass) bundler > bun loader > bun/loader-toml-file [463.71ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-shadowed-temporal-global [373.73ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-imported-temporal-binding [367.27ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-no-bundle [499.74ms]
(pass) bundler > bun loader > bun/loader-toml-datetime [391.72ms]
(pass) bundler > bun loader > bun/loader-text-file [372.35ms]
(pass) bundler > bun loader > bun/loader-xml-file [364.49ms]
(pass) bundler > node loader > bun/loader-yaml-file [387.63ms]
(pass) bundler > node loader > bun/loader-text-file [566.37ms]
(pass) bundler > node loader > bun/loader-json-file [546.14ms]
(pass) bundler > node loader 
... (truncated)

release with fix: 7 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0bf4abf195
  features     baseline

23 deps, 131 codegen, 1172 objects in 1001ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [12.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen .bind.ts → GeneratedBindings.cpp
[5/1244] fetch zlib
[zlib] up to date
[6/1244] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 28ms
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1243] gen bindgenv2
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../linker_context/generateCodeForFileInChunkJS.rs |   4 +-
 .../linker_context/generateCodeForLazyExport.rs    |  18 ++-
 test/bundler/bundler_loader.test.ts                | 159 ++++++++++++++++++++-
 test/bundler/esbuild/loader.test.ts                |   3 +-
 4 files changed, 171 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…/bundler/linker_context/generateCodeForFileInChunkJS.rs      1      2     30
src/bundler/linker_context/generateCodeForLazyExport.rs       1      2     30
test/bundler/bundler_loader.test.ts                           4      5     25
test/bundler/esbuild/loader.test.ts                           0      0      3
```

</details>

<!-- robobun:evidence:end -->