### PR TITLE
Bun.serve: read Content-Type and Range through req.headers; give stream-body blob() its type

### DIFF
--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -57,6 +57,7 @@ unsafe extern "C" {
     // safe: `FetchHeaders` is an `opaque_ffi!` ZST handle; `&mut` is ABI-identical
     // to a non-null `*mut` and the C++ refcount decrement is interior to the cell.
     safe fn WebCore__FetchHeaders__deref(arg0: &mut FetchHeaders);
+    safe fn WebCore__FetchHeaders__ref(arg0: &mut FetchHeaders);
     safe fn WebCore__FetchHeaders__fastGet_(arg0: &FetchHeaders, arg1: u8, arg2: &mut EncodedSlice);
     safe fn WebCore__FetchHeaders__fastHas_(arg0: &FetchHeaders, arg1: u8) -> bool;
     safe fn WebCore__FetchHeaders__fastRemove_(arg0: &FetchHeaders, arg1: u8);
@@ -291,6 +292,10 @@ impl FetchHeaders {
         host_fn::from_js_host_call_generic(global, || {
             NonNull::new(WebCore__FetchHeaders__cloneThis(self, global))
         })
+    }
+
+    pub fn ref_(&mut self) {
+        WebCore__FetchHeaders__ref(self)
     }
 
     pub fn deref(&mut self) {

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1144,8 +1144,15 @@ impl JSGlobalObject {
         crate::call_zero_is_throw(self, || ZigGlobalObject__readableStreamToJSON(self, value))
     }
 
-    pub fn readable_stream_to_blob(&self, value: JSValue) -> JsResult<JSValue> {
-        crate::call_zero_is_throw(self, || ZigGlobalObject__readableStreamToBlob(self, value))
+    /// `content_type`: a JS string for the resulting Blob's `type`, or `undefined`.
+    pub fn readable_stream_to_blob(
+        &self,
+        value: JSValue,
+        content_type: JSValue,
+    ) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || {
+            ZigGlobalObject__readableStreamToBlob(self, value, content_type)
+        })
     }
 
     pub fn readable_stream_to_form_data(
@@ -1565,8 +1572,11 @@ unsafe extern "C" {
         value: JSValue,
         content_type: JSValue,
     ) -> JSValue;
-    safe fn ZigGlobalObject__readableStreamToBlob(this: &JSGlobalObject, value: JSValue)
-    -> JSValue;
+    safe fn ZigGlobalObject__readableStreamToBlob(
+        this: &JSGlobalObject,
+        value: JSValue,
+        content_type: JSValue,
+    ) -> JSValue;
 
     safe fn ZigGlobalObject__makeNapiEnvForFFI(this: &JSGlobalObject) -> *mut c_void;
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -919,6 +919,6 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToText(Zig::Global
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToArrayBuffer(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToJSON(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);
-extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);
+extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue, JSC::EncodedJSValue contentType);
 
 #endif

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2595,6 +2595,10 @@ void WebCore__FetchHeaders__deref(WebCore::FetchHeaders* arg0)
 {
     arg0->deref();
 }
+void WebCore__FetchHeaders__ref(WebCore::FetchHeaders* arg0)
+{
+    arg0->ref();
+}
 
 WebCore::FetchHeaders* WebCore__FetchHeaders__createValueNotJS(JSC::JSGlobalObject* arg0, StringPointer* arg1, StringPointer* arg2, const EncodedSlice* arg3, uint32_t count)
 {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -76,6 +76,7 @@ CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1);
 CPP_DECL JSC::EncodedJSValue WebCore__FetchHeaders__createValue(JSC::JSGlobalObject* arg0, StringPointer* arg1, StringPointer* arg2, const EncodedSlice* arg3, uint32_t arg4);
 CPP_DECL void WebCore__FetchHeaders__deref(WebCore::FetchHeaders* arg0);
+CPP_DECL void WebCore__FetchHeaders__ref(WebCore::FetchHeaders* arg0);
 CPP_DECL void WebCore__FetchHeaders__fastGet_(WebCore::FetchHeaders* arg0, unsigned char arg1, EncodedSlice* arg2);
 CPP_DECL bool WebCore__FetchHeaders__fastHas_(WebCore::FetchHeaders* arg0, unsigned char arg1);
 CPP_DECL void WebCore__FetchHeaders__fastRemove_(WebCore::FetchHeaders* arg0, unsigned char arg1);

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -41,7 +41,7 @@
 #include <wtf/Vector.h>
 #include <wtf/text/StringBuilder.h>
 
-// Body.rs: set a Blob's type from a Content-Type value with the body readers' MIME rules.
+// Body.rs
 extern "C" void Body__setBlobContentType(JSC::EncodedJSValue blob, const uint8_t* contentType, size_t length);
 
 namespace WebCore {
@@ -1506,9 +1506,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToJSONFulfilled, (J
     RELEASE_AND_RETURN(scope, JSValue::encode(JSONParseWithException(globalObject, text)));
 }
 
-// `contentType` is the body's Content-Type as a JSString, or undefined. Applied through
-// Body.rs so the Blob gets the same MIME rules as the non-stream body readers, not the
-// `new Blob([], { type })` lookup table.
+// Through Body.rs, not `new Blob([], { type })`: same MIME rules as the other body readers.
 static void setBodyBlobContentType(JSGlobalObject* globalObject, JSValue blob, JSValue contentType)
 {
     auto& vm = getVM(globalObject);

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -41,6 +41,9 @@
 #include <wtf/Vector.h>
 #include <wtf/text/StringBuilder.h>
 
+// Body.rs: set a Blob's type from a Content-Type value with the body readers' MIME rules.
+extern "C" void Body__setBlobContentType(JSC::EncodedJSValue blob, const uint8_t* contentType, size_t length);
+
 namespace WebCore {
 
 using namespace JSC;
@@ -1272,7 +1275,7 @@ JSValue readableStreamToJSON(JSGlobalObject* globalObject, WebCore::JSReadableSt
     return derived;
 }
 
-JSValue readableStreamToBlob(JSGlobalObject* globalObject, WebCore::JSReadableStream* stream)
+JSValue readableStreamToBlob(JSGlobalObject* globalObject, WebCore::JSReadableStream* stream, JSValue contentType)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1280,10 +1283,24 @@ JSValue readableStreamToBlob(JSGlobalObject* globalObject, WebCore::JSReadableSt
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
     if (stream->m_disturbed)
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (!contentType.isString() || !asString(contentType)->length())
+        contentType = jsUndefined();
+    auto* runtime = JSStreamsRuntime::from(globalObject);
     JSValue fastPath = tryUseReadableStreamBufferedFastPath(globalObject, stream, builtinNames(vm).blobPublicName());
     RETURN_IF_EXCEPTION(scope, {});
-    if (fastPath)
-        return fastPath;
+    if (fastPath) {
+        if (contentType.isUndefined())
+            return fastPath;
+        // The native handle built the Blob without knowing the body's Content-Type.
+        auto* blobPromise = dynamicDowncast<JSPromise>(fastPath);
+        if (!blobPromise) [[unlikely]] {
+            blobPromise = promiseFulfilledWith(globalObject, fastPath);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+        auto* derived = JSPromise::create(vm, globalObject->promiseStructure());
+        blobPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReadableStreamToBlobSetType(), jsUndefined(), derived, contentType);
+        return derived;
+    }
     JSValue arrayResult = readableStreamToArray(globalObject, stream);
     RETURN_IF_EXCEPTION(scope, {});
     auto* arrayPromise = dynamicDowncast<JSPromise>(arrayResult);
@@ -1291,9 +1308,8 @@ JSValue readableStreamToBlob(JSGlobalObject* globalObject, WebCore::JSReadableSt
         arrayPromise = promiseFulfilledWith(globalObject, arrayResult);
         RETURN_IF_EXCEPTION(scope, {});
     }
-    auto* runtime = JSStreamsRuntime::from(globalObject);
     auto* derived = JSPromise::create(vm, globalObject->promiseStructure());
-    arrayPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReadableStreamToBlobFulfilled(), jsUndefined(), derived, jsUndefined());
+    arrayPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReadableStreamToBlobFulfilled(), jsUndefined(), derived, contentType);
     return derived;
 }
 
@@ -1305,7 +1321,8 @@ JSValue readableStreamToFormData(JSGlobalObject* globalObject, WebCore::JSReadab
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
     if (stream->m_disturbed)
         RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
-    JSValue blobResult = readableStreamToBlob(globalObject, stream);
+    // FormData.from() below takes the content type itself; the intermediate Blob does not need it.
+    JSValue blobResult = readableStreamToBlob(globalObject, stream, jsUndefined());
     RETURN_IF_EXCEPTION(scope, {});
     auto* blobPromise = dynamicDowncast<JSPromise>(blobResult);
     if (!blobPromise) [[unlikely]] {
@@ -1391,7 +1408,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionReadableStreamToBlob, (JSGlobalObject * globa
     auto* stream = dynamicDowncast<JSReadableStream>(streamValue);
     if (!stream) [[unlikely]]
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "stream"_s, "ReadableStream"_s, streamValue);
-    RELEASE_AND_RETURN(scope, JSValue::encode(Bun::WebStreams::readableStreamToBlob(globalObject, stream)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(Bun::WebStreams::readableStreamToBlob(globalObject, stream, jsUndefined())));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionReadableStreamToFormData, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -1489,6 +1506,21 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToJSONFulfilled, (J
     RELEASE_AND_RETURN(scope, JSValue::encode(JSONParseWithException(globalObject, text)));
 }
 
+// `contentType` is the body's Content-Type as a JSString, or undefined. Applied through
+// Body.rs so the Blob gets the same MIME rules as the non-stream body readers, not the
+// `new Blob([], { type })` lookup table.
+static void setBodyBlobContentType(JSGlobalObject* globalObject, JSValue blob, JSValue contentType)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!contentType.isString())
+        return;
+    auto string = contentType.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, );
+    auto utf8 = string.utf8();
+    Body__setBlobContentType(JSValue::encode(blob), reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length());
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToBlobFulfilled, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
@@ -1497,7 +1529,19 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToBlobFulfilled, (J
     arguments.append(callFrame->argument(0));
     JSObject* blob = JSC::construct(globalObject, defaultGlobalObject(globalObject)->JSBlobConstructor(), arguments, "Blob is not constructible"_s);
     RETURN_IF_EXCEPTION(scope, {});
+    setBodyBlobContentType(globalObject, blob, callFrame->argument(1));
+    RETURN_IF_EXCEPTION(scope, {});
     Bun::WebStreams::releaseInternalChunkArray(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(blob);
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onReadableStreamToBlobSetType, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue blob = callFrame->argument(0);
+    setBodyBlobContentType(globalObject, blob, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(blob);
 }

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -751,7 +751,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototypeFunction_blob, (JSGlobalObject
     auto* stream = dynamicDowncast<JSReadableStream>(callFrame->thisValue());
     if (!stream) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "ReadableStream"_s);
-    RELEASE_AND_RETURN(scope, JSValue::encode(readableStreamToBlob(lexicalGlobalObject, stream)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(readableStreamToBlob(lexicalGlobalObject, stream, jsUndefined())));
 }
 
 // Bun private-name accessor ($bunNativePtr).

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -188,11 +188,9 @@ namespace WebCore {
 // owner: BunStreamConsumers.cpp.
 //   onBufferedFastPath*: context = the JSReadableStream (the fast path's catch/finally pair).
 //   onReadableStreamTo*Fulfilled: the generic-path promise chains
-//     (toArrayBuffer/toBytes: value = the chunk array; toBlob: value = the chunk array,
-//      context = the contentType JSString or undefined; toJSON: value = the text;
-//      toFormData: value = the Blob, context = the contentType JSString).
-//   onReadableStreamToBlobSetType: toBlob's buffered fast path when a contentType is given;
-//     value = the native handle's Blob, context = the contentType JSString.
+//     (toArrayBuffer/toBytes/toBlob: value = the chunk array; toJSON: value = the text;
+//      toBlob/toFormData: context = the contentType JSString; toFormData: value = the Blob).
+//   onReadableStreamToBlobSetType: value = the fast path's Blob, context = the contentType.
 //   onIntoArrayReadMany*: readableStreamIntoArray's readMany() continuation (readMany may
 //     return a Promise); context = an InternalFieldTuple{reader, resultArray}.
 //   onDirectConsumeLoopRead*: the readableStreamTo{Text,Array}Direct read loop;

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -189,8 +189,8 @@ namespace WebCore {
 //   onBufferedFastPath*: context = the JSReadableStream (the fast path's catch/finally pair).
 //   onReadableStreamTo*Fulfilled: the generic-path promise chains
 //     (toArrayBuffer/toBytes/toBlob: value = the chunk array; toJSON: value = the text;
-//      toBlob/toFormData: context = the contentType JSString; toFormData: value = the Blob).
-//   onReadableStreamToBlobSetType: value = the fast path's Blob, context = the contentType.
+//      toFormData: value = the Blob, context = the contentType JSString).
+//   onReadableStreamToBlob{Fulfilled,SetType}: context = the body's contentType JSString or undefined.
 //   onIntoArrayReadMany*: readableStreamIntoArray's readMany() continuation (readMany may
 //     return a Promise); context = an InternalFieldTuple{reader, resultArray}.
 //   onDirectConsumeLoopRead*: the readableStreamTo{Text,Array}Direct read loop;

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -188,8 +188,11 @@ namespace WebCore {
 // owner: BunStreamConsumers.cpp.
 //   onBufferedFastPath*: context = the JSReadableStream (the fast path's catch/finally pair).
 //   onReadableStreamTo*Fulfilled: the generic-path promise chains
-//     (toArrayBuffer/toBytes/toBlob: value = the chunk array; toJSON: value = the text;
+//     (toArrayBuffer/toBytes: value = the chunk array; toBlob: value = the chunk array,
+//      context = the contentType JSString or undefined; toJSON: value = the text;
 //      toFormData: value = the Blob, context = the contentType JSString).
+//   onReadableStreamToBlobSetType: toBlob's buffered fast path when a contentType is given;
+//     value = the native handle's Blob, context = the contentType JSString.
 //   onIntoArrayReadMany*: readableStreamIntoArray's readMany() continuation (readMany may
 //     return a Promise); context = an InternalFieldTuple{reader, resultArray}.
 //   onDirectConsumeLoopRead*: the readableStreamTo{Text,Array}Direct read loop;
@@ -205,6 +208,7 @@ namespace WebCore {
     V(onReadableStreamToTextChunksFulfilled)                                                                 \
     V(onReadableStreamToJSONFulfilled)                                                                       \
     V(onReadableStreamToBlobFulfilled)                                                                       \
+    V(onReadableStreamToBlobSetType) /* buffered fast path: give the native Blob the body's contentType */   \
     V(onReadableStreamToFormDataFulfilled)                                                                   \
     V(onIntoArrayReadManyFulfilled) /* append value; !done => readMany() again; done => release + resolve */ \
     V(onIntoArrayReadManyRejected) /* release the reader, reject the result promise */                       \

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -327,13 +327,13 @@ extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToJSON(Zig::Global
     RELEASE_AND_RETURN(scope, JSValue::encode(readableStreamToJSON(globalObject, stream)));
 }
 
-extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::GlobalObject* globalObject, JSC::EncodedJSValue streamValue)
+extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::GlobalObject* globalObject, JSC::EncodedJSValue streamValue, JSC::EncodedJSValue contentType)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stream = toReadableStream(globalObject, scope, streamValue);
     RETURN_IF_EXCEPTION(scope, {});
-    RELEASE_AND_RETURN(scope, JSValue::encode(readableStreamToBlob(globalObject, stream)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(readableStreamToBlob(globalObject, stream, JSValue::decode(contentType))));
 }
 
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToFormData(Zig::GlobalObject* globalObject, JSC::EncodedJSValue streamValue, JSC::EncodedJSValue contentType)

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -652,7 +652,8 @@ JSC::JSValue readableStreamToArray(JSC::JSGlobalObject*, JSReadableStream*); // 
 JSC::JSValue readableStreamToArrayBuffer(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — BunStreamConsumers.cpp
 JSC::JSValue readableStreamToBytes(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — BunStreamConsumers.cpp
 JSC::JSValue readableStreamToJSON(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — BunStreamConsumers.cpp
-JSC::JSValue readableStreamToBlob(JSC::JSGlobalObject*, JSReadableStream*); // userJS: yes — BunStreamConsumers.cpp
+// `contentType`: a JSString to use as the resulting Blob's `type`, or undefined.
+JSC::JSValue readableStreamToBlob(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue contentType); // userJS: yes — BunStreamConsumers.cpp
 JSC::JSValue readableStreamToFormData(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue contentType); // userJS: yes — BunStreamConsumers.cpp
 
 // The buffered fast path: returns the native handle's own .text()/.arrayBuffer()/... promise,
@@ -727,7 +728,7 @@ JSC::EncodedJSValue ZigGlobalObject__readableStreamToArrayBuffer(Zig::GlobalObje
 JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::GlobalObject*, JSC::EncodedJSValue stream); // userJS: yes
 JSC::EncodedJSValue ZigGlobalObject__readableStreamToText(Zig::GlobalObject*, JSC::EncodedJSValue stream); // userJS: yes
 JSC::EncodedJSValue ZigGlobalObject__readableStreamToJSON(Zig::GlobalObject*, JSC::EncodedJSValue stream); // userJS: yes
-JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::GlobalObject*, JSC::EncodedJSValue stream); // userJS: yes
+JSC::EncodedJSValue ZigGlobalObject__readableStreamToBlob(Zig::GlobalObject*, JSC::EncodedJSValue stream, JSC::EncodedJSValue contentType); // userJS: yes
 JSC::EncodedJSValue ZigGlobalObject__readableStreamToFormData(Zig::GlobalObject*, JSC::EncodedJSValue stream, JSC::EncodedJSValue contentType); // userJS: yes
 
 } // extern "C"

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1554,8 +1554,6 @@ impl RewriterPipe {
         let Some(response) = self.response.get().as_deref() else {
             return;
         };
-        // For a waiting `.blob()`'s content type.
-        let headers = response.get_fetch_headers().map(NonNull::from);
         let body_value = response.get_body_value();
         let bytes = self.output_buffer.replace(Vec::new());
         let mut prev_value = core::mem::replace(
@@ -1565,7 +1563,7 @@ impl RewriterPipe {
                 was_string: false,
             }),
         );
-        let _ = webcore::body::Value::resolve(&mut prev_value, body_value, &self.global, headers);
+        let _ = webcore::body::Value::resolve(&mut prev_value, body_value, &self.global);
     }
 
     /// Feed the accumulated `pending_input` once unblocked, then maybe end,

--- a/src/runtime/server/RangeRequest.rs
+++ b/src/runtime/server/RangeRequest.rs
@@ -133,13 +133,6 @@ pub(crate) fn from_request(req: &AnyRequest, total: u64) -> Result {
     parse(h, total)
 }
 
-pub(crate) fn raw_from_request(req: &AnyRequest) -> Raw {
-    let Some(h) = req.header(b"range") else {
-        return Raw::None;
-    };
-    parse_raw(h)
-}
-
 /// Max bytes a `Content-Range: bytes ...` value can occupy: `"bytes "` (6) +
 /// three `u64::MAX` (20 each) + `'-'` + `'/'` = 68. 96 leaves slack.
 pub(crate) const CONTENT_RANGE_BUF: usize = 96;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -153,10 +153,12 @@ pub struct RequestContext<
     pub(crate) blob: JsCell<AnyBlob>,
 
     pub(crate) sendfile: Cell<SendfileContext>,
-    /// A ref on the `Request`'s own `FetchHeaders`, taken when the request
-    /// goes async, so that header reads at render time (`Range`) see what the
-    /// handler sees through `req.headers` even if the JS `Request` has been
-    /// collected by then. Released in `finalize_without_deinit`.
+    /// The request's `Range`, read from `req.headers` when the response is
+    /// rendered (after the handler may have set or deleted it).
+    pub(crate) range: Cell<RangeRequest::Raw>,
+    /// A ref on the `Request`'s own `FetchHeaders`, held from the moment the
+    /// request goes async until the response is rendered, so that the `Range`
+    /// read above does not depend on the JS `Request` staying alive.
     pub(crate) request_headers: JsCell<Option<response::HeadersRef>>,
 
     pub(crate) request_body_readable_stream_ref: JsCell<readable_stream::Strong>,
@@ -1420,6 +1422,7 @@ where
                     NonNull::new(server).map(|p| bun_ptr::BackRef::from_raw_mut(p.as_ptr())),
                 ),
                 defer_deinit_until_callback_completes: Cell::new(should_deinit_context),
+                range: Cell::new(RangeRequest::Raw::None),
                 request_headers: JsCell::new(None),
                 request_weakref: JsCell::new(request::WeakRef::EMPTY),
                 signal: Cell::new(None),
@@ -1900,9 +1903,7 @@ where
         // sentinel or, if JS already read `.size`, the stat'd size; a
         // `.slice(0, n)` blob has `n < stat_size`. Skip if the user
         // already set Content-Range or a non-200 status — they're
-        // managing partial responses themselves. The Range value is read
-        // here, not when the request arrived, so that it is the one the
-        // handler sees (and may have set or deleted) through `req.headers`.
+        // managing partial responses themselves.
         let user_handles_range = if let Some(r) = self.response_mut() {
             r.status_code() != 200
                 || r.get_init_headers_mut()
@@ -1915,15 +1916,13 @@ where
             && (original_size == crate::webcore::blob::MAX_SIZE || original_size == stat_size);
         // RFC 9110 §14.2: Range is only defined for GET (HEAD mirrors GET's headers).
         let method_allows_range = self.method == Method::GET || self.method == Method::HEAD;
-        let range = if is_regular && method_allows_range && !user_handles_range && is_whole_file {
-            self.request_header(jsc::HTTPHeaderName::Range, b"range")
-                .map_or(RangeRequest::Raw::None, |value| {
-                    RangeRequest::parse_raw(value.slice())
-                })
-        } else {
-            RangeRequest::Raw::None
-        };
-        if range != RangeRequest::Raw::None {
+        let range = self.range.get();
+        if is_regular
+            && method_allows_range
+            && !user_handles_range
+            && is_whole_file
+            && range != RangeRequest::Raw::None
+        {
             match range.resolve(stat_size) {
                 RangeRequest::Result::None => {}
                 RangeRequest::Result::Satisfiable { start, end } => {
@@ -2394,21 +2393,26 @@ where
         request_object.request_context.detach_request();
     }
 
-    /// One request header, as the handler sees it through `req.headers`.
-    fn request_header(
-        &self,
-        name: jsc::HTTPHeaderName,
-        wire_name: &[u8],
-    ) -> Option<bun_core::Utf8Bytes<'static>> {
-        if let Some(headers) = self.request_headers.get() {
-            let headers = bun_opaque::opaque_deref_mut(headers.as_ptr());
-            return Some(headers.fast_get(name)?.to_utf8().into_owned());
+    /// Reads `Range` as the handler sees it through `req.headers`, for
+    /// `do_sendfile`, and releases the ref taken in `to_async`: nothing after
+    /// render reads request headers.
+    fn capture_request_range(&self) {
+        let parse = |value: Option<bun_core::Utf8Bytes<'_>>| {
+            value.map_or(RangeRequest::Raw::None, |value| {
+                RangeRequest::parse_raw(value.slice())
+            })
+        };
+        if let Some(headers) = self.request_headers.replace(None) {
+            let fetch_headers = bun_opaque::opaque_deref_mut(headers.as_ptr());
+            let value = fetch_headers
+                .fast_get(jsc::HTTPHeaderName::Range)
+                .map(|value| value.to_utf8());
+            self.range.set(parse(value));
+        } else if let Some(request) = self.request_mut() {
+            self.range.set(parse(
+                request.get_header(jsc::HTTPHeaderName::Range, b"range"),
+            ));
         }
-        Some(
-            self.request_mut()?
-                .get_header(name, wire_name)?
-                .into_owned(),
-        )
     }
 
     pub(crate) fn to_async(&self, req: *mut Req<SSL_ENABLED, MUX>, request_object: &mut Request) {
@@ -4018,6 +4022,7 @@ where
     /// Same contract as [`Self::set_response`].
     pub(crate) unsafe fn render(&self, response: *mut Response) {
         ctx_log!("render");
+        self.capture_request_range();
 
         // A HEAD response never carries content (RFC 9110 §9.3.2). The normal
         // handler path branches to `do_render_head_response` before reaching

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -153,7 +153,11 @@ pub struct RequestContext<
     pub(crate) blob: JsCell<AnyBlob>,
 
     pub(crate) sendfile: Cell<SendfileContext>,
-    pub(crate) range: RangeRequest::Raw,
+    /// A ref on the `Request`'s own `FetchHeaders`, taken when the request
+    /// goes async, so that header reads at render time (`Range`) see what the
+    /// handler sees through `req.headers` even if the JS `Request` has been
+    /// collected by then. Released in `finalize_without_deinit`.
+    pub(crate) request_headers: JsCell<Option<response::HeadersRef>>,
 
     pub(crate) request_body_readable_stream_ref: JsCell<readable_stream::Strong>,
     /// Owning `+1` handle into the per-VM `Body::Value` hive pool. Shared with
@@ -1381,15 +1385,6 @@ where
     }
 
     #[inline]
-    fn any_request(r: *mut Req<SSL_ENABLED, MUX>) -> uws::AnyRequest {
-        if MUX {
-            uws::AnyRequest::H3(r.cast::<bun_uws_sys::h3::Request>())
-        } else {
-            uws::AnyRequest::H1(r.cast::<bun_uws_sys::Request>())
-        }
-    }
-
-    #[inline]
     fn req_method(r: *mut Req<SSL_ENABLED, MUX>) -> &'static [u8] {
         // SAFETY: r is a live uWS/lsquic request handle for the duration of
         // the request callback; both surfaces return request-owned slices.
@@ -1425,7 +1420,7 @@ where
                     NonNull::new(server).map(|p| bun_ptr::BackRef::from_raw_mut(p.as_ptr())),
                 ),
                 defer_deinit_until_callback_completes: Cell::new(should_deinit_context),
-                range: RangeRequest::raw_from_request(&Self::any_request(req)),
+                request_headers: JsCell::new(None),
                 request_weakref: JsCell::new(request::WeakRef::EMPTY),
                 signal: Cell::new(None),
                 cookies: JsCell::new(None),
@@ -1612,6 +1607,7 @@ where
 
         // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
         drop(self.cookies.replace(None));
+        drop(self.request_headers.replace(None));
 
         if let Some(request) = self.request_mut() {
             request.request_context = AnyRequestContext::NULL;
@@ -1904,7 +1900,9 @@ where
         // sentinel or, if JS already read `.size`, the stat'd size; a
         // `.slice(0, n)` blob has `n < stat_size`. Skip if the user
         // already set Content-Range or a non-200 status — they're
-        // managing partial responses themselves.
+        // managing partial responses themselves. The Range value is read
+        // here, not when the request arrived, so that it is the one the
+        // handler sees (and may have set or deleted) through `req.headers`.
         let user_handles_range = if let Some(r) = self.response_mut() {
             r.status_code() != 200
                 || r.get_init_headers_mut()
@@ -1917,13 +1915,16 @@ where
             && (original_size == crate::webcore::blob::MAX_SIZE || original_size == stat_size);
         // RFC 9110 §14.2: Range is only defined for GET (HEAD mirrors GET's headers).
         let method_allows_range = self.method == Method::GET || self.method == Method::HEAD;
-        if is_regular
-            && method_allows_range
-            && !user_handles_range
-            && is_whole_file
-            && self.range != RangeRequest::Raw::None
-        {
-            match self.range.resolve(stat_size) {
+        let range = if is_regular && method_allows_range && !user_handles_range && is_whole_file {
+            self.request_header(jsc::HTTPHeaderName::Range, b"range")
+                .map_or(RangeRequest::Raw::None, |value| {
+                    RangeRequest::parse_raw(value.slice())
+                })
+        } else {
+            RangeRequest::Raw::None
+        };
+        if range != RangeRequest::Raw::None {
+            match range.resolve(stat_size) {
                 RangeRequest::Result::None => {}
                 RangeRequest::Result::Satisfiable { start, end } => {
                     let mut sendfile = self.sendfile.get();
@@ -2380,10 +2381,34 @@ where
                 request_object.set_fetch_headers(Some(response::HeadersRef::create_from_uws(req)));
             }
         }
+        // Render-time header reads (`request_header`) must not depend on the JS
+        // `Request` staying alive until then.
+        if self.request_headers.get().is_none() {
+            if let Some(headers) = request_object.fetch_headers() {
+                self.request_headers.set(Some(headers.new_ref()));
+            }
+        }
 
         // This object dies after the stack frame is popped
         // so we have to clear it in here too
         request_object.request_context.detach_request();
+    }
+
+    /// One request header, as the handler sees it through `req.headers`.
+    fn request_header(
+        &self,
+        name: jsc::HTTPHeaderName,
+        wire_name: &[u8],
+    ) -> Option<bun_core::Utf8Bytes<'static>> {
+        if let Some(headers) = self.request_headers.get() {
+            let headers = bun_opaque::opaque_deref_mut(headers.as_ptr());
+            return Some(headers.fast_get(name)?.to_utf8().into_owned());
+        }
+        Some(
+            self.request_mut()?
+                .get_header(name, wire_name)?
+                .into_owned(),
+        )
     }
 
     pub(crate) fn to_async(&self, req: *mut Req<SSL_ENABLED, MUX>, request_object: &mut Request) {
@@ -4247,7 +4272,7 @@ where
                 if matches!(old, Body::Value::Locked(_)) {
                     let _exit = vm.enter_event_loop_scope();
 
-                    let _ = Body::Value::resolve(&mut old, body, global_this, None); // TODO: properly propagate exception upwards
+                    let _ = Body::Value::resolve(&mut old, body, global_this); // TODO: properly propagate exception upwards
                 }
                 return;
             }
@@ -4406,7 +4431,7 @@ where
                     }
                     let mut new_body: Body::Value = Body::Value::Null;
                     let global_this = server.global_this();
-                    let _ = Body::Value::resolve(&mut old, &mut new_body, global_this, None); // TODO: properly propagate exception upwards
+                    let _ = Body::Value::resolve(&mut old, &mut new_body, global_this); // TODO: properly propagate exception upwards
                     *body = new_body;
                 }
             }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -153,12 +153,9 @@ pub struct RequestContext<
     pub(crate) blob: JsCell<AnyBlob>,
 
     pub(crate) sendfile: Cell<SendfileContext>,
-    /// The request's `Range`, read from `req.headers` when the response is
-    /// rendered (after the handler may have set or deleted it).
+    /// `Range` as `req.headers` had it when the response was rendered.
     pub(crate) range: Cell<RangeRequest::Raw>,
-    /// A ref on the `Request`'s own `FetchHeaders`, held from the moment the
-    /// request goes async until the response is rendered, so that the `Range`
-    /// read above does not depend on the JS `Request` staying alive.
+    /// The `Request`'s `FetchHeaders`, held from `to_async` until render for `range`.
     pub(crate) request_headers: JsCell<Option<response::HeadersRef>>,
 
     pub(crate) request_body_readable_stream_ref: JsCell<readable_stream::Strong>,
@@ -2380,8 +2377,7 @@ where
                 request_object.set_fetch_headers(Some(response::HeadersRef::create_from_uws(req)));
             }
         }
-        // Render-time header reads (`request_header`) must not depend on the JS
-        // `Request` staying alive until then.
+        // For `capture_request_range`, whether or not the JS `Request` lives until render.
         if self.request_headers.get().is_none() {
             if let Some(headers) = request_object.fetch_headers() {
                 self.request_headers.set(Some(headers.new_ref()));
@@ -2393,9 +2389,7 @@ where
         request_object.request_context.detach_request();
     }
 
-    /// Reads `Range` as the handler sees it through `req.headers`, for
-    /// `do_sendfile`, and releases the ref taken in `to_async`: nothing after
-    /// render reads request headers.
+    /// Reads `Range` through `req.headers` for `do_sendfile` and drops the `to_async` ref.
     fn capture_request_range(&self) {
         let parse = |value: Option<bun_core::Utf8Bytes<'_>>| {
             value.map_or(RangeRequest::Raw::None, |value| {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4271,7 +4271,9 @@ where
                 if matches!(old, Body::Value::Locked(_)) {
                     let _exit = vm.enter_event_loop_scope();
 
-                    let _ = Body::Value::resolve(&mut old, body, global_this); // TODO: properly propagate exception upwards
+                    if let Err(err) = Body::Value::resolve(&mut old, body, global_this) {
+                        this.run_error_handler(global_this.take_exception(err));
+                    }
                 }
                 return;
             }
@@ -4430,8 +4432,11 @@ where
                     }
                     let mut new_body: Body::Value = Body::Value::Null;
                     let global_this = server.global_this();
-                    let _ = Body::Value::resolve(&mut old, &mut new_body, global_this); // TODO: properly propagate exception upwards
+                    let resolved = Body::Value::resolve(&mut old, &mut new_body, global_this);
                     *body = new_body;
+                    if let Err(err) = resolved {
+                        self.run_error_handler(global_this.take_exception(err));
+                    }
                 }
             }
         }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -14,7 +14,6 @@ use crate::webcore::{
 use bun_core::Output;
 use bun_http_types::MimeType::MimeType;
 // Re-export so callers can write `body::InternalBlob`.
-use crate::jsc::HTTPHeaderName;
 pub use crate::webcore::InternalBlob;
 use crate::webcore::form_data::AsyncFormDataExt as _;
 use bun_core::String as BunString;
@@ -65,6 +64,19 @@ fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
     }
     blob.content_type
         .set(blob::BlobContentType::from(mime_type));
+}
+
+/// `readableStreamToBlob` (BunStreamConsumers.cpp) built `blob` from a body's
+/// stream; give it the body's MIME type the way the other body readers do.
+#[unsafe(no_mangle)]
+pub extern "C" fn Body__setBlobContentType(blob: JSValue, content_type: *const u8, length: usize) {
+    let Some(blob) = <Blob as bun_jsc::JsClass>::from_js(blob) else {
+        return;
+    };
+    // SAFETY: C++ passes a live `(ptr, len)` UTF-8 buffer for the duration of the call.
+    let content_type = unsafe { bun_core::ffi::slice(content_type, length) };
+    // SAFETY: `from_js` returned the live payload of a JSBlob wrapper.
+    set_blob_content_type(unsafe { &*blob }, MimeType::init(content_type, true, None));
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -382,7 +394,7 @@ impl PendingValue {
                 Action::GetFormData(_)
                 | Action::GetText
                 | Action::GetJSON
-                | Action::GetBlob
+                | Action::GetBlob(_)
                 | Action::GetArrayBuffer
                 | Action::GetBytes => {
                     let promise = match &mut self.action {
@@ -392,7 +404,16 @@ impl PendingValue {
                         }
                         Action::GetBytes => global_this.readable_stream_to_bytes(readable.value),
                         Action::GetText => global_this.readable_stream_to_text(readable.value),
-                        Action::GetBlob => global_this.readable_stream_to_blob(readable.value),
+                        Action::GetBlob(mime_type) => {
+                            let content_type = match mime_type.take() {
+                                Some(mime_type) => bun_string_jsc::create_utf8_for_js(
+                                    global_this,
+                                    &mime_type.value,
+                                )?,
+                                None => JSValue::UNDEFINED,
+                            };
+                            global_this.readable_stream_to_blob(readable.value, content_type)
+                        }
                         Action::GetFormData(form_data) => 'brk: {
                             let fd = form_data.take().unwrap();
                             let encoding_js = match &fd.encoding {
@@ -440,7 +461,8 @@ pub enum Action {
     GetJSON,
     GetArrayBuffer,
     GetBytes,
-    GetBlob,
+    /// The owner's MIME type when `blob()` was called, for the resulting Blob.
+    GetBlob(Option<MimeType>),
     GetFormData(Option<Box<bun_core::form_data::AsyncFormData>>),
 }
 
@@ -450,7 +472,7 @@ impl Action {
     }
 }
 
-/// Tag-only equality. `GetFormData` payload is ignored.
+/// Tag-only equality. `GetBlob`/`GetFormData` payloads are ignored.
 impl PartialEq for Action {
     fn eq(&self, other: &Self) -> bool {
         core::mem::discriminant(self) == core::mem::discriminant(other)
@@ -1041,9 +1063,6 @@ impl Value {
         &mut self,
         new: &mut Value,
         global: &JSGlobalObject,
-        // Opaque C++ handle, mutated via FFI. Taking
-        // `NonNull` (not `&`/`&mut`) avoids manufacturing aliased Rust borrows.
-        headers: Option<NonNull<FetchHeaders>>,
     ) -> jsc::JsResult<()> {
         bun_core::scoped_log!(BodyValue, "resolve");
         if let Value::Locked(locked) = self {
@@ -1134,22 +1153,14 @@ impl Value {
                         // async_form_data dropped (Box<AsyncFormData> -> Drop replaces deinit)
                         result?;
                     }
-                    Action::None | Action::GetBlob => {
+                    action @ (Action::None | Action::GetBlob(_)) => {
                         let blob_ptr = Blob::new(new.use_());
                         // SAFETY: `Blob::new` returns a freshly heap-allocated *mut Blob.
                         let blob = unsafe { &mut *blob_ptr };
-                        if let Some(fetch_headers) = headers {
-                            // `headers` is a live C++ FetchHeaders handle;
-                            // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
-                            let fetch_headers =
-                                bun_opaque::opaque_deref_mut(fetch_headers.as_ptr());
-                            if let Some(content_type) =
-                                fetch_headers.fast_get(HTTPHeaderName::ContentType)
-                            {
-                                let content_slice = content_type.to_utf8();
-                                let mime_type = MimeType::init(content_slice.slice(), true, None);
-                                set_blob_content_type(blob, mime_type);
-                            }
+                        if let Action::GetBlob(Some(mime_type)) =
+                            core::mem::replace(action, Action::None)
+                        {
+                            set_blob_content_type(blob, mime_type);
                         }
                         if !blob.content_type_was_set.get() && blob.store.get().is_some() {
                             set_blob_content_type(blob, bun_http_types::MimeType::TEXT);
@@ -1582,7 +1593,7 @@ pub(crate) fn extract(global_this: &JSGlobalObject, value: JSValue) -> JsResult<
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Mixin trait with provided methods.
-/// Implementers supply `get_body_value`, `get_fetch_headers`, `get_form_data_encoding`,
+/// Implementers supply `get_body_value`, `get_fetch_headers` and `get_content_type`,
 /// and optionally override `get_body_readable_stream`.
 ///
 /// R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`. The
@@ -1600,7 +1611,26 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     /// (FFI signature is `*mut`). Returning `NonNull` instead of `&FetchHeaders`
     /// avoids deriving `&mut T` from `&T` at the call sites (UB).
     fn get_fetch_headers(&self) -> Option<NonNull<FetchHeaders>>;
-    fn get_form_data_encoding(&self) -> JsResult<Option<Box<bun_core::form_data::AsyncFormData>>>;
+    /// The owner's `Content-Type` (falling back to the body Blob's own type):
+    /// the MIME type `blob()` and `formData()` use.
+    fn get_content_type(&self) -> JsResult<Option<Utf8Bytes<'_>>>;
+
+    fn get_form_data_encoding(&self) -> JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
+        let Some(content_type) = self.get_content_type()? else {
+            return Ok(None);
+        };
+        let Some(encoding) = bun_core::form_data::Encoding::get(content_type.slice()) else {
+            return Ok(None);
+        };
+        Ok(Some(bun_core::form_data::AsyncFormData::init(encoding)))
+    }
+
+    /// The MIME type a Blob made from this body gets, read when `blob()` is called.
+    fn get_blob_mime_type(&self) -> JsResult<Option<MimeType>> {
+        Ok(self
+            .get_content_type()?
+            .map(|content_type| MimeType::init(content_type.slice(), true, None)))
+    }
 
     // ────────────────────────────────────────────────────────────────────
     // Twin methods (identical for Request/Response). These were previously
@@ -2110,8 +2140,15 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                     return Ok(handle_body_already_used(global_object));
                 }
                 value.to_blob_if_possible();
-                if let Value::Locked(locked) = value {
-                    return locked.set_promise(global_object, Action::GetBlob, Some(readable));
+                if matches!(value, Value::Locked(_)) {
+                    let mime_type = self.get_blob_mime_type()?;
+                    if let Value::Locked(locked) = self.get_body_value() {
+                        return locked.set_promise(
+                            global_object,
+                            Action::GetBlob(mime_type),
+                            Some(readable),
+                        );
+                    }
                 }
             }
             let value = self.get_body_value();
@@ -2126,26 +2163,26 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 let _ = locked;
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
-                if let Value::Locked(locked) = value {
-                    return locked.set_promise(global_object, Action::GetBlob, None);
+                if matches!(value, Value::Locked(_)) {
+                    let mime_type = self.get_blob_mime_type()?;
+                    if let Value::Locked(locked) = self.get_body_value() {
+                        return locked.set_promise(global_object, Action::GetBlob(mime_type), None);
+                    }
                 }
             }
         }
 
+        let mime_type = match self.get_body_value() {
+            Value::Blob(blob) if !blob.content_type_slice().is_empty() => None,
+            _ => self.get_blob_mime_type()?,
+        };
         let value = self.get_body_value();
         let blob_ptr = Blob::new(value.use_());
         // SAFETY: `Blob::new` returns a freshly heap-allocated, ref-counted Blob.
         let blob = unsafe { &mut *blob_ptr };
         if blob.content_type().is_empty() {
-            if let Some(fetch_headers) = BodyMixin::get_fetch_headers(self) {
-                // `fetch_headers` is a live C++ FetchHeaders handle;
-                // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
-                let fetch_headers = bun_opaque::opaque_deref_mut(fetch_headers.as_ptr());
-                if let Some(content_type) = fetch_headers.fast_get(HTTPHeaderName::ContentType) {
-                    let content_slice = content_type.to_utf8();
-                    let mime_type = MimeType::init(content_slice.slice(), true, None);
-                    set_blob_content_type(blob, mime_type);
-                }
+            if let Some(mime_type) = mime_type {
+                set_blob_content_type(blob, mime_type);
             }
             if !blob.content_type_was_set.get() && blob.store.get().is_some() {
                 set_blob_content_type(blob, bun_http_types::MimeType::TEXT);

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -66,10 +66,7 @@ fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
         .set(blob::BlobContentType::from(mime_type));
 }
 
-/// For `readableStreamToBlob` (C++): type the Blob it built like the other body readers do.
-///
-/// # Safety
-/// `content_type` must point to `length` readable bytes for the duration of the call.
+/// For `readableStreamToBlob` (C++). Safety: `content_type` is `length` readable bytes for the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Body__setBlobContentType(
     blob: JSValue,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -66,8 +66,7 @@ fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
         .set(blob::BlobContentType::from(mime_type));
 }
 
-/// `readableStreamToBlob` (BunStreamConsumers.cpp) built `blob` from a body's
-/// stream; give it the body's MIME type the way the other body readers do.
+/// For `readableStreamToBlob` (C++): type the Blob it built like the other body readers do.
 #[unsafe(no_mangle)]
 pub extern "C" fn Body__setBlobContentType(blob: JSValue, content_type: *const u8, length: usize) {
     let Some(blob) = <Blob as bun_jsc::JsClass>::from_js(blob) else {
@@ -1611,8 +1610,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     /// (FFI signature is `*mut`). Returning `NonNull` instead of `&FetchHeaders`
     /// avoids deriving `&mut T` from `&T` at the call sites (UB).
     fn get_fetch_headers(&self) -> Option<NonNull<FetchHeaders>>;
-    /// The owner's `Content-Type` (falling back to the body Blob's own type):
-    /// the MIME type `blob()` and `formData()` use.
+    /// The owner's `Content-Type`, else the body Blob's own type; used by `blob()`/`formData()`.
     fn get_content_type(&self) -> JsResult<Option<Utf8Bytes<'_>>>;
 
     fn get_form_data_encoding(&self) -> JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
@@ -2172,8 +2170,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
 
-        // A body Blob that carries its own type keeps it; otherwise the owner's
-        // Content-Type applies. Decided before `use_()` empties the body.
+        // A typed body Blob keeps its type. Checked before `use_()` empties the body.
         let has_own_type = matches!(self.get_body_value(), Value::Blob(blob) if !blob.content_type_slice().is_empty());
         let mime_type = if has_own_type {
             None

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -67,15 +67,27 @@ fn set_blob_content_type(blob: &Blob, mime_type: MimeType) {
 }
 
 /// For `readableStreamToBlob` (C++): type the Blob it built like the other body readers do.
+///
+/// # Safety
+/// `content_type` must point to `length` readable bytes for the duration of the call.
 #[unsafe(no_mangle)]
-pub extern "C" fn Body__setBlobContentType(blob: JSValue, content_type: *const u8, length: usize) {
+pub unsafe extern "C" fn Body__setBlobContentType(
+    blob: JSValue,
+    content_type: *const u8,
+    length: usize,
+) {
     let Some(blob) = <Blob as bun_jsc::JsClass>::from_js(blob) else {
         return;
     };
-    // SAFETY: C++ passes a live `(ptr, len)` UTF-8 buffer for the duration of the call.
+    // SAFETY: caller contract.
     let content_type = unsafe { bun_core::ffi::slice(content_type, length) };
     // SAFETY: `from_js` returned the live payload of a JSBlob wrapper.
     set_blob_content_type(unsafe { &*blob }, MimeType::init(content_type, true, None));
+}
+
+fn form_data_encoding(content_type: &[u8]) -> Option<Box<bun_core::form_data::AsyncFormData>> {
+    let encoding = bun_core::form_data::Encoding::get(content_type)?;
+    Some(bun_core::form_data::AsyncFormData::init(encoding))
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -1614,13 +1626,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     fn get_content_type(&self) -> JsResult<Option<Utf8Bytes<'_>>>;
 
     fn get_form_data_encoding(&self) -> JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
-        let Some(content_type) = self.get_content_type()? else {
-            return Ok(None);
-        };
-        let Some(encoding) = bun_core::form_data::Encoding::get(content_type.slice()) else {
-            return Ok(None);
-        };
-        Ok(Some(bun_core::form_data::AsyncFormData::init(encoding)))
+        Ok(self
+            .get_content_type()?
+            .and_then(|content_type| form_data_encoding(content_type.slice())))
     }
 
     /// The MIME type a Blob made from this body gets, read when `blob()` is called.

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2172,9 +2172,13 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             }
         }
 
-        let mime_type = match self.get_body_value() {
-            Value::Blob(blob) if !blob.content_type_slice().is_empty() => None,
-            _ => self.get_blob_mime_type()?,
+        // A body Blob that carries its own type keeps it; otherwise the owner's
+        // Content-Type applies. Decided before `use_()` empties the body.
+        let has_own_type = matches!(self.get_body_value(), Value::Blob(blob) if !blob.content_type_slice().is_empty());
+        let mime_type = if has_own_type {
+            None
+        } else {
+            self.get_blob_mime_type()?
         };
         let value = self.get_body_value();
         let blob_ptr = Blob::new(value.use_());

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -234,13 +234,8 @@ impl Request {
         self.headers.set(headers);
     }
 
-    /// The request's `FetchHeaders`, built from the live uWS request first if a
-    /// `Bun.serve` handler has not read `headers` yet. `None` only when there
-    /// are no headers and no uWS request to build them from.
-    ///
-    /// Every native reader of a request header goes through here, so that it
-    /// sees the same values as JS does through `req.headers` (including any
-    /// `set()`/`delete()` the handler made) instead of the original bytes.
+    /// `req.headers`, built from the live uWS request if not built yet. Native
+    /// header reads go through here so they match what JS sees, edits included.
     #[allow(clippy::mut_from_ref)]
     fn materialized_headers(&self) -> Option<&mut HeadersRef> {
         if self.headers.get().is_none() {
@@ -257,25 +252,21 @@ impl Request {
         self.headers.get().as_ref()
     }
 
-    /// One request header as `req.headers.get()` would return it. `wire_name`
-    /// is `name` in lowercase.
+    /// One header as `req.headers.get()` returns it. `wire_name` is `name` in lowercase.
     pub(crate) fn get_header(
         &self,
         name: HTTPHeaderName,
         wire_name: &[u8],
     ) -> Option<bun_core::Utf8Bytes<'_>> {
         if self.headers.get().is_none() {
-            // Not built yet, so nothing was set or deleted: a header that is not
-            // on the wire is absent. Answer that without building the headers.
+            // Nothing built, so nothing edited: absent on the wire means absent.
             let req = self.request_context.get_request()?;
             bun_opaque::opaque_deref(req).header(wire_name)?;
         }
         Some(self.materialized_headers()?.fast_get(name)?.to_utf8())
     }
 
-    /// Returns the headers of the request, creating them if they do not exist
-    /// yet: from the uWS request when served by `Bun.serve`, otherwise empty
-    /// (plus the body Blob's content type, if any).
+    /// `req.headers`, created empty (plus the body Blob's type) when there is no uWS request.
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn ensure_fetch_headers(
         &self,

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -234,8 +234,7 @@ impl Request {
         self.headers.set(headers);
     }
 
-    /// `req.headers`, built from the live uWS request if not built yet. Native
-    /// header reads go through here so they match what JS sees, edits included.
+    /// `req.headers`, built from the uWS request if not built yet: the one path for native reads.
     #[allow(clippy::mut_from_ref)]
     fn materialized_headers(&self) -> Option<&mut HeadersRef> {
         if self.headers.get().is_none() {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -181,10 +181,8 @@ impl BodyMixin for Request {
         })
     }
     #[inline]
-    fn get_form_data_encoding(
-        &self,
-    ) -> bun_jsc::JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
-        Request::get_form_data_encoding(self)
+    fn get_content_type(&self) -> JsResult<Option<bun_core::Utf8Bytes<'_>>> {
+        Request::get_content_type(self)
     }
 }
 
@@ -236,59 +234,87 @@ impl Request {
         self.headers.set(headers);
     }
 
-    /// Returns the headers of the request. If the headers are not already cached, it will create a new FetchHeaders object.
-    /// If the headers are empty, it will look at request_context to get the headers.
-    /// If the headers are empty and request_context is null, it will create an empty FetchHeaders object.
+    /// The request's `FetchHeaders`, built from the live uWS request first if a
+    /// `Bun.serve` handler has not read `headers` yet. `None` only when there
+    /// are no headers and no uWS request to build them from.
+    ///
+    /// Every native reader of a request header goes through here, so that it
+    /// sees the same values as JS does through `req.headers` (including any
+    /// `set()`/`delete()` the handler made) instead of the original bytes.
+    #[allow(clippy::mut_from_ref)]
+    fn materialized_headers(&self) -> Option<&mut HeadersRef> {
+        if self.headers.get().is_none() {
+            let req = self.request_context.get_request()?;
+            self.headers.set(Some(HeadersRef::create_from_uws(
+                req.cast::<core::ffi::c_void>(),
+            )));
+        }
+        self.headers_mut().as_mut()
+    }
+
+    /// The headers if they exist already; does not build them.
+    pub(crate) fn fetch_headers(&self) -> Option<&HeadersRef> {
+        self.headers.get().as_ref()
+    }
+
+    /// One request header as `req.headers.get()` would return it. `wire_name`
+    /// is `name` in lowercase.
+    pub(crate) fn get_header(
+        &self,
+        name: HTTPHeaderName,
+        wire_name: &[u8],
+    ) -> Option<bun_core::Utf8Bytes<'_>> {
+        if self.headers.get().is_none() {
+            // Not built yet, so nothing was set or deleted: a header that is not
+            // on the wire is absent. Answer that without building the headers.
+            let req = self.request_context.get_request()?;
+            bun_opaque::opaque_deref(req).header(wire_name)?;
+        }
+        Some(self.materialized_headers()?.fast_get(name)?.to_utf8())
+    }
+
+    /// Returns the headers of the request, creating them if they do not exist
+    /// yet: from the uWS request when served by `Bun.serve`, otherwise empty
+    /// (plus the body Blob's content type, if any).
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn ensure_fetch_headers(
         &self,
         global_this: &JSGlobalObject,
     ) -> JsResult<&mut HeadersRef> {
-        if self.headers.get().is_some() {
-            // headers is already set
-            return Ok(self.headers_mut().as_mut().unwrap());
+        if let Some(headers) = self.materialized_headers() {
+            return Ok(headers);
         }
 
-        if let Some(req) = self.request_context.get_request() {
-            // we have a request context, so we can get the headers from it
-            self.headers.set(Some(HeadersRef::create_from_uws(
-                req.cast::<core::ffi::c_void>(),
-            )));
-        } else {
-            // we don't have a request context, so we need to create an empty headers object
-            self.headers.set(Some(HeadersRef::create_empty()));
-            // Snapshot the pointer first; it stays valid across the field borrow.
-            let content_type: Option<*const [u8]> = match self.body_value() {
-                BodyValue::Blob(blob) => {
-                    Some(std::ptr::from_ref::<[u8]>(blob.content_type_slice()))
-                }
-                BodyValue::Locked(locked) => match locked.readable.get() {
-                    Some(readable) => match readable.ptr {
-                        crate::webcore::readable_stream::Source::Blob(blob) => {
-                            // SAFETY: `Source::Blob` holds a live `*mut ByteBlobLoader`
-                            // for as long as the readable stream exists; we only read
-                            // its `content_type` slice and immediately copy below.
-                            let ct: &[u8] = unsafe { (*blob).content_type.as_slice() };
-                            Some(std::ptr::from_ref::<[u8]>(ct))
-                        }
-                        _ => None,
-                    },
-                    None => None,
+        self.headers.set(Some(HeadersRef::create_empty()));
+        // Snapshot the pointer first; it stays valid across the field borrow.
+        let content_type: Option<*const [u8]> = match self.body_value() {
+            BodyValue::Blob(blob) => Some(std::ptr::from_ref::<[u8]>(blob.content_type_slice())),
+            BodyValue::Locked(locked) => match locked.readable.get() {
+                Some(readable) => match readable.ptr {
+                    crate::webcore::readable_stream::Source::Blob(blob) => {
+                        // SAFETY: `Source::Blob` holds a live `*mut ByteBlobLoader`
+                        // for as long as the readable stream exists; we only read
+                        // its `content_type` slice and immediately copy below.
+                        let ct: &[u8] = unsafe { (*blob).content_type.as_slice() };
+                        Some(std::ptr::from_ref::<[u8]>(ct))
+                    }
+                    _ => None,
                 },
-                _ => None,
-            };
+                None => None,
+            },
+            _ => None,
+        };
 
-            if let Some(content_type_) = content_type {
-                // SAFETY: the sources above are live for the duration of this
-                // call; the bytes are copied into the header map below.
-                let content_type_ = unsafe { &*content_type_ };
-                if !content_type_.is_empty() {
-                    self.headers_mut().as_mut().unwrap().put(
-                        HTTPHeaderName::ContentType,
-                        &BunString::ascii(content_type_),
-                        global_this,
-                    )?;
-                }
+        if let Some(content_type_) = content_type {
+            // SAFETY: the sources above are live for the duration of this
+            // call; the bytes are copied into the header map below.
+            let content_type_ = unsafe { &*content_type_ };
+            if !content_type_.is_empty() {
+                self.headers_mut().as_mut().unwrap().put(
+                    HTTPHeaderName::ContentType,
+                    &BunString::ascii(content_type_),
+                    global_this,
+                )?;
             }
         }
 
@@ -297,16 +323,7 @@ impl Request {
 
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn get_fetch_headers_unless_empty(&self) -> Option<&mut HeadersRef> {
-        if self.headers.get().is_none() {
-            if let Some(req) = self.request_context.get_request() {
-                // we have a request context, so we can get the headers from it
-                self.headers.set(Some(HeadersRef::create_from_uws(
-                    req.cast::<core::ffi::c_void>(),
-                )));
-            }
-        }
-
-        let headers = self.headers_mut().as_mut()?;
+        let headers = self.materialized_headers()?;
         if headers.is_empty() {
             return None;
         }
@@ -322,38 +339,15 @@ impl Request {
         &self,
         global_this: &JSGlobalObject,
     ) -> JsResult<Option<HeadersRef>> {
-        if self.headers.get().is_none() {
-            if let Some(uws_req) = self.request_context.get_request() {
-                self.headers.set(Some(HeadersRef::create_from_uws(
-                    uws_req.cast::<core::ffi::c_void>(),
-                )));
-            }
+        match self.get_fetch_headers_unless_empty() {
+            Some(headers) => headers.clone_this(global_this),
+            None => Ok(None),
         }
-
-        if let Some(head) = self.headers_mut().as_mut() {
-            if head.is_empty() {
-                return Ok(None);
-            }
-
-            return head.clone_this(global_this);
-        }
-
-        Ok(None)
     }
 
     pub(crate) fn get_content_type(&self) -> JsResult<Option<bun_core::Utf8Bytes<'_>>> {
-        if let Some(req) = self.request_context.get_request() {
-            // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
-            let req = bun_opaque::opaque_deref(req);
-            if let Some(value) = req.header(b"content-type") {
-                return Ok(Some(bun_core::Utf8Bytes::Borrowed(value)));
-            }
-        }
-
-        if let Some(headers) = self.headers_mut().as_mut() {
-            if let Some(value) = headers.fast_get(HTTPHeaderName::ContentType) {
-                return Ok(Some(value.to_utf8()));
-            }
+        if let Some(value) = self.get_header(HTTPHeaderName::ContentType, b"content-type") {
+            return Ok(Some(value));
         }
 
         if let BodyValue::Blob(blob) = self.body_value() {
@@ -432,21 +426,6 @@ impl Request {
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
         }
-    }
-
-    pub(crate) fn get_form_data_encoding(
-        &self,
-    ) -> JsResult<Option<Box<crate::webcore::form_data::AsyncFormData>>> {
-        let Some(content_type_slice) = self.get_content_type()? else {
-            return Ok(None);
-        };
-        let Some(encoding) = crate::webcore::form_data::Encoding::get(content_type_slice.slice())
-        else {
-            return Ok(None);
-        };
-        Ok(Some(crate::webcore::form_data::AsyncFormData::init(
-            encoding,
-        )))
     }
 
     pub(crate) fn estimated_size(&self) -> usize {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -30,9 +30,9 @@ use bun_ptr::weak_ptr::WeakPtrData;
 /// `WebCore__FetchHeaders__deref`. NOT a `std::rc::Rc` (the payload lives on
 /// the C++ heap and is opaque here).
 ///
-/// Intentionally not `Clone`: the only "share" operation the surface
-/// exposes is `clone_this()`, which deep-copies a fresh `FetchHeaders` on the
-/// C++ side. Transferring ownership is by-move.
+/// Intentionally not `Clone`, so that sharing the same C++ object is spelled
+/// out: `new_ref()` takes another ref on it, `clone_this()` deep-copies a
+/// fresh `FetchHeaders` on the C++ side. Transferring ownership is by-move.
 #[repr(transparent)]
 pub struct HeadersRef(NonNull<FetchHeaders>);
 
@@ -45,6 +45,14 @@ impl HeadersRef {
     #[inline]
     pub(crate) unsafe fn adopt(ptr: NonNull<FetchHeaders>) -> Self {
         Self(ptr)
+    }
+
+    /// Take an additional ref on the same C++ `FetchHeaders` (no copy): both
+    /// handles observe later mutations.
+    #[inline]
+    pub(crate) fn new_ref(&self) -> Self {
+        bun_opaque::opaque_deref_mut(self.0.as_ptr()).ref_();
+        Self(self.0)
     }
 
     #[inline]
@@ -281,7 +289,7 @@ impl crate::webcore::body::BodyOwnerJs for Response {
 
 // BodyMixin is a trait with default methods providing getText/
 // getBody/getBytes/getBodyUsed/getJSON/getArrayBuffer/getBlob/getBlobWithoutCallFrame/
-// getFormData over any type exposing getBodyValue()/getFormDataEncoding()/etc.
+// getFormData over any type exposing getBodyValue()/getContentType()/etc.
 // Response implements it.
 
 impl BodyMixin for Response {
@@ -301,10 +309,8 @@ impl BodyMixin for Response {
         })
     }
     #[inline]
-    fn get_form_data_encoding(
-        &self,
-    ) -> bun_jsc::JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
-        Response::get_form_data_encoding(self)
+    fn get_content_type(&self) -> JsResult<Option<Utf8Bytes<'_>>> {
+        Response::get_content_type(self)
     }
 }
 
@@ -436,19 +442,6 @@ impl Response {
         self.body.get().len() as usize
     }
 
-    pub(crate) fn get_form_data_encoding(
-        &self,
-    ) -> JsResult<Option<Box<bun_core::form_data::AsyncFormData>>> {
-        let Some(content_type_slice) = self.get_content_type()? else {
-            return Ok(None);
-        };
-        // content_type_slice drops at scope exit
-        let Some(encoding) = bun_core::form_data::Encoding::get(content_type_slice.slice()) else {
-            return Ok(None);
-        };
-        Ok(Some(bun_core::form_data::AsyncFormData::init(encoding)))
-    }
-
     pub(crate) fn calculate_estimated_byte_size(&self) {
         self.reported_estimated_size.set(
             self.body.get().value.get().estimated_size()
@@ -530,10 +523,6 @@ impl Response {
 }
 
 impl Response {
-    pub(crate) fn get_fetch_headers(&self) -> Option<&FetchHeaders> {
-        self.init.get().headers.as_deref()
-    }
-
     #[inline]
     pub(crate) fn status_code(&self) -> u16 {
         self.init.get().status_code

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -30,8 +30,7 @@ use bun_ptr::weak_ptr::WeakPtrData;
 /// `WebCore__FetchHeaders__deref`. NOT a `std::rc::Rc` (the payload lives on
 /// the C++ heap and is opaque here).
 ///
-/// Intentionally not `Clone`: `new_ref()` shares the C++ object, `clone_this()`
-/// deep-copies it. Transferring ownership is by-move.
+/// Not `Clone`: share with `new_ref()`, deep-copy with `clone_this()`, move to transfer.
 #[repr(transparent)]
 pub struct HeadersRef(NonNull<FetchHeaders>);
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -30,9 +30,8 @@ use bun_ptr::weak_ptr::WeakPtrData;
 /// `WebCore__FetchHeaders__deref`. NOT a `std::rc::Rc` (the payload lives on
 /// the C++ heap and is opaque here).
 ///
-/// Intentionally not `Clone`, so that sharing the same C++ object is spelled
-/// out: `new_ref()` takes another ref on it, `clone_this()` deep-copies a
-/// fresh `FetchHeaders` on the C++ side. Transferring ownership is by-move.
+/// Intentionally not `Clone`: `new_ref()` shares the C++ object, `clone_this()`
+/// deep-copies it. Transferring ownership is by-move.
 #[repr(transparent)]
 pub struct HeadersRef(NonNull<FetchHeaders>);
 
@@ -47,8 +46,7 @@ impl HeadersRef {
         Self(ptr)
     }
 
-    /// Take an additional ref on the same C++ `FetchHeaders` (no copy): both
-    /// handles observe later mutations.
+    /// Another handle on the same C++ `FetchHeaders` (+1 ref, no copy).
     #[inline]
     pub(crate) fn new_ref(&self) -> Self {
         bun_opaque::opaque_deref_mut(self.0.as_ptr()).ref_();

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -827,7 +827,8 @@ impl FetchTasklet {
                 }
             }
 
-            // raw ptr: `body` and `get_fetch_headers()` are disjoint fields but borrowck can't see through the accessors.
+            // raw ptr: `body` lives in `response`, disjoint from the `self` fields used below, but
+            // borrowck can't see through the accessors.
             let body: *mut BodyValue = response.get_body_value();
             // `BodyAbortListener::on_abort` may have set `Error` while this
             // callback was queued; checked before `buffer_reset.set(false)` so
@@ -865,15 +866,9 @@ impl FetchTasklet {
                 if matches!(old, BodyValue::Locked(_)) {
                     bun_output::scoped_log!(FetchTasklet, "onBodyReceived old.resolve");
                     let mut old = old;
-                    // BodyValue::resolve takes `Option<NonNull<FetchHeaders>>` (opaque C++ handle
-                    // mutated via FFI); the inherent `get_fetch_headers` returns `Option<&_>`, so
-                    // erase the borrow into a raw NonNull. Disjoint from `body` (response.init vs
-                    // response.body) and outlives this block.
-                    let headers = response.get_fetch_headers().map(core::ptr::NonNull::from);
-                    // SAFETY: `body` points into `response.body`, disjoint from `headers`
-                    // (response.init); both live for this block.
+                    // SAFETY: `body` points into `response.body`, live for this block.
                     let body = unsafe { &mut *body };
-                    BodyValue::resolve(&mut old, body, &self.global_this, headers)?;
+                    BodyValue::resolve(&mut old, body, &self.global_this)?;
                 }
             }
         }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -827,8 +827,7 @@ impl FetchTasklet {
                 }
             }
 
-            // raw ptr: `body` lives in `response`, disjoint from the `self` fields used below, but
-            // borrowck can't see through the accessors.
+            // raw ptr: borrowck can't see that `body` (in `response`) is disjoint from `self`.
             let body: *mut BodyValue = response.get_body_value();
             // `BodyAbortListener::on_abort` may have set `Error` while this
             // callback was queued; checked before `buffer_reset.set(false)` so

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 import { once } from "node:events";
 import * as net from "node:net";
+import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {
@@ -263,5 +265,112 @@ describe("response Connection: close closes the socket", () => {
     } finally {
       socket.destroy();
     }
+  });
+});
+
+// `req.headers` of a served Request is built lazily from the uWS request. A
+// native reader of a request header (the body's MIME type, Range for a file
+// response) must see exactly what JS sees through `req.headers`: the same
+// value whether or not the handler read the headers first, awaited first, or
+// changed them.
+describe.concurrent("native readers agree with req.headers", () => {
+  // What the handler does before the read under test. In "sync" and "touched"
+  // the uWS request is still live; "touched" has already built `req.headers`
+  // from it. A microtask still runs inside the dispatch. After a macrotask the
+  // server has copied the headers and detached the uWS request.
+  const states = {
+    sync: (req: Request): Promise<void> | undefined => undefined,
+    touched: (req: Request): Promise<void> | undefined => void req.headers.has("x-touch"),
+    microtask: (req: Request): Promise<void> | undefined => Promise.resolve(),
+    macrotask: (req: Request): Promise<void> | undefined => new Promise<void>(resolve => setImmediate(resolve)),
+  };
+  type State = keyof typeof states;
+  const urlencoded = "application/x-www-form-urlencoded";
+
+  describe.each(Object.keys(states) as State[])("%s handler", state => {
+    describe("Content-Type for body readers", () => {
+      type Op = "none" | "set" | "delete" | "clone";
+      async function read(op: Op, reader: "blob" | "formData", wireContentType: string) {
+        let result: unknown;
+        using server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            const wait = states[state](req);
+            if (wait) await wait;
+            if (op === "set") req.headers.set("content-type", urlencoded);
+            if (op === "delete") req.headers.delete("content-type");
+            const subjects = op === "clone" ? [req.clone(), req] : [req];
+            try {
+              result = await Promise.all(
+                subjects.map(async r =>
+                  reader === "blob" ? (await r.blob()).type : Object.fromEntries(await r.formData()),
+                ),
+              );
+            } catch (e) {
+              result = (e as { code?: string }).code ?? String(e);
+            }
+            return new Response("done");
+          },
+        });
+        const res = await fetch(server.url, {
+          method: "POST",
+          body: "a=1",
+          headers: { "content-type": wireContentType },
+        });
+        expect(await res.text()).toBe("done");
+        return result;
+      }
+
+      test("blob().type is the wire Content-Type", async () => {
+        expect(await read("none", "blob", urlencoded)).toEqual([urlencoded]);
+      });
+      test("blob().type follows headers.set()", async () => {
+        expect(await read("set", "blob", "text/plain")).toEqual([urlencoded]);
+      });
+      test("blob().type survives clone() on both copies", async () => {
+        expect(await read("clone", "blob", urlencoded)).toEqual([urlencoded, urlencoded]);
+      });
+      test("formData() follows headers.set()", async () => {
+        expect(await read("set", "formData", "text/plain")).toEqual([{ a: "1" }]);
+      });
+      test("formData() follows headers.delete()", async () => {
+        expect(await read("delete", "formData", urlencoded)).toEqual("ERR_FORMDATA_PARSE_ERROR");
+      });
+      test("formData() survives clone() on both copies", async () => {
+        expect(await read("clone", "formData", urlencoded)).toEqual([{ a: "1" }, { a: "1" }]);
+      });
+    });
+
+    describe("Range for a Bun.file() response", () => {
+      const contents = "0123456789abcdef";
+      async function get(op: "none" | "set" | "delete", wireRange: string | undefined) {
+        using dir = tempDir("serve-range-from-headers", { "data.txt": contents });
+        using server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            const wait = states[state](req);
+            if (wait) await wait;
+            if (op === "set") req.headers.set("range", "bytes=2-5");
+            if (op === "delete") req.headers.delete("range");
+            return new Response(Bun.file(join(String(dir), "data.txt")));
+          },
+        });
+        const res = await fetch(server.url, { headers: wireRange ? { Range: wireRange } : {} });
+        return { status: res.status, contentRange: res.headers.get("content-range"), body: await res.text() };
+      }
+
+      test("the wire Range is honored", async () => {
+        expect(await get("none", "bytes=0-3")).toEqual({ status: 206, contentRange: "bytes 0-3/16", body: "0123" });
+      });
+      test("headers.delete('range') serves the whole file", async () => {
+        expect(await get("delete", "bytes=0-3")).toEqual({ status: 200, contentRange: null, body: contents });
+      });
+      test("headers.set('range') replaces the wire Range", async () => {
+        expect(await get("set", "bytes=0-3")).toEqual({ status: 206, contentRange: "bytes 2-5/16", body: "2345" });
+      });
+      test("headers.set('range') applies with no Range on the wire", async () => {
+        expect(await get("set", undefined)).toEqual({ status: 206, contentRange: "bytes 2-5/16", body: "2345" });
+      });
+    });
   });
 });

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -350,6 +350,54 @@ for (const { body, fn } of bodyTypes) {
         });
       });
     });
+    // https://fetch.spec.whatwg.org/#dom-body-blob: the Blob's type is the
+    // body's MIME type (from Content-Type) no matter how the bytes are held.
+    // A body that is still a stream when blob() runs must not lose it.
+    describe("blob() on a stream body takes its type from Content-Type", () => {
+      const headers = { "content-type": "text/x-bun" };
+      const chunks = () =>
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("bye"));
+            controller.close();
+          },
+        });
+      const describeBlob = async (blob: Blob) => [blob.type, await blob.text()];
+
+      test("a ReadableStream body", async () => {
+        expect(await describeBlob(await fn(chunks(), headers).blob())).toEqual(["text/x-bun", "bye"]);
+      });
+
+      test("both copies of a cloned ReadableStream body", async () => {
+        const subject = fn(chunks(), headers);
+        const clone = subject.clone();
+        expect([await describeBlob(await clone.blob()), await describeBlob(await subject.blob())]).toEqual([
+          ["text/x-bun", "bye"],
+          ["text/x-bun", "bye"],
+        ]);
+      });
+
+      test("both copies when clone() tees a body the getter already streamed", async () => {
+        const subject = fn(new TextEncoder().encode("bye"), headers);
+        expect(subject.body).toBeInstanceOf(ReadableStream);
+        const clone = subject.clone();
+        expect([await describeBlob(await clone.blob()), await describeBlob(await subject.blob())]).toEqual([
+          ["text/x-bun", "bye"],
+          ["text/x-bun", "bye"],
+        ]);
+      });
+
+      test("a native stream body", async () => {
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", "process.stdout.write('bye')"],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "inherit",
+        });
+        expect(await describeBlob(await fn(proc.stdout, headers).blob())).toEqual(["text/x-bun", "bye"]);
+        expect(await proc.exited).toBe(0);
+      });
+    });
     for (const { string, buffer } of utf8) {
       describe("arrayBuffer()", () => {
         test("undefined", async () => {


### PR DESCRIPTION
### Problem
- `Bun.serve` reads some request headers from the wire, not `req.headers`. `formData()` and `blob()` take `Content-Type` from the uWS request first, so `headers.set()`/`delete()` before an `await` is ignored. A body still in flight resolves with no headers, so `(await req.blob()).type` is always `text/plain;charset=utf-8`. `Range` for `new Response(Bun.file(p))` is parsed in `RequestContext::create`, before the handler runs.
- `blob()` on a body held as a `ReadableStream` (`clone()` makes one) gets no type: `readableStreamToBlob` never sees `Content-Type`.

### Fix
- `Request::get_header()` is the one native read path: it builds `req.headers` if needed and reads it. `RequestContext` reads `Range` through it when the response is rendered, not in `create()`, and holds a ref on the request's `FetchHeaders` from `to_async()` until then.
- `blob()` reads the MIME type when called and carries it in `Action::GetBlob`. `readableStreamToBlob` takes it and applies it through `Body__setBlobContentType`. Buffered, pending and stream paths now agree.
- Verified: `bun-serve-headers.test.ts` (40 new cases, 25 fail on canary `f42e98025`), `body.test.ts` (8 new, all fail on canary). Self-reviewed: overlap with open PRs handled in the notes. Fixes #32801.

### Background
- A served `Request` is lazy: `req.headers` is built from the uWS request on first access. That request lives on the dispatch stack. `to_async()` copies url and headers off it when the handler goes async.
- `Body::Value::Locked` is a body whose bytes have not arrived. A reader parks an `Action` and a promise on it. Once JS holds it as a stream, reads go through `readableStreamToBlob` (C++) instead.
- `HeadersRef` is the Rust handle on a C++ `FetchHeaders`. `new_ref()` (added here) shares one, as `CookieMapRef` does for the cookie map.

<details><summary>Notes</summary>

Where the old reads were: `Request::get_content_type` (`src/runtime/webcore/Request.rs`) checked `req.header("content-type")` on the uWS request before `self.headers`; `RequestContext::create` stored `range: RangeRequest::raw_from_request(..)`; `on_buffered_body_chunk` / `on_start_buffering` called `Body::Value::resolve(.., None)`; `readableStreamToBlob` (`BunStreamConsumers.cpp`) built `new Blob(chunks)` with no type.

Related open PRs. #41962 (superseding #41821) fixes the same divergence in `server.upgrade()` by reading the handshake from `req.headers`; this PR leaves `on_upgrade` alone so the two do not conflict, and its body names this content-type path as the follow-up. #40483 keeps `url`/`headers` readable after a synchronous response (the late-access half). #33128 is a larger, older rework of MIME extraction per the Fetch spec that includes a version of the `Action::GetBlob` plumbing here; it is conflicting and unreviewed, so this PR takes only the part these bugs need and keeps Bun's existing `MimeType` normalization. #40416 (Latin-1 header values, invalid MIME type to `""`) edits the `get_blob`/`resolve` hunks this PR rewrites; whichever lands second moves that rule into `get_blob_mime_type`/`Body__setBlobContentType`, a small rebase either way. `Body::Value::resolve` loses its `headers` parameter; its two other callers (`FetchTasklet`, `HTMLRewriter`) get the type from `Action::GetBlob` like the server does.

Behaviour notes:
- `get_header()` does not build `req.headers` when the header is absent on the wire and nothing was built yet (nothing can have been set or deleted then), so a sync `Bun.file()` response without a `Range` line costs one raw header probe. With a `Range` line it builds `req.headers` (one `FetchHeaders`), as every async handler already does. `RequestContext::create` no longer scans for `range` at all.
- Two `Range` (or `Content-Type`) lines now read the same in every handler state: the combined value that `req.headers.get()` returns. For `Range` that value contains a comma, so it is ignored and the whole file is served (the multi-range rule), where an untouched sync handler used to honor the first line.
- The MIME type for `blob()` is read when `blob()` is called, on every path. Before, the pending path read it when the body completed and the stream path never read it.
- `RequestContext.request_headers` is taken in `to_async()` and released in `render()` (or in `finalize_without_deinit` if the request never renders); the pool's `put` drops the slot in place, so no path leaks the ref. The ref is what makes `Range` deterministic when the JS `Request` is collected before the response renders (checked with a handler that drops `req`, forces GC, then returns `Bun.file()`).
- The stream path sets the type through a Rust export instead of `new Blob(chunks, { type })` because the `Blob` constructor maps known types through a lookup table (`application/x-www-form-urlencoded` becomes `application/x-www-form-urlencoded;charset=UTF-8`), which would put this path out of step with the others.
- Unchanged, now visible on the stream path too: `MimeType::init` maps a known essence to its canned value, so `text/html; charset=iso-8859-1` reads back as `text/html;charset=utf-8`, and `set_blob_content_type` also writes the type into the Blob's store. Both are what the buffered path has always done; #33128 is the place that changes them.

Canary `f42e98025`, sync handler, wire `Content-Type: application/json`, body `hello`:

```
op       (await req.blob()).type
none     "text/plain;charset=utf-8"
touched  "text/plain;charset=utf-8"
clone    "" (both copies)
set      "text/plain;charset=utf-8"
after an await: "application/json;charset=utf-8" for none/touched/clone
```

Other suites run on the debug build: `body-clone`, `body-stream`, `blob`, `body-mixin-errors`, `fetch.stream` (five `multiple parts` cases time out at 5 s in this container regardless of the change), `FormData`, `bun-serve-file`, `bun-serve-cookies`, `serve.test.ts` (two environment failures: root can bind port 1003, no non-loopback interface), `serve-http3`, `websocket-server -t upgrade`, `websocket-server-upgrade-reentrant`, `test/js/web/request/`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->