### PR TITLE
cli: make --jsx-side-effects work alone, leave dev/prod to tsconfig and NODE_ENV

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -733,9 +733,18 @@ impl<'a> Transpiler<'a> {
             let top_level_dir = self.fs().top_level_dir;
             if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
                 if let Some(tsconfig) = root_dir.tsconfig_json() {
-                    // If we don't explicitly pass JSX, try to get it from the root tsconfig
-                    if self.options.transform_options.jsx.is_none() {
-                        self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx);
+                    match &self.options.transform_options.jsx {
+                        // If we don't explicitly pass JSX, try to get it from the root tsconfig
+                        None => self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx),
+                        // JSX options that leave dev/prod open (`--jsx-*` flags, a
+                        // bunfig.toml without `jsx`) take it from the root tsconfig,
+                        // the same as the per-file tsconfig merge in the resolver.
+                        Some(jsx) if jsx.development.is_none() => {
+                            if let Some(development) = tsconfig.jsx_development() {
+                                self.options.jsx.development = development;
+                            }
+                        }
+                        Some(_) => {}
                     }
                     self.options.emit_decorator_metadata = tsconfig.emit_decorator_metadata;
                     self.options.experimental_decorators = tsconfig.experimental_decorators;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -736,9 +736,7 @@ impl<'a> Transpiler<'a> {
                     match &self.options.transform_options.jsx {
                         // If we don't explicitly pass JSX, try to get it from the root tsconfig
                         None => self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx),
-                        // JSX options that leave dev/prod open (`--jsx-*` flags, a
-                        // bunfig.toml without `jsx`) take it from the root tsconfig,
-                        // the same as the per-file tsconfig merge in the resolver.
+                        // dev/prod left open (e.g. by `--jsx-*` flags): the root tsconfig decides.
                         Some(jsx) if jsx.development.is_none() => {
                             if let Some(development) = tsconfig.jsx_development() {
                                 self.options.jsx.development = development;

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -948,7 +948,7 @@ impl<'a> Parser<'a> {
         let mut jsx_fragment: Box<[u8]> = Box::default();
         let mut jsx_import_source: Box<[u8]> = Box::default();
         let mut jsx_runtime = api::JsxRuntime::Automatic;
-        let mut jsx_dev = true;
+        let mut jsx_dev: Option<bool> = None;
 
         if let Some(expr) = json.get(b"jsx") {
             if let Some(value) = expr.as_string(self.bump) {
@@ -956,10 +956,10 @@ impl<'a> Parser<'a> {
                     jsx_runtime = api::JsxRuntime::Classic;
                 } else if value == b"react-jsx" {
                     jsx_runtime = api::JsxRuntime::Automatic;
-                    jsx_dev = false;
+                    jsx_dev = Some(false);
                 } else if value == b"react-jsxDEV" {
                     jsx_runtime = api::JsxRuntime::Automatic;
-                    jsx_dev = true;
+                    jsx_dev = Some(true);
                 } else {
                     self.add_error(
                         expr.loc,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: `jsx.side_effects` participates in the features hash.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -195,10 +195,7 @@ impl Pragma {
     pub fn hash_for_runtime_transpiler(&self, hasher: &mut bun_wyhash::Wyhash) {
         // Uses `bun_wyhash::Wyhash` (the algorithm behind `bun.hash`) — distinct
         // from `Wyhash11`, which would yield a different cache key.
-        //
-        // Exhaustive destructure: a new field is a compile error here until it
-        // is either hashed or explicitly skipped. The caller only hashes when
-        // `parse` is set.
+        // Exhaustive, so a new field has to be hashed or skipped here.
         let Pragma {
             factory,
             fragment,

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -205,9 +205,14 @@ impl Pragma {
         hasher.update(&self.import_source.production);
         hasher.update(&self.classic_import_source);
         hasher.update(&self.package_name);
-        // `runtime` selects classic vs automatic emission; `development`
-        // selects `jsx` vs `jsxDEV`. Both shape transpiled output.
-        hasher.update(&[self.runtime as u8, self.development as u8]);
+        // `runtime` selects classic vs automatic emission, `development`
+        // selects `jsx` vs `jsxDEV`, `side_effects` decides whether unused
+        // JSX calls can be dropped. All three shape transpiled output.
+        hasher.update(&[
+            self.runtime as u8,
+            self.development as u8,
+            self.side_effects as u8,
+        ]);
     }
 
     pub fn import_source(&self) -> &[u8] {

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -195,24 +195,32 @@ impl Pragma {
     pub fn hash_for_runtime_transpiler(&self, hasher: &mut bun_wyhash::Wyhash) {
         // Uses `bun_wyhash::Wyhash` (the algorithm behind `bun.hash`) — distinct
         // from `Wyhash11`, which would yield a different cache key.
-        for factory in self.factory.iter() {
+        //
+        // Exhaustive destructure: a new field is a compile error here until it
+        // is either hashed or explicitly skipped. The caller only hashes when
+        // `parse` is set.
+        let Pragma {
+            factory,
+            fragment,
+            runtime,
+            import_source,
+            classic_import_source,
+            package_name,
+            development,
+            parse: _,
+            side_effects,
+        } = self;
+        for factory in factory.iter() {
             hasher.update(factory);
         }
-        for fragment in self.fragment.iter() {
+        for fragment in fragment.iter() {
             hasher.update(fragment);
         }
-        hasher.update(&self.import_source.development);
-        hasher.update(&self.import_source.production);
-        hasher.update(&self.classic_import_source);
-        hasher.update(&self.package_name);
-        // `runtime` selects classic vs automatic emission, `development`
-        // selects `jsx` vs `jsxDEV`, `side_effects` decides whether unused
-        // JSX calls can be dropped. All three shape transpiled output.
-        hasher.update(&[
-            self.runtime as u8,
-            self.development as u8,
-            self.side_effects as u8,
-        ]);
+        hasher.update(&import_source.development);
+        hasher.update(&import_source.production);
+        hasher.update(classic_import_source);
+        hasher.update(package_name);
+        hasher.update(&[*runtime as u8, *development as u8, *side_effects as u8]);
     }
 
     pub fn import_source(&self) -> &[u8] {
@@ -295,7 +303,9 @@ impl Pragma {
             pragma.classic_import_source = pragma.package_name.clone();
         }
 
-        pragma.development = jsx.development;
+        if let Some(development) = jsx.development {
+            pragma.development = development;
+        }
         pragma.parse = true;
         pragma
     }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -373,9 +373,7 @@ pub mod api {
         pub factory: Box<[u8]>,
         pub runtime: JsxRuntime,
         pub fragment: Box<[u8]>,
-        /// `None` when the producer (CLI flags, a bunfig.toml without `jsx`)
-        /// did not choose dev/prod: the root tsconfig.json and `NODE_ENV`
-        /// decide, exactly as when no JSX options are passed at all.
+        /// `None`: not chosen here, the root tsconfig.json and `NODE_ENV` decide.
         pub development: Option<bool>,
         pub import_source: Box<[u8]>,
         pub side_effects: bool,

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -373,7 +373,10 @@ pub mod api {
         pub factory: Box<[u8]>,
         pub runtime: JsxRuntime,
         pub fragment: Box<[u8]>,
-        pub development: bool,
+        /// `None` when the producer (CLI flags, a bunfig.toml without `jsx`)
+        /// did not choose dev/prod: the root tsconfig.json and `NODE_ENV`
+        /// decide, exactly as when no JSX options are passed at all.
+        pub development: Option<bool>,
         pub import_source: Box<[u8]>,
         pub side_effects: bool,
     }

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -230,7 +230,7 @@ impl TSConfigJSON {
     pub fn jsx_development(&self) -> Option<bool> {
         self.jsx_flags
             .contains(JsxField::Development)
-            .then(|| self.jsx.development)
+            .then_some(self.jsx.development)
     }
 
     pub fn merge_jsx(&self, current: options::jsx::Pragma) -> options::jsx::Pragma {

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -226,6 +226,14 @@ impl TSConfigJSON {
         !self.base_url.is_empty()
     }
 
+    /// `Some` only when `compilerOptions.jsx` is `react-jsx` (false) or
+    /// `react-jsxdev` (true).
+    pub fn jsx_development(&self) -> Option<bool> {
+        self.jsx_flags
+            .contains(JsxField::Development)
+            .then(|| self.jsx.development)
+    }
+
     pub fn merge_jsx(&self, current: options::jsx::Pragma) -> options::jsx::Pragma {
         let mut out = current;
 

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -226,8 +226,7 @@ impl TSConfigJSON {
         !self.base_url.is_empty()
     }
 
-    /// `Some` only when `compilerOptions.jsx` is `react-jsx` (false) or
-    /// `react-jsxdev` (true).
+    /// Set only by `"jsx": "react-jsx"` (false) or `"react-jsxdev"` (true).
     pub fn jsx_development(&self) -> Option<bool> {
         self.jsx_flags
             .contains(JsxField::Development)

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -182,7 +182,7 @@ pub mod js_bundler {
                     fragment: Box::default(),
                     runtime: api::JsxRuntime::Automatic,
                     import_source: Box::default(),
-                    development: true, // Default to development mode like old Pragma
+                    development: Some(true), // Default to development mode like old Pragma
                     ..Default::default()
                 },
                 force_node_env: options::ForceNodeEnv::Unspecified,
@@ -748,7 +748,7 @@ pub mod js_bundler {
                     if let Some(runtime) = options::JSX::RUNTIME_MAP.get(&str_lower[0..len]) {
                         this.jsx.runtime = jsx_runtime_to_api(runtime.runtime);
                         if let Some(dev) = runtime.development {
-                            this.jsx.development = dev;
+                            this.jsx.development = Some(dev);
                         }
                     } else {
                         return Err(global_this.throw_invalid_arguments(format_args!(
@@ -775,7 +775,7 @@ pub mod js_bundler {
                 }
 
                 if let Some(dev) = jsx_value.get_boolean_loose(global_this, "development")? {
-                    this.jsx.development = dev;
+                    this.jsx.development = Some(dev);
                 }
 
                 if let Some(val) = jsx_value.get_boolean_loose(global_this, "sideEffects")? {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -928,7 +928,7 @@ impl CompletionStruct for JSBundleCompletionTask {
             )
             .unwrap_or(default_fragment),
             runtime: options::jsx::Runtime::from(config.jsx.runtime),
-            development: config.jsx.development,
+            development: config.jsx.development.unwrap_or(true),
             package_name: if !jsx_import.is_empty() {
                 std::borrow::Cow::Owned(jsx_import.to_vec())
             } else {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1608,7 +1608,8 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 } else {
                     api::JsxRuntime::Automatic
                 },
-                development: true,
+                // No --jsx-* flag picks dev/prod; tsconfig and NODE_ENV do.
+                development: None,
                 side_effects: jsx_side_effects,
             });
         } else {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1593,6 +1593,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         || jsx_fragment.is_some()
         || jsx_import_source.is_some()
         || jsx_runtime.is_some()
+        || jsx_side_effects
     {
         let default_factory: &[u8] = b"";
         let default_fragment: &[u8] = b"";
@@ -1607,7 +1608,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 } else {
                     api::JsxRuntime::Automatic
                 },
-                development: false,
+                development: true,
                 side_effects: jsx_side_effects,
             });
         } else {
@@ -1623,8 +1624,8 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 } else {
                     prev.runtime
                 },
-                development: false,
-                side_effects: jsx_side_effects,
+                development: prev.development,
+                side_effects: jsx_side_effects || prev.side_effects,
             });
         }
     }

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -460,10 +460,10 @@ impl Route {
             config
                 .define
                 .put(b"process.env.NODE_ENV", b"\"production\"")?;
-            config.jsx.development = false;
+            config.jsx.development = Some(false);
         } else {
             config.force_node_env = bundler_options::ForceNodeEnv::Development;
-            config.jsx.development = true;
+            config.jsx.development = Some(true);
         }
         // Production defaults to no sourcemaps so original sources are not served publicly.
         config.source_map = if let Some(mode) = cli.args.serve_sourcemap {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1128,17 +1128,18 @@ describe("bundler", () => {
             });
             const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
             expect(stderr).toBe("");
-            expect(exitCode).toBe(0);
-            return stdout;
+            return { stdout, exitCode };
           };
 
           const baseline = await build([]);
-          expect(baseline).toContain("/* @__PURE__ */");
-          expect(baseline).toContain(expectedRuntime);
+          expect(baseline.stdout).toContain("/* @__PURE__ */");
+          expect(baseline.stdout).toContain(expectedRuntime);
+          expect(baseline.exitCode).toBe(0);
 
           const withFlag = await build(["--jsx-side-effects"]);
-          expect(withFlag).not.toContain("@__PURE__");
-          expect(withFlag).toContain(expectedRuntime);
+          expect(withFlag.stdout).not.toContain("@__PURE__");
+          expect(withFlag.stdout).toContain(expectedRuntime);
+          expect(withFlag.exitCode).toBe(0);
         });
       }
     });
@@ -1175,13 +1176,12 @@ describe("bundler", () => {
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect(stderr).toBe("");
-        expect(exitCode).toBe(0);
-        return stdout.trim();
+        return { stdout: stdout.trim(), exitCode };
       };
 
       // JSX calls are pure by default, so the unused element is removed.
-      expect(await buildAndRun([], "a.js")).toBe("hit=0");
-      expect(await buildAndRun(["--jsx-side-effects"], "b.js")).toBe("hit=1");
+      expect(await buildAndRun([], "a.js")).toEqual({ stdout: "hit=0", exitCode: 0 });
+      expect(await buildAndRun(["--jsx-side-effects"], "b.js")).toEqual({ stdout: "hit=1", exitCode: 0 });
     });
   });
 

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1093,6 +1093,86 @@ describe("bundler", () => {
         `);
       },
     });
+
+    // `--jsx-side-effects` on its own, with no other `--jsx-*` flag. The bunfig
+    // rows go through the arm of Arguments.rs that merges CLI flags into the
+    // `jsx` options bunfig.toml already created.
+    describe.each([
+      ["no bunfig", undefined, "react/jsx-dev-runtime"],
+      ["bunfig (no jsx keys)", 'logLevel = "error"\n', "react/jsx-dev-runtime"],
+      ['bunfig jsx = "react-jsx"', 'jsx = "react-jsx"\n', "react/jsx-runtime"],
+    ] as const)("cli: --jsx-side-effects alone [%s]", (_label, bunfig, expectedRuntime) => {
+      test.concurrent("drops the pure annotation without changing the runtime", async () => {
+        const files: Record<string, string> = {
+          "a.jsx": "export const a = <div />;\n",
+          "tsconfig.json": "{}",
+        };
+        if (bunfig !== undefined) files["bunfig.toml"] = bunfig;
+        using dir = tempDir("jsx-cli-side-effects", files);
+        const build = async (args: readonly string[]) => {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "build", "--no-bundle", ...args, "a.jsx"],
+            env: bunEnv,
+            cwd: String(dir),
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(exitCode).toBe(0);
+          return stdout;
+        };
+
+        const baseline = await build([]);
+        expect(baseline).toContain("/* @__PURE__ */");
+        expect(baseline).toContain(expectedRuntime);
+
+        const withFlag = await build(["--jsx-side-effects"]);
+        expect(withFlag).not.toContain("@__PURE__");
+        expect(withFlag).toContain(expectedRuntime);
+      });
+    });
+
+    test.concurrent("cli: --jsx-side-effects alone keeps an unused JSX element under --minify-syntax", async () => {
+      using dir = tempDir("jsx-cli-side-effects-bundle", {
+        "sx.jsx": `
+          function Boom() { globalThis.__hit = (globalThis.__hit || 0) + 1; return null; }
+          const h = (t, p, ...c) => { if (typeof t === "function") t(p); return { t, p, c }; };
+          const unused = <Boom />;
+          console.log("hit=" + (globalThis.__hit || 0));
+        `,
+        "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react", jsxFactory: "h" } }),
+      });
+      const buildAndRun = async (args: readonly string[], outfile: string) => {
+        {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "build", "sx.jsx", "--minify-syntax", ...args, "--outfile", outfile],
+            env: bunEnv,
+            cwd: String(dir),
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(exitCode).toBe(0);
+        }
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), outfile],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+        return stdout.trim();
+      };
+
+      // JSX calls are pure by default, so the unused element is removed.
+      expect(await buildAndRun([], "a.js")).toBe("hit=0");
+      expect(await buildAndRun(["--jsx-side-effects"], "b.js")).toBe("hit=1");
+    });
   });
 
   // https://github.com/oven-sh/bun/issues/6858

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1098,39 +1098,49 @@ describe("bundler", () => {
     // rows go through the arm of Arguments.rs that merges CLI flags into the
     // `jsx` options bunfig.toml already created.
     describe.each([
-      ["no bunfig", undefined, "react/jsx-dev-runtime"],
-      ["bunfig (no jsx keys)", 'logLevel = "error"\n', "react/jsx-dev-runtime"],
-      ['bunfig jsx = "react-jsx"', 'jsx = "react-jsx"\n', "react/jsx-runtime"],
-    ] as const)("cli: --jsx-side-effects alone [%s]", (_label, bunfig, expectedRuntime) => {
-      test.concurrent("drops the pure annotation without changing the runtime", async () => {
-        const files: Record<string, string> = {
-          "a.jsx": "export const a = <div />;\n",
-          "tsconfig.json": "{}",
-        };
-        if (bunfig !== undefined) files["bunfig.toml"] = bunfig;
-        using dir = tempDir("jsx-cli-side-effects", files);
-        const build = async (args: readonly string[]) => {
-          await using proc = Bun.spawn({
-            cmd: [bunExe(), "build", "--no-bundle", ...args, "a.jsx"],
-            env: bunEnv,
-            cwd: String(dir),
-            stdout: "pipe",
-            stderr: "pipe",
-          });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          expect(stderr).toBe("");
-          expect(exitCode).toBe(0);
-          return stdout;
-        };
+      ["tsconfig {}", { "tsconfig.json": "{}" }, "react/jsx-dev-runtime"],
+      [
+        'tsconfig "react-jsx"',
+        { "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }) },
+        "react/jsx-runtime",
+      ],
+      [
+        "bunfig (no jsx keys)",
+        { "tsconfig.json": "{}", "bunfig.toml": 'logLevel = "error"\n' },
+        "react/jsx-dev-runtime",
+      ],
+      [
+        'bunfig jsx = "react-jsx"',
+        { "tsconfig.json": "{}", "bunfig.toml": 'jsx = "react-jsx"\n' },
+        "react/jsx-runtime",
+      ],
+    ] as const)("cli: --jsx-side-effects alone [%s]", (_label, config, expectedRuntime) => {
+      for (const mode of [["--no-bundle"], ["--external", "react"]]) {
+        test.concurrent(`${mode[0]}: drops the pure annotation without changing the runtime`, async () => {
+          using dir = tempDir("jsx-cli-side-effects", { "a.jsx": "export const a = <div />;\n", ...config });
+          const build = async (args: readonly string[]) => {
+            await using proc = Bun.spawn({
+              cmd: [bunExe(), "build", ...mode, ...args, "a.jsx"],
+              env: bunEnv,
+              cwd: String(dir),
+              stdout: "pipe",
+              stderr: "pipe",
+            });
+            const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+            expect(stderr).toBe("");
+            expect(exitCode).toBe(0);
+            return stdout;
+          };
 
-        const baseline = await build([]);
-        expect(baseline).toContain("/* @__PURE__ */");
-        expect(baseline).toContain(expectedRuntime);
+          const baseline = await build([]);
+          expect(baseline).toContain("/* @__PURE__ */");
+          expect(baseline).toContain(expectedRuntime);
 
-        const withFlag = await build(["--jsx-side-effects"]);
-        expect(withFlag).not.toContain("@__PURE__");
-        expect(withFlag).toContain(expectedRuntime);
-      });
+          const withFlag = await build(["--jsx-side-effects"]);
+          expect(withFlag).not.toContain("@__PURE__");
+          expect(withFlag).toContain(expectedRuntime);
+        });
+      }
     });
 
     test.concurrent("cli: --jsx-side-effects alone keeps an unused JSX element under --minify-syntax", async () => {

--- a/test/bundler/transpiler/jsx-cli-flags.test.ts
+++ b/test/bundler/transpiler/jsx-cli-flags.test.ts
@@ -30,8 +30,7 @@ async function spawn(args: string[], cwd: string, env: Record<string, string | u
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-  return stdout;
+  return { stdout, exitCode };
 }
 
 // A --jsx-* CLI flag only overrides the field it names. It must not flip the
@@ -76,8 +75,9 @@ describe.concurrent("jsx: --jsx-* CLI flags preserve the development runtime", (
       using dir = tempDir("jsx-cli-dev", files);
       const env: Record<string, string | undefined> = { ...bunEnv, NODE_ENV: nodeEnv };
       if (nodeEnv === undefined) delete env.NODE_ENV;
-      const stdout = await spawn([...extraArgs, "a.jsx"], String(dir), env);
+      const { stdout, exitCode } = await spawn([...extraArgs, "a.jsx"], String(dir), env);
       expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
+      expect(exitCode).toBe(0);
     });
   }
 });
@@ -129,8 +129,9 @@ describe.concurrent("jsx: tsconfig dev/prod selection agrees across run, --no-bu
     for (const mode of Object.keys(modes) as (keyof typeof modes)[]) {
       test(`${mode} ${flags.join(" ") || "(no flags)"} [${label}] -> ${expected}`, async () => {
         using dir = tempDir("jsx-cli-tsconfig", { ...shimFiles, ...files });
-        const stdout = await spawn(modes[mode](flags), String(dir));
+        const { stdout, exitCode } = await spawn(modes[mode](flags), String(dir));
         expect(runtimeOf(mode, stdout)).toBe(expected);
+        expect(exitCode).toBe(0);
       });
     }
   }

--- a/test/bundler/transpiler/jsx-cli-flags.test.ts
+++ b/test/bundler/transpiler/jsx-cli-flags.test.ts
@@ -1,28 +1,44 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
+// A shim `react` package whose two runtime entry points report which one was
+// imported.
+const shimFiles = {
+  "node_modules/react/package.json": JSON.stringify({
+    name: "react",
+    version: "1.0.0",
+    exports: {
+      ".": "./index.js",
+      "./jsx-runtime": "./prod.js",
+      "./jsx-dev-runtime": "./dev.js",
+    },
+  }),
+  "node_modules/react/index.js": "module.exports = {};",
+  "node_modules/react/prod.js":
+    "exports.jsx = () => ({ rt: 'PROD' }); exports.jsxs = exports.jsx; exports.Fragment = {};",
+  "node_modules/react/dev.js": "exports.jsxDEV = () => ({ rt: 'DEV' }); exports.Fragment = {};",
+  "a.jsx": "console.log(JSON.stringify(<div/>));",
+};
+
+async function spawn(args: string[], cwd: string, env: Record<string, string | undefined> = bunEnv) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
 // A --jsx-* CLI flag only overrides the field it names. It must not flip the
 // automatic runtime from jsx-dev-runtime (development) to jsx-runtime
 // (production). Dev/prod selection follows NODE_ENV and bunfig exactly as it
 // does when no --jsx-* flag is present.
 describe.concurrent("jsx: --jsx-* CLI flags preserve the development runtime", () => {
-  const shimFiles = {
-    "node_modules/react/package.json": JSON.stringify({
-      name: "react",
-      version: "1.0.0",
-      exports: {
-        ".": "./index.js",
-        "./jsx-runtime": "./prod.js",
-        "./jsx-dev-runtime": "./dev.js",
-      },
-    }),
-    "node_modules/react/index.js": "module.exports = {};",
-    "node_modules/react/prod.js":
-      "exports.jsx = () => ({ rt: 'PROD' }); exports.jsxs = exports.jsx; exports.Fragment = {};",
-    "node_modules/react/dev.js": "exports.jsxDEV = () => ({ rt: 'DEV' }); exports.Fragment = {};",
-    "a.jsx": "console.log(JSON.stringify(<div/>));",
-  };
-
   type Case = [extraArgs: string[], nodeEnv: string | undefined, bunfig: string | undefined, expected: "DEV" | "PROD"];
   const cases: Case[] = [
     // Baselines (no --jsx-* flags): dev by default, prod only when NODE_ENV=production.
@@ -42,7 +58,7 @@ describe.concurrent("jsx: --jsx-* CLI flags preserve the development runtime", (
     [["--jsx-side-effects"], undefined, undefined, "DEV"],
     [["--jsx-side-effects"], "production", undefined, "PROD"],
     // With a bunfig present, the jsx options already exist and the CLI flags
-    // are merged into them. bunfig's `development` value must survive.
+    // are merged into them. bunfig's `jsx` value must survive.
     [["--jsx-import-source=react"], undefined, "", "DEV"],
     [["--jsx-import-source=react"], "production", "", "PROD"],
     [["--jsx-fragment=Fragment"], undefined, "", "DEV"],
@@ -60,17 +76,62 @@ describe.concurrent("jsx: --jsx-* CLI flags preserve the development runtime", (
       using dir = tempDir("jsx-cli-dev", files);
       const env: Record<string, string | undefined> = { ...bunEnv, NODE_ENV: nodeEnv };
       if (nodeEnv === undefined) delete env.NODE_ENV;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), ...extraArgs, "a.jsx"],
-        env,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
+      const stdout = await spawn([...extraArgs, "a.jsx"], String(dir), env);
       expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
-      expect(exitCode).toBe(0);
     });
+  }
+});
+
+// The root tsconfig.json `"jsx"` setting picks dev/prod the same way for
+// `bun <file>`, `bun build --no-bundle` and a bundling `bun build`, whether or
+// not a --jsx-* flag or a bunfig.toml is present.
+describe.concurrent("jsx: tsconfig dev/prod selection agrees across run, --no-bundle and bundle", () => {
+  const tsconfigs: [label: string, contents: string | undefined, expected: "DEV" | "PROD"][] = [
+    ["no tsconfig", undefined, "DEV"],
+    ["tsconfig {}", JSON.stringify({ compilerOptions: {} }), "DEV"],
+    ['tsconfig "react-jsx"', JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }), "PROD"],
+    ['tsconfig "react-jsxdev"', JSON.stringify({ compilerOptions: { jsx: "react-jsxdev" } }), "DEV"],
+  ];
+  const flagSets: string[][] = [[], ["--jsx-side-effects"], ["--jsx-import-source=react"]];
+  const modes = {
+    "run": (flags: string[]) => [...flags, "a.jsx"],
+    "--no-bundle": (flags: string[]) => ["build", "--no-bundle", ...flags, "a.jsx"],
+    "bundle": (flags: string[]) => ["build", "--external", "react", ...flags, "a.jsx"],
+  } as const;
+  const runtimeOf = (mode: keyof typeof modes, stdout: string): "DEV" | "PROD" => {
+    if (mode === "run") return JSON.parse(stdout.trim()).rt;
+    if (stdout.includes("react/jsx-dev-runtime")) return "DEV";
+    expect(stdout).toContain("react/jsx-runtime");
+    return "PROD";
+  };
+
+  type Case = [label: string, files: Record<string, string>, flags: string[], expected: "DEV" | "PROD"];
+  const cases: Case[] = [];
+  for (const [label, tsconfig, expected] of tsconfigs) {
+    for (const flags of flagSets) {
+      cases.push([label, tsconfig === undefined ? {} : { "tsconfig.json": tsconfig }, flags, expected]);
+    }
+  }
+  // A bunfig.toml without a `jsx` key leaves dev/prod to the tsconfig too.
+  for (const flags of [[], ["--jsx-side-effects"]]) {
+    cases.push([
+      'tsconfig "react-jsx" + bunfig',
+      {
+        "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }),
+        "bunfig.toml": 'logLevel = "error"\n',
+      },
+      flags,
+      "PROD",
+    ]);
+  }
+
+  for (const [label, files, flags, expected] of cases) {
+    for (const mode of Object.keys(modes) as (keyof typeof modes)[]) {
+      test(`${mode} ${flags.join(" ") || "(no flags)"} [${label}] -> ${expected}`, async () => {
+        using dir = tempDir("jsx-cli-tsconfig", { ...shimFiles, ...files });
+        const stdout = await spawn(modes[mode](flags), String(dir));
+        expect(runtimeOf(mode, stdout)).toBe(expected);
+      });
+    }
   }
 });

--- a/test/bundler/transpiler/jsx-cli-flags.test.ts
+++ b/test/bundler/transpiler/jsx-cli-flags.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// A --jsx-* CLI flag only overrides the field it names. It must not flip the
+// automatic runtime from jsx-dev-runtime (development) to jsx-runtime
+// (production). Dev/prod selection follows NODE_ENV and bunfig exactly as it
+// does when no --jsx-* flag is present.
+describe.concurrent("jsx: --jsx-* CLI flags preserve the development runtime", () => {
+  const shimFiles = {
+    "node_modules/react/package.json": JSON.stringify({
+      name: "react",
+      version: "1.0.0",
+      exports: {
+        ".": "./index.js",
+        "./jsx-runtime": "./prod.js",
+        "./jsx-dev-runtime": "./dev.js",
+      },
+    }),
+    "node_modules/react/index.js": "module.exports = {};",
+    "node_modules/react/prod.js":
+      "exports.jsx = () => ({ rt: 'PROD' }); exports.jsxs = exports.jsx; exports.Fragment = {};",
+    "node_modules/react/dev.js": "exports.jsxDEV = () => ({ rt: 'DEV' }); exports.Fragment = {};",
+    "a.jsx": "console.log(JSON.stringify(<div/>));",
+  };
+
+  type Case = [extraArgs: string[], nodeEnv: string | undefined, bunfig: string | undefined, expected: "DEV" | "PROD"];
+  const cases: Case[] = [
+    // Baselines (no --jsx-* flags): dev by default, prod only when NODE_ENV=production.
+    [[], undefined, undefined, "DEV"],
+    [[], "development", undefined, "DEV"],
+    [[], "production", undefined, "PROD"],
+    // No bunfig: the CLI flags create the jsx options from scratch.
+    [["--jsx-import-source=react"], undefined, undefined, "DEV"],
+    [["--jsx-import-source=react"], "development", undefined, "DEV"],
+    [["--jsx-import-source=react"], "production", undefined, "PROD"],
+    [["--jsx-fragment=Fragment"], undefined, undefined, "DEV"],
+    [["--jsx-fragment=Fragment"], "development", undefined, "DEV"],
+    [["--jsx-fragment=Fragment"], "production", undefined, "PROD"],
+    [["--jsx-factory=h"], undefined, undefined, "DEV"],
+    [["--jsx-runtime=automatic"], undefined, undefined, "DEV"],
+    [["--jsx-runtime=automatic"], "production", undefined, "PROD"],
+    [["--jsx-side-effects"], undefined, undefined, "DEV"],
+    [["--jsx-side-effects"], "production", undefined, "PROD"],
+    // With a bunfig present, the jsx options already exist and the CLI flags
+    // are merged into them. bunfig's `development` value must survive.
+    [["--jsx-import-source=react"], undefined, "", "DEV"],
+    [["--jsx-import-source=react"], "production", "", "PROD"],
+    [["--jsx-fragment=Fragment"], undefined, "", "DEV"],
+    [["--jsx-side-effects"], undefined, "", "DEV"],
+    [["--jsx-import-source=react"], undefined, 'jsx = "react-jsx"\n', "PROD"],
+    [["--jsx-import-source=react"], undefined, 'jsx = "react-jsxDEV"\n', "DEV"],
+  ];
+
+  for (const [extraArgs, nodeEnv, bunfig, expected] of cases) {
+    const bunfigLabel = bunfig === undefined ? "no bunfig" : bunfig === "" ? "empty bunfig" : `bunfig ${bunfig.trim()}`;
+    const label = `bun ${extraArgs.join(" ") || "(no flags)"} NODE_ENV=${nodeEnv ?? "<unset>"} [${bunfigLabel}] -> ${expected}`;
+    test(label, async () => {
+      const files: Record<string, string> = { ...shimFiles };
+      if (bunfig !== undefined) files["bunfig.toml"] = bunfig;
+      using dir = tempDir("jsx-cli-dev", files);
+      const env: Record<string, string | undefined> = { ...bunEnv, NODE_ENV: nodeEnv };
+      if (nodeEnv === undefined) delete env.NODE_ENV;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...extraArgs, "a.jsx"],
+        env,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(JSON.stringify({ rt: expected }));
+      expect(exitCode).toBe(0);
+    });
+  }
+});

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -343,17 +343,24 @@ describe("transpiler cache", () => {
 
     expect(run([])).toBe("calls=0");
     expect(newCacheCount()).toBe(1);
+    const entry = join(cache_dir, readdirSync(cache_dir)[0]);
+    const withoutFlag = readFileSync(entry);
     expect(run([])).toBe("calls=0");
     expect(newCacheCount()).toBe(0); // cache hit
+    expect(readFileSync(entry).equals(withoutFlag)).toBeTrue();
 
-    // features_hash differs -> old entry deleted, new entry written
+    // features_hash differs -> the entry for this source is rewritten in place
     expect(run(["--jsx-side-effects"])).toBe("calls=3");
     expect(newCacheCount()).toBe(0);
+    const withFlag = readFileSync(entry);
+    expect(withFlag.equals(withoutFlag)).toBeFalse();
     expect(run(["--jsx-side-effects"])).toBe("calls=3");
     expect(newCacheCount()).toBe(0); // cache hit
+    expect(readFileSync(entry).equals(withFlag)).toBeTrue();
 
     expect(run([])).toBe("calls=0");
     expect(newCacheCount()).toBe(0);
+    expect(readFileSync(entry).equals(withFlag)).toBeFalse();
   });
 
   // A define replaces an identifier at parse time, so the define table is part

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -319,6 +319,42 @@ describe("transpiler cache", () => {
     expect(run(["--feature=OTHER", "--feature=SUPER_SECRET"])).toBe("enabled");
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
+  test("--jsx-side-effects invalidates cache", () => {
+    // Without the flag a bare `<div />;` statement is a pure call and is
+    // dropped. With it the call stays. So the flag must be part of the key.
+    mkdirSync(join(temp_dir, "node_modules", "react"), { recursive: true });
+    writeFileSync(
+      join(temp_dir, "node_modules", "react", "package.json"),
+      JSON.stringify({ name: "react", exports: { "./jsx-dev-runtime": "./r.js", "./jsx-runtime": "./r.js" } }),
+    );
+    writeFileSync(
+      join(temp_dir, "node_modules", "react", "r.js"),
+      'let n=0;exports.jsxDEV=exports.jsx=exports.jsxs=()=>{n++};exports.Fragment={};process.on("exit",()=>console.log("calls="+n));',
+    );
+    writeFileSync(join(temp_dir, "tsconfig.json"), "{}");
+    const filler = Buffer.alloc((50 * 1024 * 1.5) | 0, "/").toString();
+    writeFileSync(join(temp_dir, "a.jsx"), "<div />;\n<div />;\n<div />;\n//" + filler + "\n");
+
+    const run = (extra: string[]) => {
+      const result = Bun.spawnSync({ cmd: [bunExe(), ...extra, "a.jsx"], cwd: temp_dir, env });
+      if (!result.success) throw new Error(result.stderr.toString());
+      return result.stdout.toString().trim();
+    };
+
+    expect(run([])).toBe("calls=0");
+    expect(newCacheCount()).toBe(1);
+    expect(run([])).toBe("calls=0");
+    expect(newCacheCount()).toBe(0); // cache hit
+
+    // features_hash differs -> old entry deleted, new entry written
+    expect(run(["--jsx-side-effects"])).toBe("calls=3");
+    expect(newCacheCount()).toBe(0);
+    expect(run(["--jsx-side-effects"])).toBe("calls=3");
+    expect(newCacheCount()).toBe(0); // cache hit
+
+    expect(run([])).toBe("calls=0");
+    expect(newCacheCount()).toBe(0);
+  });
 
   // A define replaces an identifier at parse time, so the define table is part
   // of the cache key. The cache is shared by every project of the user, and


### PR DESCRIPTION
### Problem
- `bun build --jsx-side-effects` is a no-op unless another `--jsx-*` flag is also passed. JSX calls keep `/* @__PURE__ */`, and `--minify-syntax` removes an unused `<Boom />` whose component has side effects (`hit=0` instead of `hit=1`). `Bun.build({ jsx: { sideEffects: true } })` works.
- Cause: `src/runtime/cli/Arguments.rs:1592` builds `opts.jsx` only for `--jsx-factory`, `--jsx-fragment`, `--jsx-import-source` or `--jsx-runtime`. `--jsx-side-effects` is read and dropped. The same block hard-codes `development: false`, so any `--jsx-*` flag also switches `jsxDEV` to `jsx`.
- Underneath, dev/prod was decided by whoever built `opts.jsx`. Once it is `Some`, `configure_linker_with_auto_jsx` (`src/bundler/transpiler.rs:736`) skips the root tsconfig, and the bundler stamps that global `development` on every file. A bunfig.toml with no `jsx` key already made a `"jsx": "react-jsx"` project bundle with `jsx-dev-runtime` while `--no-bundle` and `bun run` used `jsx-runtime`.

### Fix
- Add `jsx_side_effects` to the gate, and OR it with the bunfig value in the merge arm.
- `api::Jsx.development` becomes `Option<bool>`. `--jsx-*` flags and a bunfig without `jsx` leave it `None`. bunfig `jsx = ...`, `Bun.build` and the HTML dev server set it. For `None`, `Pragma::from_api` keeps the default and `configure_linker_with_auto_jsx` takes dev/prod from the root tsconfig's explicit `"jsx"`, as the resolver's per-file merge already does. `NODE_ENV=production` and `--production` apply as before.
- `jsx.side_effects` joins the runtime transpiler cache key (cache version 30). The hash now destructures `Pragma` exhaustively so a field cannot be left out again.
- Verified: `test/bundler/transpiler/jsx-cli-flags.test.ts` (62 cases: `bun <file>`, `--no-bundle` and bundle agree on dev/prod across tsconfig, bunfig, `NODE_ENV` and flags), `test/bundler/bundler_jsx.test.ts` (9 CLI cases with the `--minify-syntax` repro), `test/cli/run/transpiler-cache.test.ts` (1). 28 of them fail on canary `f42e98025`.

### Background
- JSX lowers to a call (`h(...)`, `jsx(...)`, `jsxDEV(...)`). Unless `jsx.side_effects` is set, the parser marks it `can_be_unwrapped_if_unused` (`src/js_parser/visit/visit_expr.rs:472`). The printer then emits `/* @__PURE__ */` and DCE may drop an unused call. esbuild's flag means the same.
- `Pragma.development` picks `jsxDEV` from `<source>/jsx-dev-runtime` or `jsx` from `<source>/jsx-runtime`. tsconfig `"react-jsx"` means prod, `"react-jsxdev"` means dev, anything else leaves the default (dev).
- `bun build --no-bundle` and `bun run` read `development` per file after the enclosing tsconfig is merged in. A bundling `bun build` uses one global value (`forced_jsx_development()`), which is why only that mode diverged.

<details><summary>Notes</summary>

- Self-reviewed: 1 concern raised, 1 addressed. The first revision defaulted `development` to `true` at the CLI site. Review found that this made a bundling `bun build` with any `--jsx-*` flag emit `jsx-dev-runtime` in a `"jsx": "react-jsx"` project (the `bun init` template), while `--no-bundle` stayed on `jsx-runtime`. The `Option<bool>` shape removes the producer-site decision instead, and the new matrix covers those rows in all three modes.
- This PR replaces #36261 and #36209, which fixed the two halves separately and had gone stale. Their tests are carried over.
- Repro from the report (bun 1.4.2 and canary):

  ```sh
  cat > sx.jsx <<'JS'
  function Boom() { globalThis.__hit = (globalThis.__hit || 0) + 1; return null; }
  const h = (t, p, ...c) => { if (typeof t === "function") t(p); return { t, p, c }; };
  const unused = <Boom />;
  console.log("hit=" + (globalThis.__hit || 0));
  JS
  echo '{"compilerOptions":{"jsx":"react","jsxFactory":"h"}}' > tsconfig.json
  bun build sx.jsx --minify-syntax --jsx-side-effects --outfile a.js && bun a.js      # hit=0 before, hit=1 after
  echo 'export const el = <div/>;' > p.jsx
  bun build --no-bundle p.jsx --jsx-side-effects | grep -c __PURE__                   # 1 before, 0 after
  bun build --no-bundle p.jsx --jsx-runtime=automatic                                 # jsx-runtime before, jsx-dev-runtime after
  ```

- Rows that change, all toward "a `--jsx-*` flag changes only the field it names":
  - no tsconfig `jsx` (or `react-jsxdev`), any `--jsx-*` flag, no `NODE_ENV`: `jsx-runtime` before, `jsx-dev-runtime` after, in every mode. Same as with no flag.
  - `"jsx": "react-jsx"` plus a bunfig.toml without `jsx`, bundling `bun build`: `jsx-dev-runtime` before, `jsx-runtime` after. Same as `--no-bundle` and `bun run`.
- Left alone (pre-existing, tracked elsewhere): bunfig `jsx` vs tsconfig `jsx` precedence differs between bundle and the other modes (#36728), and with no `--jsx-*` flag a tsconfig without `"jsx"` still resets `NODE_ENV=production` in a bundling `bun build` (#38050). With a flag, `NODE_ENV=production` now wins in that case.
- `Bun.build` keeps its explicit `development: true` default, so its output is unchanged (`jsx/sideEffectsTrueTsconfigAutomatic` snapshot still shows `jsxDEV` under a `react-jsx` tsconfig).
- `test/bundler/transpiler/jsx-production.test.ts` times out at the 5 s default under the debug ASAN build with or without this change. It passes with `--timeout 120000`. `jsx-tsconfig-react-jsx.test.ts`, `esbuild/tsconfig.test.ts` and `bun-serve-html.test.ts` pass.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->