### PR TITLE
streams: an async direct pull() that resolves without close() ends every whole-body consumer

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -64,11 +64,20 @@ const stream = new ReadableStream({
   pull(controller) {
     controller.write("hello");
     controller.write("world");
+    controller.close();
   },
 });
 ```
 
 When using a direct `ReadableStream`, the destination handles all chunk queueing. The destination receives the bytes you pass to `controller.write()`. When the stream is read from JavaScript, Bun buffers the writes and delivers them as `Uint8Array` chunks (strings are UTF-8 encoded).
+
+### Ending the stream
+
+Call `controller.close()` (or `controller.end()`) once everything is written. Every destination flushes what it has buffered and finishes at that point.
+
+A destination that takes the whole stream (a `Response` or `Request` body, `Bun.serve`, `fetch`, `Bun.write`, `Bun.spawn` stdin, `.text()`, `.bytes()`, `Bun.readableStreamToText()`, and so on) calls `pull()` once. If that `pull()` returns a promise, the stream also ends when the promise resolves, as if `pull()` had called `controller.close()` last. If the promise rejects, the destination fails with that error. A `pull()` that returns without a promise and without closing keeps the stream open until something calls `controller.close()`.
+
+A reader (`getReader()`, `for await`, `pipeTo()`, `pipeThrough()`, `tee()`) treats `pull()` as a request for more data instead: it calls `pull()` again for each read until the stream is closed, like a default `ReadableStream` does.
 
 ### Handling backpressure
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -579,6 +579,17 @@ declare module "bun" {
 
   interface DirectUnderlyingSource<R = any> {
     cancel?: UnderlyingSourceCancelCallback;
+    /**
+     * Write the stream's data with `controller.write()` and finish with
+     * `controller.close()`.
+     *
+     * A destination that consumes the whole stream (a `Response` body,
+     * `Bun.serve`, `Bun.write`, `Bun.spawn` stdin, `.text()`, ...) calls
+     * `pull()` once. If it returns a promise, the stream also ends when that
+     * promise resolves, and fails if it rejects. A reader (`getReader()`,
+     * `for await`, `pipeTo()`) calls `pull()` again for each read until the
+     * stream is closed.
+     */
     pull: (controller: ReadableStreamDirectController) => void | PromiseLike<void>;
     type: "direct";
   }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4152,10 +4152,6 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__NodeHTTPRequest__onResolve;
     } else if (handler == Bun__NodeHTTPRequest__onReject) {
         return GlobalObject::PromiseFunctions::Bun__NodeHTTPRequest__onReject;
-    } else if (handler == Bun__FileStreamWrapper__onResolveRequestStream) {
-        return GlobalObject::PromiseFunctions::Bun__FileStreamWrapper__onResolveRequestStream;
-    } else if (handler == Bun__FileStreamWrapper__onRejectRequestStream) {
-        return GlobalObject::PromiseFunctions::Bun__FileStreamWrapper__onRejectRequestStream;
     } else if (handler == Bun__FileSink__onResolveStream) {
         return GlobalObject::PromiseFunctions::Bun__FileSink__onResolveStream;
     } else if (handler == Bun__FileSink__onRejectStream) {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -382,8 +382,6 @@ public:
         Bun__onRejectEntryPointResult,
         Bun__NodeHTTPRequest__onResolve,
         Bun__NodeHTTPRequest__onReject,
-        Bun__FileStreamWrapper__onRejectRequestStream,
-        Bun__FileStreamWrapper__onResolveRequestStream,
         Bun__FileSink__onResolveStream,
         Bun__FileSink__onRejectStream,
         Bun__CronJob__onPromiseResolve,

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -768,9 +768,6 @@ BUN_DECLARE_HOST_FUNCTION(Bun__onResolveEntryPointResult);
 BUN_DECLARE_HOST_FUNCTION(Bun__onRejectEntryPointResult);
 
 
-BUN_DECLARE_HOST_FUNCTION(Bun__FileStreamWrapper__onResolveRequestStream);
-BUN_DECLARE_HOST_FUNCTION(Bun__FileStreamWrapper__onRejectRequestStream);
-
 BUN_DECLARE_HOST_FUNCTION(Bun__FetchTasklet__onResolveRequestStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__FetchTasklet__onRejectRequestStream);
 

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -944,6 +944,8 @@ static JSValue consumeDirectStreamBody(JSC::VM& vm, JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
     setUpDirectStreamController(globalObject, stream, kind);
     RETURN_IF_EXCEPTION(scope, {});
+    if (auto* controller = dynamicDowncast<JSDirectStreamController>(stream->m_controller.get()))
+        controller->m_closeOnPullSettled = true;
     stream->materializeIfNeeded(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     auto* reader = acquireReadableStreamDefaultReader(globalObject, stream);
@@ -1626,12 +1628,45 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectConsumeLoopReadRejected, (J
     return {};
 }
 
+// close()/end(), and the implicit close when an async pull() resolves without calling either.
+static void oneShotDirectClose(JSC::VM& vm, JSGlobalObject* globalObject, JSOneShotDirectSink* sink)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (sink->m_closed)
+        return;
+    sink->m_closed = true;
+    if (auto* source = sink->source()) {
+        sink->clearSource();
+        source->close(globalObject, jsUndefined());
+        RETURN_IF_EXCEPTION(scope, );
+    }
+    MarkedArgumentBuffer noArguments;
+    JSValue endResult = Bun::WebStreams::invokeMethod(vm, globalObject, sink->arrayBufferSink(), builtinNames(vm).endPublicName(), noArguments);
+    RETURN_IF_EXCEPTION(scope, );
+    if (auto* capability = sink->capabilityPromise(); capability && capability->status() == JSPromise::Status::Pending)
+        capability->fulfill(vm, endResult);
+}
+
+// pull() runs once here: its promise resolving without close()/end() is the end of the body.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onConsumeDirectToArrayBufferPullFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    const auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(1));
+    auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(1));
     auto* stream = sink->stream();
+    oneShotDirectClose(vm, globalObject, sink);
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+        TRY_CLEAR_EXCEPTION(scope, {});
+        if (stream) {
+            stream->m_lockedWithoutReader = false;
+            if (stream->m_state == ReadableStreamState::Readable) {
+                Bun::WebStreams::readableStreamError(globalObject, stream, exception->value());
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        }
+        throwException(globalObject, scope, exception->value());
+        return {};
+    }
     if (stream) {
         stream->m_lockedWithoutReader = false;
         Bun::WebStreams::readableStreamCloseIfPossible(globalObject, stream);
@@ -1682,19 +1717,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundOneShotDirectClose, (JSGlobalO
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* sink = uncheckedDowncast<JSOneShotDirectSink>(callFrame->uncheckedArgument(0));
-    if (sink->m_closed)
-        return JSValue::encode(jsUndefined());
-    sink->m_closed = true;
-    if (auto* source = sink->source()) {
-        sink->clearSource();
-        source->close(globalObject, jsUndefined());
-        RETURN_IF_EXCEPTION(scope, {});
-    }
-    MarkedArgumentBuffer noArguments;
-    JSValue endResult = Bun::WebStreams::invokeMethod(vm, globalObject, sink->arrayBufferSink(), builtinNames(vm).endPublicName(), noArguments);
+    oneShotDirectClose(vm, globalObject, sink);
     RETURN_IF_EXCEPTION(scope, {});
-    if (auto* capability = sink->capabilityPromise(); capability && capability->status() == JSPromise::Status::Pending)
-        capability->fulfill(vm, endResult);
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -853,9 +853,10 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
     JSValue maybePromise = call(globalObject, pull, getCallData(pull), source->thisValue(), pullArgs);
     RETURN_IF_EXCEPTION(scope, {});
 
+    // Resolving without close()/end() ends the sink controller first; a sync return waits for close()/end().
     if (auto* pullPromise = dynamicDowncast<JSPromise>(maybePromise)) {
         auto* result = JSPromise::create(vm, globalObject->promiseStructure());
-        pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReturnUndefined(), jsUndefined(), result, jsUndefined());
+        pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReadDirectStreamPullFulfilled(), jsUndefined(), result, state);
         return result;
     }
     if (stream->m_state == ReadableStreamState::Readable) {
@@ -1408,6 +1409,21 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundReadDirectStreamOnClose, (JSGl
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* state = uncheckedDowncast<JSDirectSinkCloseState>(callFrame->argument(0));
     Bun::WebStreams::readDirectStreamCloseImpl(vm, globalObject, state, callFrame->argument(1), callFrame->argument(2));
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsUndefined());
+}
+
+// pull() runs once for a native sink: resolving without close()/end() (which clear m_sinkController) ends it.
+JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadDirectStreamPullFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* state = uncheckedDowncast<JSDirectSinkCloseState>(callFrame->argument(1));
+    JSObject* sinkController = state->sinkController();
+    if (!sinkController)
+        return JSValue::encode(jsUndefined());
+    MarkedArgumentBuffer noArgs;
+    Bun::WebStreams::invokeMethod(vm, globalObject, sinkController, builtinNames(vm).endPublicName(), noArgs);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -1024,6 +1024,13 @@ static void directPullFulfilled(JSC::VM& vm, JSGlobalObject* globalObject, JSDir
     controller->onFlush(globalObject);
     controller->m_pullInFlight = false;
     RETURN_IF_EXCEPTION(scope, );
+    if (controller->m_closeOnPullSettled) {
+        controller->m_pullAgain = false;
+        stream = controller->m_stream.get();
+        if (!controller->m_closed && stream && stream->m_state == ReadableStreamState::Readable)
+            controller->onClose(globalObject, jsUndefined());
+        RELEASE_AND_RETURN(scope, );
+    }
     bool pullAgain = takeDirectPullAgain(controller);
     // Edge-triggered (m_pullAgain) AND level-checked (a consumer is waiting), the spec's
     // ShouldCallPull equivalent; loop so a synchronous re-pull chains to the next consumer.

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -116,6 +116,8 @@ public:
     // process.nextTick job delivers it during the same microtask/nextTick drain.
     bool m_endOfTickFlushArmed : 1 { false };
     bool m_finalChunkArmed : 1 { false };
+    // A whole-body consumer (.text() etc.): an async pull() resolving without close()/end() closes.
+    bool m_closeOnPullSettled : 1 { false };
     // ArrayBuffer sink: the bytes write() accepted since it armed m_pendingWrite (saturating).
     uint32_t m_pendingWriteLength { 0 };
     // ArrayBuffer sink: m_buffer's capacity as last reported to the heap (reportExtraMemoryAllocated);

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -52,7 +52,7 @@ namespace WebCore {
 // Signature of every entry:  name(JSC::JSValue resolutionValue, contextCell at argument(1)).
 
 // owner: WebStreamsMisc.cpp — the shared "fulfillment step that returns undefined" / no-op
-// reaction (readableStreamCancel; readDirectStream's `.then(noop)`). context: unused.
+// reaction (readableStreamCancel, tee's reader-closed watch). context: unused.
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_MISC(V) \
     V(onReturnUndefined)
 
@@ -166,11 +166,13 @@ namespace WebCore {
 //   onNativePull*: context = the JSNativeStreamSourceAdapter.
 //   onNativeSourceCallCloseMicrotask: the native source's `queueMicrotask(callClose)` job;
 //     context = the adapter.
+//   onReadDirectStreamPullFulfilled: readDirectStream's pull() resolved. context = the JSDirectSinkCloseState.
 //   onReadStreamIntoSink*: context = the JSReadStreamIntoSinkOperation.
 #define FOR_EACH_WEB_STREAMS_REACTION_HANDLER_BUN_SOURCE(V) \
     V(onNativePullFulfilled)                                \
     V(onNativePullRejected)                                 \
     V(onNativeSourceCallCloseMicrotask)                     \
+    V(onReadDirectStreamPullFulfilled)                      \
     V(onReadStreamIntoSinkReadManyFulfilled)                \
     V(onReadStreamIntoSinkChunk)                            \
     V(onReadStreamIntoSinkClose)                            \

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1566,82 +1566,15 @@ impl BlobExt for Blob {
             }
         };
 
-        // `pipe_stream` takes its own refs.
-        if let Some(promise) =
-            // SAFETY: sole owner so far; `&mut` scoped to the call.
-            unsafe { (*file_sink.as_ptr()).pipe_stream(&readable_stream, global_this) }
-        {
-            return Ok(promise);
-        }
-
-        let assignment_result: JSValue = webcore::file_sink::JSSink::assign_to_stream(
-            global_this,
-            readable_stream.value,
-            file_sink.as_non_null(),
-        );
-
-        assignment_result.ensure_still_alive();
-
-        if let Some(err) = assignment_result.to_error() {
+        // `pipe_stream` takes its own refs; init's +1 drops with `file_sink` on return.
+        let mut readable_stream = readable_stream;
+        // SAFETY: sole owner so far; `&mut` scoped to the call.
+        let result =
+            unsafe { (*file_sink.as_ptr()).pipe_stream(&mut readable_stream, global_this) };
+        if let Some(err) = result.to_error() {
             return Ok(JSPromise::rejected_promise(global_this, err).to_js());
         }
-
-        if !assignment_result.is_empty_or_undefined_or_null() {
-            global_this.bun_vm().as_mut().drain_microtasks();
-
-            assignment_result.ensure_still_alive();
-            // it returns a Promise when it goes through ReadableStreamDefaultReader
-            if let Some(promise) = assignment_result.as_any_promise() {
-                match promise.status() {
-                    jsc::js_promise::Status::Pending => {
-                        let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
-                            promise: jsc::JSPromiseStrong::init(global_this),
-                            readable_stream_ref:
-                                webcore::readable_stream::ReadableStreamStrong::init(
-                                    readable_stream,
-                                    global_this,
-                                ),
-                            sink: file_sink,
-                        }));
-                        // SAFETY: wrapper was just produced by heap::alloc; sole owner here.
-                        let promise_value = unsafe { (*wrapper).promise.value() };
-                        assignment_result.then(
-                            global_this,
-                            wrapper.cast::<c_void>(),
-                            on_file_stream_resolve_request_stream_shim,
-                            on_file_stream_reject_request_stream_shim,
-                        );
-                        return Ok(promise_value);
-                    }
-                    jsc::js_promise::Status::Fulfilled => {
-                        let written = file_sink.stream_bytes.get().unwrap_or(0);
-                        readable_stream.done();
-                        return Ok(JSPromise::resolved_promise_value(
-                            global_this,
-                            JSValue::js_number(written as f64),
-                        ));
-                    }
-                    jsc::js_promise::Status::Rejected => {
-                        readable_stream.cancel(global_this)?;
-                        promise.set_handled(global_this.vm());
-                        return Ok(JSPromise::rejected_promise(
-                            global_this,
-                            promise.result(global_this.vm()),
-                        )
-                        .to_js());
-                    }
-                }
-            } else {
-                readable_stream.cancel(global_this)?;
-                return Ok(JSPromise::rejected_promise(global_this, assignment_result).to_js());
-            }
-        }
-        let written = file_sink.stream_bytes.get().unwrap_or(0);
-
-        Ok(JSPromise::resolved_promise_value(
-            global_this,
-            JSValue::js_number(written as f64),
-        ))
+        Ok(result)
     }
 
     fn get_writer(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
@@ -5719,95 +5652,6 @@ impl Drop for S3BlobDownloadTask {
 // ──────────────────────────────────────────────────────────────────────────
 // doWrite / doUnlink / getExists
 // ──────────────────────────────────────────────────────────────────────────
-
-// ──────────────────────────────────────────────────────────────────────────
-// FileStreamWrapper / pipeReadableStreamToBlob
-// ──────────────────────────────────────────────────────────────────────────
-
-struct FileStreamWrapper {
-    pub(crate) promise: jsc::JSPromiseStrong,
-    pub(crate) readable_stream_ref: webcore::readable_stream::ReadableStreamStrong,
-    pub sink: RefPtr<webcore::FileSink>,
-}
-
-pub(crate) fn on_file_stream_resolve_request_stream(
-    global_this: &JSGlobalObject,
-    callframe: &CallFrame,
-) -> JsResult<JSValue> {
-    let args = callframe.arguments();
-    // SAFETY: last arg is a promise-ptr created by FileStreamWrapper::new in pipe_readable_stream_to_blob.
-    let mut this: Box<FileStreamWrapper> = unsafe {
-        bun_core::heap::take(args[args.len() - 1].as_number() as usize as *mut FileStreamWrapper)
-    };
-    let strong = core::mem::take(&mut this.readable_stream_ref);
-    if let Some(stream) = strong.get() {
-        stream.done();
-    }
-    let written = this.sink.stream_bytes.get().unwrap_or(0);
-    this.promise
-        .resolve(global_this, JSValue::js_number(written as f64))?;
-    Ok(JSValue::UNDEFINED)
-}
-
-pub(crate) fn on_file_stream_reject_request_stream(
-    global_this: &JSGlobalObject,
-    callframe: &CallFrame,
-) -> JsResult<JSValue> {
-    let args = callframe.arguments();
-    // Take ownership via Box so Drop runs `sink.deref()`
-    // and frees the wrapper.
-    // SAFETY: the trailing argument is the `FileStreamWrapper*` boxed and passed
-    // through `then()` from the resolve path; we are the sole consumer here.
-    let mut this: Box<FileStreamWrapper> = unsafe {
-        bun_core::heap::take(args[args.len() - 1].as_number() as usize as *mut FileStreamWrapper)
-    };
-    let err = args[0];
-
-    let strong = core::mem::take(&mut this.readable_stream_ref);
-
-    this.promise.reject(global_this, Ok(err))?;
-
-    if let Some(stream) = strong.get() {
-        stream.cancel(global_this)?;
-    }
-    Ok(JSValue::UNDEFINED)
-}
-
-// C-ABI shims for `JSValue::then`. The Rust-side
-// host fns above are `JSHostFnZig`; `then()` wants the raw `JSHostFn` shape.
-// Exported under the legacy symbol names so C++ (`BunPromiseInlines.h`) links
-// the same symbol it does today.
-bun_jsc::jsc_host_abi! {
-    #[unsafe(export_name = "Bun__FileStreamWrapper__onResolveRequestStream")]
-    unsafe fn on_file_stream_resolve_request_stream_shim(
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-        // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-        let (global, callframe) =
-            (bun_opaque::opaque_deref(global), bun_opaque::opaque_deref(callframe));
-        bun_jsc::host_fn::to_js_host_fn_result(global, on_file_stream_resolve_request_stream(global, callframe))
-    }
-}
-bun_jsc::jsc_host_abi! {
-    #[unsafe(export_name = "Bun__FileStreamWrapper__onRejectRequestStream")]
-    unsafe fn on_file_stream_reject_request_stream_shim(
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-        // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-        let (global, callframe) =
-            (bun_opaque::opaque_deref(global), bun_opaque::opaque_deref(callframe));
-        bun_jsc::host_fn::to_js_host_fn_result(global, on_file_stream_reject_request_stream(global, callframe))
-    }
-}
-
-// the local `AnyPromiseResultExt` shim was removed —
-// `bun_jsc::AnyPromise::result` is an inherent method (and `JSInternalPromise`
-// is a transparent alias for `JSPromise`), so the `.result(vm)` call below
-// resolves directly upstream.
 
 // ──────────────────────────────────────────────────────────────────────────
 // getSliceFrom / getSlice / type/name/lastModified/size getters

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -54,7 +54,7 @@ pub struct FileSink {
     pub(crate) auto_flusher: JsCell<AutoFlusher>,
     pub(crate) run_pending_later: FlushPendingTask,
 
-    /// Currently, only used when `stdin` in `Bun.spawn` is a ReadableStream.
+    /// The stream `assign_to_stream` (spawn stdin) or `pipe_stream` (`Bun.write`) is piping in.
     pub(crate) readable_stream: JsCell<readable_stream::Strong>,
 
     /// `pipe_stream`: settled from `on_close` with `stream_bytes`, or with the error that ended
@@ -1121,9 +1121,7 @@ impl FileSink {
         self.to_result(rc, accepted)
     }
 
-    /// Native-path terminator called from `SinkHandle::end`. On upstream error
-    /// (ByteStream source), close the writer without flushing — mirrors
-    /// `handle_reject_stream` — so a truncated write is not committed as EOF.
+    /// The source is done; `err` settles a piped stream. A failed ByteStream closes without a flush.
     pub(crate) fn end_from_stream(&self, err: Option<streams::StreamError>) {
         let is_byte_stream = matches!(self.source.get(), streams::SourceHandle::ByteStream(_));
         if is_byte_stream {
@@ -1266,6 +1264,8 @@ impl FileSink {
                 sys::Result::Ok(JSValue::js_number(written as f64))
             }
             WriteResult::Err(err) => {
+                // `writer.end()` below runs `on_close`, which settles a piped stream with it.
+                self.record_stream_error(streams::StreamError::Error(err.clone()));
                 self.done.set(true);
                 if has_pending {
                     // A backpressured write() left its promise outstanding.
@@ -1377,6 +1377,18 @@ impl crate::webcore::sink::JsSinkType for FileSink {
     }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue> {
         Self::end_from_js(self, global)
+    }
+    /// The JS pump's source failed, or `controller.close(error)`: a piped stream rejects with `reason`.
+    unsafe fn close_with_error(
+        this: *mut Self,
+        global: &JSGlobalObject,
+        reason: JSValue,
+    ) -> sys::Result<()> {
+        // SAFETY: caller contract; the pump promise's +1 or `assign_to_stream`'s caller keeps `this` alive.
+        unsafe { &*this }.end_from_stream(Some(streams::StreamError::JSValue(
+            bun_jsc::strong::Optional::create(reason, global),
+        )));
+        sys::Result::Ok(())
     }
     fn source(&mut self) -> Option<&mut streams::SourceHandle> {
         // SAFETY: JsCell — trait receiver is `&mut self`; sole borrow of `source`.
@@ -1550,29 +1562,37 @@ impl FlushPendingTask {
 }
 
 impl FileSink {
-    /// Does not ref or unref.
+    /// The JS pump finished: flush what it wrote and end. Does not ref or unref.
     fn handle_resolve_stream(&self) {
         if let Some(stream) = self.readable_stream.get().get().as_mut() {
             stream.done();
         }
 
         if !self.done.get() {
-            self.writer.with_mut(|w| w.close());
+            // A flush error is recorded in `stream_error` and reaches `stream_done`.
+            let _ = self.end(None);
         }
     }
 
     /// Does not ref or unref.
-    fn handle_reject_stream(&self, global_this: &JSGlobalObject, _err: JSValue) -> JsResult<()> {
-        if let Some(stream) = self.readable_stream.get().get().as_mut() {
-            let aborted = stream.abort(global_this);
-            self.readable_stream.set(readable_stream::Strong::default());
-            aborted?;
-        }
+    fn handle_reject_stream(&self, global_this: &JSGlobalObject, err: JSValue) -> JsResult<()> {
+        self.record_stream_error(streams::StreamError::JSValue(
+            bun_jsc::strong::Optional::create(err, global_this),
+        ));
+        let readable_stream = self
+            .readable_stream
+            .replace(readable_stream::Strong::default());
+        let aborted = match readable_stream.get() {
+            Some(stream) => stream.abort(global_this),
+            None => Ok(()),
+        };
 
         if !self.done.get() {
+            // The body is truncated: drop what the writer buffered instead of flushing it.
+            self.done.set(true);
             self.writer.with_mut(|w| w.close());
         }
-        Ok(())
+        aborted
     }
 }
 
@@ -1600,14 +1620,12 @@ fn on_reject_stream(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
 }
 
 impl FileSink {
-    /// `Bun.write(file, stream)`: wire `stream`'s native source straight to this sink and return a
-    /// promise for the byte count once the file is closed. `None` if the stream is not a native
-    /// source; the caller falls back to the JS pump.
+    /// `Bun.write(file, stream)`: the byte-count promise `on_close` settles, or an `Error` value.
     pub fn pipe_stream(
         &mut self,
-        stream: &ReadableStream,
+        stream: &mut ReadableStream,
         global_this: &JSGlobalObject,
-    ) -> Option<JSValue> {
+    ) -> JSValue {
         // SAFETY: `&mut self` carries write+dealloc provenance over the allocation.
         let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<FileSink>(self)) };
 
@@ -1635,17 +1653,27 @@ impl FileSink {
                         self.ref_();
                     }
                 }
-                Some(promise)
+                promise
             }
             readable_stream::NativeWireResult::EndedInline(err) => {
                 self.source.set(streams::SourceHandle::None);
                 self.end_from_stream(err);
-                Some(promise)
+                promise
             }
             readable_stream::NativeWireResult::NotNative => {
-                self.stream_done.set(bun_jsc::JSPromiseStrong::empty());
-                self.readable_stream.set(readable_stream::Strong::default());
-                None
+                let result = self.assign_to_js_stream(stream, global_this);
+                if let Some(err) = result.to_error() {
+                    self.stream_done.set(bun_jsc::JSPromiseStrong::empty());
+                    self.stream_bytes.set(None);
+                    return err;
+                }
+                // A pump that already failed reports through `stream_done`.
+                if let Some(pump) = result.as_any_promise() {
+                    if pump.status() == bun_jsc::js_promise::Status::Rejected {
+                        pump.set_handled(global_this.vm());
+                    }
+                }
+                promise
             }
         }
     }
@@ -1695,10 +1723,16 @@ impl FileSink {
             readable_stream::NativeWireResult::NotNative => {}
         }
 
-        // No per-wrapper +1 for the controller (only the transient `_guard`
-        // above): the JS builtins always call `controller.end()`/`.close()`
-        // (`${controller}__end/close` → `controller->detach()` → m_sinkPtr=null)
-        // before GC, so the controller's dtor never reaches `finalize`.
+        self.assign_to_js_stream(stream, global_this)
+    }
+
+    /// Pump a JS `stream` in through a controller; the writer is ended when the pump settles.
+    fn assign_to_js_stream(
+        &mut self,
+        stream: &mut ReadableStream,
+        global_this: &JSGlobalObject,
+    ) -> JSValue {
+        // No +1 for the controller: ending the writer detaches it before this sink is freed.
         let promise_result = JSSink::assign_to_stream(
             global_this,
             stream.value,
@@ -1710,44 +1744,31 @@ impl FileSink {
             return err;
         }
 
-        if !promise_result.is_empty_or_undefined_or_null() {
-            if let Some(promise) = promise_result.as_any_promise() {
-                // `bun_jsc::AnyPromise` (the active raw-ptr variant in
-                // lib.rs) does not yet expose `status()`/`result()`; recover the
-                // underlying `JSPromise` (JSInternalPromise subclasses JSPromise
-                // in C++, so the cast is layout-safe).
-                let js_promise: *mut bun_jsc::JSPromise = match promise {
-                    bun_jsc::AnyPromise::Normal(p) => p,
-                    bun_jsc::AnyPromise::Internal(p) => p.cast::<bun_jsc::JSPromise>(),
-                };
-                // SAFETY: `as_any_promise` returned non-null.
-                match unsafe { (*js_promise).status() } {
-                    bun_jsc::js_promise::Status::Pending => {
-                        self.writer
-                            .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
-                        self.ref_();
-                        // TODO: properly propagate exception upwards
-                        // `JSValue::then` takes already-wrapped C-ABI
-                        // host fns; the `toJSHostFunction` step is the manual
-                        // shims at the bottom of this file.
-                        promise_result.then(
-                            global_this,
-                            std::ptr::from_mut::<FileSink>(self),
-                            on_resolve_stream_shim,
-                            on_reject_stream_shim,
-                        );
-                    }
-                    bun_jsc::js_promise::Status::Fulfilled => {
-                        // These don't ref().
-                        self.handle_resolve_stream();
-                    }
-                    bun_jsc::js_promise::Status::Rejected => {
-                        // These don't ref().
-                        // SAFETY: `js_promise` is non-null (`as_any_promise`).
-                        let result = unsafe { (*js_promise).result(global_this.vm()) };
-                        crate::dispatch::fold(self.handle_reject_stream(global_this, result));
-                    }
-                }
+        let Some(promise) = promise_result.as_any_promise() else {
+            // The pump ran to the end inside `assign_to_stream`.
+            self.handle_resolve_stream();
+            return promise_result;
+        };
+        match promise.status() {
+            bun_jsc::js_promise::Status::Pending => {
+                self.writer
+                    .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
+                self.ref_();
+                promise_result.then(
+                    global_this,
+                    std::ptr::from_mut::<FileSink>(self),
+                    on_resolve_stream_shim,
+                    on_reject_stream_shim,
+                );
+            }
+            bun_jsc::js_promise::Status::Fulfilled => {
+                // These don't ref().
+                self.handle_resolve_stream();
+            }
+            bun_jsc::js_promise::Status::Rejected => {
+                // These don't ref().
+                let result = promise.result(global_this.vm());
+                crate::dispatch::fold(self.handle_reject_stream(global_this, result));
             }
         }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1563,7 +1563,7 @@ impl FlushPendingTask {
 
 impl FileSink {
     /// The JS pump finished: flush what it wrote and end. Does not ref or unref.
-    fn handle_resolve_stream(&self) {
+    fn handle_resolve_stream(&self, global_this: &JSGlobalObject) {
         if let Some(stream) = self.readable_stream.get().get().as_mut() {
             stream.done();
         }
@@ -1572,6 +1572,7 @@ impl FileSink {
             // A flush error is recorded in `stream_error` and reaches `stream_done`.
             let _ = self.end(None);
         }
+        self.detach_js_controller(global_this);
     }
 
     /// Does not ref or unref.
@@ -1592,18 +1593,31 @@ impl FileSink {
             self.done.set(true);
             self.writer.with_mut(|w| w.close());
         }
+        self.detach_js_controller(global_this);
         aborted
+    }
+
+    /// The pump is over. `on_close` normally ran the controller's `end()`, which detached it; when
+    /// its `onClose` could not run (terminating worker, pending exception) detach it here, so the
+    /// cell never outlives this sink attached.
+    fn detach_js_controller(&self, global_this: &JSGlobalObject) {
+        if let streams::SourceHandle::JSController(cell) = *self.source.get() {
+            self.source.set(streams::SourceHandle::None);
+            crate::dispatch::fold(::bun_jsc::call_check_slow(global_this, || {
+                streams::controller_abi::detach_ptr(cell)
+            }));
+        }
     }
 }
 
-fn on_resolve_stream(_global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+fn on_resolve_stream(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
     bun_core::scoped_log!(FileSink, "onResolveStream");
     let args = callframe.arguments();
     let this: *mut FileSink = args[args.len() - 1].as_promise_ptr::<FileSink>();
     // SAFETY: `this` is kept alive by the ref taken in `assign_to_stream`; this guard balances it.
     let _guard = unsafe { RefPtr::from_raw(this) };
     // SAFETY: `as_promise_ptr` recovers the `*mut FileSink` stashed by `assign_to_stream`.
-    unsafe { (*this).handle_resolve_stream() };
+    unsafe { (*this).handle_resolve_stream(global_this) };
     Ok(JSValue::UNDEFINED)
 }
 
@@ -1746,7 +1760,7 @@ impl FileSink {
 
         let Some(promise) = promise_result.as_any_promise() else {
             // The pump ran to the end inside `assign_to_stream`.
-            self.handle_resolve_stream();
+            self.handle_resolve_stream(global_this);
             return promise_result;
         };
         match promise.status() {
@@ -1763,7 +1777,7 @@ impl FileSink {
             }
             bun_jsc::js_promise::Status::Fulfilled => {
                 // These don't ref().
-                self.handle_resolve_stream();
+                self.handle_resolve_stream(global_this);
             }
             bun_jsc::js_promise::Status::Rejected => {
                 // These don't ref().

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1597,9 +1597,7 @@ impl FileSink {
         aborted
     }
 
-    /// The pump is over. `on_close` normally ran the controller's `end()`, which detached it; when
-    /// its `onClose` could not run (terminating worker, pending exception) detach it here, so the
-    /// cell never outlives this sink attached.
+    /// The pump is over: a controller whose `onClose` could not run must not outlive this sink attached.
     fn detach_js_controller(&self, global_this: &JSGlobalObject) {
         if let streams::SourceHandle::JSController(cell) = *self.source.get() {
             self.source.set(streams::SourceHandle::None);

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1023,6 +1023,75 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(Buffer.from(await Bun.file(dest).arrayBuffer())).toEqual(expected);
     });
 
+    // A direct stream's pull() runs once; its promise resolving without close() is the end of the
+    // body, as for Bun.serve. Before, bytes written after the sink's last flush were dropped while
+    // the resolved count still included them, and the sink was freed with its JS controller still
+    // attached, which read the freed sink once the controller was collected.
+    it("a direct stream whose pull() resolves without close()", async () => {
+      using dir = tempDir("bun-write-direct-no-close", {});
+      const dest = join(String(dir), "out.txt");
+      const fixture = /* js */ `
+        const { fileSinkInternals } = require("bun:internal-for-testing");
+        const nextTask = () => new Promise(resolve => setImmediate(resolve));
+        const baseline = fileSinkInternals.liveCount();
+        const stream = new ReadableStream({
+          type: "direct",
+          async pull(c) {
+            c.write("hello");
+            // The sink flushes "hello" to the file before this resolves.
+            await nextTask();
+            c.write(" ");
+            c.write(new TextEncoder().encode("wörld"));
+          },
+        });
+        const written = await Bun.write(process.env.DEST, new Response(stream));
+        const onDisk = await Bun.file(process.env.DEST).text();
+        // Collect the stream and its sink controller.
+        Bun.gc(true);
+        await nextTask();
+        Bun.gc(true);
+        console.log(JSON.stringify({ written, onDisk, leakedSinks: fileSinkInternals.liveCount() - baseline }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, DEST: dest },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ written: 12, onDisk: "hello wörld", leakedSinks: 0 });
+      expect(exitCode).toBe(0);
+    });
+
+    it("a stream whose source fails rejects with that error", async () => {
+      using dir = tempDir("bun-write-stream-reject", {});
+      const nextTask = () => new Promise(resolve => setImmediate(resolve));
+      const direct = new ReadableStream({
+        type: "direct",
+        async pull(c) {
+          c.write("hello");
+          await nextTask();
+          throw new Error("boom");
+        },
+      });
+      await expect(Bun.write(join(String(dir), "direct.txt"), new Response(direct))).rejects.toThrow("boom");
+      const midway = new ReadableStream({
+        async pull(c) {
+          c.enqueue("hello");
+          await nextTask();
+          c.error(new Error("boom"));
+        },
+      });
+      await expect(Bun.write(join(String(dir), "midway.txt"), midway)).rejects.toThrow("boom");
+      const upfront = new ReadableStream({
+        start(c) {
+          c.error(new Error("boom"));
+        },
+      });
+      await expect(Bun.write(join(String(dir), "upfront.txt"), upfront)).rejects.toThrow("boom");
+    });
+
     // /dev/full: every write fails with ENOSPC.
     it.skipIf(process.platform !== "linux")("rejects with the write error, for each kind of body", async () => {
       await using server = await origin();

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1174,6 +1174,101 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(exitCode).toBe(0);
     });
 
+    // The implicit end closes the stream like controller.close(): the source's cancel() runs once
+    // with no reason, and the controller is detached from the sink it no longer owns.
+    it("ends a direct stream's sink when its pull() returns", async () => {
+      using dir = tempDir("bun-write-direct-pull-returns", {});
+      const dest = join(String(dir), "out.txt");
+      let ctrl;
+      const cancelled = [];
+      const stream = new ReadableStream({
+        type: "direct",
+        async pull(c) {
+          ctrl = c;
+          c.write("first ");
+          await c.flush();
+          // A later event loop turn: "second" is still buffered in the sink when pull() returns.
+          await new Promise(resolve => setImmediate(resolve));
+          c.write("second");
+        },
+        cancel(reason) {
+          cancelled.push(reason);
+        },
+      });
+      expect(await Bun.write(dest, new Response(stream))).toBe(12);
+      expect(await Bun.file(dest).text()).toBe("first second");
+      expect(cancelled).toEqual([undefined]);
+      expect(() => ctrl.write("late event")).toThrow(/already been closed/);
+      expect(() => ctrl.flush()).toThrow(/already been closed/);
+      expect(ctrl.end()).toBeUndefined();
+      Bun.gc(true);
+    });
+
+    // Every way the JS pump can settle without a controller.close(), each followed by a full GC
+    // with the controller cell unreferenced. Before, the cell kept a pointer to the freed FileSink
+    // and the collection (or the sink's queued flush task) was a use-after-free. `await 1` settles
+    // in the tick the write started in; `tick()` settles on a later event-loop turn.
+    it.each([
+      [
+        "an async generator that throws right after a yield",
+        `async function* () { yield "first"; throw new Error("boom"); }`,
+        "rejected: boom",
+      ],
+      [
+        "an async generator that throws before its first yield",
+        `async function* () { throw new Error("boom"); }`,
+        "rejected: boom",
+      ],
+      [
+        "an async generator that throws on a later tick",
+        `async function* () { yield "first"; await tick(); throw new Error("boom"); }`,
+        "rejected: boom",
+      ],
+      [
+        "a direct ReadableStream whose pull rejects",
+        `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await 1; throw new Error("boom"); } })`,
+        "rejected: boom",
+      ],
+      [
+        "a direct ReadableStream whose pull resolves without closing it",
+        `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await 1; } })`,
+        `resolved: 5, "first"`,
+      ],
+      [
+        "a direct ReadableStream whose pull resolves on a later tick without closing it",
+        `() => new ReadableStream({ type: "direct", async pull(ctrl) { ctrl.write("first"); await tick(); } })`,
+        `resolved: 5, "first"`,
+      ],
+    ])("the body's sink controller is collectable after %s", async (_label, body, outcome) => {
+      using dir = tempDir("bun-write-settled-controller", {});
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const { readFileSync } = require("fs");
+           const dest = ${JSON.stringify(join(String(dir), "out.txt"))};
+           const tick = () => new Promise(resolve => setImmediate(resolve));
+           const body = ${body};
+           const outcomes = new Set();
+           for (let i = 0; i < 5; i++) {
+             outcomes.add(
+               await Bun.write(dest, new Response(body())).then(
+                 n => "resolved: " + n + ", " + JSON.stringify(readFileSync(dest, "utf8")),
+                 e => "rejected: " + e.message,
+               ),
+             );
+             Bun.gc(true);
+           }
+           console.log([...outcomes].join(" | "));`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: outcome, stderr: "" });
+      expect(exitCode).toBe(0);
+    });
+
     // /dev/full: every write fails with ENOSPC.
     it.skipIf(process.platform !== "linux")("rejects with the write error, for each kind of body", async () => {
       await using server = await origin();

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1034,9 +1034,11 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         const { fileSinkInternals } = require("bun:internal-for-testing");
         const nextTask = () => new Promise(resolve => setImmediate(resolve));
         const baseline = fileSinkInternals.liveCount();
-        const stream = new ReadableStream({
+        let controller;
+        let stream = new ReadableStream({
           type: "direct",
           async pull(c) {
+            controller = c;
             c.write("hello");
             // The sink flushes "hello" to the file before this resolves.
             await nextTask();
@@ -1046,11 +1048,21 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         });
         const written = await Bun.write(process.env.DEST, new Response(stream));
         const onDisk = await Bun.file(process.env.DEST).text();
+        // The stream ended when pull() resolved: the controller is closed and detached.
+        const late = {};
+        for (const method of ["write", "flush", "end"]) {
+          try {
+            late[method] = String(controller[method]("late"));
+          } catch (e) {
+            late[method] = e.message.split(".")[0];
+          }
+        }
         // Collect the stream and its sink controller.
+        stream = controller = undefined;
         Bun.gc(true);
         await nextTask();
         Bun.gc(true);
-        console.log(JSON.stringify({ written, onDisk, leakedSinks: fileSinkInternals.liveCount() - baseline }));
+        console.log(JSON.stringify({ written, onDisk, late, leakedSinks: fileSinkInternals.liveCount() - baseline }));
       `;
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],
@@ -1060,7 +1072,16 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual({ written: 12, onDisk: "hello wörld", leakedSinks: 0 });
+      expect(JSON.parse(stdout)).toEqual({
+        written: 12,
+        onDisk: "hello wörld",
+        late: {
+          write: "This FileSink has already been closed",
+          flush: "This FileSink has already been closed",
+          end: "undefined",
+        },
+        leakedSinks: 0,
+      });
       expect(exitCode).toBe(0);
     });
 
@@ -1076,6 +1097,12 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         },
       });
       await expect(Bun.write(join(String(dir), "direct.txt"), new Response(direct))).rejects.toThrow("boom");
+      const generator = async function* () {
+        yield "hello";
+        await nextTask();
+        throw new Error("boom");
+      };
+      await expect(Bun.write(join(String(dir), "generator.txt"), new Response(generator()))).rejects.toThrow("boom");
       const midway = new ReadableStream({
         async pull(c) {
           c.enqueue("hello");
@@ -1090,6 +1117,61 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         },
       });
       await expect(Bun.write(join(String(dir), "upfront.txt"), upfront)).rejects.toThrow("boom");
+    });
+
+    // The sink is released when the pump rejects; a controller collected after that must
+    // already be detached. A subprocess, because that GC can be the one at process exit.
+    it("survives a GC after a direct stream or a generator body fails", async () => {
+      using dir = tempDir("bun-write-body-fails-gc", {});
+      const fixture = /* js */ `
+        const dir = process.env.DEST_DIR;
+        const lines = [];
+        try {
+          await Bun.write(dir + "/gen.txt", new Response((async function* () { yield "a"; throw new Error("boom"); })()));
+        } catch (e) {
+          lines.push("gen:" + e.message);
+        }
+        let controller;
+        try {
+          await Bun.write(
+            dir + "/direct.txt",
+            new Response(
+              new ReadableStream({
+                type: "direct",
+                async pull(c) {
+                  controller = c;
+                  c.write("a");
+                  await c.flush();
+                  throw new Error("boom");
+                },
+              }),
+            ),
+          );
+        } catch (e) {
+          lines.push("direct:" + e.message);
+        }
+        try {
+          controller.write("late");
+          lines.push("late:wrote");
+        } catch {
+          lines.push("late:threw");
+        }
+        controller = undefined;
+        Bun.gc(true);
+        await new Promise(resolve => setImmediate(resolve));
+        Bun.gc(true);
+        console.log(lines.join(","));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, DEST_DIR: String(dir) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("gen:boom,direct:boom,late:threw");
+      expect(exitCode).toBe(0);
     });
 
     // /dev/full: every write fails with ENOSPC.

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -156,6 +156,32 @@ describe("spawn stdin ReadableStream", () => {
     expect(await proc.exited).toBe(0);
   });
 
+  // A direct stream's pull() runs once; its promise resolving without close() is the end of
+  // stdin. Before, the pipe was closed without flushing what the sink had buffered since its
+  // last flush, so the child saw a truncated stdin with no error anywhere.
+  test("direct ReadableStream whose pull() resolves without close()", async () => {
+    const stream = new ReadableStream({
+      type: "direct",
+      async pull(controller) {
+        controller.write("hello");
+        // The sink flushes "hello" to the pipe before this resolves.
+        await new Promise(resolve => setImmediate(resolve));
+        controller.write(" ");
+        controller.write(new TextEncoder().encode("world"));
+      },
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+      stdin: stream,
+      stdout: "pipe",
+      env: bunEnv,
+    });
+
+    expect(await proc.stdout.text()).toBe("hello world");
+    expect(await proc.exited).toBe(0);
+  });
+
   test("ReadableStream with large data", async () => {
     const largeData = "x".repeat(1024 * 1024); // 1MB
     const stream = new ReadableStream({

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1705,6 +1705,104 @@ describe("multi-chunk consumers produce exactly the concatenated bytes", () => {
     });
   });
 
+  // A consumer that takes the whole body (.text(), .bytes(), Bun.readableStreamTo*(), a native
+  // sink) calls a direct stream's pull() once. When that pull() returns a promise, the promise
+  // resolving without close()/end() is the end of the body: the consumer finishes with everything
+  // written, as Bun.serve always did. Before, these consumers pulled once and then never settled.
+  // A reader (getReader/for-await/pipeTo) is a demand signal instead and pulls again; a sync
+  // pull() that returns without closing gives no completion signal, so it waits for close().
+  describe("an async direct pull() that resolves without close() completes a whole-body consumer", () => {
+    const nextTask = () => new Promise(resolve => setImmediate(resolve));
+    const mk = (hooks = {}) =>
+      new ReadableStream({
+        type: "direct",
+        async pull(c) {
+          c.write("hello");
+          await nextTask();
+          c.write(new TextEncoder().encode("wor"));
+          c.write("ld");
+        },
+        ...hooks,
+      });
+    const decode = bytes => new TextDecoder().decode(bytes);
+
+    it("Response and Request body methods", async () => {
+      expect(await new Response(mk()).text()).toBe("helloworld");
+      expect(decode(await new Response(mk()).bytes())).toBe("helloworld");
+      expect(decode(new Uint8Array(await new Response(mk()).arrayBuffer()))).toBe("helloworld");
+      expect(await (await new Response(mk()).blob()).text()).toBe("helloworld");
+      expect(await new Request("http://example.com/", { method: "POST", body: mk() }).text()).toBe("helloworld");
+      const json = new ReadableStream({
+        type: "direct",
+        async pull(c) {
+          c.write('{"hello":');
+          await nextTask();
+          c.write('"world"}');
+        },
+      });
+      expect(await new Response(json).json()).toEqual({ hello: "world" });
+    });
+
+    it("ReadableStream methods", async () => {
+      expect(await mk().text()).toBe("helloworld");
+      expect(decode(await mk().bytes())).toBe("helloworld");
+      expect(await (await mk().blob()).text()).toBe("helloworld");
+    });
+
+    it("Bun.readableStreamTo*()", async () => {
+      expect(await readableStreamToText(mk())).toBe("helloworld");
+      expect(decode(await readableStreamToBytes(mk()))).toBe("helloworld");
+      expect(decode(new Uint8Array(await readableStreamToArrayBuffer(mk())))).toBe("helloworld");
+      const chunks = await readableStreamToArray(mk());
+      expect(chunks.map(chunk => (typeof chunk === "string" ? chunk : decode(chunk))).join("")).toBe("helloworld");
+    });
+
+    it("runs the source's close() hook once, as an explicit close() does", async () => {
+      let textCloses = 0;
+      expect(await new Response(mk({ close: () => textCloses++ })).text()).toBe("helloworld");
+      let bytesCloses = 0;
+      expect(decode(await new Response(mk({ close: () => bytesCloses++ })).bytes())).toBe("helloworld");
+      expect([textCloses, bytesCloses]).toEqual([1, 1]);
+    });
+
+    it("a sync pull() that returns without close() still waits for close()", async () => {
+      let controller;
+      const text = new Response(
+        new ReadableStream({
+          type: "direct",
+          pull(c) {
+            controller = c;
+            c.write("hello");
+          },
+        }),
+      ).text();
+      let settled = false;
+      text.finally(() => (settled = true));
+      await nextTask();
+      expect(settled).toBe(false);
+      controller.write("world");
+      controller.close();
+      expect(await text).toBe("helloworld");
+    });
+
+    it("a reader still pulls again after each pull() resolves", async () => {
+      let pulls = 0;
+      const rs = new ReadableStream({
+        type: "direct",
+        async pull(c) {
+          pulls++;
+          await nextTask();
+          c.write("x");
+          if (pulls === 3) c.close();
+        },
+      });
+      const chunks = [];
+      for await (const chunk of rs) chunks.push(decode(chunk));
+      expect(pulls).toBe(3);
+      expect(chunks.join("")).toBe("xxx");
+    });
+  });
+
   it("a patched Object.prototype.then that releases the reader mid-resolution does not crash", async () => {
     let releaseNow = null;
     Object.defineProperty(Object.prototype, "then", {


### PR DESCRIPTION
### Problem
- A `type: "direct"` stream whose async `pull()` resolves without `controller.close()` ended differently per consumer: `Bun.serve` flushed and finished; `Bun.write(file, new Response(stream))` and `Bun.spawn({ stdin })` closed the fd and dropped the bytes buffered since the last flush, with `Bun.write` resolving the full count; `.text()`, `.bytes()`, `.json()`, `Bun.readableStreamTo*()` never settled.
- `Bun.write` was also a heap-use-after-free: `Blob.rs` freed the `FileSink` with its `JSReadableFileSinkController` attached, so `JSSink::js_controller_detached` (`Sink.rs:630`) read freed memory at the next GC (a segfault on release builds).
- Cause: `readDirectStream` (`BunStreamSource.cpp`) settled the owner's promise without ending the sink, and each owner improvised: `FileSink` called `writer.close()` (no flush), `Blob.rs` freed the sink without ending or detaching it, the JS consumers had no rule.

### Fix
- One rule for whole-body consumers: `pull()` runs once, and its promise resolving without `close()` is `close()`. `readDirectStream` ends the sink controller then, so every native sink takes the `end_from_js` path of an explicit `close()`; the JS consumers close their controller the same way.
- `FileSink` ends with the flushing `end()`. `Bun.write` pipes JS streams through `FileSink::pipe_stream`: the promise settles from `on_close` with the bytes on disk or the pump's, source's or write's error, and the controller is detached before the sink is freed.
- Unchanged: readers (`getReader()`, `for await`, `pipeTo()`, `tee()`) pull per read; a sync `pull()` that does not close waits for `close()`. Docs and `bun.d.ts` state the rule. Self-reviewed: rebased past #41757; the `.bytes()`/`.text()` close-hook ordering it raised is pre-existing (#41472).
- Verified: new tests in `streams.test.js` (hang before), `bun-write.test.js` (segfault before), `spawn-stdin-readable-stream.test.ts` (truncated before); suites in Notes.

### Background
- A direct stream's `controller.write()` goes straight to the destination's sink. A native sink's controller is a generated cell holding a raw `m_sinkPtr`; `end()`/`close()` run the sink's `end_from_js` and detach it, and a controller collected while attached finalizes the sink.
- `readDirectStream` calls `pull()` once and hands a promise to the sink's owner (`RequestContext`, `FileSink`, `FetchTasklet`); before, it meant "pull() returned", not "the body is complete".
- `FileSink` buffers writes below 4 KB and flushes them from an end-of-tick task that runs after promise reactions, so a write from the tick `pull()` resolved in is still buffered when the owner reacts.

<details><summary>Notes</summary>

- Related PRs. #41895 and #41897 fixed the same `Bun.write` use-after-free from the owner's side (`Blob.rs` ends and detaches the sink on each settle path). They were closed in favor of this PR, which covers their cases (a GC after the pump settles or fails, a late `controller.write()`, a final flush still draining into a full pipe, which `end()`'s pending path waits for before `on_close` settles the count) and also fixes the spawn stdin tail, the byte count, and the JS consumers. Their test cases were carried over into `bun-write.test.js` (956af54131): six pump-settle shapes each followed by a full GC, and the in-process check that the implicit end runs `cancel()` once and detaches the controller. All seven fail on 1.4.3-canary and pass here. One difference in behavior: when `pull()` rejects, those two PRs flushed the bytes the sink still buffered before closing the file. This PR keeps what main, `Bun.spawn` stdin and `Bun.serve` do on a failed source: the buffered tail is dropped and the promise rejects with the source's error. #41721 (`controller.close(error)` fails the consumer) and #41894 (HTTP sink close/cancel details) touch the same functions and rebase mechanically on top of this; #41472's `.bytes()` close-hook ordering is untouched here (`oneShotDirectClose` keeps main's order).
- Suites run locally on the debug ASAN build: the full `streams.test.js`, `serve.test.ts`, `serve-direct-readable-stream`, `serve-body-leak`, `serve-pending-promise-abort-leak`, `serve-response-stream-sink-leak`, `body-stream`, `fetch.stream`, `html-rewriter`, `filesink`, `bun-write`, `node-stream`, `spawn-stdio-syscall-error` and the four `spawn-stdin-readable-stream*` files.
- Repro from the report, before: `Bun.write resolved 10, file has 5`; `spawn stdin -> 5`; `Bun.serve -> 10`; `.text() -> still pending after 1s`. After: 10 / 10 / 10 / `"helloworld"`. The sync docs example (`pull(c) { c.write(...) }` with no promise and no close) still waits for `close()` on every whole-body consumer, as it did before on all of them; the docs now say to close.
- ASAN report before the fix (debug build, the report's script): `heap-use-after-free in JSSink<FileSink>::js_controller_detached src/runtime/webcore/Sink.rs:630`, freed by `on_file_stream_resolve_request_stream src/runtime/webcore/Blob.rs`, from `~JSReadableFileSinkController`. Canary 1.4.3 (f42e98025) segfaults at `0xA8`/`0xB0` on the same script once a GC runs after the write.
- HTTP: for an async no-close `pull()` the response now ends through `HTTPServerWritable::end_from_js` (the `controller.close()` path, `ended_response`) instead of `finalize()`'s `flush_no_wait` + `end_stream`. When nothing was flushed before the pull resolved this sends `Content-Length` via `try_end` instead of a chunked body, exactly as an explicit `close()` already did.
- `FileSink::end_from_js` now records the flush error it hits (as `end()` and `on_auto_flush` already did), and `FileSink` implements `close_with_error` (the pump closing the controller with the source's error) by recording the reason through `end_from_stream`, as the HTMLRewriter sink does. Both were invisible before because `Blob.rs` took the error from the pump promise; the `/dev/full` and `spawn-stdio-syscall-error` (EIO on an already-errored stdout) tests cover them.
- `handle_reject_stream` marks the sink done before closing the writer, like `on_attached_process_exit` and `end_from_stream`, so the controller's `end()` that `on_close` triggers does not flush a truncated body. Both settle paths then detach a controller that is still attached (its `onClose` could not run under a terminating worker or a pending exception).
- After the implicit end, a late `controller.write()`/`flush()` throws the existing `This FileSink has already been closed. A "direct" ReadableStream terminates its underlying socket once async pull() returns.` and `end()`/`close()` are no-ops, the same as after `Bun.serve` ends a direct body.
- Local-only failures seen in the suites above and also present on `main` in this container: `bun-write.test.js` "copyFileRange ... on large files" (5 s timeout, 256 MB copy under ASAN), `serve.test.ts` root-port and loopback tests (container runs as root), `bun-server.test.ts` IPv6 listen (no IPv6), `fetch.stream.test.ts` multi-part tests (pass with a longer timeout), `streams-leak.test.ts` pipe RSS test (15k rounds under ASAN).

</details>
