### PR TITLE
Refuse a temp directory that another user owns for the bunx cache, embedded addons, and bun upgrade

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -363,7 +363,7 @@ JSC_DEFINE_CUSTOM_SETTER(Process_defaultSetter, (JSC::JSGlobalObject * globalObj
     return true;
 }
 
-extern "C" BunString Bun__resolveEmbeddedNodeFile(const BunString*);
+extern "C" BunString Bun__resolveEmbeddedNodeFile(const BunString*, BunString* errorMessage);
 #if OS(WINDOWS)
 extern "C" HMODULE Bun__LoadLibraryBunString(BunString*);
 #endif
@@ -510,12 +510,16 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
     [[maybe_unused]] bool fromEmbedded = false;
     if (filename.startsWith(StandaloneModuleGraph__base_path)) {
         BunString bunStr = Bun::toString(filename);
-        BunString resolved = Bun__resolveEmbeddedNodeFile(&bunStr);
+        BunString errorMessage = { BunStringTag::Dead, {} };
+        BunString resolved = Bun__resolveEmbeddedNodeFile(&bunStr, &errorMessage);
         if (!resolved.isDead()) {
             filename = resolved.transferToWTFString();
             // The extracted file is content-hashed and shared across dlopens
             // and restarts (#29587), so it is never deleted here.
             fromEmbedded = true;
+        } else if (!errorMessage.isDead()) {
+            // Embedded, but the temp directory it would be extracted to was refused.
+            return throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED, errorMessage.transferToWTFString());
         }
     }
 

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -6,6 +6,9 @@ use std::io::Write as _;
 use bstr::BStr;
 
 use crate::cli::command::ContextData;
+use crate::cli::upgrade_command::TempDirRefusal;
+#[cfg(unix)]
+use crate::cli::upgrade_command::open_trusted_temp_dir;
 use crate::cli::{self, Command};
 use crate::run_command::{ConfigureEnvOptions, RunCommand as Run};
 
@@ -18,7 +21,7 @@ use bun_core::{ZStr, strings};
 use bun_install::dependency::VersionTag;
 use bun_install::update_request::{self, UpdateRequest};
 use bun_parsers::json;
-use bun_paths::{self, DELIMITER};
+use bun_paths::{self, DELIMITER, PathBuffer};
 use bun_resolver::fs::RealFS;
 #[cfg(windows)]
 use bun_sys::FdExt as _;
@@ -566,6 +569,38 @@ impl BunxCommand {
         true
     }
 
+    /// The cache root below the temp dir is only as private as the directories
+    /// above it: the owner of a directory renames any entry in it whatever
+    /// that entry's own mode bits say. `is_trusted_cache_root` starts at the
+    /// first component below the temp dir, so the temp dir and everything
+    /// above it go through `open_trusted_temp_dir` here, which also creates a
+    /// temp dir that does not exist yet so that its owner is known.
+    ///
+    /// Returns the path to use from then on: the real path of the directory
+    /// that was checked, since the install and the exec resolve the path
+    /// again and a symlink on the way there could live in a directory the
+    /// check never saw.
+    #[cfg(unix)]
+    fn trusted_temp_dir<'a>(
+        temp_dir: &'a [u8],
+        real_path_buf: &'a mut PathBuffer,
+    ) -> Result<&'a [u8], TempDirRefusal> {
+        let dir = open_trusted_temp_dir(temp_dir, true)?;
+        match bun_sys::get_fd_path(dir.fd(), real_path_buf) {
+            Ok(real_path) => Ok(&*real_path),
+            Err(_) => Ok(temp_dir),
+        }
+    }
+
+    #[cfg(not(unix))]
+    #[inline(always)]
+    fn trusted_temp_dir<'a>(
+        temp_dir: &'a [u8],
+        _real_path_buf: &'a mut PathBuffer,
+    ) -> Result<&'a [u8], TempDirRefusal> {
+        Ok(temp_dir)
+    }
+
     #[cfg(unix)]
     fn is_trusted_cache_root(cache_root: &[u8], temp_dir_len: usize, uid: libc::uid_t) -> bool {
         let mut buf = bun_paths::path_buffer_pool::get();
@@ -896,7 +931,15 @@ impl BunxCommand {
             BStr::new(result_package_name)
         );
 
-        let temp_dir = RealFS::platform_temp_dir();
+        let mut real_temp_dir_buf = bun_paths::path_buffer_pool::get();
+        let temp_dir: &[u8] =
+            match Self::trusted_temp_dir(RealFS::platform_temp_dir(), &mut real_temp_dir_buf) {
+                Ok(dir) => dir,
+                Err(refusal) => {
+                    refusal.print(RealFS::platform_temp_dir());
+                    Global::exit(1);
+                }
+            };
 
         let path_for_bin_dirs: Vec<u8> = 'brk: {
             if ignore_cwd.is_empty() {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -569,17 +569,10 @@ impl BunxCommand {
         true
     }
 
-    /// The cache root below the temp dir is only as private as the directories
-    /// above it: the owner of a directory renames any entry in it whatever
-    /// that entry's own mode bits say. `is_trusted_cache_root` starts at the
-    /// first component below the temp dir, so the temp dir and everything
-    /// above it go through `open_trusted_temp_dir` here, which also creates a
-    /// temp dir that does not exist yet so that its owner is known.
-    ///
-    /// Returns the path to use from then on: the real path of the directory
-    /// that was checked, since the install and the exec resolve the path
-    /// again and a symlink on the way there could live in a directory the
-    /// check never saw.
+    /// `is_trusted_cache_root` covers the components below the temp dir; this
+    /// covers the temp dir and everything above it. Returns the real path of
+    /// the checked directory so the install and exec do not re-resolve a
+    /// symlink through a directory the check never saw.
     #[cfg(unix)]
     fn trusted_temp_dir<'a>(
         temp_dir: &'a [u8],

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -569,10 +569,8 @@ impl BunxCommand {
         true
     }
 
-    /// `is_trusted_cache_root` covers the components below the temp dir; this
-    /// covers the temp dir and everything above it. Returns the real path of
-    /// the checked directory so the install and exec do not re-resolve a
-    /// symlink through a directory the check never saw.
+    /// `is_trusted_cache_root` starts below the temp dir; this covers the temp dir and up.
+    /// Returns the checked directory's real path so later lookups by path hit what was checked.
     #[cfg(unix)]
     fn trusted_temp_dir<'a>(
         temp_dir: &'a [u8],
@@ -581,7 +579,7 @@ impl BunxCommand {
         let dir = open_trusted_temp_dir(temp_dir, true)?;
         match bun_sys::get_fd_path(dir.fd(), real_path_buf) {
             Ok(real_path) => Ok(&*real_path),
-            Err(_) => Ok(temp_dir),
+            Err(err) => Err(TempDirRefusal::Open(err)),
         }
     }
 

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -46,12 +46,112 @@ fn spawn_windows_options() -> crate::api::bun::process::WindowsOptions {
 // in `resolver/lib.rs`) does not yet expose `tmpdir()`; the full impl lives in
 // the un-exported `fs_full` module. Shim it locally — open
 // `RealFS::tmpdir_path()` as a `sys::Dir`, mirroring `RealFS::open_tmp_dir`.
+//
+// Every caller puts code there that bun runs or loads again by path: the
+// `bun upgrade` download, the addons embedded in a compiled executable, the
+// `bun:ffi` cc() headers. So the directory goes through
+// `open_trusted_temp_dir`.
 pub(crate) trait FileSystemTmpdirExt {
-    fn tmpdir(&mut self) -> crate::Result<sys::Dir>;
+    fn tmpdir(&mut self) -> Result<sys::Dir, TempDirRefusal>;
 }
 impl FileSystemTmpdirExt for fs::FileSystem {
-    fn tmpdir(&mut self) -> crate::Result<sys::Dir> {
-        sys::Dir::open(fs::RealFS::tmpdir_path()).map_err(Into::into)
+    fn tmpdir(&mut self) -> Result<sys::Dir, TempDirRefusal> {
+        open_trusted_temp_dir(fs::RealFS::tmpdir_path(), false)
+    }
+}
+
+/// Why `open_trusted_temp_dir` gave no directory back.
+pub(crate) enum TempDirRefusal {
+    /// The directory could not be opened, created, or inspected.
+    Open(sys::Error),
+    /// `dir`, the temp directory itself (`depth` 0) or a directory `depth`
+    /// levels above it, belongs to `uid`, which is neither the current user
+    /// nor root.
+    ForeignOwner {
+        dir: Box<[u8]>,
+        depth: usize,
+        uid: u32,
+    },
+}
+
+impl TempDirRefusal {
+    /// The sentence after "error: " (or inside a thrown JS error) for a
+    /// refusal of `temp_dir`.
+    pub(crate) fn message(&self, temp_dir: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::new();
+        match self {
+            Self::Open(err) => {
+                let _ = write!(
+                    &mut msg,
+                    "cannot use temp directory \"{}\": {}",
+                    bstr::BStr::new(temp_dir),
+                    bstr::BStr::new(err.name()),
+                );
+            }
+            Self::ForeignOwner { dir, depth, uid } => {
+                let _ = write!(
+                    &mut msg,
+                    "refusing to use temp directory \"{}\": ",
+                    bstr::BStr::new(temp_dir)
+                );
+                if *depth > 0 {
+                    let _ = write!(&mut msg, "\"{}\" above it", bstr::BStr::new(dir));
+                } else {
+                    msg.extend_from_slice(b"it");
+                }
+                let _ = write!(
+                    &mut msg,
+                    " is owned by uid {uid}, not by the current user or root, so that user could replace the files bun puts there. Point TMPDIR (or BUN_TMPDIR) at a directory you own."
+                );
+            }
+        }
+        msg
+    }
+
+    pub(crate) fn print(&self, temp_dir: &[u8]) {
+        Output::err_generic("{}", (bstr::BStr::new(&self.message(temp_dir)),));
+    }
+}
+
+/// Opens the temp directory `path` for files that bun runs or loads again by
+/// path afterwards, creating it first when `create` is set and it does not
+/// exist. The owner of a directory renames any entry in it whatever that
+/// entry's own mode bits say, so the directory is refused when it, or any
+/// directory above it, belongs to a user other than the current one and root:
+/// that user could swap what bun put there for a file of their own between
+/// the write and the exec or dlopen.
+pub(crate) fn open_trusted_temp_dir(path: &[u8], create: bool) -> Result<sys::Dir, TempDirRefusal> {
+    let dir = match sys::Dir::open(path) {
+        Ok(dir) => dir,
+        Err(err) if create && err.get_errno() == sys::E::ENOENT => {
+            sys::mkdir_recursive(path).map_err(TempDirRefusal::Open)?;
+            sys::Dir::open(path).map_err(TempDirRefusal::Open)?
+        }
+        Err(err) => return Err(TempDirRefusal::Open(err)),
+    };
+    #[cfg(unix)]
+    // SAFETY: geteuid() takes no arguments and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+    #[cfg(not(unix))]
+    let euid = 0;
+    match sys::foreign_owned_ancestor(dir.fd(), euid) {
+        Ok(None) => Ok(dir),
+        Ok(Some(owner)) => {
+            let mut real_path_buf = bun_paths::path_buffer_pool::get();
+            let mut foreign_dir: &[u8] = match sys::get_fd_path(dir.fd(), &mut real_path_buf) {
+                Ok(real_path) => real_path,
+                Err(_) => path,
+            };
+            for _ in 0..owner.depth {
+                foreign_dir = bun_paths::dirname(foreign_dir).unwrap_or(b"/");
+            }
+            Err(TempDirRefusal::ForeignOwner {
+                dir: Box::from(foreign_dir),
+                depth: owner.depth,
+                uid: owner.uid,
+            })
+        }
+        Err(err) => Err(TempDirRefusal::Open(err)),
     }
 }
 
@@ -728,8 +828,8 @@ impl UpgradeCommand {
 
             let save_dir_: sys::Dir = match filesystem.tmpdir() {
                 Ok(d) => d,
-                Err(err) => {
-                    Output::err_generic("Failed to open temporary directory: {}", (err.name(),));
+                Err(refusal) => {
+                    refusal.print(fs::RealFS::tmpdir_path());
                     Global::exit(1);
                 }
             };

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -46,11 +46,7 @@ fn spawn_windows_options() -> crate::api::bun::process::WindowsOptions {
 // in `resolver/lib.rs`) does not yet expose `tmpdir()`; the full impl lives in
 // the un-exported `fs_full` module. Shim it locally — open
 // `RealFS::tmpdir_path()` as a `sys::Dir`, mirroring `RealFS::open_tmp_dir`.
-//
-// Every caller puts code there that bun runs or loads again by path: the
-// `bun upgrade` download, the addons embedded in a compiled executable, the
-// `bun:ffi` cc() headers. So the directory goes through
-// `open_trusted_temp_dir`.
+// Every caller runs or loads what it puts there, hence `open_trusted_temp_dir`.
 pub(crate) trait FileSystemTmpdirExt {
     fn tmpdir(&mut self) -> Result<sys::Dir, TempDirRefusal>;
 }
@@ -60,13 +56,11 @@ impl FileSystemTmpdirExt for fs::FileSystem {
     }
 }
 
-/// Why `open_trusted_temp_dir` gave no directory back.
 pub(crate) enum TempDirRefusal {
     /// The directory could not be opened, created, or inspected.
     Open(sys::Error),
-    /// `dir`, the temp directory itself (`depth` 0) or a directory `depth`
-    /// levels above it, belongs to `uid`, which is neither the current user
-    /// nor root.
+    /// `dir`, `depth` levels above the temp dir (0 = the temp dir), is owned
+    /// by `uid`, which is neither the current user nor root.
     ForeignOwner {
         dir: Box<[u8]>,
         depth: usize,
@@ -75,8 +69,7 @@ pub(crate) enum TempDirRefusal {
 }
 
 impl TempDirRefusal {
-    /// The sentence after "error: " (or inside a thrown JS error) for a
-    /// refusal of `temp_dir`.
+    /// User-facing text, without the "error: " prefix.
     pub(crate) fn message(&self, temp_dir: &[u8]) -> Vec<u8> {
         let mut msg = Vec::new();
         match self {
@@ -113,13 +106,9 @@ impl TempDirRefusal {
     }
 }
 
-/// Opens the temp directory `path` for files that bun runs or loads again by
-/// path afterwards, creating it first when `create` is set and it does not
-/// exist. The owner of a directory renames any entry in it whatever that
-/// entry's own mode bits say, so the directory is refused when it, or any
-/// directory above it, belongs to a user other than the current one and root:
-/// that user could swap what bun put there for a file of their own between
-/// the write and the exec or dlopen.
+/// Opens (and with `create`, first makes) the temp dir `path` for files bun
+/// later runs or loads by path. Refused when it or a directory above it is
+/// owned by another non-root user, who could otherwise swap those files.
 pub(crate) fn open_trusted_temp_dir(path: &[u8], create: bool) -> Result<sys::Dir, TempDirRefusal> {
     let dir = match sys::Dir::open(path) {
         Ok(dir) => dir,

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1441,16 +1441,12 @@ impl FFI {
                 &mut filepath_buf[..],
             ) {
                 Ok(Some(len)) => {
-                    // NUL-terminate in place so `DynLib::open`
-                    // can pass the slice to libc without copying. `resolve_*_to_buf`
-                    // is bounded by `Fs::FileSystem::tmpname` + a tmpdir join (both
-                    // fit in `PATH_MAX`), so `filepath_buf[len]` is in bounds.
+                    // NUL-terminate in place for `DynLib::open`; the result is a
+                    // tmpdir join bounded by `PATH_MAX`, so `len` is in bounds.
                     filepath_buf[len] = 0;
                     break 'brk &filepath_buf[0..len];
                 }
                 Ok(None) => {}
-                // Embedded, but the temp directory it would be extracted to
-                // was refused.
                 Err(refusal) => {
                     let system_error = SystemError {
                         code: bun_core::String::clone_utf8(b"ERR_DLOPEN_FAILED"),

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1435,17 +1435,33 @@ impl FFI {
             // can't see the bunfs virtual FS. The helper lives in
             // `crate::jsc_hooks` — same crate, so a direct call.
             let _ = vm;
-            if let Some(len) = crate::jsc_hooks::resolve_embedded_file_to_buf(
+            match crate::jsc_hooks::resolve_embedded_file_to_buf(
                 name_slice.slice(),
                 ext,
                 &mut filepath_buf[..],
             ) {
-                // NUL-terminate in place so `DynLib::open`
-                // can pass the slice to libc without copying. `resolve_*_to_buf`
-                // is bounded by `Fs::FileSystem::tmpname` + a tmpdir join (both
-                // fit in `PATH_MAX`), so `filepath_buf[len]` is in bounds.
-                filepath_buf[len] = 0;
-                break 'brk &filepath_buf[0..len];
+                Ok(Some(len)) => {
+                    // NUL-terminate in place so `DynLib::open`
+                    // can pass the slice to libc without copying. `resolve_*_to_buf`
+                    // is bounded by `Fs::FileSystem::tmpname` + a tmpdir join (both
+                    // fit in `PATH_MAX`), so `filepath_buf[len]` is in bounds.
+                    filepath_buf[len] = 0;
+                    break 'brk &filepath_buf[0..len];
+                }
+                Ok(None) => {}
+                // Embedded, but the temp directory it would be extracted to
+                // was refused.
+                Err(refusal) => {
+                    let system_error = SystemError {
+                        code: bun_core::String::clone_utf8(b"ERR_DLOPEN_FAILED"),
+                        message: bun_core::String::clone_utf8(
+                            &refusal.message(Fs::RealFS::tmpdir_path()),
+                        ),
+                        syscall: bun_core::String::clone_utf8(b"dlopen"),
+                        ..Default::default()
+                    };
+                    return Ok(system_error.to_error_instance(global));
+                }
             }
 
             break 'brk name_slice.slice();

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -624,6 +624,14 @@ impl CompileC {
             zstr!("-std=c11 -Wl,--export-all-symbols -g -O2")
         };
 
+        let compiler_rt_dir = CompilerRT::dir();
+        if compiler_rt_dir.is_none()
+            && let Some(refusal) = COMPILER_RT_DIR_REFUSAL.get()
+        {
+            global_this.throw(format_args!("{}", BStr::new(refusal)));
+            return Err(crate::Error::JSError);
+        }
+
         // TODO: correctly handle invalid user-provided options
         let state_ptr = match TCC::State::init::<CompileC, true>(&TCC::Config {
             options: Some(NonNull::from(compile_options)),
@@ -646,7 +654,7 @@ impl CompileC {
         // we hold the only reference for the rest of this function.
         let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
 
-        if let Some(compiler_rt_dir) = CompilerRT::dir() {
+        if let Some(compiler_rt_dir) = compiler_rt_dir {
             if state.add_sys_include_path(compiler_rt_dir).is_err() {
                 bun_output::scoped_log!(TCC, "TinyCC failed to add sysinclude path");
             }
@@ -2298,15 +2306,23 @@ impl CompilerRtSources {
 }
 
 static CREATE_COMPILER_RT_DIR_ONCE: Once = Once::new();
+/// Set when the temp dir was refused for its owner; `cc()` throws it.
+static COMPILER_RT_DIR_REFUSAL: OnceLock<Box<[u8]>> = OnceLock::new();
 
 impl CompilerRT {
     fn create_compiler_rt_dir() {
         // `bun_resolver::fs::FileSystem` (the inline canonical surface) doesn't
         // yet expose an inherent `tmpdir()`; reuse the crate-local
         // `FileSystemTmpdirExt` shim already in service for `jsc_hooks`.
-        use crate::cli::upgrade_command::FileSystemTmpdirExt as _;
-        let Ok(tmpdir) = Fs::FileSystem::instance().tmpdir() else {
-            return;
+        use crate::cli::upgrade_command::{FileSystemTmpdirExt as _, TempDirRefusal};
+        let tmpdir = match Fs::FileSystem::instance().tmpdir() {
+            Ok(tmpdir) => tmpdir,
+            Err(refusal @ TempDirRefusal::ForeignOwner { .. }) => {
+                let message = refusal.message(Fs::RealFS::tmpdir_path());
+                let _ = COMPILER_RT_DIR_REFUSAL.set(message.into_boxed_slice());
+                return;
+            }
+            Err(TempDirRefusal::Open(_)) => return,
         };
 
         // Prefer the reusable per-user directory; if it cannot be safely

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -44,7 +44,7 @@ use bun_resolver::fs as Fs;
 use bun_resolver::node_fallbacks;
 use bun_resolver::{GlobalCache, ResultUnion as ResolveResultUnion};
 
-use crate::cli::upgrade_command::FileSystemTmpdirExt as _;
+use crate::cli::upgrade_command::{FileSystemTmpdirExt as _, TempDirRefusal};
 use crate::timer;
 use crate::webcore::blob::BlobExt as _;
 
@@ -4613,20 +4613,39 @@ pub extern "C" fn Bun__transpileVirtualModule(
 ///
 /// The filename is a hash of the contents, so every `dlopen()` of the same
 /// embedded library — across calls, Worker VMs, and restarts — shares one
-/// file instead of leaking a copy per call (#29585). Returns `None` when the
-/// input is empty, absent from the graph, or a filesystem step fails.
+/// file instead of leaking a copy per call (#29585). Returns `Ok(None)` when
+/// the input is empty, absent from the graph, or a filesystem step fails, and
+/// `Err` when the temp directory is one whose files another user could
+/// replace before they are loaded.
 pub(crate) fn resolve_embedded_file_to_buf(
     input_path: &[u8],
     extname: &[u8],
     out_buf: &mut [u8],
-) -> Option<usize> {
+) -> Result<Option<usize>, TempDirRefusal> {
     if input_path.is_empty() {
-        return None;
+        return Ok(None);
     }
+    let Some(graph) = bun_standalone_graph::Graph::get_ref() else {
+        return Ok(None);
+    };
+    let Some(file) = graph.find_ref(input_path) else {
+        return Ok(None);
+    };
+    let tmpdir = (*Fs::FileSystem::instance()).tmpdir()?;
+    Ok(extract_embedded_file(
+        &tmpdir,
+        file.contents.as_bytes(),
+        extname,
+        out_buf,
+    ))
+}
 
-    let file = bun_standalone_graph::Graph::get_ref()?.find_ref(input_path)?;
-    let file_contents: &[u8] = file.contents.as_bytes();
-
+fn extract_embedded_file(
+    tmpdir: &bun_sys::Dir,
+    file_contents: &[u8],
+    extname: &[u8],
+    out_buf: &mut [u8],
+) -> Option<usize> {
     // `.bun-{uid}-{wyhash(contents)}.{ext}`: the hash dedupes; the uid keeps
     // users on a shared `/tmp` from colliding.
     let content_hash = bun_wyhash::hash(file_contents);
@@ -4643,11 +4662,18 @@ pub(crate) fn resolve_embedded_file_to_buf(
     )
     .ok()?;
 
+    let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
+    // `dlopen(2)` resolves the path again, so give it the real path of the
+    // directory `tmpdir()` checked instead of the `$TMPDIR` spelling: a
+    // symlink on the way there could live in a directory the check never saw.
+    let mut tmpdir_path_buf = bun_paths::path_buffer_pool::get();
+    let tmpdir_path: &[u8] = match bun_sys::get_fd_path(tmpdir_fd, &mut tmpdir_path_buf) {
+        Ok(real_path) => real_path,
+        Err(_) => Fs::RealFS::tmpdir_path(),
+    };
     // Reuse the canonical file from a previous run if it is still ours with
     // the right size. `lstatat` so a planted symlink fails the ISREG check
     // instead of being followed.
-    let tmpdir = (*Fs::FileSystem::instance()).tmpdir().ok()?;
-    let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
     if let Ok(st) = bun_sys::lstatat(tmpdir_fd, canonical_name) {
         let size_ok = st.st_size as usize == file_contents.len();
         #[cfg(unix)]
@@ -4655,11 +4681,7 @@ pub(crate) fn resolve_embedded_file_to_buf(
         #[cfg(windows)]
         let ours = true;
         if size_ok && ours {
-            return write_absolute(
-                out_buf,
-                Fs::RealFS::tmpdir_path(),
-                canonical_name.as_bytes(),
-            );
+            return write_absolute(out_buf, tmpdir_path, canonical_name.as_bytes());
         }
     }
 
@@ -4689,7 +4711,7 @@ pub(crate) fn resolve_embedded_file_to_buf(
     } else {
         scratch_name
     };
-    write_absolute(out_buf, Fs::RealFS::tmpdir_path(), final_name.as_bytes())
+    write_absolute(out_buf, tmpdir_path, final_name.as_bytes())
 }
 
 /// Writes `{tmpdir}/{name}` into `out_buf` and returns the length.
@@ -4716,8 +4738,13 @@ fn extract_owner_uid() -> u32 {
 }
 
 /// Support embedded .node files. `Dead` when `path` is not an embedded file.
+/// When the file is embedded but the temp directory it would be extracted to
+/// is refused, `error_message` says why and the result is `Dead` too.
 #[unsafe(no_mangle)]
-pub extern "C" fn Bun__resolveEmbeddedNodeFile(path: &bun_core::String) -> bun_core::String {
+pub extern "C" fn Bun__resolveEmbeddedNodeFile(
+    path: &bun_core::String,
+    error_message: &mut bun_core::String,
+) -> bun_core::String {
     bun_jsc::mark_binding();
     if VirtualMachine::get().standalone_module_graph.is_none() {
         return bun_core::String::DEAD;
@@ -4725,8 +4752,13 @@ pub extern "C" fn Bun__resolveEmbeddedNodeFile(path: &bun_core::String) -> bun_c
     let input_path = path.to_utf8();
     let mut path_buf = bun_paths::path_buffer_pool::get();
     match resolve_embedded_file_to_buf(input_path.slice(), b"node", &mut path_buf[..]) {
-        Some(len) => bun_core::String::clone_utf8(&path_buf[..len]),
-        None => bun_core::String::DEAD,
+        Ok(Some(len)) => bun_core::String::clone_utf8(&path_buf[..len]),
+        Ok(None) => bun_core::String::DEAD,
+        Err(refusal) => {
+            *error_message =
+                bun_core::String::clone_utf8(&refusal.message(Fs::RealFS::tmpdir_path()));
+            bun_core::String::DEAD
+        }
     }
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4613,10 +4613,9 @@ pub extern "C" fn Bun__transpileVirtualModule(
 ///
 /// The filename is a hash of the contents, so every `dlopen()` of the same
 /// embedded library — across calls, Worker VMs, and restarts — shares one
-/// file instead of leaking a copy per call (#29585). Returns `Ok(None)` when
-/// the input is empty, absent from the graph, or a filesystem step fails, and
-/// `Err` when the temp directory is one whose files another user could
-/// replace before they are loaded.
+/// file instead of leaking a copy per call (#29585). `Ok(None)` when the
+/// input is empty, absent from the graph, or a filesystem step fails; `Err`
+/// when the temp directory is refused (see `open_trusted_temp_dir`).
 pub(crate) fn resolve_embedded_file_to_buf(
     input_path: &[u8],
     extname: &[u8],
@@ -4663,9 +4662,8 @@ fn extract_embedded_file(
     .ok()?;
 
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
-    // `dlopen(2)` resolves the path again, so give it the real path of the
-    // directory `tmpdir()` checked instead of the `$TMPDIR` spelling: a
-    // symlink on the way there could live in a directory the check never saw.
+    // dlopen() gets the real path of the checked directory, not the `$TMPDIR`
+    // spelling, so a symlink on the way is not resolved a second time.
     let mut tmpdir_path_buf = bun_paths::path_buffer_pool::get();
     let tmpdir_path: &[u8] = match bun_sys::get_fd_path(tmpdir_fd, &mut tmpdir_path_buf) {
         Ok(real_path) => real_path,
@@ -4737,9 +4735,8 @@ fn extract_owner_uid() -> u32 {
     bun_sys::windows::user_unique_id()
 }
 
-/// Support embedded .node files. `Dead` when `path` is not an embedded file.
-/// When the file is embedded but the temp directory it would be extracted to
-/// is refused, `error_message` says why and the result is `Dead` too.
+/// Support embedded .node files. `Dead` when `path` is not an embedded file,
+/// or, with `error_message` set, when the temp directory was refused.
 #[unsafe(no_mangle)]
 pub extern "C" fn Bun__resolveEmbeddedNodeFile(
     path: &bun_core::String,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4631,8 +4631,19 @@ pub(crate) fn resolve_embedded_file_to_buf(
         return Ok(None);
     };
     let tmpdir = (*Fs::FileSystem::instance()).tmpdir()?;
+    // dlopen() gets the real path of the checked directory, so a symlink in the
+    // `$TMPDIR` spelling is not resolved a second time.
+    let mut tmpdir_path_buf = bun_paths::path_buffer_pool::get();
+    let tmpdir_path: &[u8] = match bun_sys::get_fd_path(tmpdir.fd, &mut tmpdir_path_buf) {
+        Ok(real_path) => real_path,
+        #[cfg(unix)]
+        Err(err) => return Err(TempDirRefusal::Open(err)),
+        #[cfg(not(unix))]
+        Err(_) => Fs::RealFS::tmpdir_path(),
+    };
     Ok(extract_embedded_file(
         &tmpdir,
+        tmpdir_path,
         file.contents.as_bytes(),
         extname,
         out_buf,
@@ -4641,6 +4652,7 @@ pub(crate) fn resolve_embedded_file_to_buf(
 
 fn extract_embedded_file(
     tmpdir: &bun_sys::Dir,
+    tmpdir_path: &[u8],
     file_contents: &[u8],
     extname: &[u8],
     out_buf: &mut [u8],
@@ -4662,13 +4674,6 @@ fn extract_embedded_file(
     .ok()?;
 
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
-    // dlopen() gets the real path of the checked directory, not the `$TMPDIR`
-    // spelling, so a symlink on the way is not resolved a second time.
-    let mut tmpdir_path_buf = bun_paths::path_buffer_pool::get();
-    let tmpdir_path: &[u8] = match bun_sys::get_fd_path(tmpdir_fd, &mut tmpdir_path_buf) {
-        Ok(real_path) => real_path,
-        Err(_) => Fs::RealFS::tmpdir_path(),
-    };
     // Reuse the canonical file from a previous run if it is still ours with
     // the right size. `lstatat` so a planted symlink fails the ISREG check
     // instead of being followed.

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -479,23 +479,18 @@ impl FdDirExt for Fd {
     }
 }
 
-/// A directory, at or above one that was checked, whose owner is neither the
-/// checking user nor root. `depth` 0 is the checked directory itself, 1 its
-/// parent, and so on up to the root.
+/// Result of `foreign_owned_ancestor`: the directory `depth` levels above the
+/// checked one (0 = itself) is owned by `uid`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ForeignOwner {
     pub depth: usize,
     pub uid: u32,
 }
 
-/// Finds the first directory, from `dir` up to the root, that a user other
-/// than `euid` and root owns.
-///
-/// The owner of a directory renames its entries whatever mode bits the entry
-/// itself has, so a file below `dir` that is found again by path is only as
-/// private as every directory above it. Walks `..` from `dir` instead of the
-/// components of a path, so the real parents of a symlinked directory are the
-/// ones checked, and the walk needs only search permission on them.
+/// First directory from `dir` up to `/` owned by neither `euid` nor root. A
+/// directory's owner can rename its entries, so a file found again by path is
+/// only as private as every directory above it. Walks `..` through the fd so
+/// the real parents are checked and only search permission is needed.
 #[cfg(all(unix, not(target_os = "android")))]
 pub fn foreign_owned_ancestor(dir: Fd, euid: u32) -> Maybe<Option<ForeignOwner>> {
     let foreign = |uid: u32| uid != euid && uid != 0 && Some(uid) != unmapped_uid();
@@ -536,10 +531,8 @@ pub fn foreign_owned_ancestor(dir: Fd, euid: u32) -> Maybe<Option<ForeignOwner>>
     }
 }
 
-/// Android gives every app its own uid and keeps apps out of each other's
-/// directories, and `/data` itself belongs to `system`, so the walk would
-/// refuse every temp directory there for a threat the platform already rules
-/// out.
+/// No-op on Android: apps are sandboxed per uid and `/data` belongs to
+/// `system`, so the walk would flag every temp directory.
 #[cfg(target_os = "android")]
 #[inline(always)]
 pub fn foreign_owned_ancestor(_dir: Fd, _euid: u32) -> Maybe<Option<ForeignOwner>> {
@@ -552,12 +545,9 @@ pub fn foreign_owned_ancestor(_dir: Fd, _euid: u32) -> Maybe<Option<ForeignOwner
     Ok(None)
 }
 
-/// Inside a user namespace that does not map every uid (rootless containers,
-/// toolbox, flatpak, bubblewrap sandboxes), a file whose owner has no mapping
-/// reports the overflow uid. That is what everything the host's root owns
-/// looks like from inside, so such an owner counts as root. The namespace's
-/// own `nobody` reports the same uid; that is accepted, since it is the same
-/// host user's sandbox either way.
+/// The overflow uid when inside a user namespace, else `None`. Unmapped owners
+/// (the host's root in rootless containers, toolbox, flatpak, bubblewrap)
+/// report that uid, so `foreign_owned_ancestor` treats it like root.
 #[cfg(target_os = "linux")]
 fn unmapped_uid() -> Option<u32> {
     static UNMAPPED_UID: std::sync::OnceLock<Option<u32>> = std::sync::OnceLock::new();
@@ -588,8 +578,7 @@ fn unmapped_uid() -> Option<u32> {
     None
 }
 
-/// Parses whitespace-separated decimal numbers into `out` and returns how many
-/// there were, counting (but not storing) the ones past `out.len()`.
+/// Parses whitespace-separated decimals into `out`; returns the total count.
 #[cfg(target_os = "linux")]
 fn decimal_fields(bytes: &[u8], out: &mut [u64]) -> usize {
     let mut count = 0usize;

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -597,7 +597,12 @@ fn decimal_fields(bytes: &[u8], out: &mut [u64]) -> usize {
     for &byte in bytes.iter().chain(core::iter::once(&b' ')) {
         if byte.is_ascii_digit() {
             let digit = u64::from(byte - b'0');
-            current = Some(current.unwrap_or(0).saturating_mul(10).saturating_add(digit));
+            current = Some(
+                current
+                    .unwrap_or(0)
+                    .saturating_mul(10)
+                    .saturating_add(digit),
+            );
         } else if let Some(value) = current.take() {
             if let Some(slot) = out.get_mut(count) {
                 *slot = value;

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -479,6 +479,135 @@ impl FdDirExt for Fd {
     }
 }
 
+/// A directory, at or above one that was checked, whose owner is neither the
+/// checking user nor root. `depth` 0 is the checked directory itself, 1 its
+/// parent, and so on up to the root.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ForeignOwner {
+    pub depth: usize,
+    pub uid: u32,
+}
+
+/// Finds the first directory, from `dir` up to the root, that a user other
+/// than `euid` and root owns.
+///
+/// The owner of a directory renames its entries whatever mode bits the entry
+/// itself has, so a file below `dir` that is found again by path is only as
+/// private as every directory above it. Walks `..` from `dir` instead of the
+/// components of a path, so the real parents of a symlinked directory are the
+/// ones checked, and the walk needs only search permission on them.
+#[cfg(all(unix, not(target_os = "android")))]
+pub fn foreign_owned_ancestor(dir: Fd, euid: u32) -> Maybe<Option<ForeignOwner>> {
+    let foreign = |uid: u32| uid != euid && uid != 0 && Some(uid) != unmapped_uid();
+    let mut st = fstat(dir)?;
+    if foreign(st.st_uid) {
+        return Ok(Some(ForeignOwner {
+            depth: 0,
+            uid: st.st_uid,
+        }));
+    }
+    let mut dots = bun_paths::path_buffer_pool::get();
+    let mut len = 0usize;
+    let mut depth = 0usize;
+    loop {
+        if len + b"/..".len() >= dots.len() {
+            return Err(Error::from_code_int(libc::ENAMETOOLONG, Tag::fstatat));
+        }
+        if len > 0 {
+            dots[len] = bun_paths::SEP;
+            len += 1;
+        }
+        dots[len..len + 2].copy_from_slice(b"..");
+        len += 2;
+        dots[len] = 0;
+        let up = fstatat(dir, ZStr::from_buf(&dots[..], len))?;
+        // ".." of the root is the root itself.
+        if up.st_dev == st.st_dev && up.st_ino == st.st_ino {
+            return Ok(None);
+        }
+        depth += 1;
+        if foreign(up.st_uid) {
+            return Ok(Some(ForeignOwner {
+                depth,
+                uid: up.st_uid,
+            }));
+        }
+        st = up;
+    }
+}
+
+/// Android gives every app its own uid and keeps apps out of each other's
+/// directories, and `/data` itself belongs to `system`, so the walk would
+/// refuse every temp directory there for a threat the platform already rules
+/// out.
+#[cfg(target_os = "android")]
+#[inline(always)]
+pub fn foreign_owned_ancestor(_dir: Fd, _euid: u32) -> Maybe<Option<ForeignOwner>> {
+    Ok(None)
+}
+
+#[cfg(not(unix))]
+#[inline(always)]
+pub fn foreign_owned_ancestor(_dir: Fd, _euid: u32) -> Maybe<Option<ForeignOwner>> {
+    Ok(None)
+}
+
+/// Inside a user namespace that does not map every uid (rootless containers,
+/// toolbox, flatpak, bubblewrap sandboxes), a file whose owner has no mapping
+/// reports the overflow uid. That is what everything the host's root owns
+/// looks like from inside, so such an owner counts as root. The namespace's
+/// own `nobody` reports the same uid; that is accepted, since it is the same
+/// host user's sandbox either way.
+#[cfg(target_os = "linux")]
+fn unmapped_uid() -> Option<u32> {
+    static UNMAPPED_UID: std::sync::OnceLock<Option<u32>> = std::sync::OnceLock::new();
+    *UNMAPPED_UID.get_or_init(|| {
+        let read = |path: &[u8]| {
+            File::openat(Fd::cwd(), path, O::RDONLY, 0)
+                .and_then(|file| file.read_to_end_small())
+                .ok()
+        };
+        let mut map = [0u64; 4];
+        // One line "0 0 4294967295": every uid maps onto itself, none is unmapped.
+        if decimal_fields(&read(b"/proc/self/uid_map")?, &mut map) == 3
+            && map[..3] == [0, 0, 4294967295]
+        {
+            return None;
+        }
+        let mut overflow = [65534u64; 1];
+        if let Some(bytes) = read(b"/proc/sys/kernel/overflowuid") {
+            decimal_fields(&bytes, &mut overflow);
+        }
+        u32::try_from(overflow[0]).ok()
+    })
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[inline(always)]
+fn unmapped_uid() -> Option<u32> {
+    None
+}
+
+/// Parses whitespace-separated decimal numbers into `out` and returns how many
+/// there were, counting (but not storing) the ones past `out.len()`.
+#[cfg(target_os = "linux")]
+fn decimal_fields(bytes: &[u8], out: &mut [u64]) -> usize {
+    let mut count = 0usize;
+    let mut current: Option<u64> = None;
+    for &byte in bytes.iter().chain(core::iter::once(&b' ')) {
+        if byte.is_ascii_digit() {
+            let digit = u64::from(byte - b'0');
+            current = Some(current.unwrap_or(0).saturating_mul(10).saturating_add(digit));
+        } else if let Some(value) = current.take() {
+            if let Some(slot) = out.get_mut(count) {
+                *slot = value;
+            }
+            count += 1;
+        }
+    }
+    count
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1952,11 +1952,7 @@ describe("embedded addon extraction and the temp directory", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [, buildStderr, buildExit] = await Promise.all([
-        build.stdout.text(),
-        build.stderr.text(),
-        build.exited,
-      ]);
+      const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
       expect(buildStderr).not.toContain("error:");
       expect(buildExit).toBe(0);
       return { dir: cwd, exe: join(cwd, "app") };

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
-import { rmSync } from "fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import { chmodSync, chownSync, readdirSync, rmSync, symlinkSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
@@ -1922,4 +1922,117 @@ test("a standalone executable does not run a synchronous full GC after loading i
   expect(stderr).toMatch(/\[GC<(0x)?[0-9a-fA-F]+>: starting /); // %p: "0x7f…" on POSIX, "00007FF6…" on Windows
   expect(stderr).not.toContain("FullCollection");
   expect(exitCode).toBe(0);
+});
+
+// A standalone executable writes each embedded native library into the temp
+// dir and loads it back with dlopen() by path. The owner of a directory
+// renames any entry in it whatever that entry's own mode bits say, so a user
+// who owns the temp dir, or a directory above it, could swap the file for one
+// of their own between the write and the load. Unix only: the rule is about
+// uids.
+describe("embedded addon extraction and the temp directory", () => {
+  // Not a real addon, so the load always fails, and the dlopen() error names
+  // the path it got. What these tests read is whether bun put the bytes in
+  // the temp dir at all, and which path it loaded them by.
+  let built: Promise<{ dir: string; exe: string }> | undefined;
+  afterAll(async () => {
+    if (built) rmSync((await built).dir, { recursive: true, force: true });
+  });
+  const buildOnce = () =>
+    (built ??= (async () => {
+      const dir = tempDir("compile-embedded-addon-temp-dir", {
+        "fake.node": "not an addon\n",
+        "app.js": `try { require("./fake.node"); } catch (e) { console.log("load failed: " + e.message); }`,
+      });
+      const cwd = String(dir);
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "app.js", "--outfile", "app"],
+        env: bunEnv,
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, buildStderr, buildExit] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      expect(buildStderr).not.toContain("error:");
+      expect(buildExit).toBe(0);
+      return { dir: cwd, exe: join(cwd, "app") };
+    })());
+
+  const runWithTempDir = async (tmp: string) => {
+    const { dir, exe } = await buildOnce();
+    await using proc = Bun.spawn({
+      cmd: [exe],
+      env: { ...bunEnv, BUN_TMPDIR: tmp, TMPDIR: tmp },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  };
+  const extracted = (tmp: string) => readdirSync(tmp).filter(entry => entry.endsWith(".node"));
+
+  test.skipIf(isWindows)(
+    "loads the addon by the real path of the temp directory",
+    async () => {
+      // World-writable without the sticky bit is what a disk-backed Kubernetes
+      // emptyDir or a `chmod 777 /tmp` image looks like. The owner is still
+      // us, so it is accepted.
+      using ours = tempDir("compile-embedded-addon-ours", {});
+      chmodSync(String(ours), 0o777);
+      {
+        const [stdout, stderr, exitCode] = await runWithTempDir(String(ours));
+        expect(stderr).toBe("");
+        expect(extracted(String(ours))).toHaveLength(1);
+        expect(stdout).toStartWith("load failed: ");
+        expect(stdout).toContain(join(String(ours), extracted(String(ours))[0]));
+        expect(exitCode).toBe(0);
+      }
+
+      // Reached through a symlink, the directory is checked where it really
+      // lives and the addon is loaded by its real path: the symlink itself
+      // could sit in a directory that someone else owns, who could point it
+      // elsewhere between the check and the load.
+      using other = tempDir("compile-embedded-addon-link", {});
+      const link = join(String(other), "temp");
+      symlinkSync(String(ours), link);
+      {
+        const [stdout, stderr, exitCode] = await runWithTempDir(link);
+        expect(stderr).toBe("");
+        expect(stdout).toStartWith("load failed: ");
+        expect(stdout).toContain(join(String(ours), extracted(String(ours))[0]));
+        expect(stdout).not.toContain(link);
+        expect(exitCode).toBe(0);
+      }
+    },
+    60_000,
+  );
+
+  // Making a directory that another user owns takes root.
+  test.skipIf(isWindows || process.getuid?.() !== 0)(
+    "refuses a temp directory that another local user owns",
+    async () => {
+      const otherUser = 4242;
+      using foreign = tempDir("compile-embedded-addon-foreign", { "below": {} });
+      chownSync(String(foreign), otherUser, otherUser);
+
+      for (const [tmp, culprit] of [
+        [String(foreign), "it"],
+        [join(String(foreign), "below"), `"${foreign}" above it`],
+      ]) {
+        const [stdout, stderr, exitCode] = await runWithTempDir(tmp);
+        // process.dlopen() throws the refusal itself, so the program sees why.
+        expect(stdout).toBe(
+          `load failed: refusing to use temp directory "${tmp}": ${culprit} is owned by uid ${otherUser}, not by the current user or root, so that user could replace the files bun puts there. Point TMPDIR (or BUN_TMPDIR) at a directory you own.\n`,
+        );
+        expect(stderr).toBe("");
+        expect(extracted(tmp)).toHaveLength(0);
+        expect(exitCode).toBe(0);
+      }
+    },
+    60_000,
+  );
 });

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { upgrade_test_helpers } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { bunExe, bunEnv as env, isMusl, isWindows, tempDir, tls, tmpdirSync } from "harness";
-import { existsSync, statSync } from "node:fs";
+import { chownSync, existsSync, readdirSync, statSync } from "node:fs";
 import { copyFile, writeFile } from "node:fs/promises";
 import { basename, join } from "path";
 const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
@@ -349,6 +349,50 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
   // The bogus archive must not be installed; the upgrade fails cleanly.
   expect(exitCode).toBe(1);
 });
+
+// The staging directory is created under the temp dir and the new binary is
+// unpacked and run from it by path. The owner of a directory renames any
+// entry in it whatever that entry's own mode bits say, so a user who owns the
+// temp dir could swap the staging directory for their own between the
+// download and the exec. Making a directory that another user owns takes
+// root.
+it.skipIf(isWindows || process.getuid?.() !== 0)(
+  "refuses to stage the download in a temp dir that another local user owns",
+  async () => {
+    const tagName = "bun-v9.9.9";
+    const otherUser = 4242;
+    using stagingRoot = tempDir("bun-upgrade-foreign-staging", {});
+    const stagingRootPath = String(stagingRoot);
+    chownSync(stagingRootPath, otherUser, otherUser);
+
+    using server = startReleaseServer({ tagName });
+
+    const cwd = tmpdirSync();
+    const execPath = join(cwd, basename(bunExe()));
+    await copyFile(bunExe(), execPath);
+
+    await using proc = Bun.spawn({
+      cmd: [execPath, "upgrade", "--stable"],
+      cwd,
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...server.env,
+        BUN_TMPDIR: stagingRootPath,
+      },
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("9.9.9");
+    expect(stderr).toContain(
+      `error: refusing to use temp directory "${stagingRootPath}": it is owned by uid ${otherUser}, not by the current user or root`,
+    );
+    expect(readdirSync(stagingRootPath)).toEqual([]);
+    expect(exitCode).toBe(1);
+  },
+);
 
 it("verifies the downloaded release archive against the digest reported by the release asset", async () => {
   const archiveBody = "this is not a real zip archive";

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
-import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
+import { chmodSync, chownSync, copyFileSync, readdirSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
@@ -1326,6 +1326,131 @@ it.concurrent.skipIf(isWindows)(
     }
   },
 );
+
+// The cache root check above starts at the first path component below the
+// temp dir, so it says nothing about the temp dir itself or the directories
+// above it. The owner of a directory renames any entry in it whatever that
+// entry's own mode bits say, so a user who owns one of those directories can
+// swap the whole cache root for a tree of their own after bunx checked it.
+// bunx refuses such a temp dir before it reads or writes anything under it.
+// Making a directory that another user owns takes root.
+it.concurrent.skipIf(isWindows || process.getuid?.() !== 0)(
+  "refuses a temp directory that another local user owns",
+  async () => {
+    const { x_dir, env } = setup();
+    const pkg = "bunx-temp-dir-fixture";
+    const otherUser = 4242;
+
+    const run = (tmp: string) => {
+      const subprocess = spawn({
+        cmd: [bunExe(), "x", "--no-install", pkg],
+        cwd: x_dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: { ...env, TEMP: tmp, TMPDIR: tmp, BUN_TMPDIR: tmp },
+      });
+      return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+    };
+
+    const foreign = tmpdirSync();
+    chownSync(foreign, otherUser, otherUser);
+    await mkdir(join(foreign, "ours"));
+
+    // The foreign directory itself, a directory of ours below it, and one
+    // below it that does not exist yet (bunx creates it, then sees who owns
+    // what above it) are all refused, naming the directory and its owner.
+    for (const [tmp, culprit] of [
+      [foreign, "it"],
+      [join(foreign, "ours"), `"${foreign}" above it`],
+      [join(foreign, "missing", "temp"), `"${foreign}" above it`],
+    ]) {
+      const [err, out, exitCode] = await run(tmp);
+      expect(err).toContain(
+        `error: refusing to use temp directory "${tmp}": ${culprit} is owned by uid ${otherUser}, not by the current user or root`,
+      );
+      expect(err).not.toContain(`Could not find an existing '${pkg}' binary to run.`);
+      expect(out).toHaveLength(0);
+      expect(exitCode).toBe(1);
+    }
+
+    // Handed back to us, the same directories are accepted: bunx gets past
+    // the check and fails later with the normal --no-install message.
+    chownSync(foreign, 0, 0);
+    for (const tmp of [foreign, join(foreign, "ours"), join(foreign, "missing", "temp")]) {
+      const [err, out, exitCode] = await run(tmp);
+      expect(err).not.toContain("temp directory");
+      expect(err).toContain(`Could not find an existing '${pkg}' binary to run.`);
+      expect(out).toHaveLength(0);
+      expect(exitCode).toBe(1);
+    }
+  },
+);
+
+// Mode bits alone do not make bunx refuse a temp dir: a world-writable
+// directory without the sticky bit is what a disk-backed Kubernetes emptyDir
+// or a `chmod 777 /tmp` container image looks like, and the owner is still us
+// or root there. A temp dir that does not exist yet is created.
+it.concurrent.skipIf(isWindows)("accepts a temp directory of ours whatever its mode bits", async () => {
+  const { x_dir, env } = setup();
+  const pkg = "bunx-temp-dir-mode-fixture";
+
+  chmodSync(env.TMPDIR, 0o777);
+  for (const tmp of [env.TMPDIR, join(env.TMPDIR, "missing", "temp")]) {
+    await using subprocess = spawn({
+      cmd: [bunExe(), "x", "--no-install", pkg],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: { ...env, TEMP: tmp, TMPDIR: tmp, BUN_TMPDIR: tmp },
+    });
+    const [err, out, exitCode] = await Promise.all([
+      subprocess.stderr.text(),
+      subprocess.stdout.text(),
+      subprocess.exited,
+    ]);
+    expect(err).not.toContain("temp directory");
+    expect(err).toContain(`Could not find an existing '${pkg}' binary to run.`);
+    expect(statSync(tmp).isDirectory()).toBe(true);
+    expect(out).toHaveLength(0);
+    expect(exitCode).toBe(1);
+  }
+});
+
+// A temp dir that is reached through a symlink is checked where it really
+// lives, and from then on bunx uses its real path: the symlink itself could
+// sit in a directory that someone else owns, who could point it elsewhere
+// between the check and the exec.
+it.concurrent.skipIf(isWindows)("runs a cached binary by the real path of a symlinked temp directory", async () => {
+  const { x_dir, env } = setup();
+  const pkg = "bunx-temp-dir-symlink-fixture";
+
+  // A cache entry made by hand, the way an earlier `bunx` run leaves it.
+  const bin = join(env.TMPDIR, `bunx-${process.getuid!()}-${pkg}@latest`, "node_modules", ".bin", pkg);
+  await mkdir(join(bin, ".."), { recursive: true });
+  await writeFile(bin, `#!/bin/sh\necho "ran $0"\n`, { mode: 0o755 });
+
+  const link = join(tmpdirSync(), "temp");
+  symlinkSync(env.TMPDIR, link);
+
+  await using subprocess = spawn({
+    cmd: [bunExe(), "x", "--no-install", pkg],
+    cwd: x_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env: { ...env, TEMP: link, TMPDIR: link, BUN_TMPDIR: link },
+  });
+  const [err, out, exitCode] = await Promise.all([
+    subprocess.stderr.text(),
+    subprocess.stdout.text(),
+    subprocess.exited,
+  ]);
+  expect(err).not.toContain("refusing to use temp directory");
+  expect(out).toBe(`ran ${bin}\n`);
+  expect(exitCode).toBe(0);
+});
 
 it.concurrent.skipIf(isWindows)(
   "validates every path component of a scoped package's bunx cache directory",

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1426,10 +1426,14 @@ it.concurrent.skipIf(isWindows)("runs a cached binary by the real path of a syml
   const { x_dir, env } = setup();
   const pkg = "bunx-temp-dir-symlink-fixture";
 
-  // A cache entry made by hand, the way an earlier `bunx` run leaves it.
-  const bin = join(env.TMPDIR, `bunx-${process.getuid!()}-${pkg}@latest`, "node_modules", ".bin", pkg);
+  // A cache entry made by hand, the way an earlier `bunx` run leaves it
+  // (0755, since the cache-root check refuses group/other-writable dirs).
+  const cacheRoot = join(env.TMPDIR, `bunx-${process.getuid!()}-${pkg}@latest`);
+  const bin = join(cacheRoot, "node_modules", ".bin", pkg);
   await mkdir(join(bin, ".."), { recursive: true });
+  for (const dir of [cacheRoot, join(cacheRoot, "node_modules"), join(bin, "..")]) chmodSync(dir, 0o755);
   await writeFile(bin, `#!/bin/sh\necho "ran $0"\n`, { mode: 0o755 });
+  chmodSync(bin, 0o755);
 
   const link = join(tmpdirSync(), "temp");
   symlinkSync(env.TMPDIR, link);

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -2,6 +2,7 @@ import { cc, CString, JSCallback, ptr, type FFIFunction, type Library } from "bu
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import {
   chmodSync,
+  chownSync,
   existsSync,
   promises as fs,
   mkdirSync,
@@ -1189,6 +1190,45 @@ describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", ()
     expect(exitCode).toBe(0);
   });
 });
+
+// The owner of the temp dir could swap the staged headers for their own before
+// TinyCC reads them, so cc() refuses before it compiles anything (hence no ASan
+// skip). Making a directory another user owns takes root.
+it.skipIf(isWindows || process.getuid?.() !== 0)(
+  "cc() does not stage compiler runtime headers in a temp directory that another local user owns",
+  async () => {
+    const otherUser = 4242;
+    using dir = tempDir("bun-ffi-cc-rt-dir-foreign", {
+      "add.c": `int add(int a, int b) { return a + b; }\n`,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "add.c"),
+          symbols: { add: { args: ["int", "int"], returns: "int" } },
+        });
+        console.log(symbols.add(1, 2));
+      `,
+    });
+    chownSync(String(dir), otherUser, otherUser);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: { ...bunEnv, BUN_TMPDIR: String(dir) },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(readdirSync(String(dir)).sort()).toEqual(["add.c", "fixture.js"]);
+    expect(stderr).toContain(
+      `refusing to use temp directory "${dir}": it is owned by uid ${otherUser}, not by the current user or root`,
+    );
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  },
+);
 
 // The gate runs before any option is read or any C is compiled, so these do
 // not need a working TinyCC and run under ASan too. Without the gate, the


### PR DESCRIPTION
### Problem
- bun writes code into the temp directory and then runs or loads it again by path: the bunx cache tree, the native addons embedded in a compiled executable, the `bun upgrade` download. The owner of a directory can rename any entry in it, whatever that entry's mode bits say. With `$TMPDIR` set to a directory another user owns, that user exchanged root's verified `bunx-0-<pkg>@latest` for a tree of their own and root ran the planted bin (4/200 runs on 1.4.2). The same swap works on the extracted `.bun-<uid>-<hash>.node` between its `lstat` and the `dlopen`, and on the `bun upgrade` staging directory between the download and the exec.
- `is_trusted_cache_root` (`src/runtime/cli/bunx_command.rs`) starts its walk at the first component below the temp dir, so the temp dir and its parents were never checked. `resolve_embedded_file_to_buf` (`src/runtime/jsc_hooks.rs`) and `bun upgrade` used the temp dir with no check at all.

### Fix
- `bun_sys::foreign_owned_ancestor(fd, euid)` walks `..` from an open directory up to the root and reports the first directory whose owner is neither the current user nor root. `open_trusted_temp_dir` (`upgrade_command.rs`) opens the temp dir, runs that walk, and on refusal names the directory and its uid. bunx, `bun upgrade`, embedded addon extraction (`process.dlopen` and `bun:ffi`), and the cc() header directory go through it.
- bunx and the addon path then use the real path of the checked directory, so a symlink on the way to `$TMPDIR` is not resolved a second time through a directory the walk never saw. bunx creates a missing `$TMPDIR` first and checks it through the fd.
- Mode bits are not part of the rule, and inside a Linux user namespace the overflow uid counts as root. See Background.
- Verified: new tests in `test/cli/install/bunx.test.ts`, `test/bundler/bundler_compile.test.ts`, `test/cli/install/bun-upgrade.test.ts` (the refusal cases need root to `chown` and skip otherwise). The existing bunx cache-root tests and `test/regression/issue/29585.test.ts` still pass.

### Background
- On Unix, renaming or unlinking a directory entry needs write permission on the directory, not on the entry. The directory's owner can always grant themselves that. So a file is only as private as every directory above it, and `renameat2(RENAME_EXCHANGE)` makes the swap atomic.
- Walking `..` from the opened fd (instead of the path's components) checks the real parents even when `$TMPDIR` is reached through a symlink, and needs only search permission.
- A world-writable directory without the sticky bit would also allow the swap, but that is exactly what a disk-backed Kubernetes `emptyDir` mounted at `/tmp` or a `chmod 777 /tmp` image looks like, with root still the owner. Refusing those would break compiled executables and bunx in common single-tenant containers, so the rule is ownership only.
- In a rootless container, toolbox, flatpak, or bubblewrap sandbox, the host's root is not mapped into the user namespace and its directories report the overflow uid (65534). No refusal there: the check reads `/proc/self/uid_map` once and, outside the initial namespace, treats the overflow uid like root.

<details><summary>Notes</summary>

- Reported by an internal fuzzing pass against 1.4.2 and canary with `TMPDIR` set to a 0777 directory owned by uid 65534 and root as the victim. In the default root-owned sticky `/tmp` every plant shape was already refused by the existing leaf checks; this only matters when `$TMPDIR` (or a directory above it) belongs to another non-root user: a shared scratch directory, or `su`/`sudo -E` with an inherited per-user `TMPDIR`.
- Error text, bunx and `bun upgrade` (exit 1): `error: refusing to use temp directory "/scratch/t": it is owned by uid 65534, not by the current user or root, so that user could replace the files bun puts there. Point TMPDIR (or BUN_TMPDIR) at a directory you own.` For a parent: `... "/scratch" above it is owned by uid 65534 ...`. `process.dlopen()` / `require()` of an embedded `.node` and `bun:ffi` `dlopen()` of an embedded library throw the same text as `ERR_DLOPEN_FAILED` instead of failing later with `cannot open shared object file` on the `/$bunfs/` path. `bun:ffi` `cc()` throws it instead of compiling without its bundled headers. If the real path of the checked directory cannot be resolved (no `/proc` on Linux), bunx and the addon path refuse with `cannot use temp directory ...: <errno>` rather than fall back to the `$TMPDIR` spelling.
- Android: the check is a no-op. Apps have their own uids and cannot reach each other's directories, and `/data` belongs to `system`, so the walk would refuse every temp dir there.
- macOS: `$TMPDIR` is `/var/folders/xx/<id>/T` (user-owned, parents root-owned), which passes. Because bunx and the addon path now use the real path of the checked directory, the bunx cache path and the extracted addon path are spelled `/private/var/...` there. `bun pm cache rm` lists the same directory.
- Not covered here, same class: `bun install` stages tarball extraction under the temp dir before moving it into the cache when both are on one filesystem. #31447 (bunx cache under the per-user install cache) would make the bunx part of this mostly moot but keeps a `$TMPDIR` fallback.
- I first had the rule include group/other-writable-without-sticky. Review found it refuses Kubernetes disk-backed `emptyDir` at `/tmp` (created 0777 by the kubelet), `chmod 777 /tmp` images, and `umask 002` home directories, so I dropped it. The fuzzer's precondition was ownership.
- Self-reviewed: 7 concerns raised, 6 addressed (false refusals from the mode rule, user namespaces, Android, the create race for a missing `$TMPDIR`, misleading message on open failure, the message naming `$TMPDIR` when `BUN_TMPDIR` is the knob). Not addressed: bunx now needs read permission on `$TMPDIR` itself to open it (a `1733` `/tmp` is refused with `cannot use temp directory ...: EACCES`); the other callers already opened it that way.
</details>
