### PR TITLE
Bun.serve: decide the development default from the live process.env

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1166,6 +1166,14 @@ impl JSGlobalObject {
         ZigGlobalObject__makeNapiEnvForFFI(self)
     }
 
+    /// The live `process.env` object (the same object as `Bun.env` and
+    /// `import.meta.env`). Runtime writes such as `process.env.FOO = "x"` and
+    /// `delete process.env.FOO` land only on this object, while
+    /// `VirtualMachine::env_loader()` keeps the startup snapshot.
+    pub fn process_env(&self) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || Bun__Process__getEnvObject(self))
+    }
+
     // returns false if it throws
     pub fn validate_object(
         &self,
@@ -1517,6 +1525,7 @@ unsafe extern "C" {
         function: unsafe extern "C" fn(*mut c_void),
     );
 
+    safe fn Bun__Process__getEnvObject(global_object: &JSGlobalObject) -> JSValue;
     safe fn Bun__Process__emitWarning(
         global_object: &JSGlobalObject,
         warning: JSValue,

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1166,10 +1166,8 @@ impl JSGlobalObject {
         ZigGlobalObject__makeNapiEnvForFFI(self)
     }
 
-    /// The live `process.env` object (the same object as `Bun.env` and
-    /// `import.meta.env`). Runtime writes such as `process.env.FOO = "x"` and
-    /// `delete process.env.FOO` land only on this object, while
-    /// `VirtualMachine::env_loader()` keeps the startup snapshot.
+    /// The live `process.env` object. Runtime `process.env` writes land only
+    /// here; `VirtualMachine::env_loader()` is the startup snapshot.
     pub fn process_env(&self) -> JsResult<JSValue> {
         crate::call_zero_is_throw(self, || Bun__Process__getEnvObject(self))
     }

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1166,8 +1166,7 @@ impl JSGlobalObject {
         ZigGlobalObject__makeNapiEnvForFFI(self)
     }
 
-    /// The live `process.env` object. Runtime `process.env` writes land only
-    /// here; `VirtualMachine::env_loader()` is the startup snapshot.
+    /// The live `process.env` object (runtime writes land here, not in `env_loader()`).
     pub fn process_env(&self) -> JsResult<JSValue> {
         crate::call_zero_is_throw(self, || Bun__Process__getEnvObject(self))
     }

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -1154,3 +1154,13 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 #endif
 }
 }
+
+extern "C" JSC::EncodedJSValue Bun__Process__getEnvObject(JSC::JSGlobalObject* lexicalGlobalObject)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSObject* env = globalObject->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(env);
+}

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -554,8 +554,7 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     Ok(())
 }
 
-/// The live `process.env.NODE_ENV` / `BUN_ENV` decide. With neither set, only a
-/// production flag that did not come from the env (`--define`) still counts.
+/// Live `process.env` decides; with neither key set, only a non-env `--define` production flag counts.
 fn default_is_production(global: &JSGlobalObject, vm: &VirtualMachine) -> JsResult<bool> {
     let process_env = global.process_env()?;
     let is_production = |key: &str| -> JsResult<Option<bool>> {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -554,7 +554,7 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     Ok(())
 }
 
-/// Live `process.env` decides; with neither key set, only a non-env `--define` production flag counts.
+/// Live `process.env` decides when it has either key; otherwise the startup production mode stands.
 fn default_is_production(global: &JSGlobalObject, vm: &VirtualMachine) -> JsResult<bool> {
     let process_env = global.process_env()?;
     let is_production = |key: &str| -> JsResult<Option<bool>> {
@@ -567,7 +567,7 @@ fn default_is_production(global: &JSGlobalObject, vm: &VirtualMachine) -> JsResu
     };
     let (node_env, bun_env) = (is_production("NODE_ENV")?, is_production("BUN_ENV")?);
     if node_env.is_none() && bun_env.is_none() {
-        return Ok(vm.transpiler.options.production && vm.env_loader().get_node_env().is_none());
+        return Ok(vm.transpiler.options.production);
     }
     Ok(node_env == Some(true) || bun_env == Some(true))
 }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -15,7 +15,9 @@ pub use http_method::{Method, Optional as MethodOptional};
 use super::server_body::ServerInitContext;
 use super::web_socket_server_context::WebSocketServerContext;
 use super::{AnyRoute, AnyServer};
-use crate::server::jsc::{JSGlobalObject, JSPropertyIterator, JSValue, JsResult, Strong};
+use crate::server::jsc::{
+    JSGlobalObject, JSPropertyIterator, JSValue, JsResult, Strong, VirtualMachine,
+};
 use bun_core::fmt as bun_fmt;
 
 pub use crate::socket::ssl_config::SSLConfig;
@@ -552,6 +554,31 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     Ok(())
 }
 
+/// Whether `development` defaults to off for a `Bun.serve()` call made now.
+///
+/// `NODE_ENV` / `BUN_ENV` are read from the live `process.env`, not the
+/// startup snapshot in `vm.env_loader()`, so a runtime assignment or `delete`
+/// made before the call counts (the timing frameworks get when they read
+/// `process.env.NODE_ENV` at app creation). When neither is set, a process
+/// put in production mode by other means (`--define process.env.NODE_ENV`)
+/// still defaults to off.
+fn default_is_production(global: &JSGlobalObject, vm: &VirtualMachine) -> JsResult<bool> {
+    let process_env = global.process_env()?;
+    let is_production = |key: &str| -> JsResult<Option<bool>> {
+        Ok(match process_env.get(global, key)? {
+            Some(value) if value.is_string() => {
+                Some(value.to_js_string_view(global)?.eq_ascii(b"production"))
+            }
+            None | Some(_) => None,
+        })
+    };
+    let (node_env, bun_env) = (is_production("NODE_ENV")?, is_production("BUN_ENV")?);
+    if node_env.is_none() && bun_env.is_none() {
+        return Ok(vm.transpiler.options.production && vm.env_loader().get_node_env().is_none());
+    }
+    Ok(node_env == Some(true) || bun_env == Some(true))
+}
+
 fn get_routes_object(global: &JSGlobalObject, arg: JSValue) -> JsResult<Option<JSValue>> {
     for key in ["routes", "static"] {
         if let Some(routes) = arg.get(global, key)? {
@@ -636,11 +663,7 @@ impl ServerConfig {
         };
         let mut has_hostname = false;
 
-        if env.get(b"NODE_ENV").unwrap_or(b"") == b"production" {
-            args.development = DevelopmentOption::Production;
-        }
-
-        if arguments.vm.transpiler.options.production {
+        if default_is_production(global, vm)? {
             args.development = DevelopmentOption::Production;
         }
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -554,22 +554,21 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     Ok(())
 }
 
-/// Live `process.env` decides when it has either key; otherwise the startup production mode stands.
+/// A production start is sticky; otherwise the live `process.env` can still opt in (a startup snapshot cannot).
 fn default_is_production(global: &JSGlobalObject, vm: &VirtualMachine) -> JsResult<bool> {
-    let process_env = global.process_env()?;
-    let is_production = |key: &str| -> JsResult<Option<bool>> {
-        Ok(match process_env.get(global, key)? {
-            Some(value) if value.is_string() => {
-                Some(value.to_js_string_view(global)?.eq_ascii(b"production"))
-            }
-            None | Some(_) => None,
-        })
-    };
-    let (node_env, bun_env) = (is_production("NODE_ENV")?, is_production("BUN_ENV")?);
-    if node_env.is_none() && bun_env.is_none() {
-        return Ok(vm.transpiler.options.production);
+    if vm.transpiler.options.production {
+        return Ok(true);
     }
-    Ok(node_env == Some(true) || bun_env == Some(true))
+    let process_env = global.process_env()?;
+    for key in ["NODE_ENV", "BUN_ENV"] {
+        if let Some(value) = process_env.get(global, key)?
+            && value.is_string()
+            && value.to_js_string_view(global)?.eq_ascii(b"production")
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn get_routes_object(global: &JSGlobalObject, arg: JSValue) -> JsResult<Option<JSValue>> {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -554,14 +554,8 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     Ok(())
 }
 
-/// Whether `development` defaults to off for a `Bun.serve()` call made now.
-///
-/// `NODE_ENV` / `BUN_ENV` are read from the live `process.env`, not the
-/// startup snapshot in `vm.env_loader()`, so a runtime assignment or `delete`
-/// made before the call counts (the timing frameworks get when they read
-/// `process.env.NODE_ENV` at app creation). When neither is set, a process
-/// put in production mode by other means (`--define process.env.NODE_ENV`)
-/// still defaults to off.
+/// The live `process.env.NODE_ENV` / `BUN_ENV` decide. With neither set, only a
+/// production flag that did not come from the env (`--define`) still counts.
 fn default_is_production(global: &JSGlobalObject, vm: &VirtualMachine) -> JsResult<bool> {
     let process_env = global.process_env()?;
     let is_production = |key: &str| -> JsResult<Option<bool>> {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -1,6 +1,6 @@
 import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tmpdirSync } from "../../../harness";
+import { bunEnv, bunExe, isWindows, tmpdirSync } from "../../../harness";
 
 const defaultHostname = "localhost";
 
@@ -260,6 +260,103 @@ describe("Bun.serve development options", () => {
     expect(server.port).toBeGreaterThan(0);
     expect(server.development).toBe(false);
     server.stop();
+  });
+
+  // The default for `development` is decided from `process.env.NODE_ENV` as it
+  // is when `Bun.serve()` is called, so a runtime assignment or delete before
+  // the call counts (the same timing as frameworks that read it at app
+  // creation). An explicit `development` option still wins.
+  const nodeEnvFixture = /* js */ `
+    const results = {};
+    async function probe(label, options = {}) {
+      const server = Bun.serve({
+        port: 0,
+        fetch() {
+          throw new Error("secret-in-error-message");
+        },
+        ...options,
+      });
+      const res = await fetch(server.url);
+      const body = await res.text();
+      results[label] = {
+        development: server.development,
+        errorPage: (res.headers.get("content-type") ?? "").split(";")[0] + (body.includes("secret-in-error-message") ? " with message" : ""),
+      };
+      await server.stop(true);
+    }
+    await probe("at launch");
+    process.env.NODE_ENV = "production";
+    await probe("assigned production");
+    await probe("assigned production, development: true", { development: true });
+    process.env.NODE_ENV = "development";
+    await probe("assigned development");
+    await probe("assigned development, development: false", { development: false });
+    delete process.env.NODE_ENV;
+    await probe("deleted");
+    console.log(JSON.stringify(results));
+  `;
+
+  async function runNodeEnvFixture(NODE_ENV: string | undefined) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", nodeEnvFixture],
+      env: { ...bunEnv, NODE_ENV },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The exit code is 1 because the handler errors are unhandled; stderr
+    // carries them. Only the printed JSON matters here.
+    try {
+      return JSON.parse(stdout);
+    } catch {
+      throw new Error(`fixture did not print JSON.\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    }
+  }
+
+  const devPage = { development: true, errorPage: "text/html with message" };
+  const prodPage = { development: false, errorPage: "text/plain" };
+
+  test.concurrent("NODE_ENV is read from process.env when serve() is called (unset at launch)", async () => {
+    expect(await runNodeEnvFixture(undefined)).toEqual({
+      "at launch": devPage,
+      "assigned production": prodPage,
+      "assigned production, development: true": devPage,
+      "assigned development": devPage,
+      "assigned development, development: false": prodPage,
+      "deleted": devPage,
+    });
+  });
+
+  test.concurrent("NODE_ENV is read from process.env when serve() is called (production at launch)", async () => {
+    expect(await runNodeEnvFixture("production")).toEqual({
+      "at launch": prodPage,
+      "assigned production": prodPage,
+      "assigned production, development: true": devPage,
+      "assigned development": devPage,
+      "assigned development, development: false": prodPage,
+      "deleted": devPage,
+    });
+  });
+
+  test.concurrent("--define process.env.NODE_ENV still selects the production default", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--define",
+        'process.env.NODE_ENV="production"',
+        "-e",
+        `const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+         console.log(JSON.stringify({ inEnvObject: Object.hasOwn(process.env, "NODE_ENV"), development: server.development }));
+         await server.stop(true);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ inEnvObject: false, development: false });
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -262,11 +262,12 @@ describe("Bun.serve development options", () => {
     server.stop();
   });
 
-  // The default for `development` is decided from `process.env.NODE_ENV` as it
-  // is when `Bun.serve()` is called, so a runtime assignment or delete before
-  // the call counts (the same timing as frameworks that read it at app
-  // creation). An explicit `development` option still wins.
-  const nodeEnvFixture = /* js */ `
+  // The default for `development` is decided from `process.env.NODE_ENV` (or
+  // `BUN_ENV`) as it is when `Bun.serve()` is called, so a runtime assignment
+  // or delete before the call counts (the same timing as frameworks that read
+  // it at app creation). An explicit `development` option still wins.
+  const envTimingFixture = (key: string) => /* js */ `
+    const key = ${JSON.stringify(key)};
     const results = {};
     async function probe(label, options = {}) {
       const server = Bun.serve({
@@ -285,21 +286,21 @@ describe("Bun.serve development options", () => {
       await server.stop(true);
     }
     await probe("at launch");
-    process.env.NODE_ENV = "production";
+    process.env[key] = "production";
     await probe("assigned production");
     await probe("assigned production, development: true", { development: true });
-    process.env.NODE_ENV = "development";
+    process.env[key] = "development";
     await probe("assigned development");
     await probe("assigned development, development: false", { development: false });
-    delete process.env.NODE_ENV;
+    delete process.env[key];
     await probe("deleted");
     console.log(JSON.stringify(results));
   `;
 
-  async function runNodeEnvFixture(NODE_ENV: string | undefined) {
+  async function runEnvTimingFixture(key: string, launchValue: string | undefined) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", nodeEnvFixture],
-      env: { ...bunEnv, NODE_ENV },
+      cmd: [bunExe(), "-e", envTimingFixture(key)],
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined, [key]: launchValue },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -316,25 +317,27 @@ describe("Bun.serve development options", () => {
   const devPage = { development: true, errorPage: "text/html with message" };
   const prodPage = { development: false, errorPage: "text/plain" };
 
-  test.concurrent("NODE_ENV is read from process.env when serve() is called (unset at launch)", async () => {
-    expect(await runNodeEnvFixture(undefined)).toEqual({
-      "at launch": devPage,
-      "assigned production": prodPage,
-      "assigned production, development: true": devPage,
-      "assigned development": devPage,
-      "assigned development, development: false": prodPage,
-      "deleted": devPage,
+  describe.each(["NODE_ENV", "BUN_ENV"])("%s is read from process.env when serve() is called", key => {
+    test.concurrent("unset at launch", async () => {
+      expect(await runEnvTimingFixture(key, undefined)).toEqual({
+        "at launch": devPage,
+        "assigned production": prodPage,
+        "assigned production, development: true": devPage,
+        "assigned development": devPage,
+        "assigned development, development: false": prodPage,
+        "deleted": devPage,
+      });
     });
-  });
 
-  test.concurrent("NODE_ENV is read from process.env when serve() is called (production at launch)", async () => {
-    expect(await runNodeEnvFixture("production")).toEqual({
-      "at launch": prodPage,
-      "assigned production": prodPage,
-      "assigned production, development: true": devPage,
-      "assigned development": devPage,
-      "assigned development, development: false": prodPage,
-      "deleted": devPage,
+    test.concurrent("production at launch", async () => {
+      expect(await runEnvTimingFixture(key, "production")).toEqual({
+        "at launch": prodPage,
+        "assigned production": prodPage,
+        "assigned production, development: true": devPage,
+        "assigned development": devPage,
+        "assigned development, development: false": prodPage,
+        "deleted": devPage,
+      });
     });
   });
 

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -264,8 +264,9 @@ describe("Bun.serve development options", () => {
 
   // The default for `development` is decided from `process.env.NODE_ENV` (or
   // `BUN_ENV`) as it is when `Bun.serve()` is called, so a runtime assignment
-  // or delete before the call counts (the same timing as frameworks that read
-  // it at app creation). An explicit `development` option still wins.
+  // before the call counts (the same timing as frameworks that read it at app
+  // creation). With neither key present, the mode the process started in
+  // stands. An explicit `development` option still wins.
   const envTimingFixture = (key: string) => /* js */ `
     const key = ${JSON.stringify(key)};
     const results = {};
@@ -336,11 +337,14 @@ describe("Bun.serve development options", () => {
         "assigned production, development: true": devPage,
         "assigned development": devPage,
         "assigned development, development: false": prodPage,
-        "deleted": devPage,
+        // Absent again: the process started in production mode, so that stands.
+        "deleted": prodPage,
       });
     });
   });
 
+  // A `process.env` without the key does not undo a production start: a
+  // `--define`d NODE_ENV, or a worker whose `env` option omits it.
   test.concurrent("--define process.env.NODE_ENV still selects the production default", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -352,13 +356,41 @@ describe("Bun.serve development options", () => {
          console.log(JSON.stringify({ inEnvObject: Object.hasOwn(process.env, "NODE_ENV"), development: server.development }));
          await server.stop(true);`,
       ],
-      env: bunEnv,
+      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({ inEnvObject: false, development: false });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a worker whose env option omits NODE_ENV keeps the production default", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { Worker } from "node:worker_threads";
+         const worker = new Worker(
+           \`const { parentPort } = require("node:worker_threads");
+            const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+            parentPort.postMessage({ hasNodeEnv: "NODE_ENV" in process.env, development: server.development });
+            server.stop(true);\`,
+           { eval: true, env: { SOME_OTHER_VAR: "1" } },
+         );
+         worker.once("message", message => {
+           console.log(JSON.stringify(message));
+           worker.terminate();
+         });`,
+      ],
+      env: { ...bunEnv, NODE_ENV: "production", BUN_ENV: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ hasNodeEnv: false, development: false });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -262,11 +262,11 @@ describe("Bun.serve development options", () => {
     server.stop();
   });
 
-  // The default for `development` is decided from `process.env.NODE_ENV` (or
-  // `BUN_ENV`) as it is when `Bun.serve()` is called, so a runtime assignment
-  // before the call counts (the same timing as frameworks that read it at app
-  // creation). With neither key present, the mode the process started in
-  // stands. An explicit `development` option still wins.
+  // `development` defaults to off when the process started in production mode
+  // (sticky), or when `process.env.NODE_ENV` / `BUN_ENV` is "production" at
+  // the time `Bun.serve()` is called, so a runtime assignment before the call
+  // counts like it does for frameworks that read it at app creation. An
+  // explicit `development` option still wins.
   const envTimingFixture = (key: string) => /* js */ `
     const key = ${JSON.stringify(key)};
     const results = {};
@@ -331,21 +331,20 @@ describe("Bun.serve development options", () => {
     });
 
     test.concurrent("production at launch", async () => {
+      // A production start is sticky: only an explicit `development: true`
+      // brings the dev error page back.
       expect(await runEnvTimingFixture(key, "production")).toEqual({
         "at launch": prodPage,
         "assigned production": prodPage,
         "assigned production, development: true": devPage,
-        "assigned development": devPage,
+        "assigned development": prodPage,
         "assigned development, development: false": prodPage,
-        // Absent again: the process started in production mode, so that stands.
         "deleted": prodPage,
       });
     });
   });
 
-  // A `process.env` without the key does not undo a production start: a
-  // `--define`d NODE_ENV, or a worker whose `env` option omits it.
-  test.concurrent("--define process.env.NODE_ENV still selects the production default", async () => {
+  test.concurrent("--define process.env.NODE_ENV selects the production default over the environment", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -353,16 +352,16 @@ describe("Bun.serve development options", () => {
         'process.env.NODE_ENV="production"',
         "-e",
         `const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
-         console.log(JSON.stringify({ inEnvObject: Object.hasOwn(process.env, "NODE_ENV"), development: server.development }));
+         console.log(JSON.stringify({ inEnvObject: process.env["NODE" + "_ENV"], development: server.development }));
          await server.stop(true);`,
       ],
-      env: { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined },
+      env: { ...bunEnv, NODE_ENV: "development", BUN_ENV: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual({ inEnvObject: false, development: false });
+    expect(JSON.parse(stdout)).toEqual({ inEnvObject: "development", development: false });
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Problem
- `Bun.serve()` takes the `development` default from `NODE_ENV` as it was at process start. `process.env.NODE_ENV = "production"` assigned before the first `Bun.serve()` leaves `server.development === true`, so an uncaught throw serves the HTML dev error page (message, stack, source lines, absolute path).
- Cause: `ServerConfig::from_js` (`src/runtime/server/ServerConfig.rs`) read `vm.env_loader()` and `vm.transpiler.options.production`, both startup snapshots. `process.env` writes never reach them.

### Fix
- `default_is_production()`: the default is production when the process started in production mode (`vm.transpiler.options.production`, as before), or when the live `process.env` has `NODE_ENV` or `BUN_ENV` equal to `"production"` at call time. An explicit `development` option still wins.
- A production start is sticky: a runtime assignment can turn the dev error page off, never back on. Every configuration that defaulted to production before still does (`NODE_ENV=production` launches, `--define 'process.env.NODE_ENV="production"'`, workers whose `env` option omits the key, `delete` after a production launch).
- `JSGlobalObject::process_env()` (new) exposes the object that `process.execve` and `new Worker()` already read.
- Verified: `test/js/bun/http/bun-serve-args.test.ts` (a `NODE_ENV`/`BUN_ENV` timing matrix that stock bun fails, plus `--define` and worker cases), Linux and Windows.

### Background
- `process.env` (also `Bun.env`, `import.meta.env`) is one lazily created JS object per global (a `Proxy` on Windows). Writes stay on it.
- `vm.env_loader()` is the `bun_dotenv::Loader` filled at startup from `environ` and `.env` files. `vm.transpiler.options.production` comes from its `NODE_ENV`/`BUN_ENV` or a `process.env.NODE_ENV` define. A worker clones the parent's loader, while its `process.env` can be an `env` option without the key.
- Node frameworks read `process.env.NODE_ENV` at app creation. `src/js/internal/html.ts` already reads it at `serve()` time.

<details><summary>Notes</summary>

- Repro (NODE_ENV unset at launch):
  ```js
  process.env.NODE_ENV = "production";
  const server = Bun.serve({ port: 0, fetch() { throw new Error("db password is hunter2"); } });
  const r = await fetch(server.url);
  console.log(server.development, r.status, r.headers.get("content-type"), (await r.text()).includes("hunter2"));
  // before: true 500 text/html;charset=utf-8 true
  // after:  false 500 text/plain false
  ```
- The rule is `production = started_in_production || live NODE_ENV == "production" || live BUN_ENV == "production"`. The first term is what the code checked before, so the set of production configurations only grows. Two earlier revisions of this PR let the live value turn production off as well (full Node-style symmetry). Review found two configurations where that flipped a server from production to the dev error page: a worker with an explicit `env` that omits `NODE_ENV` inside a `NODE_ENV=production` process, and `NODE_ENV=development` in the shell combined with `--define 'process.env.NODE_ENV="production"'`. Making the production start sticky removes that class. The cost is that `process.env.NODE_ENV = "development"` at runtime after a production launch does not enable development mode. Pass `development: true` for that.
- The runtime does not inline `process.env.NODE_ENV` into user code unless a define is given, so the live object is what user code sees too.
- `server.reload()` cannot flip the mode: `development` is a const generic of the server type, fixed at construction.
- `NODE_UNIQUE_ID` (the `reusePort` default for node:cluster children) and the `BUN_PORT`/`PORT`/`NODE_PORT` defaults still read the startup snapshot. `node:cluster` deletes `NODE_UNIQUE_ID` from `process.env` in the child on purpose, so that one must stay a snapshot read. `PORT` could take the same live read if wanted. It is not part of this change.
- Docs (`docs/runtime/http/error-handling.mdx`) say development mode "is turned off when `NODE_ENV=production` is set", and `serve.d.ts` documents `@default process.env.NODE_ENV !== 'production'`. An in-process assignment to `"production"` now satisfies both, so no doc change.
- Related open PRs that touch the same lines with different goals: #38118 (make production the default), #41506 (compiled executables default to production through `options.production`, which this change still honors).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-args.test.ts

<!-- robobun:evidence:end -->