### PR TITLE
install: forward SIGINT/SIGTERM/SIGHUP to running lifecycle scripts and wait for them

### DIFF
--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -357,21 +357,17 @@ impl MiniEventLoop {
         unsafe { (*self.loop_ptr()).wakeup() };
     }
 
-    /// [`enqueue_task_concurrent`](Self::enqueue_task_concurrent) without a
-    /// `&mut Self`, for a caller that cannot own one: a signal handler that
-    /// interrupted this thread inside `tick`. The push is the lock-free
-    /// `UnboundedQueue` producer side and the wakeup is `us_wakeup_loop`,
-    /// both async-signal-safe.
+    /// [`enqueue_task_concurrent`](Self::enqueue_task_concurrent) for a
+    /// signal handler, which may have interrupted `tick` and so must not form
+    /// `&mut Self`. Async-signal-safe (lock-free push + `us_wakeup_loop`).
     ///
     /// # Safety
-    /// `this` points to a live `MiniEventLoop`. `task` outlives the queued
-    /// work item and is not already in the queue.
+    /// `this` is live; `task` outlives the queued item and is not queued yet.
     pub unsafe fn enqueue_task_concurrent_raw(
         this: *const Self,
         task: NonNull<AnyTaskWithExtraContext>,
     ) {
-        // SAFETY: per fn contract. `addr_of!` projects to the fields without
-        // materializing a `&Self`; `push` takes `&UnboundedQueue` over atomics.
+        // SAFETY: per fn contract; field projection only, no `&Self`.
         unsafe {
             (*core::ptr::addr_of!((*this).concurrent_tasks)).push(task);
             bun_uws::us_wakeup_loop((*this).loop_);

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -357,6 +357,27 @@ impl MiniEventLoop {
         unsafe { (*self.loop_ptr()).wakeup() };
     }
 
+    /// [`enqueue_task_concurrent`](Self::enqueue_task_concurrent) without a
+    /// `&mut Self`, for a caller that cannot own one: a signal handler that
+    /// interrupted this thread inside `tick`. The push is the lock-free
+    /// `UnboundedQueue` producer side and the wakeup is `us_wakeup_loop`,
+    /// both async-signal-safe.
+    ///
+    /// # Safety
+    /// `this` points to a live `MiniEventLoop`. `task` outlives the queued
+    /// work item and is not already in the queue.
+    pub unsafe fn enqueue_task_concurrent_raw(
+        this: *const Self,
+        task: NonNull<AnyTaskWithExtraContext>,
+    ) {
+        // SAFETY: per fn contract. `addr_of!` projects to the fields without
+        // materializing a `&Self`; `push` takes `&UnboundedQueue` over atomics.
+        unsafe {
+            (*core::ptr::addr_of!((*this).concurrent_tasks)).push(task);
+            bun_uws::us_wakeup_loop((*this).loop_);
+        }
+    }
+
     /// The caller supplies `field_offset = core::mem::offset_of!(C, <field>)` of the
     /// embedded `AnyTaskWithExtraContext`.
     ///

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -116,6 +116,8 @@ pub mod git_runner;
 pub mod hoisted_install;
 pub mod isolated_install;
 pub mod lifecycle_script_runner;
+#[cfg(unix)]
+pub(crate) mod lifecycle_signals;
 pub mod migration;
 #[path = "PackageInstall.rs"]
 pub mod package_install;

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -850,8 +850,8 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         // fields (`heap`/`manager`) — see `ensure_not_in_heap` doc.
         unsafe { Self::ensure_not_in_heap(std::ptr::from_mut::<Self>(self)) };
 
-        // Draining after a forwarded signal: do not chain or exit on this
-        // script's status; `on_script_exited` ends the process after the last.
+        // A signal is pending: do not chain or exit on this script's status;
+        // `on_script_exited` ends the process after the last one.
         #[cfg(unix)]
         if crate::lifecycle_signals::pending().is_some() {
             if let Status::Signaled(signal) = status {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -650,6 +650,11 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 },
 
                 stream: false,
+                // The kernel kills the script when bun dies without a chance to
+                // forward a signal (SIGKILL, a crash), so no script outlives
+                // the install.
+                #[cfg(any(target_os = "linux", target_os = "android"))]
+                linux_pdeathsig: Some(bun_sys::SignalCode::SIGKILL.0),
                 ..Default::default()
             };
 
@@ -661,6 +666,10 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             (*manager)
                 .active_lifecycle_scripts
                 .insert(this.cast::<LifecycleScriptSubprocess<'static>>());
+            // Before the spawn, so that no signal can end `bun install` between
+            // the child's start and the handler's installation.
+            #[cfg(unix)]
+            crate::lifecycle_signals::on_script_started(manager);
             let spawned = match bun_spawn::spawn_process(
                 &spawn_options,
                 // argv is `[*const c_char; 4]` with trailing null — exactly the
@@ -670,6 +679,8 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             ) {
                 Ok(Ok(s)) => s,
                 res => {
+                    #[cfg(unix)]
+                    crate::lifecycle_signals::on_script_exited();
                     #[cfg(windows)]
                     {
                         // `spawn_process_windows` only `heap::take`s the `Stdio::Buffer`
@@ -842,6 +853,24 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         // fields (`heap`/`manager`) — see `ensure_not_in_heap` doc.
         unsafe { Self::ensure_not_in_heap(std::ptr::from_mut::<Self>(self)) };
 
+        #[cfg(unix)]
+        if crate::lifecycle_signals::pending().is_some() {
+            // `bun install` received a signal and forwarded it to this script.
+            // Whatever the script's status, do not chain into its next
+            // script. `on_script_exited` dies by the signal after the last
+            // running script is gone.
+            if let Status::Signaled(signal) = status {
+                self.print_terminated_by(signal);
+            }
+            crate::lifecycle_signals::on_script_exited();
+            self.decrement_pending_script_tasks();
+            // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
+            unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
+            return;
+        }
+        #[cfg(unix)]
+        crate::lifecycle_signals::on_script_exited();
+
         match status {
             Status::Exited(exit) => {
                 if exit.code > 0 {
@@ -960,15 +989,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
             }
             Status::Signaled(signal) => {
-                self.print_output();
-                let signal_code = bun_sys::SignalCode::from(signal);
-
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" terminated by {}<r>",
-                    bstr::BStr::new(self.script_name()),
-                    bstr::BStr::new(&self.package_name),
-                    signal_code.fmt(Output::enable_ansi_colors_stderr()),
-                );
+                self.print_terminated_by(signal);
 
                 // `Status::signal_code()` range-checks 1..=31 (`bun_core::SignalCode` is
                 // exhaustive); RT signals (>31) fall back to SIGTERM so the diverging
@@ -1012,6 +1033,17 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 ));
             }
         }
+    }
+
+    fn print_terminated_by(&mut self, signal: u8) {
+        self.print_output();
+        let signal_code = bun_sys::SignalCode::from(signal);
+        bun_core::pretty_errorln!(
+            "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" terminated by {}<r>",
+            bstr::BStr::new(self.script_name()),
+            bstr::BStr::new(&self.package_name),
+            signal_code.fmt(Output::enable_ansi_colors_stderr()),
+        );
     }
 
     /// This function may free the *LifecycleScriptSubprocess
@@ -1086,6 +1118,11 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         foreground: bool,
         ctx: Option<InstallCtx<'a>>,
     ) -> Result<(), crate::Error> {
+        // `bun install` is about to die by a forwarded signal. Start nothing new.
+        #[cfg(unix)]
+        if crate::lifecycle_signals::pending().is_some() {
+            return Ok(());
+        }
         let package_name = list.package_name.clone();
         let lifecycle_subprocess = Self::new(LifecycleScriptSubprocess {
             manager: bun_ptr::BackRef::new_mut(manager),

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -650,9 +650,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 },
 
                 stream: false,
-                // The kernel kills the script when bun dies without a chance to
-                // forward a signal (SIGKILL, a crash), so no script outlives
-                // the install.
+                // No script outlives a killed or crashed install.
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 linux_pdeathsig: Some(bun_sys::SignalCode::SIGKILL.0),
                 ..Default::default()
@@ -666,8 +664,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             (*manager)
                 .active_lifecycle_scripts
                 .insert(this.cast::<LifecycleScriptSubprocess<'static>>());
-            // Before the spawn, so that no signal can end `bun install` between
-            // the child's start and the handler's installation.
+            // Hooked before the spawn so no signal lands in between.
             #[cfg(unix)]
             crate::lifecycle_signals::on_script_started(manager);
             let spawned = match bun_spawn::spawn_process(
@@ -853,12 +850,10 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         // fields (`heap`/`manager`) — see `ensure_not_in_heap` doc.
         unsafe { Self::ensure_not_in_heap(std::ptr::from_mut::<Self>(self)) };
 
+        // Draining after a forwarded signal: do not chain or exit on this
+        // script's status; `on_script_exited` ends the process after the last.
         #[cfg(unix)]
         if crate::lifecycle_signals::pending().is_some() {
-            // `bun install` received a signal and forwarded it to this script.
-            // Whatever the script's status, do not chain into its next
-            // script. `on_script_exited` dies by the signal after the last
-            // running script is gone.
             if let Status::Signaled(signal) = status {
                 self.print_terminated_by(signal);
             }
@@ -1118,7 +1113,6 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         foreground: bool,
         ctx: Option<InstallCtx<'a>>,
     ) -> Result<(), crate::Error> {
-        // `bun install` is about to die by a forwarded signal. Start nothing new.
         #[cfg(unix)]
         if crate::lifecycle_signals::pending().is_some() {
             return Ok(());

--- a/src/install/lifecycle_signals.rs
+++ b/src/install/lifecycle_signals.rs
@@ -1,8 +1,6 @@
 //! Forwards SIGINT/SIGTERM/SIGHUP sent to `bun install` to its running
-//! lifecycle scripts instead of dying at once and orphaning them. After
-//! forwarding, the hook is removed (a second signal takes the default action),
-//! no new script starts, and once the last script exits `bun install` dies by
-//! the same signal. The hook itself is `bun_spawn::exit_signals`.
+//! lifecycle scripts, waits for them, then dies by the same signal (hook:
+//! `bun_spawn::exit_signals`). After forwarding, a second signal is default.
 
 use core::ffi::c_int;
 use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
@@ -32,9 +30,8 @@ fn signal_code(sig: c_int) -> bun_core::SignalCode {
         .unwrap_or(bun_core::SignalCode::DEFAULT)
 }
 
-/// Call before spawning a lifecycle script. `manager` must be the
-/// allocation-rooted `PackageManager` pointer; it is dereferenced from the
-/// signal callback until the last script exits.
+/// Call before spawning a lifecycle script. `manager` (allocation-rooted) is
+/// dereferenced from the signal callback until the last script exits.
 pub(crate) fn on_script_started(manager: *mut PackageManager) {
     if RUNNING.fetch_add(1, Ordering::Relaxed) != 0 {
         return;

--- a/src/install/lifecycle_signals.rs
+++ b/src/install/lifecycle_signals.rs
@@ -1,0 +1,110 @@
+//! SIGINT, SIGTERM and SIGHUP sent to `bun install` while a lifecycle script
+//! runs (CI cancellation, `docker stop`, `timeout(1)`, a hung-up ssh session).
+//!
+//! Without this the default action ends `bun install` at once and every
+//! running script is reparented to init, still writing into `node_modules`.
+//! Instead, while at least one script runs, the signal is forwarded to each
+//! script and `bun install` waits. No new script starts. When the last
+//! script has exited, `bun install` dies by the forwarded signal, the same way
+//! it already does for a script that dies by a signal on its own. The hook
+//! comes out as soon as the signal is forwarded, so a second signal takes the
+//! default action (on Linux the scripts then die with `bun install`, see
+//! `linux_pdeathsig` in the runner).
+//!
+//! The hook itself is `bun_spawn::exit_signals`. This module is the install
+//! half: which scripts run, what to forward, when to exit.
+
+use core::ffi::c_int;
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+
+use bun_spawn::exit_signals;
+
+use crate::PackageManager;
+use crate::lifecycle_script_runner::LifecycleScriptSubprocess;
+
+/// Number of lifecycle scripts that are running right now.
+static RUNNING: AtomicUsize = AtomicUsize::new(0);
+/// Set once the signal has been forwarded and the install is draining.
+static DRAINING: AtomicBool = AtomicBool::new(false);
+static MANAGER: AtomicPtr<PackageManager> = AtomicPtr::new(core::ptr::null_mut());
+
+/// The signal that `bun install` forwarded to the running scripts, if any.
+/// While this is `Some`, no new lifecycle script starts and an exiting script
+/// does not chain into the next one.
+pub(crate) fn pending() -> Option<bun_core::SignalCode> {
+    if !DRAINING.load(Ordering::Relaxed) {
+        return None;
+    }
+    exit_signals::received().map(signal_code)
+}
+
+fn signal_code(sig: c_int) -> bun_core::SignalCode {
+    u8::try_from(sig)
+        .ok()
+        .and_then(bun_core::SignalCode::from_raw)
+        .unwrap_or(bun_core::SignalCode::DEFAULT)
+}
+
+/// A lifecycle script is about to be spawned. Hooks the signals on the first
+/// one.
+///
+/// `manager` is the live `PackageManager` that owns the script. The signal
+/// callback dereferences it until the last script has exited, so it must
+/// carry allocation-rooted provenance, not a transient `&mut` reborrow.
+pub(crate) fn on_script_started(manager: *mut PackageManager) {
+    if RUNNING.fetch_add(1, Ordering::Relaxed) != 0 {
+        return;
+    }
+    MANAGER.store(manager, Ordering::Relaxed);
+    // SAFETY: `manager` is live (caller contract). Only the `event_loop`
+    // field is borrowed, and the borrow ends with this statement.
+    let event_loop =
+        bun_event_loop::EventLoopHandle::from_any(unsafe { &mut (*manager).event_loop });
+    exit_signals::hook(event_loop, on_signal);
+}
+
+/// A lifecycle script exited (after it left `active_lifecycle_scripts`), or
+/// failed to spawn. After the last one: dies by the forwarded signal when
+/// draining, else unhooks.
+pub(crate) fn on_script_exited() {
+    if RUNNING.fetch_sub(1, Ordering::Relaxed) != 1 {
+        return;
+    }
+    if let Some(sig) = pending() {
+        die(sig);
+    }
+    exit_signals::unhook();
+    MANAGER.store(core::ptr::null_mut(), Ordering::Relaxed);
+}
+
+fn die(sig: bun_core::SignalCode) -> ! {
+    bun_core::Output::flush();
+    bun_core::Global::raise_ignoring_panic_handler(sig);
+}
+
+/// Runs on the install thread, between event loop ticks.
+fn on_signal(sig: c_int) {
+    let manager = MANAGER.load(Ordering::Relaxed);
+    if manager.is_null() || RUNNING.load(Ordering::Relaxed) == 0 {
+        // The last script exited between the handler and this callback.
+        // Nothing to wait for: the default action, now.
+        die(signal_code(sig));
+    }
+    DRAINING.store(true, Ordering::Relaxed);
+    exit_signals::unhook();
+    let forward = signal_code(sig) as u8;
+    // SAFETY: `manager` is the live `PackageManager` stored by
+    // `on_script_started`; nothing else walks or mutates the heap while this
+    // runs on the install thread.
+    unsafe {
+        (*manager).active_lifecycle_scripts.for_each(
+            |script: *mut LifecycleScriptSubprocess<'static>| {
+                if let Some(process) = &(*script).process
+                    && !process.process_mut().has_exited()
+                {
+                    let _ = process.kill(forward);
+                }
+            },
+        );
+    }
+}

--- a/src/install/lifecycle_signals.rs
+++ b/src/install/lifecycle_signals.rs
@@ -1,18 +1,8 @@
-//! SIGINT, SIGTERM and SIGHUP sent to `bun install` while a lifecycle script
-//! runs (CI cancellation, `docker stop`, `timeout(1)`, a hung-up ssh session).
-//!
-//! Without this the default action ends `bun install` at once and every
-//! running script is reparented to init, still writing into `node_modules`.
-//! Instead, while at least one script runs, the signal is forwarded to each
-//! script and `bun install` waits. No new script starts. When the last
-//! script has exited, `bun install` dies by the forwarded signal, the same way
-//! it already does for a script that dies by a signal on its own. The hook
-//! comes out as soon as the signal is forwarded, so a second signal takes the
-//! default action (on Linux the scripts then die with `bun install`, see
-//! `linux_pdeathsig` in the runner).
-//!
-//! The hook itself is `bun_spawn::exit_signals`. This module is the install
-//! half: which scripts run, what to forward, when to exit.
+//! Forwards SIGINT/SIGTERM/SIGHUP sent to `bun install` to its running
+//! lifecycle scripts instead of dying at once and orphaning them. After
+//! forwarding, the hook is removed (a second signal takes the default action),
+//! no new script starts, and once the last script exits `bun install` dies by
+//! the same signal. The hook itself is `bun_spawn::exit_signals`.
 
 use core::ffi::c_int;
 use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
@@ -22,15 +12,12 @@ use bun_spawn::exit_signals;
 use crate::PackageManager;
 use crate::lifecycle_script_runner::LifecycleScriptSubprocess;
 
-/// Number of lifecycle scripts that are running right now.
 static RUNNING: AtomicUsize = AtomicUsize::new(0);
-/// Set once the signal has been forwarded and the install is draining.
+/// A signal was forwarded; the install is draining.
 static DRAINING: AtomicBool = AtomicBool::new(false);
 static MANAGER: AtomicPtr<PackageManager> = AtomicPtr::new(core::ptr::null_mut());
 
-/// The signal that `bun install` forwarded to the running scripts, if any.
-/// While this is `Some`, no new lifecycle script starts and an exiting script
-/// does not chain into the next one.
+/// The forwarded signal, if draining. While `Some`, no script starts or chains.
 pub(crate) fn pending() -> Option<bun_core::SignalCode> {
     if !DRAINING.load(Ordering::Relaxed) {
         return None;
@@ -45,27 +32,22 @@ fn signal_code(sig: c_int) -> bun_core::SignalCode {
         .unwrap_or(bun_core::SignalCode::DEFAULT)
 }
 
-/// A lifecycle script is about to be spawned. Hooks the signals on the first
-/// one.
-///
-/// `manager` is the live `PackageManager` that owns the script. The signal
-/// callback dereferences it until the last script has exited, so it must
-/// carry allocation-rooted provenance, not a transient `&mut` reborrow.
+/// Call before spawning a lifecycle script. `manager` must be the
+/// allocation-rooted `PackageManager` pointer; it is dereferenced from the
+/// signal callback until the last script exits.
 pub(crate) fn on_script_started(manager: *mut PackageManager) {
     if RUNNING.fetch_add(1, Ordering::Relaxed) != 0 {
         return;
     }
     MANAGER.store(manager, Ordering::Relaxed);
-    // SAFETY: `manager` is live (caller contract). Only the `event_loop`
-    // field is borrowed, and the borrow ends with this statement.
+    // SAFETY: `manager` is live; only `event_loop` is borrowed, for this call.
     let event_loop =
         bun_event_loop::EventLoopHandle::from_any(unsafe { &mut (*manager).event_loop });
     exit_signals::hook(event_loop, on_signal);
 }
 
-/// A lifecycle script exited (after it left `active_lifecycle_scripts`), or
-/// failed to spawn. After the last one: dies by the forwarded signal when
-/// draining, else unhooks.
+/// Call when a lifecycle script exited or failed to spawn. After the last
+/// one, dies by the forwarded signal if draining, else unhooks.
 pub(crate) fn on_script_exited() {
     if RUNNING.fetch_sub(1, Ordering::Relaxed) != 1 {
         return;
@@ -82,20 +64,18 @@ fn die(sig: bun_core::SignalCode) -> ! {
     bun_core::Global::raise_ignoring_panic_handler(sig);
 }
 
-/// Runs on the install thread, between event loop ticks.
+/// Install thread, between event loop ticks.
 fn on_signal(sig: c_int) {
     let manager = MANAGER.load(Ordering::Relaxed);
     if manager.is_null() || RUNNING.load(Ordering::Relaxed) == 0 {
-        // The last script exited between the handler and this callback.
-        // Nothing to wait for: the default action, now.
+        // The last script exited before this ran: nothing to wait for.
         die(signal_code(sig));
     }
     DRAINING.store(true, Ordering::Relaxed);
     exit_signals::unhook();
     let forward = signal_code(sig) as u8;
-    // SAFETY: `manager` is the live `PackageManager` stored by
-    // `on_script_started`; nothing else walks or mutates the heap while this
-    // runs on the install thread.
+    // SAFETY: `manager` is live (see `on_script_started`); the heap is only
+    // touched on this thread.
     unsafe {
         (*manager).active_lifecycle_scripts.for_each(
             |script: *mut LifecycleScriptSubprocess<'static>| {

--- a/src/install/lifecycle_signals.rs
+++ b/src/install/lifecycle_signals.rs
@@ -3,7 +3,7 @@
 //! `bun_spawn::exit_signals`). After forwarding, a second signal is default.
 
 use core::ffi::c_int;
-use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 
 use bun_spawn::exit_signals;
 
@@ -11,15 +11,11 @@ use crate::PackageManager;
 use crate::lifecycle_script_runner::LifecycleScriptSubprocess;
 
 static RUNNING: AtomicUsize = AtomicUsize::new(0);
-/// A signal was forwarded; the install is draining.
-static DRAINING: AtomicBool = AtomicBool::new(false);
 static MANAGER: AtomicPtr<PackageManager> = AtomicPtr::new(core::ptr::null_mut());
 
-/// The forwarded signal, if draining. While `Some`, no script starts or chains.
+/// A hooked signal arrived (forwarded or about to be). While `Some`, no
+/// script starts or chains, and the install ends by it after the last script.
 pub(crate) fn pending() -> Option<bun_core::SignalCode> {
-    if !DRAINING.load(Ordering::Relaxed) {
-        return None;
-    }
     exit_signals::received().map(signal_code)
 }
 
@@ -43,17 +39,19 @@ pub(crate) fn on_script_started(manager: *mut PackageManager) {
     exit_signals::hook(event_loop, on_signal);
 }
 
-/// Call when a lifecycle script exited or failed to spawn. After the last
-/// one, dies by the forwarded signal if draining, else unhooks.
+/// Call when a lifecycle script exited or failed to spawn. After the last one
+/// unhooks, then dies by a signal that arrived while hooked, if any.
 pub(crate) fn on_script_exited() {
     if RUNNING.fetch_sub(1, Ordering::Relaxed) != 1 {
         return;
     }
+    exit_signals::unhook();
+    MANAGER.store(core::ptr::null_mut(), Ordering::Relaxed);
+    // Checked after `unhook` so a signal either shows up here or already took
+    // the default action; none is lost in between.
     if let Some(sig) = pending() {
         die(sig);
     }
-    exit_signals::unhook();
-    MANAGER.store(core::ptr::null_mut(), Ordering::Relaxed);
 }
 
 fn die(sig: bun_core::SignalCode) -> ! {
@@ -68,7 +66,6 @@ fn on_signal(sig: c_int) {
         // The last script exited before this ran: nothing to wait for.
         die(signal_code(sig));
     }
-    DRAINING.store(true, Ordering::Relaxed);
     exit_signals::unhook();
     let forward = signal_code(sig) as u8;
     // SAFETY: `manager` is live (see `on_script_started`); the heap is only

--- a/src/io/heap.rs
+++ b/src/io/heap.rs
@@ -99,6 +99,23 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
         result
     }
 
+    /// Visit every element in the heap, in no particular order. `f` must not
+    /// insert into or remove from the heap. This is an O(N) operation.
+    pub unsafe fn for_each(&self, mut f: impl FnMut(*mut T)) {
+        // SAFETY: all reachable nodes from `self.root` are valid for the heap's lifetime.
+        Self::for_each_internal(self.root, &mut f);
+    }
+
+    unsafe fn for_each_internal(node: *mut T, f: &mut impl FnMut(*mut T)) {
+        if node.is_null() {
+            return;
+        }
+        f(node);
+        // SAFETY: `node` is non-null and valid (checked above / invariant).
+        Self::for_each_internal((*node).heap().child, f);
+        Self::for_each_internal((*node).heap().next, f);
+    }
+
     /// Look at the next maximum value but do not remove it. This is an O(N) operation.
     pub unsafe fn find_max(&self) -> *mut T {
         if self.root.is_null() {

--- a/src/io/heap.rs
+++ b/src/io/heap.rs
@@ -99,8 +99,7 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
         result
     }
 
-    /// Visit every element in the heap, in no particular order. `f` must not
-    /// insert into or remove from the heap. This is an O(N) operation.
+    /// Visit every element (unordered, O(N)). `f` must not insert or remove.
     pub unsafe fn for_each(&self, mut f: impl FnMut(*mut T)) {
         // SAFETY: all reachable nodes from `self.root` are valid for the heap's lifetime.
         Self::for_each_internal(self.root, &mut f);

--- a/src/spawn/exit_signals.rs
+++ b/src/spawn/exit_signals.rs
@@ -1,0 +1,155 @@
+//! SIGINT, SIGTERM and SIGHUP for a bun process that supervises background
+//! children: `bun install` while lifecycle scripts run. Such a process must
+//! not go away before the children have seen the signal, so it hooks the
+//! signals, forwards one to the children, waits for them, and then ends the
+//! way the signal asked. This module is the hook. It records the signal and
+//! runs the supervisor's callback on the thread that ticks its event loop.
+//! What to forward and when to exit stays with the supervisor.
+//!
+//! The handler does async-signal-safe work only: atomics, one lock-free
+//! `UnboundedQueue` push and the loop's wakeup write, through
+//! `MiniEventLoop::enqueue_task_concurrent` (the entry other threads use to
+//! post to the loop). A disposition inherited as `SIG_IGN` (`nohup`, a `&`
+//! job in a non-interactive shell) is left alone.
+//!
+//! This is not [`crate::ctrl_c`]: that one is for a foreground child that
+//! shares the terminal, where a Ctrl+C already reaches the child and nothing
+//! is forwarded.
+
+use core::ffi::c_int;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, Ordering};
+
+use bun_core::Mutex;
+use bun_event_loop::AnyTaskWithExtraContext::{AnyTaskWithExtraContext, New};
+use bun_event_loop::EventLoopHandle;
+use bun_event_loop::MiniEventLoop::MiniEventLoop;
+
+pub const SIGNALS: [c_int; 3] = [libc::SIGINT, libc::SIGTERM, libc::SIGHUP];
+
+/// The last hooked signal received since `hook`, 0 when none.
+static RECEIVED: AtomicI32 = AtomicI32::new(0);
+/// Set while `TASK` sits in the event loop queue: a node must not be pushed
+/// twice. `RECEIVED` and `QUEUED` are `SeqCst`: a handler that finds
+/// `QUEUED` set relies on the queued task to read its `RECEIVED` store, and
+/// the handler can run on any thread.
+static QUEUED: AtomicBool = AtomicBool::new(false);
+static EVENT_LOOP: AtomicPtr<MiniEventLoop> = AtomicPtr::new(core::ptr::null_mut());
+/// Allocated by the first `hook`, never freed: the handler must not allocate.
+static TASK: AtomicPtr<AnyTaskWithExtraContext> = AtomicPtr::new(core::ptr::null_mut());
+/// Only read on the event loop thread.
+static ON_SIGNAL: Mutex<Option<fn(c_int)>> = Mutex::new(None);
+/// The dispositions `hook` replaced, `None` while not hooked.
+static PREVIOUS: Mutex<Option<[libc::sigaction; SIGNALS.len()]>> = Mutex::new(None);
+
+/// Hooks SIGINT, SIGTERM and SIGHUP. From now until [`unhook`], a signal runs
+/// `on_signal(signal)` on the thread that ticks `event_loop`, at its next
+/// tick, and the loop is woken for it. Signals that arrive before the
+/// callback runs coalesce into one call with the latest. Call it from that
+/// thread.
+///
+/// Returns `false` and hooks nothing for a JS event loop: the runtime owns
+/// the process signals there.
+pub fn hook(event_loop: EventLoopHandle, on_signal: fn(c_int)) -> bool {
+    let EventLoopHandle::Mini(mini) = event_loop else {
+        return false;
+    };
+    let mut previous = PREVIOUS.lock();
+    *ON_SIGNAL.lock() = Some(on_signal);
+    if previous.is_some() {
+        return true;
+    }
+    if TASK.load(Ordering::Relaxed).is_null() {
+        // The callback reads the statics; the task context is unused.
+        let task = New::<(), ()>::init(NonNull::<()>::dangling().as_ptr(), run_task);
+        TASK.store(bun_core::heap::into_raw(Box::new(task)), Ordering::Relaxed);
+    }
+    RECEIVED.store(0, Ordering::SeqCst);
+    // Before the dispositions: the handler never runs without a loop. The
+    // loop outlives the hook (the `EventLoopHandle` invariant).
+    EVENT_LOOP.store(mini.as_ptr(), Ordering::Release);
+
+    let mut saved: [libc::sigaction; SIGNALS.len()] = [bun_core::ffi::zeroed(); SIGNALS.len()];
+    // SAFETY: all-zero is a valid `libc::sigaction`; `sigemptyset` and
+    // `sigaction` get pointers to live stack values.
+    unsafe {
+        let mut act: libc::sigaction = bun_core::ffi::zeroed();
+        act.sa_sigaction = handler as *const () as usize;
+        act.sa_flags = libc::SA_RESTART;
+        libc::sigemptyset(&raw mut act.sa_mask);
+        for (i, sig) in SIGNALS.iter().enumerate() {
+            if libc::sigaction(*sig, core::ptr::null(), &raw mut saved[i]) != 0 {
+                continue;
+            }
+            if saved[i].sa_sigaction == libc::SIG_IGN {
+                continue;
+            }
+            libc::sigaction(*sig, &raw const act, core::ptr::null_mut());
+        }
+    }
+    *previous = Some(saved);
+    true
+}
+
+/// Restores the dispositions [`hook`] replaced: a later signal takes the
+/// previous action, and the default one ends the process. [`received`] keeps
+/// its value. Does nothing when not hooked.
+pub fn unhook() {
+    let mut previous = PREVIOUS.lock();
+    let Some(saved) = previous.take() else {
+        return;
+    };
+    // SAFETY: `saved` holds dispositions the kernel returned in `hook`.
+    unsafe {
+        for (i, sig) in SIGNALS.iter().enumerate() {
+            libc::sigaction(*sig, &raw const saved[i], core::ptr::null_mut());
+        }
+    }
+    // After the dispositions: the handler never runs without a loop.
+    EVENT_LOOP.store(core::ptr::null_mut(), Ordering::Release);
+}
+
+/// The last hooked signal received since [`hook`], if any. Still set after
+/// [`unhook`], for a supervisor that ends by it once its children are gone.
+pub fn received() -> Option<c_int> {
+    match RECEIVED.load(Ordering::SeqCst) {
+        0 => None,
+        sig => Some(sig),
+    }
+}
+
+extern "C" fn handler(sig: c_int) {
+    RECEIVED.store(sig, Ordering::SeqCst);
+    if QUEUED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let event_loop = EVENT_LOOP.load(Ordering::Acquire);
+    let task = NonNull::new(TASK.load(Ordering::Relaxed));
+    let (false, Some(task)) = (event_loop.is_null(), task) else {
+        // Only reachable on another thread while `unhook` restores the
+        // dispositions. Take the default action rather than drop the signal:
+        // `sig` is blocked inside its own handler, so the re-raise lands on
+        // return.
+        QUEUED.store(false, Ordering::SeqCst);
+        // SAFETY: all-zero is a valid `libc::sigaction`; both calls are
+        // async-signal-safe.
+        unsafe {
+            let mut act: libc::sigaction = bun_core::ffi::zeroed();
+            act.sa_sigaction = libc::SIG_DFL;
+            libc::sigaction(sig, &raw const act, core::ptr::null_mut());
+            libc::raise(sig);
+        }
+        return;
+    };
+    // SAFETY: `EVENT_LOOP` is live while the dispositions are installed (see
+    // `hook`/`unhook`), and `task` is not in the queue (`QUEUED` was false).
+    unsafe { (*event_loop).enqueue_task_concurrent(task) };
+}
+
+fn run_task(_: *mut (), _: *mut ()) {
+    QUEUED.store(false, Ordering::SeqCst);
+    let on_signal = *ON_SIGNAL.lock();
+    if let (Some(on_signal), Some(sig)) = (on_signal, received()) {
+        on_signal(sig);
+    }
+}

--- a/src/spawn/exit_signals.rs
+++ b/src/spawn/exit_signals.rs
@@ -27,7 +27,9 @@ use bun_event_loop::MiniEventLoop::MiniEventLoop;
 
 pub const SIGNALS: [c_int; 3] = [libc::SIGINT, libc::SIGTERM, libc::SIGHUP];
 
-/// The last hooked signal received since `hook`, 0 when none.
+/// The last hooked signal received, 0 when none. Never cleared: a signal
+/// that lands while the supervisor swaps one child for the next (unhook,
+/// hook again) is still acted on by the task it queued.
 static RECEIVED: AtomicI32 = AtomicI32::new(0);
 /// Set while `TASK` sits in the event loop queue: a node must not be pushed
 /// twice. `RECEIVED` and `QUEUED` are `SeqCst`: a handler that finds
@@ -45,8 +47,9 @@ static PREVIOUS: Mutex<Option<[libc::sigaction; SIGNALS.len()]>> = Mutex::new(No
 /// Hooks SIGINT, SIGTERM and SIGHUP. From now until [`unhook`], a signal runs
 /// `on_signal(signal)` on the thread that ticks `event_loop`, at its next
 /// tick, and the loop is woken for it. Signals that arrive before the
-/// callback runs coalesce into one call with the latest. Call it from that
-/// thread.
+/// callback runs coalesce into one call with the latest. A callback queued
+/// under an earlier hook still runs, with this `on_signal`. Call it from the
+/// loop's thread.
 ///
 /// Returns `false` and hooks nothing for a JS event loop: the runtime owns
 /// the process signals there.
@@ -64,7 +67,6 @@ pub fn hook(event_loop: EventLoopHandle, on_signal: fn(c_int)) -> bool {
         let task = New::<(), ()>::init(NonNull::<()>::dangling().as_ptr(), run_task);
         TASK.store(bun_core::heap::into_raw(Box::new(task)), Ordering::Relaxed);
     }
-    RECEIVED.store(0, Ordering::SeqCst);
     // Before the dispositions: the handler never runs without a loop. The
     // loop outlives the hook (the `EventLoopHandle` invariant).
     EVENT_LOOP.store(mini.as_ptr(), Ordering::Release);
@@ -109,8 +111,8 @@ pub fn unhook() {
     EVENT_LOOP.store(core::ptr::null_mut(), Ordering::Release);
 }
 
-/// The last hooked signal received since [`hook`], if any. Still set after
-/// [`unhook`], for a supervisor that ends by it once its children are gone.
+/// The last hooked signal received, if any. Still set after [`unhook`], for
+/// a supervisor that ends by it once its children are gone.
 pub fn received() -> Option<c_int> {
     match RECEIVED.load(Ordering::SeqCst) {
         0 => None,
@@ -143,7 +145,8 @@ extern "C" fn handler(sig: c_int) {
     };
     // SAFETY: `EVENT_LOOP` is live while the dispositions are installed (see
     // `hook`/`unhook`), and `task` is not in the queue (`QUEUED` was false).
-    unsafe { (*event_loop).enqueue_task_concurrent(task) };
+    // The raw form: this may have interrupted the loop's thread inside `tick`.
+    unsafe { MiniEventLoop::enqueue_task_concurrent_raw(event_loop, task) };
 }
 
 fn run_task(_: *mut (), _: *mut ()) {

--- a/src/spawn/exit_signals.rs
+++ b/src/spawn/exit_signals.rs
@@ -1,11 +1,8 @@
-//! SIGINT/SIGTERM/SIGHUP hook for a process that supervises background
-//! children and must forward the signal to them before it exits (today:
-//! `bun install` while lifecycle scripts run). The handler records the
-//! signal and posts a task to the supervisor's `MiniEventLoop`; the
-//! supervisor's callback decides what to forward and when to exit.
-//!
-//! Unlike [`crate::ctrl_c`] (foreground child sharing the terminal, nothing
-//! forwarded), this is for children that a pid-targeted signal never reaches.
+//! SIGINT/SIGTERM/SIGHUP hook for a supervisor of background children (`bun
+//! install` running lifecycle scripts): the handler records the signal and
+//! posts the supervisor's callback to its `MiniEventLoop`. Contrast
+//! [`crate::ctrl_c`], where the child shares the terminal and nothing is
+//! forwarded.
 
 use core::ffi::c_int;
 use core::ptr::NonNull;
@@ -31,11 +28,9 @@ static ON_SIGNAL: Mutex<Option<fn(c_int)>> = Mutex::new(None);
 /// Dispositions replaced by `hook`; `None` while not hooked.
 static PREVIOUS: Mutex<Option<[libc::sigaction; SIGNALS.len()]>> = Mutex::new(None);
 
-/// Until [`unhook`], a hooked signal wakes `event_loop` and runs
-/// `on_signal(sig)` on its thread at the next tick (signals coalesce; the
-/// latest wins). An inherited `SIG_IGN` is left alone. Returns `false` for a
-/// JS event loop, where the runtime owns process signals. Call from the
-/// loop's thread.
+/// Until [`unhook`], a hooked signal runs `on_signal(sig)` on the loop's
+/// thread at its next tick (coalesced; latest wins). Skips an inherited
+/// `SIG_IGN`. Returns `false` (no hook) for a JS event loop.
 pub fn hook(event_loop: EventLoopHandle, on_signal: fn(c_int)) -> bool {
     let EventLoopHandle::Mini(mini) = event_loop else {
         return false;

--- a/src/spawn/exit_signals.rs
+++ b/src/spawn/exit_signals.rs
@@ -1,20 +1,11 @@
-//! SIGINT, SIGTERM and SIGHUP for a bun process that supervises background
-//! children: `bun install` while lifecycle scripts run. Such a process must
-//! not go away before the children have seen the signal, so it hooks the
-//! signals, forwards one to the children, waits for them, and then ends the
-//! way the signal asked. This module is the hook. It records the signal and
-//! runs the supervisor's callback on the thread that ticks its event loop.
-//! What to forward and when to exit stays with the supervisor.
+//! SIGINT/SIGTERM/SIGHUP hook for a process that supervises background
+//! children and must forward the signal to them before it exits (today:
+//! `bun install` while lifecycle scripts run). The handler records the
+//! signal and posts a task to the supervisor's `MiniEventLoop`; the
+//! supervisor's callback decides what to forward and when to exit.
 //!
-//! The handler does async-signal-safe work only: atomics, one lock-free
-//! `UnboundedQueue` push and the loop's wakeup write, through
-//! `MiniEventLoop::enqueue_task_concurrent` (the entry other threads use to
-//! post to the loop). A disposition inherited as `SIG_IGN` (`nohup`, a `&`
-//! job in a non-interactive shell) is left alone.
-//!
-//! This is not [`crate::ctrl_c`]: that one is for a foreground child that
-//! shares the terminal, where a Ctrl+C already reaches the child and nothing
-//! is forwarded.
+//! Unlike [`crate::ctrl_c`] (foreground child sharing the terminal, nothing
+//! forwarded), this is for children that a pid-targeted signal never reaches.
 
 use core::ffi::c_int;
 use core::ptr::NonNull;
@@ -27,32 +18,24 @@ use bun_event_loop::MiniEventLoop::MiniEventLoop;
 
 pub const SIGNALS: [c_int; 3] = [libc::SIGINT, libc::SIGTERM, libc::SIGHUP];
 
-/// The last hooked signal received, 0 when none. Never cleared: a signal
-/// that lands while the supervisor swaps one child for the next (unhook,
-/// hook again) is still acted on by the task it queued.
+/// Last hooked signal received, 0 when none. Never cleared, so a task queued
+/// under one hook still sees it after an unhook/hook cycle.
 static RECEIVED: AtomicI32 = AtomicI32::new(0);
-/// Set while `TASK` sits in the event loop queue: a node must not be pushed
-/// twice. `RECEIVED` and `QUEUED` are `SeqCst`: a handler that finds
-/// `QUEUED` set relies on the queued task to read its `RECEIVED` store, and
-/// the handler can run on any thread.
+/// `TASK` is in the loop's queue. `SeqCst` with `RECEIVED`: a handler (any
+/// thread) that sees this set relies on the queued task reading its store.
 static QUEUED: AtomicBool = AtomicBool::new(false);
 static EVENT_LOOP: AtomicPtr<MiniEventLoop> = AtomicPtr::new(core::ptr::null_mut());
-/// Allocated by the first `hook`, never freed: the handler must not allocate.
+/// Allocated once, never freed: the handler must not allocate.
 static TASK: AtomicPtr<AnyTaskWithExtraContext> = AtomicPtr::new(core::ptr::null_mut());
-/// Only read on the event loop thread.
 static ON_SIGNAL: Mutex<Option<fn(c_int)>> = Mutex::new(None);
-/// The dispositions `hook` replaced, `None` while not hooked.
+/// Dispositions replaced by `hook`; `None` while not hooked.
 static PREVIOUS: Mutex<Option<[libc::sigaction; SIGNALS.len()]>> = Mutex::new(None);
 
-/// Hooks SIGINT, SIGTERM and SIGHUP. From now until [`unhook`], a signal runs
-/// `on_signal(signal)` on the thread that ticks `event_loop`, at its next
-/// tick, and the loop is woken for it. Signals that arrive before the
-/// callback runs coalesce into one call with the latest. A callback queued
-/// under an earlier hook still runs, with this `on_signal`. Call it from the
+/// Until [`unhook`], a hooked signal wakes `event_loop` and runs
+/// `on_signal(sig)` on its thread at the next tick (signals coalesce; the
+/// latest wins). An inherited `SIG_IGN` is left alone. Returns `false` for a
+/// JS event loop, where the runtime owns process signals. Call from the
 /// loop's thread.
-///
-/// Returns `false` and hooks nothing for a JS event loop: the runtime owns
-/// the process signals there.
 pub fn hook(event_loop: EventLoopHandle, on_signal: fn(c_int)) -> bool {
     let EventLoopHandle::Mini(mini) = event_loop else {
         return false;
@@ -63,17 +46,14 @@ pub fn hook(event_loop: EventLoopHandle, on_signal: fn(c_int)) -> bool {
         return true;
     }
     if TASK.load(Ordering::Relaxed).is_null() {
-        // The callback reads the statics; the task context is unused.
         let task = New::<(), ()>::init(NonNull::<()>::dangling().as_ptr(), run_task);
         TASK.store(bun_core::heap::into_raw(Box::new(task)), Ordering::Relaxed);
     }
-    // Before the dispositions: the handler never runs without a loop. The
-    // loop outlives the hook (the `EventLoopHandle` invariant).
+    // Published before the dispositions so the handler always finds a loop.
     EVENT_LOOP.store(mini.as_ptr(), Ordering::Release);
 
     let mut saved: [libc::sigaction; SIGNALS.len()] = [bun_core::ffi::zeroed(); SIGNALS.len()];
-    // SAFETY: all-zero is a valid `libc::sigaction`; `sigemptyset` and
-    // `sigaction` get pointers to live stack values.
+    // SAFETY: zeroed `sigaction` is valid; all pointers are to live locals.
     unsafe {
         let mut act: libc::sigaction = bun_core::ffi::zeroed();
         act.sa_sigaction = handler as *const () as usize;
@@ -93,9 +73,8 @@ pub fn hook(event_loop: EventLoopHandle, on_signal: fn(c_int)) -> bool {
     true
 }
 
-/// Restores the dispositions [`hook`] replaced: a later signal takes the
-/// previous action, and the default one ends the process. [`received`] keeps
-/// its value. Does nothing when not hooked.
+/// Restores the dispositions [`hook`] replaced. [`received`] keeps its value.
+/// No-op when not hooked.
 pub fn unhook() {
     let mut previous = PREVIOUS.lock();
     let Some(saved) = previous.take() else {
@@ -107,12 +86,10 @@ pub fn unhook() {
             libc::sigaction(*sig, &raw const saved[i], core::ptr::null_mut());
         }
     }
-    // After the dispositions: the handler never runs without a loop.
     EVENT_LOOP.store(core::ptr::null_mut(), Ordering::Release);
 }
 
-/// The last hooked signal received, if any. Still set after [`unhook`], for
-/// a supervisor that ends by it once its children are gone.
+/// The last hooked signal received, if any (also after [`unhook`]).
 pub fn received() -> Option<c_int> {
     match RECEIVED.load(Ordering::SeqCst) {
         0 => None,
@@ -128,13 +105,10 @@ extern "C" fn handler(sig: c_int) {
     let event_loop = EVENT_LOOP.load(Ordering::Acquire);
     let task = NonNull::new(TASK.load(Ordering::Relaxed));
     let (false, Some(task)) = (event_loop.is_null(), task) else {
-        // Only reachable on another thread while `unhook` restores the
-        // dispositions. Take the default action rather than drop the signal:
-        // `sig` is blocked inside its own handler, so the re-raise lands on
-        // return.
+        // Raced with `unhook` on another thread: take the default action.
+        // `sig` is blocked in its own handler, so the raise lands on return.
         QUEUED.store(false, Ordering::SeqCst);
-        // SAFETY: all-zero is a valid `libc::sigaction`; both calls are
-        // async-signal-safe.
+        // SAFETY: zeroed `sigaction` is valid; both calls are async-signal-safe.
         unsafe {
             let mut act: libc::sigaction = bun_core::ffi::zeroed();
             act.sa_sigaction = libc::SIG_DFL;
@@ -143,9 +117,8 @@ extern "C" fn handler(sig: c_int) {
         }
         return;
     };
-    // SAFETY: `EVENT_LOOP` is live while the dispositions are installed (see
-    // `hook`/`unhook`), and `task` is not in the queue (`QUEUED` was false).
-    // The raw form: this may have interrupted the loop's thread inside `tick`.
+    // SAFETY: the loop is live while hooked; `task` is not queued (`QUEUED`
+    // was false). Raw form because this may interrupt the loop inside `tick`.
     unsafe { MiniEventLoop::enqueue_task_concurrent_raw(event_loop, task) };
 }
 

--- a/src/spawn/lib.rs
+++ b/src/spawn/lib.rs
@@ -38,6 +38,10 @@ pub mod posix_spawn {
 /// Ctrl+C handling for a process acting as a shell for foreground children.
 #[path = "ctrl_c.rs"]
 pub mod ctrl_c;
+/// SIGINT/SIGTERM/SIGHUP hook for a supervisor of background children.
+#[cfg(unix)]
+#[path = "exit_signals.rs"]
+pub mod exit_signals;
 /// `Process` / `Poller` / `WaiterThread` / `spawn_process` / `sync` /
 /// `Status` / `SpawnOptions` / `SpawnResult`.
 #[path = "process.rs"]

--- a/test/cli/install/bun-install-lifecycle-signals.test.ts
+++ b/test/cli/install/bun-install-lifecycle-signals.test.ts
@@ -70,29 +70,35 @@ function killQuietly(pid: number) {
   } catch {}
 }
 
-function startInstall(dir: string) {
-  return Bun.spawn({
+// Spawns `bun install` in `dir` and waits until the hook runs. `stderr` is
+// drained from the start; it resolves once bun install and the hook (which
+// inherits it) are both gone.
+async function startInstall(dir: string) {
+  const proc = Bun.spawn({
     cmd: [bunExe(), "install"],
     env: bunEnv,
     cwd: dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
   });
-}
-
-async function readHookPid(dir: string): Promise<number> {
-  const pid = Number(await waitForFile(join(dir, "hook-pid")));
+  const stderr = proc.stderr.text();
+  const hookPid = await Promise.race([
+    waitForFile(join(dir, "hook-pid")).then(Number),
+    proc.exited.then(async code => {
+      throw new Error(`bun install exited with ${code} before the hook started: ${await stderr}`);
+    }),
+  ]);
   // Never hand 0 or NaN to kill(): pid 0 is the whole process group.
-  expect(pid).toBeGreaterThan(1);
-  return pid;
+  expect(hookPid).toBeGreaterThan(1);
+  return { proc, stderr, hookPid };
 }
 
 describe.skipIf(!isPosix).concurrent("bun install forwards signals to lifecycle scripts", () => {
   for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
     test(`${signal} reaches the postinstall script and bun install waits for it`, async () => {
       using dir = tempDir("install-signal", files("exit"));
-      await using proc = startInstall(String(dir));
-      const hookPid = await readHookPid(String(dir));
+      const { proc, stderr, hookPid } = await startInstall(String(dir));
+      await using _ = proc;
       try {
         expect(isAlive(hookPid)).toBe(true);
 
@@ -100,10 +106,9 @@ describe.skipIf(!isPosix).concurrent("bun install forwards signals to lifecycle 
         await proc.exited;
 
         // bun install reaps the hook before it dies, so the hook is gone by now.
-        // (An orphaned hook also holds the inherited stderr pipe open.)
         expect(isAlive(hookPid)).toBe(false);
         expect(await waitForFile(join(String(dir), "got-signal"))).toBe(signal);
-        expect(await proc.stderr.text()).not.toContain("error:");
+        expect(await stderr).not.toContain("error:");
         expect(proc.signalCode).toBe(signal);
       } finally {
         killQuietly(hookPid);
@@ -113,8 +118,8 @@ describe.skipIf(!isPosix).concurrent("bun install forwards signals to lifecycle 
 
   test("bun install waits for a script that outlives the first signal, a second one ends it", async () => {
     using dir = tempDir("install-signal-twice", files("stay"));
-    await using proc = startInstall(String(dir));
-    const hookPid = await readHookPid(String(dir));
+    const { proc, hookPid } = await startInstall(String(dir));
+    await using _ = proc;
     try {
       proc.kill("SIGTERM");
       // bun install must still be alive once the hook has seen the signal.
@@ -140,8 +145,8 @@ describe.skipIf(!isPosix).concurrent("bun install forwards signals to lifecycle 
   // No signal to forward here: the kernel does it (PR_SET_PDEATHSIG).
   test.skipIf(!isLinux)("a script does not outlive a bun install that is SIGKILLed", async () => {
     using dir = tempDir("install-sigkill", files("stay"));
-    await using proc = startInstall(String(dir));
-    const hookPid = await readHookPid(String(dir));
+    const { proc, hookPid } = await startInstall(String(dir));
+    await using _ = proc;
     try {
       proc.kill("SIGKILL");
       await proc.exited;

--- a/test/cli/install/bun-install-lifecycle-signals.test.ts
+++ b/test/cli/install/bun-install-lifecycle-signals.test.ts
@@ -1,0 +1,154 @@
+// A signal sent to `bun install` while a lifecycle script runs is forwarded
+// to the script. `bun install` waits for the script, then dies by the same
+// signal. Without this the script keeps running, reparented to init, and
+// keeps writing into node_modules. On Linux a script also dies with a bun
+// install that had no chance to forward anything (SIGKILL).
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isPosix, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The hook records its pid, then waits. On TERM/INT/HUP it records the
+// signal. In "exit" mode it then exits 0, otherwise it keeps running so that
+// the test can check the escalation path. `wait` on a background `sleep`
+// returns as soon as a trapped signal arrives, so the trap runs at once.
+const hook = `
+on_signal() {
+  printf %s "$1" > got-signal.tmp && mv got-signal.tmp got-signal
+  if [ "$mode" = exit ]; then exit 0; fi
+}
+mode=$1
+trap 'on_signal SIGTERM' TERM
+trap 'on_signal SIGINT' INT
+trap 'on_signal SIGHUP' HUP
+printf %s "$$" > hook-pid.tmp && mv hook-pid.tmp hook-pid
+while :; do
+  sleep 1 &
+  wait $!
+done
+`;
+
+const files = (mode: "exit" | "stay") => ({
+  "package.json": JSON.stringify({
+    name: "app",
+    version: "1.0.0",
+    // `exec` so that the hook is the direct child of bun install whatever
+    // the system shell does with `sh -c`.
+    scripts: { postinstall: `exec sh hook.sh ${mode}` },
+  }),
+  "hook.sh": hook,
+});
+
+// Both files are written with a rename, so they are never seen half-written.
+async function waitForFile(path: string): Promise<string> {
+  for (;;) {
+    try {
+      return readFileSync(path, "utf8");
+    } catch {}
+    await Bun.sleep(10);
+  }
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: any) {
+    return err.code !== "ESRCH";
+  }
+}
+
+async function waitForExit(pid: number) {
+  while (isAlive(pid)) {
+    await Bun.sleep(10);
+  }
+}
+
+function killQuietly(pid: number) {
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {}
+}
+
+function startInstall(dir: string) {
+  return Bun.spawn({
+    cmd: [bunExe(), "install"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+async function readHookPid(dir: string): Promise<number> {
+  const pid = Number(await waitForFile(join(dir, "hook-pid")));
+  // Never hand 0 or NaN to kill(): pid 0 is the whole process group.
+  expect(pid).toBeGreaterThan(1);
+  return pid;
+}
+
+describe.skipIf(!isPosix).concurrent("bun install forwards signals to lifecycle scripts", () => {
+  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+    test(`${signal} reaches the postinstall script and bun install waits for it`, async () => {
+      using dir = tempDir("install-signal", files("exit"));
+      await using proc = startInstall(String(dir));
+      const hookPid = await readHookPid(String(dir));
+      try {
+        expect(isAlive(hookPid)).toBe(true);
+
+        proc.kill(signal);
+        await proc.exited;
+
+        // bun install reaps the hook before it dies, so the hook is gone by now.
+        // (An orphaned hook also holds the inherited stderr pipe open.)
+        expect(isAlive(hookPid)).toBe(false);
+        expect(await waitForFile(join(String(dir), "got-signal"))).toBe(signal);
+        expect(await proc.stderr.text()).not.toContain("error:");
+        expect(proc.signalCode).toBe(signal);
+      } finally {
+        killQuietly(hookPid);
+      }
+    });
+  }
+
+  test("bun install waits for a script that outlives the first signal, a second one ends it", async () => {
+    using dir = tempDir("install-signal-twice", files("stay"));
+    await using proc = startInstall(String(dir));
+    const hookPid = await readHookPid(String(dir));
+    try {
+      proc.kill("SIGTERM");
+      // bun install must still be alive once the hook has seen the signal.
+      const first = await Promise.race([waitForFile(join(String(dir), "got-signal")), proc.exited]);
+      expect(first).toBe("SIGTERM");
+      expect(isAlive(hookPid)).toBe(true);
+      expect(proc.exitCode).toBeNull();
+
+      // The hook is out after the first signal, so this one takes the
+      // default action.
+      proc.kill("SIGTERM");
+      await proc.exited;
+      expect(proc.signalCode).toBe("SIGTERM");
+      if (isLinux) {
+        // PR_SET_PDEATHSIG: the kernel kills the script with bun install.
+        await waitForExit(hookPid);
+      }
+    } finally {
+      killQuietly(hookPid);
+    }
+  });
+
+  // No signal to forward here: the kernel does it (PR_SET_PDEATHSIG).
+  test.skipIf(!isLinux)("a script does not outlive a bun install that is SIGKILLed", async () => {
+    using dir = tempDir("install-sigkill", files("stay"));
+    await using proc = startInstall(String(dir));
+    const hookPid = await readHookPid(String(dir));
+    try {
+      proc.kill("SIGKILL");
+      await proc.exited;
+      await waitForExit(hookPid);
+      expect(proc.signalCode).toBe("SIGKILL");
+    } finally {
+      killQuietly(hookPid);
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- SIGTERM, SIGINT or SIGHUP sent to `bun install` while a lifecycle script runs (CI cancellation, `docker stop`) ends `bun install` at once. The script keeps running, reparented to init, still writing into `node_modules`.
- Cause: `src/install/lifecycle_script_runner.rs` spawns scripts on the install event loop, and nothing sets a disposition for these signals. npm forwards TERM and INT and waits.

### Fix
- While a script runs, `bun install` hooks INT, TERM and HUP through a new shared module, `bun_spawn::exit_signals`. It records the signal and runs a callback on the event loop thread. The install half forwards the signal to every running script and unhooks, so a second signal takes the default action. No new script starts. When the last script exits, `bun install` dies by the same signal.
- On Linux, lifecycle scripts get `PR_SET_PDEATHSIG` SIGKILL, as git children already do. A script does not outlive a `bun install` that could not forward anything.
- Correct because the handler does only async-signal-safe work: atomics, a lock-free queue push, the loop wakeup (`MiniEventLoop::enqueue_task_concurrent_raw`, no `&mut` to the loop). All package manager access runs on the install thread.
- Self-reviewed: 3 concerns, 2 addressed (shared hook, pdeathsig), 1 kept (see Notes). Verified: `test/cli/install/bun-install-lifecycle-signals.test.ts` (5 tests, fail on 1.4.3, pass here), `bun-install-lifecycle-scripts.test.ts` (122 pass).

### Background
- Lifecycle scripts are child processes of `bun install`, tracked in the intrusive heap `PackageManager.active_lifecycle_scripts`. The install waits for them by ticking a `MiniEventLoop`, a JS-free event loop over usockets.
- `MiniEventLoop::enqueue_task_concurrent` is the cross-thread entry: an `UnboundedQueue` push plus `us_wakeup_loop` (an eventfd write or a kevent). Both are safe in a signal handler, and the wakeup makes the poll return. The new `_raw` form does the same through a raw pointer.
- `PR_SET_PDEATHSIG` asks the Linux kernel to signal a child when the thread that spawned it dies.

<details><summary>Notes</summary>

- Covered script kinds: root `preinstall`/`install`/`postinstall`/`prepare` and a trusted dependency's scripts (node-gyp builds, prisma generate, binary downloaders). A terminal Ctrl-C was never affected: the tty signals the whole foreground process group.
- Windows is unchanged. An inherited `SIG_IGN` (`nohup`, a `&` job in a non-interactive shell) is left alone.
- The review of the first shape asked for a shared primitive instead of another per-command copy of "hook INT/TERM/HUP, skip an inherited SIG_IGN, save the previous dispositions, wake the loop, restore". `bun_spawn::exit_signals` is that primitive. The `bun test --parallel` coordinator (`Coordinator.rs`, INT/TERM today, no HUP) and the `--filter`/`--parallel` runners (#41478) use the same loop wakeup and can move onto it. This PR does not touch them.
- Kept from the review: the install dies by the forwarded signal rather than `exit(128+n)`, through `Global::raise_ignoring_panic_handler`, the path `lifecycle_script_runner.rs` already takes for a script killed by a signal. #38877 covers the PID 1 case where that re-raise cannot land.
- Second signal: after forwarding, the hook comes out. A second TERM ends `bun install` by the default action. On Linux the scripts then die with it (pdeathsig). This matches the coordinator and #41478.
- Under `bun install` embedded in a JS event loop (`AnyEventLoop::Js`) nothing is hooked; the runtime owns process signals there.
- An exiting script during the drain does not chain into its next script (`preinstall` → `install` → `postinstall`), and `spawn_package_scripts` starts nothing new.
- `Intrusive::for_each` in `src/io/heap.rs` is a pre-order walk over `child`/`next`. The heap holds at most a handful of nodes.
- `PR_SET_PDEATHSIG` covers the direct child only (it is cleared on fork), the same limit the git children have (`git_runner.rs`).
- Manual checks with the debug build: hoisted linker, two trusted `file:` dependencies each running `exec sleep`, `kill -TERM` on bun: both scripts get TERM, rc 143, nothing left alive. Isolated linker, `kill -INT`: rc 130, nothing left alive. Isolated linker, `kill -KILL` on bun: both scripts gone (pdeathsig).
- `cargo check -p bun_install -p bun_spawn` passes for x86_64-pc-windows-msvc, aarch64-apple-darwin and x86_64-unknown-freebsd. `cargo clippy` is clean.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-signals.test.ts

<!-- robobun:evidence:end -->