### PR TITLE
bun test: honor --pass-with-no-tests when a single path argument does not exist

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2039,9 +2039,11 @@ impl TestCommand {
                     Ok(()) => {}
                     Err(scanner::ScanError::OutOfMemory) => bun::out_of_memory(),
                     // don't error if multiple are passed; one might fail
-                    // but the others may not
+                    // but the others may not. With --pass-with-no-tests, fall
+                    // through to the shared "did not match any test files"
+                    // path, which reports and exits 0.
                     Err(scanner::ScanError::DoesNotExist) => {
-                        if file_or_dirnames.len() == 1 {
+                        if file_or_dirnames.len() == 1 && !ctx.test_options.pass_with_no_tests {
                             if Output::is_ai_agent() {
                                 pretty_errorln!(
                                     "Test filter <b>{}<r> had no matches in --cwd={}",

--- a/test/cli/test/pass-with-no-tests.test.ts
+++ b/test/cli/test/pass-with-no-tests.test.ts
@@ -40,6 +40,44 @@ test("--pass-with-no-tests exits with 0 when filters match no tests", async () =
   expect(exitCode).toBe(0);
 });
 
+test.each([
+  ["a path that does not exist", ["./does-not-exist"]],
+  ["several paths that do not exist", ["./does-not-exist", "./also-missing"]],
+  ["a directory with no test files", ["./empty"]],
+])("--pass-with-no-tests exits with 0 when given %s", async (_label, paths) => {
+  using dir = tempDir("pass-with-no-tests-path", {
+    "some.test.ts": `import { test } from "bun:test"; test("example", () => {});`,
+    "empty/not-a-test.ts": `console.log("hello");`,
+  });
+
+  await using failing = Bun.spawn({
+    cmd: [bunExe(), "test", ...paths],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: bunEnv,
+  });
+  const [failErr, failExitCode] = await Promise.all([failing.stderr.text(), failing.exited]);
+  expect(failErr).toContain(paths[0]);
+  expect(failErr).not.toContain("example");
+  expect(failExitCode).toBe(1);
+
+  await using passing = Bun.spawn({
+    cmd: [bunExe(), "test", ...paths, "--pass-with-no-tests"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: bunEnv,
+  });
+  const [passErr, passExitCode] = await Promise.all([passing.stderr.text(), passing.exited]);
+  expect(passErr).toContain("The following filters did not match any test files:");
+  expect(passErr).toContain(paths[0]);
+  expect(passErr).not.toContain("example");
+  expect(passExitCode).toBe(0);
+});
+
 test("without --pass-with-no-tests, exits with 1 when no test files found", async () => {
   using dir = tempDir("fail-with-no-tests", {
     "not-a-test.ts": `console.log("hello");`,


### PR DESCRIPTION
### Problem
- `bun test ./does-not-exist --pass-with-no-tests` prints `Test filter "./does-not-exist" had no matches` and exits 1. The same flag already gives exit 0 for two missing paths, for a directory with no test files, for `-t` with no match, and for an empty project. A monorepo step like `bun test ./packages/$P --pass-with-no-tests` fails for a package that has no tests yet, which is the main use of jest's `--passWithNoTests`.
- The cause is the single-path `ScanError::DoesNotExist` branch in `src/runtime/cli/test_command.rs:2044`. It sets exit code 1 and calls `global_exit()` before anything reads `ctx.test_options.pass_with_no_tests`.

### Fix
- Take the early exit only when `--pass-with-no-tests` is not set. With the flag, the single missing path falls through to the shared "The following filters did not match any test files:" report, which already honors the flag at `test_command.rs:2662` and exits 0.
- Correct because every other no-tests shape goes through that shared path. The single-path branch only exists to print a shorter message and skip the scan summary. Without the flag its output and exit code are unchanged.
- Verified: `test/cli/test/pass-with-no-tests.test.ts` (three new `test.each` rows, stock bun fails the single-path row). Also ran the scanner path cases in `test/cli/test/bun-test.test.ts`.

### Background
- `bun test` treats a positional that starts with `./` or `../`, or is absolute, as a path to scan. Any other positional is a substring filter over discovered test file paths. Only the path form can hit `DoesNotExist`.
- `--pass-with-no-tests` maps to `ctx.test_options.pass_with_no_tests`. It only flips the final exit code when no test ran. It does not suppress the report of what was searched.
