### PR TITLE
bun test: let an explicit --only satisfy the CI .only guard

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -191,6 +191,10 @@ The following command runs only tests #2 and #3.
 bun test --only
 ```
 
+Without `--only`, a file that contains `.only` still runs only its focused tests, but other files run all of their tests. With `--only`, files that contain no `.only` run nothing.
+
+In CI environments (when `CI=true` or a known CI provider is detected), `test.only()` and `describe.only()` throw an error so that a stray `.only` cannot silently skip the rest of the suite. Pass `--only` to confirm that you want the focused run, or set `CI=false`.
+
 ### test.if
 
 To run a test conditionally, use `test.if()`. The test runs if the condition is truthy. Use it for tests that should only run on a specific architecture or operating system.

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -470,7 +470,7 @@ impl ScopeFunctions {
         if cfg.self_mode == SelfMode::Failing && self.mode == Mode::Describe {
             return Err(global.throw(format_args!("Cannot {} on {}", bstr::BStr::new(name), self)));
         }
-        if cfg.self_only {
+        if cfg.self_only && !jest::Jest::runner().is_some_and(|runner| runner.only) {
             error_in_ci(global, b".only")?;
         }
         let Some(extended) = self.cfg.extend(cfg) else {
@@ -483,7 +483,7 @@ impl ScopeFunctions {
 fn error_in_ci(global: &JSGlobalObject, signature: &[u8]) -> JsResult<()> {
     if crate::cli::ci_info::is_ci() {
         return Err(global.throw(format_args!(
-            "{} is disabled in CI environments to prevent accidentally skipping tests. To override, set the environment variable CI=false.",
+            "{} is disabled in CI environments to prevent accidentally skipping tests. To override, pass --only or set the environment variable CI=false.",
             bstr::BStr::new(signature)
         )));
     }

--- a/test/js/bun/test/ci-restrictions.test.ts
+++ b/test/js/bun/test/ci-restrictions.test.ts
@@ -55,8 +55,52 @@ test.only("should fail in CI", () => {
 
       expect(exitCode).toBe(1);
       expect(stderr).toContain(
-        "error: .only is disabled in CI environments to prevent accidentally skipping tests. To override, set the environment variable CI=false.",
+        "error: .only is disabled in CI environments to prevent accidentally skipping tests. To override, pass --only or set the environment variable CI=false.",
       );
+    });
+
+    test("test.only and describe.only should work with --only when GITHUB_ACTIONS=1", async () => {
+      const dir = tempDirWithFiles("ci-test-only-flag", {
+        "focused.test.js": `
+import { test, expect, describe } from "bun:test";
+
+test.only("focused test runs", () => {
+  expect(1 + 1).toBe(2);
+});
+
+describe.only("focused describe", () => {
+  test("runs", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+
+test("unfocused test is skipped", () => {
+  expect(false).toBe(true);
+});
+        `,
+        "other.test.js": `
+import { test, expect } from "bun:test";
+
+test("unfocused file is skipped", () => {
+  expect(false).toBe(true);
+});
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--only"],
+        env: { ...bunEnv, GITHUB_ACTIONS: "1" },
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).not.toContain("is disabled in CI environments");
+      expect(stderr).toContain("2 pass");
+      expect(stderr).toContain("0 fail");
+      expect(exitCode).toBe(0);
     });
 
     test("describe.only should fail when GITHUB_ACTIONS=1", async () => {
@@ -84,7 +128,7 @@ describe.only("CI test", () => {
 
       expect(exitCode).toBe(1);
       expect(stderr).toContain(
-        "error: .only is disabled in CI environments to prevent accidentally skipping tests. To override, set the environment variable CI=false.",
+        "error: .only is disabled in CI environments to prevent accidentally skipping tests. To override, pass --only or set the environment variable CI=false.",
       );
     });
   });


### PR DESCRIPTION
### Problem
- `CI=true bun test --only` fails every focused test with `error: .only is disabled in CI environments to prevent accidentally skipping tests.` The explicit `--only` does not satisfy the guard, so the flag documented as "Run only tests that are marked with test.only()" cannot do that in CI.
- The cause is `generic_extend` in `src/runtime/test_runner/ScopeFunctions.rs:473`. It calls `error_in_ci` for every `.only` scope and checks `ci_info::is_ci()` alone. It never reads the runner's `only` option.

### Fix
- Skip the guard when `Jest::runner()` has `only` set (the `--only` flag). The error message now reads `To override, pass --only or set the environment variable CI=false.`
- This matches the snapshot guard next to it: CI refuses to create snapshots unless `--update-snapshots` is passed. The guard exists to catch a stray `.only` left in a commit. A run that passes `--only` asked for the focused run, so there is nothing accidental to catch.
- `docs/test/writing-tests.mdx` now says what `--only` changes across files and describes the CI behavior, which was undocumented.
- Verified: `test/js/bun/test/ci-restrictions.test.ts` (new `--only` under `GITHUB_ACTIONS=1` case, stock bun fails it). Also ran `test/cli/env/ci-info.test.ts`.

### Background
- Without `--only`, a file that contains `.only` auto-focuses: only its `.only` tests run. Other files still run everything. With `--only`, the root scope of every file starts as "contains only" (`Collection::init`), so files with no `.only` run nothing.
- `ci_info::is_ci()` is true when `CI` is set to anything but `false`, or when a known provider variable such as `GITHUB_ACTIONS` is present.

<details><summary>Notes</summary>

Reported in an internal single-flag census as "`bun test --only` never changes an outcome". That holds for a single file because of auto-focus, but not across files: `bun test --only` with `o.test.ts` (has `.only`) and `p.test.ts` (no `.only`) runs 1 test, plain `bun test` runs 2. The CI half of the report is the bug fixed here.

</details>
