### PR TITLE
docs(serve): give the buffered static-route example a Content-Type

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -163,10 +163,14 @@ Bun caches static route responses for the lifetime of the server object. To relo
 Serving a file from a route behaves differently depending on whether you buffer the file content or serve it directly:
 
 ```ts
+const logo = Bun.file("./logo.png");
+
 Bun.serve({
   routes: {
     // Static route - content is buffered in memory at startup
-    "/logo.png": new Response(await Bun.file("./logo.png").bytes()),
+    "/logo.png": new Response(await logo.bytes(), {
+      headers: { "Content-Type": logo.type },
+    }),
 
     // File route - content is read from filesystem on each request
     "/download.zip": new Response(Bun.file("./download.zip")),
@@ -181,6 +185,7 @@ Bun.serve({
 - **If-None-Match** - Returns `304 Not Modified` when client ETag matches
 - **No 404 handling** - Missing files cause startup errors, not runtime 404s
 - **Memory usage** - Full file content stored in RAM
+- **Explicit Content-Type** - A byte buffer carries no type, so set the `Content-Type` header yourself (`file.type` is derived from the file extension). A `Bun.file()` body sets it for you.
 - **Best for**: Small static assets, API responses, frequently accessed files
 
 **File routes** (`new Response(Bun.file(path))`) read from filesystem per request:


### PR DESCRIPTION
### Problem
- The "File Responses vs Static Responses" example in `docs/runtime/http/routing.mdx` serves `new Response(await Bun.file("./logo.png").bytes())` as a static route. A byte buffer has no type, so that route sends no `Content-Type` header at all (bun 1.4.0 through canary). Under `X-Content-Type-Options: nosniff` the image does not render.
- The same body returned from a `fetch` handler gets `application/octet-stream`, and `new Response(Bun.file(p))` gets `image/png`, so a reader who copies the example gets the one variant with no type.

### Fix
- The example passes `headers: { "Content-Type": logo.type }` next to the buffered bytes, and the static-route property list says that a buffered body needs an explicit `Content-Type` while a `Bun.file()` body sets it.
- Docs only. Verified the amended example locally: `/logo.png` now answers `content-type: image/png` and keeps its ETag.

### Background
- Static routes (`routes: { "/x": new Response(...) }`) copy the `Response` headers and body once at startup. They derive nothing from the body, unlike the `fetch` handler path, which falls back to `application/octet-stream` for untyped bytes.
- `Bun.file(path).type` is the MIME type Bun infers from the file extension. It is what a `Bun.file()` body would have sent.
