### PR TITLE
npmrc: cut inline comments and read boolean options (ignore-scripts=1 etc.) the way npm does

### DIFF
--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1235,8 +1235,7 @@ mod draft {
     // loadNpmrcConfig / loadNpmrc
     // ──────────────────────────────────────────────────────────────────────────
 
-    /// npm's Boolean coercion (`@npmcli/config` parse-field + nopt `validateBoolean`):
-    /// only `false`, `null` and a numeric zero are false; `undefined` keeps the default.
+    /// npm's Boolean coercion: `@npmcli/config` parse-field, then nopt `validateBoolean`.
     fn npmrc_bool(expr: &Expr) -> Option<bool> {
         match &expr.data {
             ExprData::EBoolean(b) => Some(b.value),

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -632,8 +632,7 @@ mod draft {
                                 unesc.push(b'$');
                             }
                             b';' | b'#' => {
-                                // ini cuts an unquoted string at the first unescaped
-                                // comment char and trims what is left
+                                // the rest of the line is a comment (ini `unsafe()`)
                                 let kept = bun_core::trim_right(&unesc, b" \n\r\t").len();
                                 unesc.truncate(kept);
                                 did_any_escape = true;

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1235,11 +1235,8 @@ mod draft {
     // loadNpmrcConfig / loadNpmrc
     // ──────────────────────────────────────────────────────────────────────────
 
-    /// A Boolean `.npmrc` option gets the value npm gives it (`@npmcli/config`
-    /// parse-field, then nopt's `validateBoolean`): a bare key or an empty
-    /// value is true, `false`, `null` and a numeric zero are false,
-    /// `undefined` keeps the default, and every other string (`1`, `True`,
-    /// `yes`, even `no`) is true.
+    /// npm's Boolean coercion (`@npmcli/config` parse-field + nopt `validateBoolean`):
+    /// only `false`, `null` and a numeric zero are false; `undefined` keeps the default.
     fn npmrc_bool(expr: &Expr) -> Option<bool> {
         match &expr.data {
             ExprData::EBoolean(b) => Some(b.value),

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -122,7 +122,7 @@ bun_core::comptime_string_map! {
 
 pub use draft::{
     ConfigIterator, Parser, RegistryAuth, ScopeItem, ScopeIterator, ToStringFormatter,
-    apply_registry_auth, load_npmrc, load_npmrc_config,
+    apply_registry_auth, load_npmrc, load_npmrc_config, npm_config_bool,
 };
 
 mod draft {
@@ -631,7 +631,14 @@ mod draft {
                                 }
                                 unesc.push(b'$');
                             }
-                            b';' | b'#' => break,
+                            b';' | b'#' => {
+                                // ini cuts an unquoted string at the first unescaped
+                                // comment char and trims what is left
+                                let kept = bun_core::trim_right(&unesc, b" \n\r\t").len();
+                                unesc.truncate(kept);
+                                did_any_escape = true;
+                                break;
+                            }
                             b'\\' => {
                                 esc = true;
                                 did_any_escape = true;
@@ -1236,26 +1243,25 @@ mod draft {
     // ──────────────────────────────────────────────────────────────────────────
 
     /// npm's Boolean coercion: `@npmcli/config` parse-field, then nopt `validateBoolean`.
+    pub fn npm_config_bool(value: &[u8]) -> bool {
+        let value = bun_core::trim(value, b" \n\r\t");
+        if value == b"false" || value == b"null" || value == b"undefined" {
+            return false;
+        }
+        let numeric_zero = core::str::from_utf8(value)
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .is_some_and(|n| n == 0.0);
+        !numeric_zero
+    }
+
     fn npmrc_bool(expr: &Expr) -> Option<bool> {
         match &expr.data {
             ExprData::EBoolean(b) => Some(b.value),
-            ExprData::ENull(_) => Some(false),
+            ExprData::ENull(_) | ExprData::EUndefined(_) => Some(false),
             // a single-quoted `'1'` is JSON-parsed to a number, as in ini
             ExprData::ENumber(_) => expr.as_number().map(|n| n != 0.0),
-            ExprData::EString(_) => {
-                let str_ = bun_core::trim(expr.as_utf8_string_literal()?, b" \n\r\t");
-                if str_ == b"undefined" {
-                    return None;
-                }
-                if str_ == b"false" || str_ == b"null" {
-                    return Some(false);
-                }
-                let numeric_zero = core::str::from_utf8(str_)
-                    .ok()
-                    .and_then(|s| s.parse::<f64>().ok())
-                    .is_some_and(|n| n == 0.0);
-                Some(!numeric_zero)
-            }
+            ExprData::EString(_) => expr.as_utf8_string_literal().map(npm_config_bool),
             _ => None,
         }
     }

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1244,6 +1244,8 @@ mod draft {
         match &expr.data {
             ExprData::EBoolean(b) => Some(b.value),
             ExprData::ENull(_) => Some(false),
+            // a single-quoted `'1'` is JSON-parsed to a number, as in ini
+            ExprData::ENumber(_) => expr.as_number().map(|n| n != 0.0),
             ExprData::EString(_) => {
                 let str_ = bun_core::trim(expr.as_utf8_string_literal()?, b" \n\r\t");
                 if str_ == b"undefined" {

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1235,6 +1235,33 @@ mod draft {
     // loadNpmrcConfig / loadNpmrc
     // ──────────────────────────────────────────────────────────────────────────
 
+    /// A Boolean `.npmrc` option gets the value npm gives it (`@npmcli/config`
+    /// parse-field, then nopt's `validateBoolean`): a bare key or an empty
+    /// value is true, `false`, `null` and a numeric zero are false,
+    /// `undefined` keeps the default, and every other string (`1`, `True`,
+    /// `yes`, even `no`) is true.
+    fn npmrc_bool(expr: &Expr) -> Option<bool> {
+        match &expr.data {
+            ExprData::EBoolean(b) => Some(b.value),
+            ExprData::ENull(_) => Some(false),
+            ExprData::EString(_) => {
+                let str_ = bun_core::trim(expr.as_utf8_string_literal()?, b" \n\r\t");
+                if str_ == b"undefined" {
+                    return None;
+                }
+                if str_ == b"false" || str_ == b"null" {
+                    return Some(false);
+                }
+                let numeric_zero = core::str::from_utf8(str_)
+                    .ok()
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .is_some_and(|n| n == 0.0);
+                Some(!numeric_zero)
+            }
+            _ => None,
+        }
+    }
+
     pub fn load_npmrc_config(
         install: &mut BunInstall,
         env: &DotEnvLoader,
@@ -1360,9 +1387,7 @@ mod draft {
         }
 
         if let Some(query) = out.as_property(b"dry-run") {
-            if let Some(str_) = query.expr.as_utf8_string_literal() {
-                install.dry_run = Some(str_ == b"true");
-            } else if let Some(b) = query.expr.as_bool() {
+            if let Some(b) = npmrc_bool(&query.expr) {
                 install.dry_run = Some(b);
             }
         }
@@ -1444,19 +1469,19 @@ mod draft {
         }
 
         if let Some(ignore_scripts) = out.get(b"ignore-scripts") {
-            if let Some(ignore) = ignore_scripts.as_bool() {
+            if let Some(ignore) = npmrc_bool(&ignore_scripts) {
                 install.ignore_scripts = Some(ignore);
             }
         }
 
         if let Some(link_workspace_packages) = out.get(b"link-workspace-packages") {
-            if let Some(link) = link_workspace_packages.as_bool() {
+            if let Some(link) = npmrc_bool(&link_workspace_packages) {
                 install.link_workspace_packages = Some(link);
             }
         }
 
         if let Some(save_exact) = out.get(b"save-exact") {
-            if let Some(exact) = save_exact.as_bool() {
+            if let Some(exact) = npmrc_bool(&save_exact) {
                 install.exact = Some(exact);
             }
         }
@@ -1507,7 +1532,7 @@ mod draft {
         }
 
         if let Some(hoist_expr) = out.get(b"hoist") {
-            if let Some(hoist) = hoist_expr.as_bool() {
+            if let Some(hoist) = npmrc_bool(&hoist_expr) {
                 install.hoist = Some(hoist);
             }
         }

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -120,9 +120,17 @@ impl IniTestingAPIs {
             default_registry_username: BunString,
             default_registry_password: BunString,
             default_registry_email: BunString,
+            ignore_scripts: Option<bool>,
+            link_workspace_packages: Option<bool>,
+            save_exact: Option<bool>,
+            hoist: Option<bool>,
+            dry_run: Option<bool>,
+        }
+        fn optional_bool(b: Option<bool>) -> JSValue {
+            b.map_or(JSValue::UNDEFINED, JSValue::js_boolean)
         }
         impl bun_jsc::js_object::PojoFields for Pojo {
-            const FIELD_COUNT: usize = 5;
+            const FIELD_COUNT: usize = 10;
             fn put_fields(
                 &self,
                 global: &JSGlobalObject,
@@ -148,6 +156,14 @@ impl IniTestingAPIs {
                     b"default_registry_email",
                     self.default_registry_email.to_js(global)?,
                 )?;
+                put(b"ignore_scripts", optional_bool(self.ignore_scripts))?;
+                put(
+                    b"link_workspace_packages",
+                    optional_bool(self.link_workspace_packages),
+                )?;
+                put(b"save_exact", optional_bool(self.save_exact))?;
+                put(b"hoist", optional_bool(self.hoist))?;
+                put(b"dry_run", optional_bool(self.dry_run))?;
                 Ok(())
             }
         }
@@ -157,6 +173,11 @@ impl IniTestingAPIs {
             default_registry_username,
             default_registry_password,
             default_registry_email,
+            ignore_scripts: install.ignore_scripts,
+            link_workspace_packages: install.link_workspace_packages,
+            save_exact: install.exact,
+            hoist: install.hoist,
+            dry_run: install.dry_run,
         };
         Ok(bun_jsc::JSObject::create(&pojo, global)?.to_js())
     }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -139,6 +139,31 @@ test.concurrent("ignore-scripts is read from npmrc", async () => {
   expect(await checkScripts()).toEqual([true, true]);
 });
 
+// npm treats every value of a Boolean option other than `false`, `null` and a
+// numeric zero as true, so a CI .npmrc written for npm must skip scripts here too
+test.concurrent.each(["ignore-scripts=1", "ignore-scripts=True", "ignore-scripts="])("%s in npmrc", async line => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.2.3",
+        dependencies: { "no-deps": "1.0.0" },
+        scripts: {
+          postinstall: `${bunExe()} -e 'await Bun.write("postinstall.txt", "postinstall!!")'`,
+        },
+      }),
+    ),
+    write(join(packageDir, ".npmrc"), line),
+  ]);
+
+  await runBunInstall(env, packageDir);
+  expect(await exists(join(packageDir, "node_modules", "no-deps", "package.json"))).toBe(true);
+  expect(await exists(join(packageDir, "postinstall.txt"))).toBe(false);
+});
+
 test.concurrent("trustedDependencies matches the resolved package name, not the dependency alias", async () => {
   using ctx = await setupTest();
   const { packageDir, packageJson, env } = ctx;

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -550,8 +550,25 @@ registry=https://somehost.com/org1/npm/registry/
     expect(result.default_registry_token).toBe("");
   });
 
-  // npm (nopt Boolean): a bare key or an empty value is true, `false`, `null`
-  // and a numeric zero are false, and every other string is true
+  test("an inline comment is not part of the registry url or the auth token", () => {
+    // ini cuts an unquoted value at the first unescaped `;` or `#`. With the
+    // comment left in, the registry URL no longer matched its `//host/` credential.
+    expect(
+      loadNpmrc(`
+registry=http://127.0.0.1:4873/ ; default registry
+//127.0.0.1:4873/:_authToken=SECRET # token
+`),
+    ).toEqual({
+      default_registry_url: "http://127.0.0.1:4873/",
+      default_registry_token: "SECRET",
+      default_registry_username: "",
+      default_registry_password: "",
+      default_registry_email: "",
+    });
+  });
+
+  // npm (nopt Boolean): a bare key or an empty value is true, `false`, `null`,
+  // `undefined` and a numeric zero are false, and every other string is true
   test.each([
     ["ignore-scripts", true],
     ["ignore-scripts=", true],
@@ -573,7 +590,7 @@ registry=https://somehost.com/org1/npm/registry/
     ["ignore-scripts=00", false],
     ["ignore-scripts=0.0", false],
     ["ignore-scripts=-0", false],
-    ["ignore-scripts=undefined", undefined],
+    ["ignore-scripts=undefined", false],
     ["ignore-scripts= 0 ", false],
     ["ignore-scripts= 1 ", true],
     // ini JSON-parses a single-quoted value, so these reach the loader as numbers
@@ -582,6 +599,11 @@ registry=https://somehost.com/org1/npm/registry/
     ['ignore-scripts="1"', true],
     ['ignore-scripts="0"', false],
     ["ignore-scripts='null'", false],
+    // the inline comment is cut before the value is coerced
+    ["ignore-scripts=false ; allow scripts", false],
+    ["ignore-scripts=0 # allow scripts", false],
+    ["ignore-scripts=true ; no scripts", true],
+    ["ignore-scripts = ; bare", true],
   ])("boolean option: %s", (line, expected) => {
     expect(loadNpmrc(line + "\n").ignore_scripts).toBe(expected);
   });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -550,6 +550,52 @@ registry=https://somehost.com/org1/npm/registry/
     expect(result.default_registry_token).toBe("");
   });
 
+  // npm (nopt Boolean): a bare key or an empty value is true, `false`, `null`
+  // and a numeric zero are false, and every other string is true
+  test.each([
+    ["ignore-scripts", true],
+    ["ignore-scripts=", true],
+    ["ignore-scripts=true", true],
+    ["ignore-scripts='true'", true],
+    ["ignore-scripts=1", true],
+    ["ignore-scripts=2", true],
+    ["ignore-scripts=True", true],
+    ["ignore-scripts=TRUE", true],
+    ["ignore-scripts=yes", true],
+    ["ignore-scripts=on", true],
+    ["ignore-scripts=no", true],
+    ["ignore-scripts=off", true],
+    ["ignore-scripts=False", true],
+    ["ignore-scripts=false", false],
+    ['ignore-scripts="false"', false],
+    ["ignore-scripts=null", false],
+    ["ignore-scripts=0", false],
+    ["ignore-scripts=00", false],
+    ["ignore-scripts=0.0", false],
+    ["ignore-scripts=-0", false],
+    ["ignore-scripts=undefined", undefined],
+    ["ignore-scripts= 0 ", false],
+    ["ignore-scripts= 1 ", true],
+  ])("boolean option: %s", (line, expected) => {
+    expect(loadNpmrc(line + "\n").ignore_scripts).toBe(expected);
+  });
+
+  test("every boolean option uses the same coercion", () => {
+    expect(loadNpmrc("save-exact=1\nlink-workspace-packages=0\nhoist=TRUE\ndry-run=yes\n")).toMatchObject({
+      save_exact: true,
+      link_workspace_packages: false,
+      hoist: true,
+      dry_run: true,
+    });
+    expect(loadNpmrc("registry=https://somehost.com/\n")).toMatchObject({
+      ignore_scripts: undefined,
+      save_exact: undefined,
+      link_workspace_packages: undefined,
+      hoist: undefined,
+      dry_run: undefined,
+    });
+  });
+
   describe("credentials keyed to a bracketed IPv6 host", () => {
     // The `//` is stripped off the key before it is parsed as a URL, leaving
     // `[::1]:4873/`. A leading `[` used to parse to an empty host, so these keys

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -576,6 +576,12 @@ registry=https://somehost.com/org1/npm/registry/
     ["ignore-scripts=undefined", undefined],
     ["ignore-scripts= 0 ", false],
     ["ignore-scripts= 1 ", true],
+    // ini JSON-parses a single-quoted value, so these reach the loader as numbers
+    ["ignore-scripts='1'", true],
+    ["ignore-scripts='0'", false],
+    ['ignore-scripts="1"', true],
+    ['ignore-scripts="0"', false],
+    ["ignore-scripts='null'", false],
   ])("boolean option: %s", (line, expected) => {
     expect(loadNpmrc(line + "\n").ignore_scripts).toBe(expected);
   });

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -404,6 +404,40 @@ bar = 'baz'
     });
   });
 
+  test("inline comments are cut from unquoted values, keys and sections", () => {
+    // npm/ini cuts an unquoted value at the first unescaped `;` or `#` and
+    // trims what is left. An escaped comment char stays in the value.
+    const ini = /* ini */ `
+a = hello ; comment
+b = world # comment
+c = x\\;y ; z
+d = foo#bar
+e ; comment = v
+h = http://r/#frag
+i = true ;c
+j = "q" ;c
+k = "a;b#c"
+[sec ; comment]
+f = 1
+[x.y # comment]
+g = 2
+`;
+
+    expect(parse(ini)).toEqual({
+      a: "hello",
+      b: "world",
+      c: "x;y",
+      d: "foo",
+      e: "v",
+      h: "http://r/",
+      i: true,
+      j: '"q"',
+      k: "a;b#c",
+      sec: { f: "1" },
+      x: { y: { g: "2" } },
+    });
+  });
+
   test("key and then section edgecase", () => {
     const ini = /* ini */ `
 foo = 'hihihi'


### PR DESCRIPTION
### Problem
- A `.npmrc` boolean option only takes effect in bun when it is spelled exactly `true` or `false` (or is a bare key). `ignore-scripts=1`, `=True`, `=yes` and `=` are silently ignored, so a CI `.npmrc` hardened for npm with `ignore-scripts=1` runs dependency lifecycle scripts under `bun install`; `save-exact=1` saves `^1.0.0`. npm honours all of these. Found by diffing against npm 11.16; there is no user report.
- An unquoted value also keeps its inline comment: `_authToken=SECRET # ci token` sends `SECRET # ci token`, and `registry=http://host/ ; note` no longer matches its `//host/` credentials. npm's `ini` cuts at the first unescaped `;` or `#`.
- Causes, both in `src/ini/lib.rs`: `load_npmrc` reads the five Boolean keys with `Expr::as_bool()`, which is `Some` only for the literal `true`/`false`; and `prepare_str`'s walk stops at an unescaped `;`/`#` but its Value and Key tails return the untruncated input unless a backslash was seen.

### Fix
- On an unescaped `;`/`#`, truncate the unescaped buffer to its trimmed length and mark it used, so values, keys and section names end where `ini` ends them. Escaped `\;`/`\#` and quoted values are unchanged.
- Add `npm_config_bool` (npm's rule: `@npmcli/config` parse-field, then nopt `validateBoolean`) and read `ignore-scripts`, `save-exact`, `link-workspace-packages`, `hoist` and `dry-run` through it: a bare key or empty value is true; `false`, `null`, `undefined` and a numeric zero (also single-quoted `'0'`, which `ini` JSON-parses to a number) are false; every other string is true. The cut has to come first, otherwise `ignore-scripts=false ; note` would read as true.
- The `bun:internal-for-testing` `loadNpmrc` binding now also returns the five options so the rule is unit-testable offline.
- Verified: `test/cli/install/npmrc.test.ts` (33-row "boolean option" table including `false ; note`, plus the registry/token comment case), `test/js/bun/ini/ini.test.ts` (values, keys, sections), `test/cli/install/bun-install-lifecycle-scripts.test.ts` (`ignore-scripts=1`, `=True`, `=` skip the root postinstall). All new cases fail on bun 1.4.3. `config-precedence.test.ts` and the full files pass.

### Background
- bun reads `~/.npmrc` and `./.npmrc` through its own port of npm's `ini` parser (`src/ini/lib.rs`); `load_npmrc` maps known keys onto the `BunInstall` config. bunfig and CLI flags still take precedence.
- `ini` only turns the exact strings `true`, `false`, `null` into non-strings. npm's typed layer on top (`@npmcli/config` + nopt) is what turns `1` or `yes` into a boolean; bun had no equivalent of that layer for these keys.

<details><summary>Notes</summary>

npm's effective values, from running npm 11.16's bundled `@npmcli/config/lib/parse-field.js` and `nopt.clean` with `{ "ignore-scripts": Boolean }`:

```
"true"  -> true     "1"    -> true    "True"/"TRUE" -> true   "yes"/"on" -> true
"false" -> false    "0"    -> false   "no"/"off"    -> true   "False"    -> true
""      -> true     "null" -> false   "00"/"0.0"    -> false  "2"/"-1"   -> true
"undefined" -> false (after validate)  " 1 " -> true (trimmed)  'x'     -> true
'1' -> 1 -> true    '0' -> 0 -> false  (single quotes: ini JSON-parses the value)
```

`no`, `off` and `False` meaning true is surprising but it is what npm does, and matching npm exactly is the point of reading `.npmrc`. A numeric string is detected with Rust's `f64` parse; it differs from JS `Number()` only for hex/binary/octal spellings of zero (`0x0`), which nobody writes in an `.npmrc`.

Before/after for the reported table (root `postinstall` marker):

```
.npmrc line            npm 11             bun 1.4.3   this PR
ignore-scripts=true    scripts skipped    skipped     skipped
ignore-scripts=1       scripts skipped    RAN         skipped
ignore-scripts=True    scripts skipped    RAN         skipped
ignore-scripts=yes     scripts skipped    RAN         skipped
ignore-scripts=        scripts skipped    RAN         skipped
save-exact=1           "1.0.0" saved      "^1.0.0"    "1.0.0"
```

Inline comments, bun 1.4.3 vs this PR (= npm `ini` 6):

```
k=xy ;c          "xy ;c"        -> "xy"
k=val#x          "val#x"        -> "val"
k=x\y ;c         "x\y "         -> "x\y"
a;b=1            {"a;b":"1"}    -> {"a":"1"}
[sec ;c]         {"sec ":{...}} -> {"sec":{...}}
k="a;b" / k=a\;b unchanged ("a;b")
```

The inline-comment hunk is the same change as #41684; it is folded in here because the boolean rule depends on it (`ignore-scripts=false ; note` must stay false), and a test row enforces that ordering.

`dry-run` from `.npmrc` is parsed into `BunInstall.dry_run` but the install options do not consume it yet, so that part is inert today. `npm_config_bool` is exported so other npm-config readers (env `npm_config_*`, `strict-ssl`) can share one rule.
</details>
