### PR TITLE
pack, publish: open packed files and directories without following symlinks

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2688,6 +2688,8 @@ pub mod ffi {
     #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::FILE_BASIC_INFORMATION {}
     #[cfg(windows)]
+    unsafe impl Zeroable for bun_windows_sys::externs::FILE_ATTRIBUTE_TAG_INFORMATION {}
+    #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::FILE_ALL_INFORMATION {}
     #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::FILE_FS_DEVICE_INFORMATION {}

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -841,6 +841,7 @@ pub(crate) fn open_walk_dir_beneath(root: &Dir, sub_path: &[u8]) -> bun_sys::May
             .open_dir(component, WALK_DIR_OPTIONS)?;
         dir = Some(next);
     }
+    // `.` or empty names the root itself, which the tree walk covers: report it absent, not twice.
     dir.ok_or_else(|| bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::open))
 }
 
@@ -853,9 +854,11 @@ pub(crate) struct PackFileOpener {
 }
 
 impl PackFileOpener {
-    /// `O_PATH` where it exists: passing through a directory needs search permission, not read.
-    const DIR_FLAGS: i32 =
-        bun_sys::O::PATH | bun_sys::O::DIRECTORY | bun_sys::O::NOFOLLOW | bun_sys::O::CLOEXEC;
+    /// Passed through, not listed.
+    const DIR_OPTIONS: bun_sys::OpenDirOptions = bun_sys::OpenDirOptions {
+        iterate: false,
+        no_follow: true,
+    };
 
     /// `O_NONBLOCK` so a FIFO fails the type check in `open()` below instead of blocking.
     #[cfg(not(windows))]
@@ -864,17 +867,19 @@ impl PackFileOpener {
     #[cfg(windows)]
     const FILE_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW;
 
-    /// Windows `O_NOFOLLOW` opens the link itself and resolves through it, so ask the handle.
-    fn check_not_a_link(fd: Fd, path: &[u8]) -> bun_sys::Maybe<()> {
+    /// `openat(O_NOFOLLOW)`; Windows opens a link itself under that flag, so it is refused after.
+    fn open_file_no_follow(dir: Fd, name: &[u8]) -> bun_sys::Maybe<File> {
+        let file = File::openat(dir, name, Self::FILE_FLAGS, 0)?;
         #[cfg(windows)]
-        if bun_sys::is_link_reparse_point(fd)? {
-            return Err(
-                bun_sys::Error::from_code(bun_sys::E::ELOOP, bun_sys::Tag::open).with_path(path),
-            );
-        }
-        #[cfg(not(windows))]
-        let _ = (fd, path);
-        Ok(())
+        let file = File::from_fd(bun_sys::finish_no_follow_open(
+            file.into_raw(),
+            name,
+            || {
+                File::openat(dir, name, Self::FILE_FLAGS & !bun_sys::O::NOFOLLOW, 0)
+                    .map(File::into_raw)
+            },
+        )?);
+        Ok(file)
     }
 
     pub(crate) fn new() -> PackFileOpener {
@@ -896,9 +901,7 @@ impl PackFileOpener {
             None => (&b""[..], bytes),
         };
         let dir = self.open_dir(root, dirname)?;
-        let file =
-            File::openat(dir, basename, Self::FILE_FLAGS, 0).map_err(|err| err.with_path(bytes))?;
-        Self::check_not_a_link(file.handle, bytes)?;
+        let file = Self::open_file_no_follow(dir, basename).map_err(|err| err.with_path(bytes))?;
         let stat = file.stat().map_err(|err| err.with_path(bytes))?;
         match bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode) {
             bun_sys::FileKind::File => Ok((file, stat)),
@@ -940,8 +943,7 @@ impl PackFileOpener {
         };
         for component in path_components(dirname).skip(reused) {
             check_path_component(component)?;
-            let dir = Dir::borrow(&current).open_at_with(component, Self::DIR_FLAGS)?;
-            Self::check_not_a_link(dir.fd(), component)?;
+            let dir = Dir::borrow(&current).open_dir(component, Self::DIR_OPTIONS)?;
             current = dir.fd();
             if !self.dir_path.is_empty() {
                 self.dir_path.push(b'/');

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -868,18 +868,27 @@ impl PackFileOpener {
         bun_sys::O::PATH | bun_sys::O::DIRECTORY | bun_sys::O::NOFOLLOW | bun_sys::O::CLOEXEC;
 
     /// `O_NONBLOCK` so that a FIFO fails the file type check below instead of
-    /// blocking in `open()`.
-    ///
-    /// Windows keeps the flags it had: there, no-follow opens the reparse point
-    /// itself, which reports a size and then fails the read. The directory
-    /// components above carry the no-follow, and a reparse point is not a
-    /// directory a relative open can pass through, so a swapped-in link still
-    /// cannot reach a file outside the package.
+    /// blocking in `open()`. Windows has neither flag.
     #[cfg(not(windows))]
     const FILE_FLAGS: i32 =
         bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW | bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC;
     #[cfg(windows)]
-    const FILE_FLAGS: i32 = bun_sys::O::RDONLY;
+    const FILE_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW;
+
+    /// Fails when `fd` is a reparse point. `O_NOFOLLOW` refuses the open on
+    /// POSIX, so this only has work to do on Windows, where the same flag opens
+    /// the reparse point itself and a relative open still resolves through it.
+    fn check_not_a_link(fd: Fd, path: &[u8]) -> bun_sys::Maybe<()> {
+        #[cfg(windows)]
+        if bun_sys::is_reparse_point(fd)? {
+            return Err(
+                bun_sys::Error::from_code(bun_sys::E::ELOOP, bun_sys::Tag::open).with_path(path),
+            );
+        }
+        #[cfg(not(windows))]
+        let _ = (fd, path);
+        Ok(())
+    }
 
     pub(crate) fn new() -> PackFileOpener {
         PackFileOpener {
@@ -907,6 +916,7 @@ impl PackFileOpener {
         let dir = self.open_dir(root, dirname)?;
         let file =
             File::openat(dir, basename, Self::FILE_FLAGS, 0).map_err(|err| err.with_path(bytes))?;
+        Self::check_not_a_link(file.handle, bytes)?;
         let stat = file.stat().map_err(|err| err.with_path(bytes))?;
         match bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode) {
             bun_sys::FileKind::File => Ok((file, stat)),
@@ -949,6 +959,7 @@ impl PackFileOpener {
         for component in path_components(dirname).skip(reused) {
             check_path_component(component)?;
             let dir = Dir::borrow(&current).open_at_with(component, Self::DIR_FLAGS)?;
+            Self::check_not_a_link(dir.fd(), component)?;
             current = dir.fd();
             if !self.dir_path.is_empty() {
                 self.dir_path.push(b'/');

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -31,9 +31,7 @@ use bun_core::{ZStr, strings};
 use bun_paths::resolve_path;
 use bun_semver as Semver;
 use bun_sha_hmac::sha;
-use bun_sys::{
-    self, CloseOnDrop, Dir, Fd, FdDirExt as _, FdExt as _, File, dir_iterator as DirIterator,
-};
+use bun_sys::{self, Dir, Fd, FdDirExt as _, File, dir_iterator as DirIterator};
 
 // ───────────────────────────────────────────────────────────────────────────
 // local shims for upstream-stub gaps
@@ -791,15 +789,17 @@ fn add_entire_tree(
     Ok(())
 }
 
+/// How the tree walk opens a directory below the package root: for iteration,
+/// and not through a symlink. The walk only descends into entries it listed as
+/// directories, so `no_follow` only refuses one that was replaced by a symlink
+/// since (`ENOTDIR` on Linux, `ELOOP` elsewhere).
+const WALK_DIR_OPTIONS: bun_sys::OpenDirOptions = bun_sys::OpenDirOptions {
+    iterate: true,
+    no_follow: true,
+};
+
 fn open_subdir(dir: &Dir, entry_name: &[u8], entry_subpath: &ZStr) -> Dir {
-    match dir_open_dir_z(
-        dir,
-        entry_name_z(entry_name, entry_subpath),
-        bun_sys::OpenDirOptions {
-            iterate: true,
-            ..Default::default()
-        },
-    ) {
+    match dir.open_dir(entry_name, WALK_DIR_OPTIONS) {
         Ok(d) => d,
         Err(err) => {
             Output::err(
@@ -809,6 +809,154 @@ fn open_subdir(dir: &Dir, entry_name: &[u8], entry_subpath: &ZStr) -> Dir {
             );
             Global::crash();
         }
+    }
+}
+
+/// The components of a relative `/`-separated path, without the empty ones a
+/// doubled or trailing `/` produces, and without `.`.
+fn path_components<'a>(path: &'a [u8]) -> impl Iterator<Item = &'a [u8]> + 'a {
+    strings::split(path, b"/").filter(|c| !c.is_empty() && !strings::eql(c, b"."))
+}
+
+/// Refuses `..`, the one component that takes a path opened one component at a
+/// time out of the directory it started from.
+fn check_path_component(name: &[u8]) -> bun_sys::Maybe<()> {
+    if strings::eql(name, b"..") {
+        return Err(
+            bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::open).with_path(name),
+        );
+    }
+    Ok(())
+}
+
+/// Opens the directory at `sub_path` (relative, `/`-separated) for the tree
+/// walk, one component at a time, so that none is reached through a symlink.
+pub(crate) fn open_walk_dir_beneath(root: &Dir, sub_path: &[u8]) -> bun_sys::Maybe<Dir> {
+    let mut dir: Option<Dir> = None;
+    for component in path_components(sub_path) {
+        check_path_component(component)?;
+        let next = dir
+            .as_ref()
+            .unwrap_or(root)
+            .open_dir(component, WALK_DIR_OPTIONS)?;
+        dir = Some(next);
+    }
+    dir.ok_or_else(|| bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::open))
+}
+
+/// Opens the files that go into the tarball. A path is resolved below the
+/// package root one component at a time with `O_NOFOLLOW`, so no file is read
+/// through a symlink, not even one that replaced a directory after the tree
+/// walk listed the files in it.
+///
+/// The directories that lead to the last file stay open. The pack queue pops
+/// its paths in sorted order, which keeps each subtree together, so every
+/// directory is opened once.
+pub(crate) struct PackFileOpener {
+    /// Directory of the last file, relative to the root, no trailing `/`.
+    dir_path: Vec<u8>,
+    /// One open directory per component of `dir_path`, outermost first, with
+    /// the offset in `dir_path` where that component ends.
+    dirs: Vec<(usize, Dir)>,
+}
+
+impl PackFileOpener {
+    /// `O_PATH` where it exists: resolving the next component needs search
+    /// permission on a directory, as it did as part of a longer path, not read
+    /// permission.
+    const DIR_FLAGS: i32 =
+        bun_sys::O::PATH | bun_sys::O::DIRECTORY | bun_sys::O::NOFOLLOW | bun_sys::O::CLOEXEC;
+
+    /// `O_NONBLOCK` so that a FIFO fails the file type check below instead of
+    /// blocking in `open()`.
+    ///
+    /// Windows keeps the flags it had: there, no-follow opens the reparse point
+    /// itself, which reports a size and then fails the read. The directory
+    /// components above carry the no-follow, and a reparse point is not a
+    /// directory a relative open can pass through, so a swapped-in link still
+    /// cannot reach a file outside the package.
+    #[cfg(not(windows))]
+    const FILE_FLAGS: i32 =
+        bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW | bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC;
+    #[cfg(windows)]
+    const FILE_FLAGS: i32 = bun_sys::O::RDONLY;
+
+    pub(crate) fn new() -> PackFileOpener {
+        PackFileOpener {
+            dir_path: Vec::new(),
+            dirs: Vec::new(),
+        }
+    }
+
+    /// Opens `path` (relative to `root`, `/`-separated, normalized) for
+    /// reading. Fails with the `openat` error of the first component that does
+    /// not open this way (`ELOOP`, or `ENOTDIR` for a directory component on
+    /// Linux, when it is a symlink), with `EISDIR` when `path` names a
+    /// directory, and with `ENODEV` when it names another kind of file that
+    /// is not a regular one.
+    pub(crate) fn open(
+        &mut self,
+        root: &Dir,
+        path: &ZStr,
+    ) -> bun_sys::Maybe<(File, bun_sys::Stat)> {
+        let bytes = path.as_bytes();
+        let (dirname, basename) = match strings::last_index_of_char(bytes, b'/') {
+            Some(slash) => (&bytes[..slash], &bytes[slash + 1..]),
+            None => (&b""[..], bytes),
+        };
+        let dir = self.open_dir(root, dirname)?;
+        let file =
+            File::openat(dir, basename, Self::FILE_FLAGS, 0).map_err(|err| err.with_path(bytes))?;
+        let stat = file.stat().map_err(|err| err.with_path(bytes))?;
+        match bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode) {
+            bun_sys::FileKind::File => Ok((file, stat)),
+            bun_sys::FileKind::Directory => Err(bun_sys::Error::from_code(
+                bun_sys::E::EISDIR,
+                bun_sys::Tag::open,
+            )
+            .with_path(bytes)),
+            _ => Err(
+                bun_sys::Error::from_code(bun_sys::E::ENODEV, bun_sys::Tag::open).with_path(bytes),
+            ),
+        }
+    }
+
+    fn open_dir(&mut self, root: &Dir, dirname: &[u8]) -> bun_sys::Maybe<Fd> {
+        // Keep the open directories that `dirname` starts with.
+        let mut reused = 0usize;
+        let mut offset = 0usize;
+        for component in path_components(dirname) {
+            let end = offset + component.len();
+            match self.dirs.get(reused) {
+                Some(&(cached_end, _))
+                    if cached_end == end
+                        && strings::eql(&self.dir_path[offset..end], component) =>
+                {
+                    reused += 1;
+                    offset = end + 1;
+                }
+                _ => break,
+            }
+        }
+        self.dirs.truncate(reused);
+        self.dir_path
+            .truncate(self.dirs.last().map_or(0, |&(end, _)| end));
+
+        let mut current = match self.dirs.last() {
+            Some((_, dir)) => dir.fd(),
+            None => root.fd(),
+        };
+        for component in path_components(dirname).skip(reused) {
+            check_path_component(component)?;
+            let dir = Dir::borrow(&current).open_at_with(component, Self::DIR_FLAGS)?;
+            current = dir.fd();
+            if !self.dir_path.is_empty() {
+                self.dir_path.push(b'/');
+            }
+            self.dir_path.extend_from_slice(component);
+            self.dirs.push((self.dir_path.len(), dir));
+        }
+        Ok(current)
     }
 }
 
@@ -847,20 +995,13 @@ fn iterate_bundled_deps(
         return Ok(bundled_pack_queue);
     }
 
-    let dir: Dir = match dir_open_dir_z(
-        root_dir,
-        ZStr::from_static(b"node_modules\0"),
-        bun_sys::OpenDirOptions {
-            iterate: true,
-            ..Default::default()
-        },
-    ) {
+    let dir: Dir = match root_dir.open_dir(b"node_modules", WALK_DIR_OPTIONS) {
         Ok(d) => d,
         Err(err) => {
             // ignore node_modules if it isn't a directory, or doesn't exist
             if matches!(
-                err,
-                crate::Error::Sys(bun_errno::SystemErrno::ENOTDIR | bun_errno::SystemErrno::ENOENT)
+                err.get_errno(),
+                bun_sys::E::ENOTDIR | bun_sys::E::ENOENT | bun_sys::E::ELOOP
             ) {
                 return Ok(bundled_pack_queue);
             }
@@ -892,22 +1033,18 @@ fn iterate_bundled_deps(
 
         if strings::starts_with_char(entry_name, b'@') {
             let scope_name = entry_name;
-            let scope_subpath = entry_subpath(b"node_modules", scope_name)?;
 
-            let scope_dir: Dir = match dir_open_dir_z(
-                root_dir,
-                &scope_subpath,
-                bun_sys::OpenDirOptions {
-                    iterate: true,
-                    ..Default::default()
-                },
-            ) {
+            let scope_dir: Dir = match dir.open_dir(scope_name, WALK_DIR_OPTIONS) {
                 Ok(d) => d,
                 Err(_) => continue,
             };
 
             let mut scope_iter = DirIterator::iterate(Fd::from_std_dir(&scope_dir));
             while let Some(scope_entry) = scope_iter.next().ok().flatten() {
+                if scope_entry.kind != bun_sys::FileKind::Directory {
+                    continue;
+                }
+
                 let dep_name = entry_subpath(scope_name, scope_entry.name.slice_u8())?;
 
                 let Some(dep) = bundled_deps.iter_mut().find(|dep| {
@@ -926,7 +1063,7 @@ fn iterate_bundled_deps(
                     continue;
                 }
 
-                let subdir = open_subdir(&dir, dep_name.as_bytes(), &dep_subpath);
+                let subdir = open_subdir(&scope_dir, scope_entry.name.slice_u8(), &dep_subpath);
                 add_bundled_dep(
                     stats,
                     log,
@@ -1109,14 +1246,7 @@ fn add_bundled_dep(
                                 // starting at `node_modules/is-even/node_modules/is-odd`
                                 let mut dep_dir_depth: usize = bundled_root_depth + 2;
 
-                                match dir_open_dir_z(
-                                    root_dir,
-                                    dep_subpath,
-                                    bun_sys::OpenDirOptions {
-                                        iterate: true,
-                                        ..Default::default()
-                                    },
-                                ) {
+                                match open_walk_dir_beneath(root_dir, dep_subpath.as_bytes()) {
                                     Ok(dep_dir) => {
                                         let dedupe_entry =
                                             dedupe.get_or_put(dep_subpath.as_bytes())?;
@@ -1155,13 +1285,9 @@ fn add_bundled_dep(
                                                 ZStr::from_buf(&dep_subpath_buf[..], parent_len);
                                             remain_end = node_modules_start;
 
-                                            let parent_dep_dir = match dir_open_dir_z(
+                                            let parent_dep_dir = match open_walk_dir_beneath(
                                                 root_dir,
-                                                parent_dep_subpath,
-                                                bun_sys::OpenDirOptions {
-                                                    iterate: true,
-                                                    ..Default::default()
-                                                },
+                                                parent_dep_subpath.as_bytes(),
                                             ) {
                                                 Ok(d) => d,
                                                 Err(_) => continue,
@@ -1829,8 +1955,8 @@ fn new_boxed_buffered_file_reader(file: bun_sys::File) -> Box<BufferedFileReader
 /// the 512 KiB stack temporary that `*file_reader = BufferedFileReader { ... }`
 /// would create.
 ///
-/// `unbuffered_reader` is a *view* of a fd that the call site owns (e.g. via
-/// a `CloseOnDrop` or a `File` whose Drop fires after the read loop). The
+/// `unbuffered_reader` is a *view* of a fd that the call site owns (a `File`
+/// whose Drop fires after the read loop). The
 /// previous fd may already be closed; disarm its `File::Drop` before
 /// overwriting so we never close a stale (potentially-recycled) fd.
 #[inline]
@@ -1909,14 +2035,7 @@ pub(crate) fn published_files(
                 })?;
             }
             BinType::Dir => {
-                let bin_dir = match dir_open_dir_z(
-                    root_dir,
-                    &bin.path,
-                    bun_sys::OpenDirOptions {
-                        iterate: true,
-                        ..Default::default()
-                    },
-                ) {
+                let bin_dir = match open_walk_dir_beneath(root_dir, bin.path.as_bytes()) {
                     Ok(d) => d,
                     Err(_) => {
                         // non-existent bins are ignored
@@ -2618,14 +2737,11 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 .complete_one();
         }
 
+        let mut opener = PackFileOpener::new();
+
         while let Some(item) = pack_queue.remove_or_null() {
-            let file = match bun_sys::openat(
-                Fd::from_std_dir(&root_dir),
-                &item.path,
-                bun_sys::O::RDONLY,
-                0,
-            ) {
-                Ok(f) => f,
+            let (file, stat) = match opener.open(&root_dir, &item.path) {
+                Ok(opened) => opened,
                 Err(err) => {
                     if item.optional {
                         ctx.stats.total_files -= 1;
@@ -2645,34 +2761,6 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 }
             };
 
-            let fd: Fd = match file
-                .make_lib_uv_owned_for_syscall(bun_sys::Tag::open, bun_sys::ErrorCase::CloseOnFail)
-            {
-                Ok(fd) => fd,
-                Err(err) => {
-                    Output::err(
-                        err,
-                        "failed to open file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
-
-            let _close_fd = CloseOnDrop::new(fd);
-
-            let stat = match bun_sys::sys_uv::fstat(fd) {
-                Ok(s) => s,
-                Err(err) => {
-                    Output::err(
-                        err,
-                        "failed to stat file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
-
             pack_list.push(PackListEntry {
                 subpath: ZBox::from_bytes(item.path.as_bytes()),
                 size: usize::try_from(stat.st_size).expect("int cast"),
@@ -2680,7 +2768,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
 
             entry = add_archive_entry(
                 ctx,
-                fd,
+                file.handle,
                 &stat,
                 &item.path,
                 &mut read_buf,
@@ -2701,8 +2789,8 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         }
 
         while let Some(item) = bundled_pack_queue.remove_or_null() {
-            let file = match root_dir.open_file(&item.path, bun_sys::O::RDONLY, 0) {
-                Ok(f) => f,
+            let (file, stat) = match opener.open(&root_dir, &item.path) {
+                Ok(opened) => opened,
                 Err(err) => {
                     if item.optional {
                         ctx.stats.total_files -= 1;
@@ -2716,17 +2804,6 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     Output::err(
                         err,
                         "failed to open file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
-            let stat = match file.stat() {
-                Ok(s) => s,
-                Err(err) => {
-                    Output::err(
-                        err,
-                        "failed to stat file: \"{}\"",
                         format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
                     );
                     Global::crash();
@@ -3823,9 +3900,10 @@ fn print_archived_files_and_packages<const IS_DRY_RUN: bool>(
             "package.json",
         );
 
+        let mut opener = PackFileOpener::new();
         while let Some(item) = pack_queue.remove_or_null() {
-            let stat = match bun_sys::fstatat(root_dir, &item.path) {
-                Ok(s) => s,
+            let stat = match opener.open(root_dir_std, &item.path) {
+                Ok((_, stat)) => stat,
                 Err(err) => {
                     if item.optional {
                         ctx.stats.total_files -= 1;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -793,7 +793,7 @@ fn add_entire_tree(
 /// and not through a symlink. The walk only descends into entries it listed as
 /// directories, so `no_follow` only refuses one that was replaced by a symlink
 /// since (`ENOTDIR` on Linux, `ELOOP` elsewhere).
-const WALK_DIR_OPTIONS: bun_sys::OpenDirOptions = bun_sys::OpenDirOptions {
+pub(crate) const WALK_DIR_OPTIONS: bun_sys::OpenDirOptions = bun_sys::OpenDirOptions {
     iterate: true,
     no_follow: true,
 };
@@ -812,10 +812,18 @@ fn open_subdir(dir: &Dir, entry_name: &[u8], entry_subpath: &ZStr) -> Dir {
     }
 }
 
-/// The components of a relative `/`-separated path, without the empty ones a
-/// doubled or trailing `/` produces, and without `.`.
+/// What separates the components of a path handed to `openat`. Pack joins with
+/// `/`, but a `bin` path from package.json can carry a `\`, which Windows
+/// resolves as a separator too, so it has to be opened one side at a time there.
+#[cfg(windows)]
+const PATH_SEPARATORS: &[u8] = b"/\\";
+#[cfg(not(windows))]
+const PATH_SEPARATORS: &[u8] = b"/";
+
+/// The components of a relative path, without the empty ones a doubled or
+/// trailing separator produces, and without `.`.
 fn path_components<'a>(path: &'a [u8]) -> impl Iterator<Item = &'a [u8]> + 'a {
-    strings::split(path, b"/").filter(|c| !c.is_empty() && !strings::eql(c, b"."))
+    strings::tokenize_any(path, PATH_SEPARATORS).filter(|c| !strings::eql(c, b"."))
 }
 
 /// Refuses `..`, the one component that takes a path opened one component at a
@@ -875,12 +883,13 @@ impl PackFileOpener {
     #[cfg(windows)]
     const FILE_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW;
 
-    /// Fails when `fd` is a reparse point. `O_NOFOLLOW` refuses the open on
-    /// POSIX, so this only has work to do on Windows, where the same flag opens
-    /// the reparse point itself and a relative open still resolves through it.
+    /// Fails when `fd` is a symlink or a junction. `O_NOFOLLOW` refuses the
+    /// open on POSIX, so this only has work to do on Windows, where the same
+    /// flag opens the reparse point itself and a relative open still resolves
+    /// through it.
     fn check_not_a_link(fd: Fd, path: &[u8]) -> bun_sys::Maybe<()> {
         #[cfg(windows)]
-        if bun_sys::is_reparse_point(fd)? {
+        if bun_sys::is_link_reparse_point(fd)? {
             return Err(
                 bun_sys::Error::from_code(bun_sys::E::ELOOP, bun_sys::Tag::open).with_path(path),
             );
@@ -909,7 +918,7 @@ impl PackFileOpener {
         path: &ZStr,
     ) -> bun_sys::Maybe<(File, bun_sys::Stat)> {
         let bytes = path.as_bytes();
-        let (dirname, basename) = match strings::last_index_of_char(bytes, b'/') {
+        let (dirname, basename) = match strings::last_index_of_any(bytes, PATH_SEPARATORS) {
             Some(slash) => (&bytes[..slash], &bytes[slash + 1..]),
             None => (&b""[..], bytes),
         };

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -789,10 +789,7 @@ fn add_entire_tree(
     Ok(())
 }
 
-/// How the tree walk opens a directory below the package root: for iteration,
-/// and not through a symlink. The walk only descends into entries it listed as
-/// directories, so `no_follow` only refuses one that was replaced by a symlink
-/// since (`ENOTDIR` on Linux, `ELOOP` elsewhere).
+/// For iteration, and never through a symlink that replaced a directory the walk listed.
 pub(crate) const WALK_DIR_OPTIONS: bun_sys::OpenDirOptions = bun_sys::OpenDirOptions {
     iterate: true,
     no_follow: true,
@@ -812,22 +809,18 @@ fn open_subdir(dir: &Dir, entry_name: &[u8], entry_subpath: &ZStr) -> Dir {
     }
 }
 
-/// What separates the components of a path handed to `openat`. Pack joins with
-/// `/`, but a `bin` path from package.json can carry a `\`, which Windows
-/// resolves as a separator too, so it has to be opened one side at a time there.
+/// Windows resolves a `\` inside a package.json `bin` path as a separator too.
 #[cfg(windows)]
 const PATH_SEPARATORS: &[u8] = b"/\\";
 #[cfg(not(windows))]
 const PATH_SEPARATORS: &[u8] = b"/";
 
-/// The components of a relative path, without the empty ones a doubled or
-/// trailing separator produces, and without `.`.
+/// The non-empty components of a relative path, `.` dropped.
 fn path_components<'a>(path: &'a [u8]) -> impl Iterator<Item = &'a [u8]> + 'a {
     strings::tokenize_any(path, PATH_SEPARATORS).filter(|c| !strings::eql(c, b"."))
 }
 
-/// Refuses `..`, the one component that takes a path opened one component at a
-/// time out of the directory it started from.
+/// `..` is the one component that leaves the directory a walk started from.
 fn check_path_component(name: &[u8]) -> bun_sys::Maybe<()> {
     if strings::eql(name, b"..") {
         return Err(
@@ -837,8 +830,7 @@ fn check_path_component(name: &[u8]) -> bun_sys::Maybe<()> {
     Ok(())
 }
 
-/// Opens the directory at `sub_path` (relative, `/`-separated) for the tree
-/// walk, one component at a time, so that none is reached through a symlink.
+/// Opens `sub_path` below `root` one component at a time, never through a symlink.
 pub(crate) fn open_walk_dir_beneath(root: &Dir, sub_path: &[u8]) -> bun_sys::Maybe<Dir> {
     let mut dir: Option<Dir> = None;
     for component in path_components(sub_path) {
@@ -852,41 +844,27 @@ pub(crate) fn open_walk_dir_beneath(root: &Dir, sub_path: &[u8]) -> bun_sys::May
     dir.ok_or_else(|| bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::open))
 }
 
-/// Opens the files that go into the tarball. A path is resolved below the
-/// package root one component at a time with `O_NOFOLLOW`, so no file is read
-/// through a symlink, not even one that replaced a directory after the tree
-/// walk listed the files in it.
-///
-/// The directories that lead to the last file stay open. The pack queue pops
-/// its paths in sorted order, which keeps each subtree together, so every
-/// directory is opened once.
+/// Opens tarball members below the root one component at a time, never through a symlink.
 pub(crate) struct PackFileOpener {
-    /// Directory of the last file, relative to the root, no trailing `/`.
+    /// Directory of the last member, relative to the root.
     dir_path: Vec<u8>,
-    /// One open directory per component of `dir_path`, outermost first, with
-    /// the offset in `dir_path` where that component ends.
+    /// (end offset in `dir_path`, open directory) per component; sorted input opens each once.
     dirs: Vec<(usize, Dir)>,
 }
 
 impl PackFileOpener {
-    /// `O_PATH` where it exists: resolving the next component needs search
-    /// permission on a directory, as it did as part of a longer path, not read
-    /// permission.
+    /// `O_PATH` where it exists: passing through a directory needs search permission, not read.
     const DIR_FLAGS: i32 =
         bun_sys::O::PATH | bun_sys::O::DIRECTORY | bun_sys::O::NOFOLLOW | bun_sys::O::CLOEXEC;
 
-    /// `O_NONBLOCK` so that a FIFO fails the file type check below instead of
-    /// blocking in `open()`. Windows has neither flag.
+    /// `O_NONBLOCK` so a FIFO fails the type check in `open()` below instead of blocking.
     #[cfg(not(windows))]
     const FILE_FLAGS: i32 =
         bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW | bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC;
     #[cfg(windows)]
     const FILE_FLAGS: i32 = bun_sys::O::RDONLY | bun_sys::O::NOFOLLOW;
 
-    /// Fails when `fd` is a symlink or a junction. `O_NOFOLLOW` refuses the
-    /// open on POSIX, so this only has work to do on Windows, where the same
-    /// flag opens the reparse point itself and a relative open still resolves
-    /// through it.
+    /// Windows `O_NOFOLLOW` opens the link itself and resolves through it, so ask the handle.
     fn check_not_a_link(fd: Fd, path: &[u8]) -> bun_sys::Maybe<()> {
         #[cfg(windows)]
         if bun_sys::is_link_reparse_point(fd)? {
@@ -906,12 +884,7 @@ impl PackFileOpener {
         }
     }
 
-    /// Opens `path` (relative to `root`, `/`-separated, normalized) for
-    /// reading. Fails with the `openat` error of the first component that does
-    /// not open this way (`ELOOP`, or `ENOTDIR` for a directory component on
-    /// Linux, when it is a symlink), with `EISDIR` when `path` names a
-    /// directory, and with `ENODEV` when it names another kind of file that
-    /// is not a regular one.
+    /// Fails `ELOOP`/`ENOTDIR` at a symlink, `EISDIR` at a directory, `ENODEV` at another non-file.
     pub(crate) fn open(
         &mut self,
         root: &Dir,
@@ -1975,8 +1948,8 @@ fn new_boxed_buffered_file_reader(file: bun_sys::File) -> Box<BufferedFileReader
 /// the 512 KiB stack temporary that `*file_reader = BufferedFileReader { ... }`
 /// would create.
 ///
-/// `unbuffered_reader` is a *view* of a fd that the call site owns (a `File`
-/// whose Drop fires after the read loop). The
+/// `unbuffered_reader` is a *view* of a fd that the call site owns (e.g. via
+/// a `File` whose Drop fires after the read loop). The
 /// previous fd may already be closed; disarm its `File::Drop` before
 /// overwriting so we never close a stale (potentially-recycled) fd.
 #[inline]

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -598,21 +598,28 @@ fn read_dir_tree(root: &[u8]) -> Result<Tree, crate::Error> {
                     &bump,
                     bun_install::package_manager::LogLevel::Silent,
                 )?;
-                let _ = dir.into_raw();
+                // Same opens as pack: an optional (bin) entry that does not open is left out, and
+                // nothing is read through a symlink.
+                let mut opener = crate::cli::pack_command::PackFileOpener::new();
                 for (path, optional) in queue.into_paths() {
                     let rel = path.as_bytes();
-                    match bun_sys::File::read_from(root_fd, rel) {
-                        Err(err) if optional && err.get_errno() == bun_sys::E::ENOENT => {}
-                        Ok(bytes) => {
+                    let read = match opener.open(&dir, path.as_zstr()) {
+                        Ok((file, stat)) => file.read_to_end().map(|bytes| (bytes, stat)),
+                        Err(err) => Err(err),
+                    };
+                    match read {
+                        Err(_) if optional => {}
+                        Ok((bytes, _stat)) => {
                             #[cfg(not(windows))]
-                            if let Ok(st) = bun_sys::fstatat(root_fd, path.as_zstr()) {
-                                tree.modes.insert(rel.to_vec(), st.st_mode as u32 & 0o777);
-                            }
+                            tree.modes
+                                .insert(rel.to_vec(), _stat.st_mode as u32 & 0o777);
                             tree.files.insert(rel.to_vec(), bytes);
                         }
                         Err(err) => fail(err, rel),
                     }
                 }
+                drop(opener);
+                let _ = dir.into_raw();
                 tree.files.insert(b"package.json".to_vec(), pkg);
                 root_fd.close();
                 return Ok(tree);

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -598,8 +598,7 @@ fn read_dir_tree(root: &[u8]) -> Result<Tree, crate::Error> {
                     &bump,
                     bun_install::package_manager::LogLevel::Silent,
                 )?;
-                // Same opens as pack: an optional (bin) entry that does not open is left out, and
-                // nothing is read through a symlink.
+                // Opened as pack opens them: never through a symlink, unopenable bins left out.
                 let mut opener = crate::cli::pack_command::PackFileOpener::new();
                 for (path, optional) in queue.into_paths() {
                     let rel = path.as_bytes();

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1844,15 +1844,12 @@ impl PublishCommand {
                         });
 
                         if entry.kind == bun_sys::EntryKind::Directory {
-                            let Ok(subdir) = bun_sys::openat(
-                                dir,
-                                name,
-                                bun_sys::O::DIRECTORY | bun_sys::O::NOFOLLOW,
-                                0,
-                            ) else {
+                            let Ok(subdir) = bun_sys::Dir::borrow(&dir)
+                                .open_dir(name.as_bytes(), pack::WALK_DIR_OPTIONS)
+                            else {
                                 continue;
                             };
-                            dirs.push((subdir, subpath.as_bytes().into(), true));
+                            dirs.push((subdir.into_raw(), subpath.as_bytes().into(), true));
                         }
                     }
                 }

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1757,8 +1757,7 @@ impl PublishCommand {
                 ) {
                     Ok(dir) => dir.into_raw(),
                     Err(e) => {
-                        // `ENOTDIR`/`ELOOP`: it, or a directory on the way to it, is a symlink
-                        // (pack does not follow one either) or some other non-directory.
+                        // ENOTDIR/ELOOP: a symlink on the way; pack does not follow it either.
                         if matches!(
                             e.get_errno(),
                             bun_sys::E::ENOENT | bun_sys::E::ENOTDIR | bun_sys::E::ELOOP

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -1751,15 +1751,18 @@ impl PublishCommand {
                     return Ok(());
                 }
 
-                let bin_dir = match bun_sys::openat(
-                    workspace_root,
-                    &normalized_bin_dir,
-                    bun_sys::O::DIRECTORY,
-                    0,
+                let bin_dir = match pack::open_walk_dir_beneath(
+                    bun_sys::Dir::borrow(&workspace_root),
+                    normalized_bin_dir.as_bytes(),
                 ) {
-                    Ok(fd) => fd,
+                    Ok(dir) => dir.into_raw(),
                     Err(e) => {
-                        if e.get_errno() == bun_sys::E::ENOENT {
+                        // `ENOTDIR`/`ELOOP`: it, or a directory on the way to it, is a symlink
+                        // (pack does not follow one either) or some other non-directory.
+                        if matches!(
+                            e.get_errno(),
+                            bun_sys::E::ENOENT | bun_sys::E::ENOTDIR | bun_sys::E::ELOOP
+                        ) {
                             bun_core::warn!(
                                 "bin directory '{}' does not exist",
                                 bstr::BStr::new(normalized_bin_dir.as_bytes()),
@@ -1841,8 +1844,12 @@ impl PublishCommand {
                         });
 
                         if entry.kind == bun_sys::EntryKind::Directory {
-                            let Ok(subdir) = bun_sys::openat(dir, name, bun_sys::O::DIRECTORY, 0)
-                            else {
+                            let Ok(subdir) = bun_sys::openat(
+                                dir,
+                                name,
+                                bun_sys::O::DIRECTORY | bun_sys::O::NOFOLLOW,
+                                0,
+                            ) else {
                                 continue;
                             };
                             dirs.push((subdir, subpath.as_bytes().into(), true));

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -436,21 +436,23 @@ impl Dir {
     pub fn open_dir(&self, sub_path: &[u8], opts: OpenDirOptions) -> Maybe<Dir> {
         #[cfg(windows)]
         {
-            let dir = open_dir_at_windows_a(
-                self.fd,
-                sub_path,
-                WindowsOpenDirOptions {
-                    iterable: opts.iterate,
-                    no_follow: opts.no_follow,
-                    ..Default::default()
-                },
-            )
-            .map(Dir::from_fd)?;
-            // `no_follow` opened the link itself; refuse it with `ELOOP` like POSIX `O_NOFOLLOW`.
-            if opts.no_follow && is_link_reparse_point(dir.fd)? {
-                return Err(Error::from_code(E::ELOOP, Tag::open).with_path(sub_path));
+            let open = |no_follow: bool| {
+                open_dir_at_windows_a(
+                    self.fd,
+                    sub_path,
+                    WindowsOpenDirOptions {
+                        iterable: opts.iterate,
+                        no_follow,
+                        ..Default::default()
+                    },
+                )
+            };
+            let fd = open(opts.no_follow)?;
+            if !opts.no_follow {
+                return Ok(Dir::from_fd(fd));
             }
-            return Ok(dir);
+            // `no_follow` opened a link itself instead of failing; refuse it as POSIX does.
+            return finish_no_follow_open(fd, sub_path, || open(false)).map(Dir::from_fd);
         }
         #[cfg(not(windows))]
         {

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -423,15 +423,16 @@ impl Dir {
         open_dir_at(self.fd, sub_path.as_bytes()).map(Dir::from_fd)
     }
 
-    /// Open `sub_path` as an iterable, no-follow `Dir` handle with sub-path
-    /// access.
+    /// Open `sub_path` as a `Dir` handle with sub-path access.
     ///
-    /// On POSIX, `iterate` / `access_sub_paths` are advisory (the handle is
-    /// opened with `O_DIRECTORY | O_RDONLY | O_CLOEXEC` regardless). On Windows
-    /// the flags select the access mask: `iterate` adds `FILE_LIST_DIRECTORY`,
-    /// and the handle is opened **without** `read_only` so the caller may
-    /// create/rename children — unlike the read-only `open_dir_*` iteration
-    /// helpers.
+    /// `no_follow` refuses a symlink as the last component of `sub_path`
+    /// (`O_NOFOLLOW`: `ENOTDIR` on Linux, `ELOOP` elsewhere; on Windows the
+    /// reparse point itself is opened). On POSIX, `iterate` is advisory (the
+    /// handle is opened with `O_DIRECTORY | O_RDONLY | O_CLOEXEC` regardless).
+    /// On Windows the flags select the access mask: `iterate` adds
+    /// `FILE_LIST_DIRECTORY`, and the handle is opened **without** `read_only`
+    /// so the caller may create/rename children — unlike the read-only
+    /// `open_dir_*` iteration helpers.
     #[inline]
     pub fn open_dir(&self, sub_path: &[u8], opts: OpenDirOptions) -> Maybe<Dir> {
         #[cfg(windows)]
@@ -450,8 +451,14 @@ impl Dir {
         }
         #[cfg(not(windows))]
         {
-            let _ = opts;
-            open_dir_at(self.fd, sub_path).map(Dir::from_fd)
+            let no_follow = if opts.no_follow { O::NOFOLLOW } else { 0 };
+            openat_a(
+                self.fd,
+                sub_path,
+                O::DIRECTORY | O::CLOEXEC | O::RDONLY | no_follow,
+                0,
+            )
+            .map(Dir::from_fd)
         }
     }
 }

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -425,19 +425,20 @@ impl Dir {
 
     /// Open `sub_path` as a `Dir` handle with sub-path access.
     ///
-    /// `no_follow` refuses a symlink as the last component of `sub_path`
-    /// (`O_NOFOLLOW`: `ENOTDIR` on Linux, `ELOOP` elsewhere; on Windows the
-    /// reparse point itself is opened). On POSIX, `iterate` is advisory (the
-    /// handle is opened with `O_DIRECTORY | O_RDONLY | O_CLOEXEC` regardless).
-    /// On Windows the flags select the access mask: `iterate` adds
-    /// `FILE_LIST_DIRECTORY`, and the handle is opened **without** `read_only`
-    /// so the caller may create/rename children — unlike the read-only
-    /// `open_dir_*` iteration helpers.
+    /// `no_follow` refuses a link as the last component of `sub_path`:
+    /// `ENOTDIR` on Linux, `ELOOP` on the other POSIX targets and on Windows,
+    /// where the open itself takes the reparse point and this reports it. On
+    /// POSIX, `iterate` is advisory (the handle is opened with
+    /// `O_DIRECTORY | O_RDONLY | O_CLOEXEC` regardless). On Windows the flags
+    /// select the access mask: `iterate` adds `FILE_LIST_DIRECTORY`, and the
+    /// handle is opened **without** `read_only` so the caller may
+    /// create/rename children — unlike the read-only `open_dir_*` iteration
+    /// helpers.
     #[inline]
     pub fn open_dir(&self, sub_path: &[u8], opts: OpenDirOptions) -> Maybe<Dir> {
         #[cfg(windows)]
         {
-            return open_dir_at_windows_a(
+            let dir = open_dir_at_windows_a(
                 self.fd,
                 sub_path,
                 WindowsOpenDirOptions {
@@ -446,8 +447,11 @@ impl Dir {
                     ..Default::default()
                 },
             )
-            .map(Dir::from_fd)
-            .map_err(Into::into);
+            .map(Dir::from_fd)?;
+            if opts.no_follow && is_reparse_point(dir.fd)? {
+                return Err(Error::from_code(E::ELOOP, Tag::open).with_path(sub_path));
+            }
+            return Ok(dir);
         }
         #[cfg(not(windows))]
         {

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -427,8 +427,8 @@ impl Dir {
     ///
     /// `no_follow` refuses a link as the last component of `sub_path`:
     /// `ENOTDIR` on Linux, `ELOOP` on the other POSIX targets and on Windows,
-    /// where the open itself takes the reparse point and this reports it. On
-    /// POSIX, `iterate` is advisory (the handle is opened with
+    /// where the open itself takes the symlink or junction and this reports it.
+    /// On POSIX, `iterate` is advisory (the handle is opened with
     /// `O_DIRECTORY | O_RDONLY | O_CLOEXEC` regardless). On Windows the flags
     /// select the access mask: `iterate` adds `FILE_LIST_DIRECTORY`, and the
     /// handle is opened **without** `read_only` so the caller may
@@ -448,7 +448,7 @@ impl Dir {
                 },
             )
             .map(Dir::from_fd)?;
-            if opts.no_follow && is_reparse_point(dir.fd)? {
+            if opts.no_follow && is_link_reparse_point(dir.fd)? {
                 return Err(Error::from_code(E::ELOOP, Tag::open).with_path(sub_path));
             }
             return Ok(dir);

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -423,15 +423,13 @@ impl Dir {
         open_dir_at(self.fd, sub_path.as_bytes()).map(Dir::from_fd)
     }
 
-    /// Open `sub_path` as a `Dir` handle with sub-path access.
+    /// Open `sub_path` as an iterable, no-follow `Dir` handle with sub-path
+    /// access.
     ///
-    /// `no_follow` refuses a link as the last component of `sub_path`:
-    /// `ENOTDIR` on Linux, `ELOOP` on the other POSIX targets and on Windows,
-    /// where the open itself takes the symlink or junction and this reports it.
-    /// On POSIX, `iterate` is advisory (the handle is opened with
-    /// `O_DIRECTORY | O_RDONLY | O_CLOEXEC` regardless). On Windows the flags
-    /// select the access mask: `iterate` adds `FILE_LIST_DIRECTORY`, and the
-    /// handle is opened **without** `read_only` so the caller may
+    /// On POSIX, `iterate` is advisory and `no_follow` adds `O_NOFOLLOW` (the handle is
+    /// opened with `O_DIRECTORY | O_RDONLY | O_CLOEXEC` regardless). On Windows
+    /// the flags select the access mask: `iterate` adds `FILE_LIST_DIRECTORY`,
+    /// and the handle is opened **without** `read_only` so the caller may
     /// create/rename children — unlike the read-only `open_dir_*` iteration
     /// helpers.
     #[inline]
@@ -448,6 +446,7 @@ impl Dir {
                 },
             )
             .map(Dir::from_fd)?;
+            // `no_follow` opened the link itself; refuse it with `ELOOP` like POSIX `O_NOFOLLOW`.
             if opts.no_follow && is_link_reparse_point(dir.fd)? {
                 return Err(Error::from_code(E::ELOOP, Tag::open).with_path(sub_path));
             }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3703,16 +3703,7 @@ mod windows_impl {
         // the caller's HANDLE, so it leaked a CRT slot per call).
         fstat_handle(fd)
     }
-    /// `true` when `fd` is a reparse point that names another path: a symlink,
-    /// a junction, or any other tag with the name-surrogate bit. Reparse points
-    /// that only decorate the file in place (dedup, cloud placeholders,
-    /// AppExecLink, WOF compression) are not links and report `false`.
-    ///
-    /// `O::NOFOLLOW` maps to `FILE_OPEN_REPARSE_POINT`, which opens the reparse
-    /// point itself instead of failing the open, and `NtCreateFile` still
-    /// resolves a relative path through such a handle. So a caller that must
-    /// not follow a link asks the handle it got. `fstat` cannot answer: libuv's
-    /// `uv_stat_t` reports a reparse point as the kind it points at.
+    /// `true` for a symlink or junction (name-surrogate tag), `false` for in-place tags like dedup.
     pub fn is_link_reparse_point(fd: Fd) -> Maybe<bool> {
         let mut io: w::IO_STATUS_BLOCK = bun_core::ffi::zeroed();
         let mut info: w::FILE_ATTRIBUTE_TAG_INFORMATION = bun_core::ffi::zeroed();

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3703,6 +3703,32 @@ mod windows_impl {
         // the caller's HANDLE, so it leaked a CRT slot per call).
         fstat_handle(fd)
     }
+    /// `true` when `fd`'s attributes carry `FILE_ATTRIBUTE_REPARSE_POINT`
+    /// (a symlink, a junction or another reparse point).
+    ///
+    /// `O::NOFOLLOW` maps to `FILE_OPEN_REPARSE_POINT`, which opens the reparse
+    /// point itself instead of failing the open, and `NtCreateFile` still
+    /// resolves a relative path through such a handle. So a caller that must
+    /// not follow a link asks the handle it got. `fstat` cannot answer: libuv's
+    /// `uv_stat_t` reports a reparse point as the kind it points at.
+    pub fn is_reparse_point(fd: Fd) -> Maybe<bool> {
+        let mut io: w::IO_STATUS_BLOCK = bun_core::ffi::zeroed();
+        let mut info: w::FILE_BASIC_INFORMATION = bun_core::ffi::zeroed();
+        // SAFETY: FFI; `fd` is a live HANDLE and `info` is valid for write.
+        let rc = unsafe {
+            w::ntdll::NtQueryInformationFile(
+                fd.native(),
+                &mut io,
+                core::ptr::from_mut(&mut info).cast(),
+                core::mem::size_of::<w::FILE_BASIC_INFORMATION>() as u32,
+                w::FILE_INFORMATION_CLASS::FileBasicInformation,
+            )
+        };
+        if w::NT_ERROR(rc) {
+            return Err(Error::new(rc, Tag::fstat).with_fd(fd));
+        }
+        Ok((info.FileAttributes & w::FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+    }
     /// Port of libuv's `fs__fstat_handle` + `fs__stat_handle` +
     /// `fs__stat_assign_statbuf` (`src/win/fs.c`). Fills a `uv_stat_t` from a
     /// raw HANDLE without touching the CRT fd table.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3703,8 +3703,8 @@ mod windows_impl {
         // the caller's HANDLE, so it leaked a CRT slot per call).
         fstat_handle(fd)
     }
-    /// `true` for a symlink or junction (name-surrogate tag), `false` for in-place tags like dedup.
-    pub fn is_link_reparse_point(fd: Fd) -> Maybe<bool> {
+    /// The reparse tag of `fd`, 0 when it is not a reparse point.
+    fn reparse_tag(fd: Fd) -> Maybe<u32> {
         let mut io: w::IO_STATUS_BLOCK = bun_core::ffi::zeroed();
         let mut info: w::FILE_ATTRIBUTE_TAG_INFORMATION = bun_core::ffi::zeroed();
         // SAFETY: FFI; `fd` is a live HANDLE and `info` is valid for write.
@@ -3720,8 +3720,43 @@ mod windows_impl {
         if w::NT_ERROR(rc) {
             return Err(Error::new(rc, Tag::fstat).with_fd(fd));
         }
-        Ok((info.FileAttributes & w::FILE_ATTRIBUTE_REPARSE_POINT) != 0
-            && bun_windows_sys::is_reparse_tag_name_surrogate(info.ReparseTag))
+        if (info.FileAttributes & w::FILE_ATTRIBUTE_REPARSE_POINT) == 0 {
+            return Ok(0);
+        }
+        Ok(info.ReparseTag)
+    }
+    /// POSIX `O_NOFOLLOW` after an `O::NOFOLLOW` open: a link fails `ELOOP`, other tags `reopen()`.
+    pub fn finish_no_follow_open(
+        fd: Fd,
+        path: &[u8],
+        reopen: impl FnOnce() -> Maybe<Fd>,
+    ) -> Maybe<Fd> {
+        let tag = match reparse_tag(fd) {
+            Ok(tag) => tag,
+            Err(err) => {
+                let _ = close(fd);
+                return Err(err);
+            }
+        };
+        if tag == 0 {
+            return Ok(fd);
+        }
+        let _close = CloseOnDrop::new(fd);
+        let eloop = || Error::from_code(E::ELOOP, Tag::open).with_path(path);
+        if bun_windows_sys::is_reparse_tag_name_surrogate(tag) {
+            return Err(eloop());
+        }
+        // Dedup and cloud-file tags: only an open without the flag reads through their filter.
+        let reopened = reopen()?;
+        let same_file = match (fstat_handle(fd), fstat_handle(reopened)) {
+            (Ok(a), Ok(b)) => a.st_ino == b.st_ino && a.st_dev == b.st_dev,
+            _ => false,
+        };
+        if !same_file {
+            let _ = close(reopened);
+            return Err(eloop());
+        }
+        Ok(reopened)
     }
     /// Port of libuv's `fs__fstat_handle` + `fs__stat_handle` +
     /// `fs__stat_assign_statbuf` (`src/win/fs.c`). Fills a `uv_stat_t` from a

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3703,31 +3703,34 @@ mod windows_impl {
         // the caller's HANDLE, so it leaked a CRT slot per call).
         fstat_handle(fd)
     }
-    /// `true` when `fd`'s attributes carry `FILE_ATTRIBUTE_REPARSE_POINT`
-    /// (a symlink, a junction or another reparse point).
+    /// `true` when `fd` is a reparse point that names another path: a symlink,
+    /// a junction, or any other tag with the name-surrogate bit. Reparse points
+    /// that only decorate the file in place (dedup, cloud placeholders,
+    /// AppExecLink, WOF compression) are not links and report `false`.
     ///
     /// `O::NOFOLLOW` maps to `FILE_OPEN_REPARSE_POINT`, which opens the reparse
     /// point itself instead of failing the open, and `NtCreateFile` still
     /// resolves a relative path through such a handle. So a caller that must
     /// not follow a link asks the handle it got. `fstat` cannot answer: libuv's
     /// `uv_stat_t` reports a reparse point as the kind it points at.
-    pub fn is_reparse_point(fd: Fd) -> Maybe<bool> {
+    pub fn is_link_reparse_point(fd: Fd) -> Maybe<bool> {
         let mut io: w::IO_STATUS_BLOCK = bun_core::ffi::zeroed();
-        let mut info: w::FILE_BASIC_INFORMATION = bun_core::ffi::zeroed();
+        let mut info: w::FILE_ATTRIBUTE_TAG_INFORMATION = bun_core::ffi::zeroed();
         // SAFETY: FFI; `fd` is a live HANDLE and `info` is valid for write.
         let rc = unsafe {
             w::ntdll::NtQueryInformationFile(
                 fd.native(),
                 &mut io,
                 core::ptr::from_mut(&mut info).cast(),
-                core::mem::size_of::<w::FILE_BASIC_INFORMATION>() as u32,
-                w::FILE_INFORMATION_CLASS::FileBasicInformation,
+                core::mem::size_of::<w::FILE_ATTRIBUTE_TAG_INFORMATION>() as u32,
+                w::FILE_INFORMATION_CLASS::FileAttributeTagInformation,
             )
         };
         if w::NT_ERROR(rc) {
             return Err(Error::new(rc, Tag::fstat).with_fd(fd));
         }
-        Ok((info.FileAttributes & w::FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+        Ok((info.FileAttributes & w::FILE_ATTRIBUTE_REPARSE_POINT) != 0
+            && bun_windows_sys::is_reparse_tag_name_surrogate(info.ReparseTag))
     }
     /// Port of libuv's `fs__fstat_handle` + `fs__stat_handle` +
     /// `fs__stat_assign_statbuf` (`src/win/fs.c`). Fills a `uv_stat_t` from a

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -140,6 +140,7 @@ pub use bun_windows_sys::FILE_ATTRIBUTE_HIDDEN;
 pub use bun_windows_sys::FILE_ATTRIBUTE_NORMAL;
 pub use bun_windows_sys::FILE_ATTRIBUTE_READONLY;
 pub use bun_windows_sys::FILE_ATTRIBUTE_REPARSE_POINT;
+pub use bun_windows_sys::FILE_ATTRIBUTE_TAG_INFORMATION;
 pub use bun_windows_sys::FILE_ATTRIBUTE_TEMPORARY;
 pub use bun_windows_sys::FILE_BASIC_INFORMATION;
 pub use bun_windows_sys::FILE_DEVICE_CONSOLE;

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -352,6 +352,15 @@ pub struct FILE_BASIC_INFORMATION {
     pub FileAttributes: ULONG,
 }
 
+/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`) — output of
+/// `NtQueryInformationFile(.., FileAttributeTagInformation)`. `ReparseTag` is
+/// 0 when the file is not a reparse point.
+#[repr(C)]
+pub struct FILE_ATTRIBUTE_TAG_INFORMATION {
+    pub FileAttributes: ULONG,
+    pub ReparseTag: ULONG,
+}
+
 /// `FILE_DIRECTORY_INFORMATION` (`ntifs.h`) — `NtQueryDirectoryFile` record.
 /// `FileName` is a flexible array; declared `[WCHAR; 1]` to match C layout
 /// (read past it via `FileNameLength`).
@@ -381,6 +390,7 @@ impl FILE_INFORMATION_CLASS {
     pub const FileDispositionInformation: Self = Self(13);
     pub const FileAllInformation: Self = Self(18);
     pub const FileEndOfFileInformation: Self = Self(20);
+    pub const FileAttributeTagInformation: Self = Self(35);
     pub const FileDispositionInformationEx: Self = Self(64);
 }
 

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -352,9 +352,7 @@ pub struct FILE_BASIC_INFORMATION {
     pub FileAttributes: ULONG,
 }
 
-/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`) — output of
-/// `NtQueryInformationFile(.., FileAttributeTagInformation)`. `ReparseTag` is
-/// 0 when the file is not a reparse point.
+/// `FILE_ATTRIBUTE_TAG_INFORMATION` (`ntifs.h`). `ReparseTag` is 0 unless a reparse point.
 #[repr(C)]
 pub struct FILE_ATTRIBUTE_TAG_INFORMATION {
     pub FileAttributes: ULONG,

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1942,6 +1942,23 @@ describe.concurrent("bins", () => {
     expect(tarball.entries[2].perm & 0o755).toBe(0o755);
   });
 
+  // The package root as the bin directory does not pack its files a second time.
+  test.each(["", ".", "./"])("directory %p packs each file once", async binDir => {
+    using dir = tempDir("pack-bins-dir-root", {
+      "package.json": JSON.stringify({ name: "pack-bins-dir-root", version: "1.2.3", directories: { bin: binDir } }),
+      "bin1.js": "#!/usr/bin/env bun\n",
+    });
+
+    const { err, exitCode } = await runPack(dir);
+    expect(err).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(tarballEntries(join(dir, "pack-bins-dir-root-1.2.3.tgz"))).toEqual([
+      "package/package.json",
+      "package/bin1.js",
+    ]);
+  });
+
   test('are included even if not included in "files"', async () => {
     using dir = tempDir("pack-bins-and-files-1", {
       "package.json": JSON.stringify({

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1978,6 +1978,33 @@ describe.concurrent("bins", () => {
     ]);
   });
 
+  // npm skips a `bin` entry that is not a regular file. It must not fail the pack either.
+  test("that name a directory or nothing are ignored", async () => {
+    using dir = tempDir("pack-bins-not-files", {
+      "package.json": JSON.stringify({
+        name: "pack-bins-not-files",
+        version: "1.0.0",
+        bin: { "a-directory": "lib", "empty": "", "real": "real-bin.js" },
+      }),
+      "index.js": "console.log('index')",
+      "lib/a.js": "console.log('a')",
+      "real-bin.js": "console.log('real bin')",
+    });
+
+    const { err, exitCode } = await runPack(dir);
+    expect(err).toBe("");
+    expect(exitCode).toBe(0);
+
+    const tarball = readTarball(join(dir, "pack-bins-not-files-1.0.0.tgz"));
+    expect(entryNames(tarball)).toEqual([
+      "package/package.json",
+      "package/index.js",
+      "package/lib/a.js",
+      "package/real-bin.js",
+    ]);
+    expect(tarball.entries[3].perm & 0o755).toBe(0o755);
+  });
+
   test('are included even if not included in "files"', async () => {
     using dir = tempDir("pack-bins-and-files-1", {
       "package.json": JSON.stringify({
@@ -2212,6 +2239,61 @@ describe.concurrent("symlinks", () => {
     expect(await packed(dir, "pack-link-bin-1.0.0.tgz")).toEqual(["package/package.json"]);
   });
 
+  // Wherever the link points: outside the package (relative or absolute), inside it,
+  // or through a linked directory. A real bin next to them is still packed, and
+  // `--dry-run` lists the same files. True symlinks on Windows too, not junctions.
+  test("bins that are symlinks are neither packed nor listed by --dry-run", async () => {
+    using dir = tempDir("pack-link-bins", {
+      "pkg/package.json": JSON.stringify({
+        name: "pack-link-bins",
+        version: "1.0.0",
+        // `files` leaves every bin out, so only the bin handling can add them.
+        files: ["index.js"],
+        bin: {
+          "real": "real-bin.js",
+          "relative-link": "relative-link.js",
+          "absolute-link": "absolute-link.js",
+          "link-inside-package": "link-to-real.js",
+          "through-linked-dir": "linked-dir/inner.js",
+          "through-linked-dir-backslash": "linked-dir\\inner.js",
+        },
+      }),
+      "pkg/index.js": "console.log('index')",
+      "pkg/real-bin.js": "console.log('real bin')",
+      "outside/secret.js": "outside\n",
+      "outside/nested/inner.js": "outside\n",
+    });
+    symlinkSync(join("..", "outside", "secret.js"), join(String(dir), "pkg", "relative-link.js"), "file");
+    symlinkSync(outside(dir, "secret.js"), join(String(dir), "pkg", "absolute-link.js"), "file");
+    symlinkSync("real-bin.js", join(String(dir), "pkg", "link-to-real.js"), "file");
+    symlinkSync(join("..", "outside", "nested"), join(String(dir), "pkg", "linked-dir"), "dir");
+
+    const dryRun = await runPack(join(String(dir), "pkg"), ["--dry-run"]);
+    expect(dryRun.err).toBe("");
+    expect(dryRun.out).toMatchInlineSnapshot(`
+      "bun pack <version> (<revision>)
+
+      packed 300B package.json
+      packed 20B index.js
+      packed 23B real-bin.js
+
+      pack-link-bins-1.0.0.tgz
+
+      Total files: 3
+      Unpacked size: 343B"
+    `);
+    expect(dryRun.exitCode).toBe(0);
+
+    const { err, exitCode } = await runPack(join(String(dir), "pkg"));
+    expect(err).toBe("");
+    expect(exitCode).toBe(0);
+
+    const tarball = readTarball(join(String(dir), "pkg", "pack-link-bins-1.0.0.tgz"));
+    expect(entryNames(tarball)).toEqual(["package/package.json", "package/index.js", "package/real-bin.js"]);
+    expect(tarball.entries[2].contents).toBe("console.log('real bin')");
+    expect(tarball.entries[2].perm & 0o755).toBe(0o755);
+  });
+
   test("a bin inside a symlinked directory is not packed", async () => {
     using dir = tempDir("pack-link-bin-dir", {
       "pkg/package.json": JSON.stringify({ name: "pack-link-bin-dir", version: "1.0.0", bin: "sub/cli.js" }),
@@ -2246,6 +2328,25 @@ describe.concurrent("symlinks", () => {
     linkOutside(dir, "sub", "sub", "junction");
 
     expect(await packed(dir, "pack-link-bins-dir-1.0.0.tgz")).toEqual(["package/package.json"]);
+  });
+
+  test('a "directories.bin" that is itself a symlink is not packed', async () => {
+    using dir = tempDir("pack-link-bins-dir-last", {
+      "pkg/package.json": JSON.stringify({
+        name: "pack-link-bins-dir-last",
+        version: "1.0.0",
+        directories: { bin: "./bins/" },
+      }),
+      "pkg/index.js": "console.log('index')",
+      "outside/bins/a.js": "outside\n",
+      "outside/bins/b.js": "outside\n",
+    });
+    linkOutside(dir, "bins", "bins", "junction");
+
+    expect(await packed(dir, "pack-link-bins-dir-last-1.0.0.tgz")).toEqual([
+      "package/package.json",
+      "package/index.js",
+    ]);
   });
 
   test("a bundled dependency inside a symlinked node_modules is not packed", async () => {

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -2186,6 +2186,18 @@ describe.concurrent("symlinks", () => {
     expect(await packed(dir, "pack-link-bin-dir-1.0.0.tgz")).toEqual(["package/package.json"]);
   });
 
+  // Windows resolves `\` in a bin path as a separator too, so the junction is an
+  // intermediate component there even though pack only splits on `/` elsewhere.
+  test.skipIf(!isWindows)("a bin inside a symlinked directory named with a backslash is not packed", async () => {
+    using dir = tempDir("pack-link-bin-backslash", {
+      "pkg/package.json": JSON.stringify({ name: "pack-link-bin-backslash", version: "1.0.0", bin: "sub\\cli.js" }),
+      "outside/sub/cli.js": "outside\n",
+    });
+    linkOutside(dir, "sub", "sub", "junction");
+
+    expect(await packed(dir, "pack-link-bin-backslash-1.0.0.tgz")).toEqual(["package/package.json"]);
+  });
+
   test('a symlinked "directories.bin" is not packed', async () => {
     using dir = tempDir("pack-link-bins-dir", {
       "pkg/package.json": JSON.stringify({

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1,6 +1,7 @@
 import { write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
+import { symlinkSync } from "fs";
 import { readdir, rm } from "fs/promises";
 import { bunEnv, bunExe, isLinux, isWindows, normalizeBunSnapshot, runBunInstall, tempDir } from "harness";
 import { join } from "path";
@@ -2149,4 +2150,93 @@ test.concurrent("$npm_lifecycle_event is accurate", async () => {
     postpack"
   `);
   expect(exitCode).toBe(0);
+});
+
+describe.concurrent("symlinks", () => {
+  // The tree walk lists only regular files and directories, the same as npm-packlist
+  // (`follow: false`). The steps that resolve a path instead of a listed entry must do
+  // the same, or a link inside the package puts a file from outside it in the tarball.
+  const outside = (dir: string, rel: string) => join(String(dir), "outside", rel);
+  const linkOutside = (dir: string, rel: string, target: string, type?: "junction") =>
+    symlinkSync(outside(dir, target), join(String(dir), "pkg", rel), type);
+  const packed = async (dir: string, name: string) => {
+    const { err, exitCode } = await runPack(join(String(dir), "pkg"));
+    expect(err).toBe("");
+    expect(exitCode).toBe(0);
+    return tarballEntries(join(String(dir), "pkg", name));
+  };
+
+  test.skipIf(isWindows)("a bin that is a symlink is not packed", async () => {
+    using dir = tempDir("pack-link-bin", {
+      "pkg/package.json": JSON.stringify({ name: "pack-link-bin", version: "1.0.0", bin: "cli.js" }),
+      "outside/secret.js": "outside\n",
+    });
+    linkOutside(dir, "cli.js", "secret.js");
+
+    expect(await packed(dir, "pack-link-bin-1.0.0.tgz")).toEqual(["package/package.json"]);
+  });
+
+  test("a bin inside a symlinked directory is not packed", async () => {
+    using dir = tempDir("pack-link-bin-dir", {
+      "pkg/package.json": JSON.stringify({ name: "pack-link-bin-dir", version: "1.0.0", bin: "sub/cli.js" }),
+      "outside/sub/cli.js": "outside\n",
+    });
+    linkOutside(dir, "sub", "sub", "junction");
+
+    expect(await packed(dir, "pack-link-bin-dir-1.0.0.tgz")).toEqual(["package/package.json"]);
+  });
+
+  test('a symlinked "directories.bin" is not packed', async () => {
+    using dir = tempDir("pack-link-bins-dir", {
+      "pkg/package.json": JSON.stringify({
+        name: "pack-link-bins-dir",
+        version: "1.0.0",
+        directories: { bin: "sub/bins" },
+      }),
+      "outside/sub/bins/cli.js": "outside\n",
+    });
+    linkOutside(dir, "sub", "sub", "junction");
+
+    expect(await packed(dir, "pack-link-bins-dir-1.0.0.tgz")).toEqual(["package/package.json"]);
+  });
+
+  test("a bundled dependency inside a symlinked node_modules is not packed", async () => {
+    using dir = tempDir("pack-link-node-modules", {
+      "pkg/package.json": JSON.stringify({
+        name: "pack-link-node-modules",
+        version: "1.0.0",
+        dependencies: { dep1: "1.1.1" },
+        bundledDependencies: ["dep1"],
+      }),
+      "outside/node_modules/dep1/package.json": JSON.stringify({ name: "dep1", version: "1.1.1" }),
+      "outside/node_modules/dep1/secret.js": "outside\n",
+    });
+    linkOutside(dir, "node_modules", "node_modules", "junction");
+
+    expect(await packed(dir, "pack-link-node-modules-1.0.0.tgz")).toEqual(["package/package.json"]);
+  });
+
+  test("a dependency of a bundled dependency inside a symlinked node_modules is not packed", async () => {
+    using dir = tempDir("pack-link-nested", {
+      "pkg/package.json": JSON.stringify({
+        name: "pack-link-nested",
+        version: "1.0.0",
+        dependencies: { dep1: "1.1.1" },
+        bundledDependencies: ["dep1"],
+      }),
+      "pkg/node_modules/dep1/package.json": JSON.stringify({
+        name: "dep1",
+        version: "1.1.1",
+        dependencies: { dep2: "1.1.1" },
+      }),
+      "outside/node_modules/dep2/package.json": JSON.stringify({ name: "dep2", version: "1.1.1" }),
+      "outside/node_modules/dep2/secret.js": "outside\n",
+    });
+    linkOutside(dir, "node_modules/dep1/node_modules", "node_modules", "junction");
+
+    expect(await packed(dir, "pack-link-nested-1.0.0.tgz")).toEqual([
+      "package/package.json",
+      "package/node_modules/dep1/package.json",
+    ]);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun pm pack` lists the package tree, closes each directory handle, then opens each member by path from the package root (`pack_command.rs:2621`, `:2703`). A symlink that replaces a directory in between sends the open outside the package. `bun publish` and `bun pm diff` use the same list.
- A `renameat2(RENAME_EXCHANGE)` loop swapping `pkg/lib` with `pkg/lnk -> /outside` put outside files under `package/lib/` in 20 of 20 tarballs on 1.4.3.
- Three paths need no race: `node_modules`, a nested bundled dependency's `node_modules`, and a `bin` path with a directory in it.

### Fix
- `PackFileOpener` resolves a member one component at a time with `O_NOFOLLOW`, then `fstat`s it to confirm a regular file. The walked directories stay open, so the sorted queue costs one `openat` per directory.
- The tree walk, the `node_modules` scan, the nested lookup and `directories.bin` open their directories the same way.
- Correct because the walk takes only regular files and real directories, as npm-packlist does with `follow: false`. The opens now agree with it: under the swapper 0 of 20 tarballs leaked, 15 runs failed closed with `ENOTDIR`.
- Verified: `test/cli/install/bun-pack.test.ts`, 6 new symlink tests (one Windows-only) that need no race and that stock bun fails. Also the pack, publish and `pm diff` suites, on linux-x64 and Windows.
- Self-reviewed: 6 review concerns raised, 5 fixed; the sixth (Windows `openat` routing of dotted names) is pre-existing in `bun_sys`, see Notes

### Background
- Pack keeps each member's relative path for the tar entry name, the `bin` exec bit and ignore matching. It does not need to open by it.
- `O_NOFOLLOW` refuses a link as the last component only, so each component is opened on its own. Linux reports `ENOTDIR` with `O_DIRECTORY`, the other POSIX targets `ELOOP`.
- Windows has no `O_NOFOLLOW`. The flag maps to `FILE_OPEN_REPARSE_POINT`, which opens a link itself and resolves through it. So `bun_sys::finish_no_follow_open` reads the reparse tag after the open: a symlink or junction fails with `ELOOP`, and an in-place tag (dedup, cloud file) is reopened without the flag so its filter serves the reads. A `\` in a `bin` path is a separator there too.
- `Dir::open_dir` has a `no_follow` option that only its Windows arm read. The POSIX arm now passes the flag. Pack is its only caller that sets it.

<details><summary>Notes</summary>

Reproduction (linux-x64, ext4):

```
pkg/lib/        200 files, "inside-N"
outside/        200 files with the same names, "SECRET-N"
pkg/lnk -> /abs/outside
swapper: renameat2(AT_FDCWD,"lib",AT_FDCWD,"lnk",RENAME_EXCHANGE) every 2 ms
20x: cd pkg && bun pm pack --destination /out ; tar xOzf /out/pk-1.0.0.tgz | grep -c SECRET
```

| build | tarballs with outside content | failed | clean |
| --- | --- | --- | --- |
| 1.4.3 release | 20 | 0 | 0 |
| this branch (debug) | 0 | 15 | 5 |

One leaked tarball held 102 of its 200 `package/lib/*` entries from the outside directory. The same probe with no pause between swaps, and with 0.5 ms, leaked 30 of 30 on 1.4.3. A failed run prints `ENOTDIR: Not a directory: failed to open file: "lib/c1.txt"`, which is what pack already printed (with `ENOENT`) when a listed file disappeared mid-pack.

The 5 new tests cover the links that were followed by path with no race: a `bin` that is a symlink, a `bin` and a `directories.bin` under a symlinked directory, a bundled dependency under a symlinked `node_modules`, and a nested bundled dependency under a symlinked `node_modules`. They use a junction on Windows, so four of the five run there; the one that links a file is POSIX only.

Also checked: a 328-file tree, 12 directories deep, with bundled dependencies and `directories.bin`, packs to the same shasum and the same `--dry-run` output as the release build.

Other behaviour this changes:

- A member that is not a regular file is skipped when it is optional (a `bin` entry) and is an error otherwise. Only `bin` entries can name one, because the walk drops everything that is not a file or a directory. `"bin": ""` normalizes to `"."`, which failed the whole pack with `EISDIR: failed to read file: "."` and left an empty `.tgz`. It is now skipped, as npm does. #38707 fixes that case with an `lstat` before the queue and still works with this change.
- A FIFO named by a `bin` entry blocked pack in `open()` until a writer appeared. `O_NONBLOCK` plus the file type check ends that.
- A symlinked `node_modules` is no longer followed for `bundledDependencies`. A symlinked dependency directory inside `node_modules` was already dropped by the walk's entry-kind filter, so this closes the two levels that were resolved by path.
- `bun pm diff` of a directory that holds a `package.json` reads the published set through the same opener, so a `bin` entry it cannot open is left out of the tree instead of failing the diff. A directory with no `package.json` keeps the old walk, which reads a symlinked file through on purpose.

Fd cost: one open directory per component of the deepest packed path, which the tree walk already held while it listed that path.

Known Windows limitation, pre-existing and left for a separate change: `bun_sys`'s Windows `openat` resolves a single path component against the directory handle only when the name has no `.` in it. A name such as `foo.js` is rebuilt from `GetFinalPathNameByHandle(dir)` and opened by absolute path (`normalize_path_windows_opts`), so the last component is not handle-relative there. Directory names, which carry the junction case, usually are.

Review changes: on Windows only name-surrogate reparse points count as links, and other reparse points (dedup, cloud placeholder, AppExecLink) are reopened without `FILE_OPEN_REPARSE_POINT` with a file-id check, so their filter drivers still serve the content; a `bin` path with `\` is split per component on Windows; the `directories.bin` walk in `bun publish` opens subdirectories through the same no-follow helper; a `directories.bin` that names the package root (`""`, `"."`, `"./"`) is skipped instead of packing every root file a second time as `package/./<name>` (what `""` did before).

</details>
