### PR TITLE
Bun.build: inline the live process.env for env: "inline" and env: "PREFIX_*"

### DIFF
--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -55,10 +55,7 @@ fn env_string_store_put(
     // `Expr.Data.Store` — `configureDefines` resets that store on return, so
     // the env-define payloads must outlive it. Allocate from `bump` (the
     // transpiler arena) so the slab is bulk-freed with the `Define` table
-    // instead of leaking a `Box` per env var. The value bytes are copied there
-    // too: the source map may be a `process.env` snapshot that the caller frees
-    // after the build is configured, or the VM's env map, whose entries a
-    // `process.env` write can replace mid-build.
+    // instead of leaking a `Box` per env var. The value is copied there too.
     let value: &[u8] = bump.alloc_slice_copy(value);
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
         bump.alloc(bun_ast::E::EString::init(value)),
@@ -73,8 +70,7 @@ fn env_string_store_put(
     Ok(())
 }
 
-/// Copies `process.env.*` entries from `env` into `to_string` according to
-/// `behavior` (all of them, or only those starting with `prefix`).
+/// One `process.env.<KEY>` define per `env` entry (`Prefix`: only keys starting with `prefix`).
 pub(crate) fn copy_env_for_define(
     env: &bun_dotenv::Map,
     to_string: &mut UserDefinesArray,

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -55,8 +55,11 @@ fn env_string_store_put(
     // `Expr.Data.Store` — `configureDefines` resets that store on return, so
     // the env-define payloads must outlive it. Allocate from `bump` (the
     // transpiler arena) so the slab is bulk-freed with the `Define` table
-    // instead of leaking a `Box` per env var. Value bytes alias the long-lived
-    // env-map storage.
+    // instead of leaking a `Box` per env var. The value bytes are copied there
+    // too: the source map may be a `process.env` snapshot that the caller frees
+    // after the build is configured, or the VM's env map, whose entries a
+    // `process.env` write can replace mid-build.
+    let value: &[u8] = bump.alloc_slice_copy(value);
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
         bump.alloc(bun_ast::E::EString::init(value)),
     ));
@@ -70,10 +73,10 @@ fn env_string_store_put(
     Ok(())
 }
 
-/// Copies `process.env.*` entries from the dotenv loader into `to_string`
-/// according to `behavior` (all of them, or only those starting with `prefix`).
+/// Copies `process.env.*` entries from `env` into `to_string` according to
+/// `behavior` (all of them, or only those starting with `prefix`).
 pub(crate) fn copy_env_for_define(
-    env: &bun_dotenv::Loader,
+    env: &bun_dotenv::Map,
     to_string: &mut UserDefinesArray,
     behavior: bun_dotenv::DotEnvBehavior,
     prefix: &[u8],
@@ -92,8 +95,8 @@ pub(crate) fn copy_env_for_define(
     let mut key_buf: Vec<u8> = Vec::new();
     // borrowck — iterate parallel slices instead of `iterator()` so the
     // map borrow stays shared while we write into the define store.
-    let keys = env.map.map.keys();
-    let values = env.map.map.values();
+    let keys = env.map.keys();
+    let values = env.map.values();
     for (k, v) in keys.iter().zip(values.iter()) {
         if k.is_empty() {
             continue;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1604,9 +1604,7 @@ impl<'a> BundleOptions<'a> {
         b"react-refresh",
     ];
 
-    /// `env_map` is the environment `process.env.*` defines are inlined from
-    /// (for `env.behavior` `load_all` / `prefix`), and `node_env` the value of
-    /// `BUN_ENV` / `NODE_ENV` in it, if any.
+    /// `env_map`: what `process.env.*` defines inline from; `node_env`: its `BUN_ENV` / `NODE_ENV`.
     pub(crate) fn load_defines(
         &mut self,
         arena: &bun_alloc::Arena,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -836,7 +836,8 @@ pub(crate) fn defines_from_transform_options(
     // drops the redundant outer `keys.clone() + values.clone()`.
     maybe_input_define: Option<&api::StringMap>,
     target: Target,
-    env_loader: Option<&mut DotEnv::Loader>,
+    // The map `process.env.*` defines are inlined from.
+    env_map: Option<&DotEnv::Map>,
     framework_env: Option<&Env>,
     node_env: Option<&[u8]>,
     drop: &[&[u8]],
@@ -859,7 +860,7 @@ pub(crate) fn defines_from_transform_options(
     let mut behavior = api::DotEnvBehavior::disable;
 
     'load_env: {
-        let Some(env) = env_loader else {
+        let Some(env) = env_map else {
             break 'load_env;
         };
         let Some(framework) = framework_env else {
@@ -1603,10 +1604,14 @@ impl<'a> BundleOptions<'a> {
         b"react-refresh",
     ];
 
+    /// `process_env`, when given, is the map `process.env.*` defines are
+    /// inlined from (for `env.behavior` `load_all` / `prefix`) instead of
+    /// `loader_`'s map: `Bun.build` passes the caller's live `process.env`.
     pub(crate) fn load_defines(
         &mut self,
         arena: &bun_alloc::Arena,
-        loader_: Option<&mut DotEnv::Loader>,
+        loader_: Option<&DotEnv::Loader>,
+        process_env: Option<&DotEnv::Map>,
     ) -> Result<(), crate::Error> {
         // Forwarding the env as an `Option<&Env>` parameter forced the
         // caller into an aliased-`&mut` UB
@@ -1621,28 +1626,22 @@ impl<'a> BundleOptions<'a> {
         if self.defines_loaded {
             return Ok(());
         }
-        // PERF: borrowed static literals for the three
-        // constant cases; only the env-loader case needs an owned copy (it has
-        // to outlive the `&mut loader_` we pass below, so it can't stay a borrow
-        // into the loader). `Cow` keeps the literals zero-alloc — matters because
-        // every VM with no `NODE_ENV` in its env hits the `"development"` arm.
-        let node_env: Option<Cow<[u8]>> = 'node_env: {
-            if let Some(e) = loader_.as_deref() {
-                if let Some(env_) = e.get_node_env() {
-                    break 'node_env Some(Cow::Owned(env_.to_vec()));
-                }
+        let node_env: Option<&[u8]> = 'node_env: {
+            if let Some(env_) = loader_.and_then(|e| e.get_node_env()) {
+                break 'node_env Some(env_);
             }
 
             if self.is_test() {
-                break 'node_env Some(Cow::Borrowed(b"\"test\"".as_slice()));
+                break 'node_env Some(b"\"test\"".as_slice());
             }
 
             if self.production {
-                break 'node_env Some(Cow::Borrowed(b"\"production\"".as_slice()));
+                break 'node_env Some(b"\"production\"".as_slice());
             }
 
-            Some(Cow::Borrowed(b"\"development\"".as_slice()))
+            Some(b"\"development\"".as_slice())
         };
+        let env_map = process_env.or(loader_.map(|loader| &loader.map));
         // reshaped for borrowck — node_env computed before passing self.log
         self.define = defines_from_transform_options(
             // No other `&mut Log` is live across this call (see `log_mut`
@@ -1650,9 +1649,9 @@ impl<'a> BundleOptions<'a> {
             self.log_mut(),
             self.transform_options.define.as_ref(),
             self.target,
-            loader_,
+            env_map,
             Some(&self.env),
-            node_env.as_deref(),
+            node_env,
             // `&self.drop` is `Box<[Box<[u8]>]>`; the callee wants `&[&[u8]]`,
             // so re-borrow per call (cold path: once per options build).
             &self.drop.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1604,14 +1604,14 @@ impl<'a> BundleOptions<'a> {
         b"react-refresh",
     ];
 
-    /// `process_env`, when given, is the map `process.env.*` defines are
-    /// inlined from (for `env.behavior` `load_all` / `prefix`) instead of
-    /// `loader_`'s map: `Bun.build` passes the caller's live `process.env`.
+    /// `env_map` is the environment `process.env.*` defines are inlined from
+    /// (for `env.behavior` `load_all` / `prefix`), and `node_env` the value of
+    /// `BUN_ENV` / `NODE_ENV` in it, if any.
     pub(crate) fn load_defines(
         &mut self,
         arena: &bun_alloc::Arena,
-        loader_: Option<&DotEnv::Loader>,
-        process_env: Option<&DotEnv::Map>,
+        env_map: &DotEnv::Map,
+        node_env: Option<&[u8]>,
     ) -> Result<(), crate::Error> {
         // Forwarding the env as an `Option<&Env>` parameter forced the
         // caller into an aliased-`&mut` UB
@@ -1626,22 +1626,12 @@ impl<'a> BundleOptions<'a> {
         if self.defines_loaded {
             return Ok(());
         }
-        let node_env: Option<&[u8]> = 'node_env: {
-            if let Some(env_) = loader_.and_then(|e| e.get_node_env()) {
-                break 'node_env Some(env_);
-            }
-
-            if self.is_test() {
-                break 'node_env Some(b"\"test\"".as_slice());
-            }
-
-            if self.production {
-                break 'node_env Some(b"\"production\"".as_slice());
-            }
-
-            Some(b"\"development\"".as_slice())
+        let node_env: &[u8] = match node_env {
+            Some(node_env) => node_env,
+            None if self.is_test() => b"\"test\"",
+            None if self.production => b"\"production\"",
+            None => b"\"development\"",
         };
-        let env_map = process_env.or(loader_.map(|loader| &loader.map));
         // reshaped for borrowck — node_env computed before passing self.log
         self.define = defines_from_transform_options(
             // No other `&mut Log` is live across this call (see `log_mut`
@@ -1649,9 +1639,9 @@ impl<'a> BundleOptions<'a> {
             self.log_mut(),
             self.transform_options.define.as_ref(),
             self.target,
-            env_map,
+            Some(env_map),
             Some(&self.env),
-            node_env,
+            Some(node_env),
             // `&self.drop` is `Box<[Box<[u8]>]>`; the callee wants `&[&[u8]]`,
             // so re-borrow per call (cold path: once per options build).
             &self.drop.iter().map(|s| s.as_ref()).collect::<Vec<_>>(),

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -578,7 +578,19 @@ impl<'a> Transpiler<'a> {
 
     /// Load env files and build `options.define`. Idempotent — a no-op once
     /// `options.defines_loaded` is set.
+    #[inline]
     pub fn configure_defines(&mut self) -> crate::Result<()> {
+        self.configure_defines_with_process_env(None)
+    }
+
+    /// [`Self::configure_defines`], but `process.env.*` defines (for
+    /// `env.behavior` `load_all` / `prefix`) are inlined from `process_env`
+    /// instead of the env loader's map, which holds the environment the
+    /// process started with. `Bun.build` passes the caller's live `process.env`.
+    pub fn configure_defines_with_process_env(
+        &mut self,
+        process_env: Option<&dot_env::Map>,
+    ) -> crate::Result<()> {
         if self.options.defines_loaded {
             return Ok(());
         }
@@ -590,7 +602,7 @@ impl<'a> Transpiler<'a> {
 
         self.run_env_loader(self.options.env.disable_default_env_files)?;
 
-        let env_loader = self.env_mut();
+        let env_loader = self.env();
         let mut is_production = env_loader.is_production();
 
         // `load_defines` injects a default `process.env.NODE_ENV`; sample the
@@ -620,7 +632,8 @@ impl<'a> Transpiler<'a> {
         // Spec passed `&this.options.env` as a separate arg; `load_defines` now
         // reads `&self.env` internally so the disjoint borrow is resolved
         // inside the `&mut self` scope without `unsafe`.
-        self.options.load_defines(self.arena, Some(env_loader))?;
+        self.options
+            .load_defines(self.arena, Some(env_loader), process_env)?;
 
         let mut is_development = false;
         if had_explicit_node_env {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -583,10 +583,11 @@ impl<'a> Transpiler<'a> {
         self.configure_defines_with_process_env(None)
     }
 
-    /// [`Self::configure_defines`], but `process.env.*` defines (for
-    /// `env.behavior` `load_all` / `prefix`) are inlined from `process_env`
-    /// instead of the env loader's map, which holds the environment the
-    /// process started with. `Bun.build` passes the caller's live `process.env`.
+    /// [`Self::configure_defines`], but with `process_env` given, the
+    /// `process.env.*` defines (for `env.behavior` `load_all` / `prefix`) and
+    /// `NODE_ENV` / `BUN_ENV` are read from that map instead of the env loader,
+    /// which holds the environment the process started with. `Bun.build`
+    /// passes the caller's live `process.env`.
     pub fn configure_defines_with_process_env(
         &mut self,
         process_env: Option<&dot_env::Map>,
@@ -603,12 +604,16 @@ impl<'a> Transpiler<'a> {
         self.run_env_loader(self.options.env.disable_default_env_files)?;
 
         let env_loader = self.env();
-        let mut is_production = env_loader.is_production();
+        let (env_map, node_env) = match process_env {
+            Some(env) => (env, env.get(b"BUN_ENV").or_else(|| env.get(b"NODE_ENV"))),
+            None => (&env_loader.map, env_loader.get_node_env()),
+        };
+        let mut is_production = node_env == Some(b"production");
 
         // `load_defines` injects a default `process.env.NODE_ENV`; sample the
         // explicit sources first so that default isn't mistaken for user intent
         // and `force_node_env` stays `Unspecified` (tsconfig jsx stays in control).
-        let had_explicit_node_env = env_loader.get_node_env().is_some()
+        let had_explicit_node_env = node_env.is_some()
             || self
                 .options
                 .transform_options
@@ -632,8 +637,7 @@ impl<'a> Transpiler<'a> {
         // Spec passed `&this.options.env` as a separate arg; `load_defines` now
         // reads `&self.env` internally so the disjoint borrow is resolved
         // inside the `&mut self` scope without `unsafe`.
-        self.options
-            .load_defines(self.arena, Some(env_loader), process_env)?;
+        self.options.load_defines(self.arena, env_map, node_env)?;
 
         let mut is_development = false;
         if had_explicit_node_env {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -583,11 +583,7 @@ impl<'a> Transpiler<'a> {
         self.configure_defines_with_process_env(None)
     }
 
-    /// [`Self::configure_defines`], but with `process_env` given, the
-    /// `process.env.*` defines (for `env.behavior` `load_all` / `prefix`) and
-    /// `NODE_ENV` / `BUN_ENV` are read from that map instead of the env loader,
-    /// which holds the environment the process started with. `Bun.build`
-    /// passes the caller's live `process.env`.
+    /// [`Self::configure_defines`], with env defines and `NODE_ENV` read from `process_env` when given.
     pub fn configure_defines_with_process_env(
         &mut self,
         process_env: Option<&dot_env::Map>,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1416,7 +1416,7 @@ impl Map {
     }
 
     #[inline]
-    pub(crate) fn init() -> Map {
+    pub fn init() -> Map {
         Map {
             map: HashTable::default(),
         }

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -952,10 +952,7 @@ impl JSGlobalObject {
         JSC__JSGlobalObject__generateHeapSnapshot(self)
     }
 
-    /// The object `process.env` (and `Bun.env`) resolves to, created on first
-    /// use. Its own enumerable properties are the live environment as JS sees
-    /// it, unlike `VirtualMachine::env_loader`, which is the environment the
-    /// process started with.
+    /// The live `process.env` / `Bun.env` object (the env loader only has the startup environment).
     pub fn process_env(&self) -> JsResult<JSValue> {
         crate::cpp::Bun__Process__getEnvObject(self)
     }

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -334,6 +334,13 @@ impl JSGlobalObject {
         JSGlobalObject__setTimeZone(self, time_zone)
     }
 
+    /// The live `process.env` object (also `Bun.env` and `import.meta.env`).
+    /// Reads through it see runtime writes from JS. `bun_vm().env_loader()`
+    /// does not: it is the snapshot taken at startup.
+    pub fn process_env(&self) -> JsResult<JSValue> {
+        crate::cpp::JSGlobalObject__processEnv(self)
+    }
+
     #[inline]
     pub fn to_js_value(&self) -> JSValue {
         // JSValue is #[repr(transparent)] over the encoded pointer-width word; a
@@ -950,11 +957,6 @@ impl JSGlobalObject {
 
     pub(crate) fn generate_heap_snapshot(&self) -> JSValue {
         JSC__JSGlobalObject__generateHeapSnapshot(self)
-    }
-
-    /// The live `process.env` / `Bun.env` object (the env loader only has the startup environment).
-    pub fn process_env(&self) -> JsResult<JSValue> {
-        crate::cpp::Bun__Process__getEnvObject(self)
     }
 
     /// DEPRECATED — use [`TopExceptionScope`](crate::TopExceptionScope) to check for exceptions

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -952,6 +952,14 @@ impl JSGlobalObject {
         JSC__JSGlobalObject__generateHeapSnapshot(self)
     }
 
+    /// The object `process.env` (and `Bun.env`) resolves to, created on first
+    /// use. Its own enumerable properties are the live environment as JS sees
+    /// it, unlike `VirtualMachine::env_loader`, which is the environment the
+    /// process started with.
+    pub fn process_env(&self) -> JsResult<JSValue> {
+        crate::cpp::Bun__Process__getEnvObject(self)
+    }
+
     /// DEPRECATED — use [`TopExceptionScope`](crate::TopExceptionScope) to check for exceptions
     /// and signal exceptions by returning `JsError`.
     ///

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -42,6 +42,17 @@ extern "C" BunString Bun__getEnvValueBunString(JSGlobalObject* globalObject, con
 extern "C" void Bun__setEnvValue(JSGlobalObject* globalObject, const BunString* name, const BunString* value);
 extern "C" bool Bun__Node__ProcessPendingDeprecation;
 
+// The object `process.env` and `Bun.env` resolve to (on Windows, the Proxy).
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__Process__getEnvObject(JSC::JSGlobalObject* lexicalGlobalObject)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* env = globalObject->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(env);
+}
+
 namespace Bun {
 
 using namespace WebCore;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -42,17 +42,6 @@ extern "C" BunString Bun__getEnvValueBunString(JSGlobalObject* globalObject, con
 extern "C" void Bun__setEnvValue(JSGlobalObject* globalObject, const BunString* name, const BunString* value);
 extern "C" bool Bun__Node__ProcessPendingDeprecation;
 
-// The object `process.env` and `Bun.env` resolve to (on Windows, the Proxy).
-extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__Process__getEnvObject(JSC::JSGlobalObject* lexicalGlobalObject)
-{
-    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSObject* env = globalObject->processEnvObject();
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSValue::encode(env);
-}
-
 namespace Bun {
 
 using namespace WebCore;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3202,6 +3202,17 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);
 }
 
+// The live `process.env` object (also `Bun.env` and `import.meta.env`), as
+// opposed to the env loader map, which is a snapshot taken at startup.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSGlobalObject__processEnv(JSC::JSGlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* env = defaultGlobalObject(globalObject)->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(env);
+}
+
 extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, const EncodedSlice* timeZone)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -104,6 +104,47 @@ pub mod js_bundler {
         Ok(this)
     }
 
+    /// Copy the own enumerable entries of `process.env` as it is now (only
+    /// those whose key starts with `prefix`, when given). The VM's env loader
+    /// map is not the same thing: it is the environment the process started
+    /// with, so a key the script deleted is still in it and a key the script
+    /// set is not.
+    fn process_env_snapshot(
+        global_this: &JSGlobalObject,
+        prefix: Option<&[u8]>,
+    ) -> JsResult<bun_dotenv::Map> {
+        let mut map = bun_dotenv::Map::init();
+        let Some(process_env) = global_this.process_env()?.get_object() else {
+            return Ok(map);
+        };
+
+        let iter = jsc::JSPropertyIterator::init(
+            global_this,
+            process_env,
+            jsc::JSPropertyIteratorOptions {
+                skip_empty_name: true,
+                include_value: true,
+                ..Default::default()
+            },
+        )?;
+        map.ensure_unused_capacity(iter.len)?;
+
+        while let Some((key, value)) = iter.next()? {
+            // On Windows `process.env` is a Proxy that also owns a `toJSON` function.
+            if value.is_undefined_or_null() || value.is_callable() {
+                continue;
+            }
+            let key = key.to_utf8();
+            if prefix.is_some_and(|prefix| !key.starts_with(prefix)) {
+                continue;
+            }
+            let value = value.to_bun_string(global_this)?;
+            map.put(&key, &value.to_utf8())?;
+        }
+
+        Ok(map)
+    }
+
     pub struct Config {
         pub(crate) target: Target,
         pub(crate) entry_points: StringSet,
@@ -151,6 +192,10 @@ pub mod js_bundler {
         pub(crate) throw_on_error: bool,
         pub(crate) env_behavior: api::DotEnvBehavior,
         pub(crate) env_prefix: OwnedString,
+        /// `process.env` as it was when `Bun.build` was called. `env: "inline"`
+        /// and `env: "PREFIX_*"` inline these values, not the environment the
+        /// process started with.
+        pub(crate) process_env: Option<bun_dotenv::Map>,
         pub(crate) compile: Option<CompileOptions>,
         /// In-memory files that can be used as entrypoints or imported.
         /// These files do not need to exist on disk.
@@ -216,6 +261,7 @@ pub mod js_bundler {
                 throw_on_error: true,
                 env_behavior: api::DotEnvBehavior::Disable,
                 env_prefix: OwnedString::default(),
+                process_env: None,
                 compile: None,
                 files: FileMap::default(),
                 metafile: false,
@@ -721,6 +767,19 @@ pub mod js_bundler {
                         )));
                     }
                 }
+            }
+
+            match this.env_behavior {
+                api::DotEnvBehavior::LoadAll => {
+                    this.process_env = Some(process_env_snapshot(global_this, None)?);
+                }
+                api::DotEnvBehavior::Prefix => {
+                    this.process_env = Some(process_env_snapshot(
+                        global_this,
+                        Some(this.env_prefix.list.as_slice()),
+                    )?);
+                }
+                _ => {}
             }
 
             if let Some(packages) = config.get_optional_enum_from_map(

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -104,10 +104,7 @@ pub mod js_bundler {
         Ok(this)
     }
 
-    /// Copy the own enumerable entries of `process.env` as it is now. The VM's
-    /// env loader map is not the same thing: it is the environment the process
-    /// started with, so a key the script deleted is still in it and a key the
-    /// script set is not.
+    /// Own enumerable entries of the live `process.env`; the env loader map only has the startup environment.
     fn process_env_snapshot(global_this: &JSGlobalObject) -> JsResult<bun_dotenv::Map> {
         let mut map = bun_dotenv::Map::init();
         let Some(process_env) = global_this.process_env()?.get_object() else {
@@ -184,10 +181,7 @@ pub mod js_bundler {
         pub(crate) throw_on_error: bool,
         pub(crate) env_behavior: api::DotEnvBehavior,
         pub(crate) env_prefix: OwnedString,
-        /// `process.env` as it was when `Bun.build` was called, taken for
-        /// `env: "inline"` and `env: "PREFIX_*"`. Those inline these values (and
-        /// read `NODE_ENV` / `BUN_ENV` from them), not the environment the
-        /// process started with.
+        /// Live `process.env` at `Bun.build()` time, for `env: "inline"` / `"PREFIX_*"` to inline from.
         pub(crate) process_env: Option<bun_dotenv::Map>,
         pub(crate) compile: Option<CompileOptions>,
         /// In-memory files that can be used as entrypoints or imported.

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -104,15 +104,11 @@ pub mod js_bundler {
         Ok(this)
     }
 
-    /// Copy the own enumerable entries of `process.env` as it is now (only
-    /// those whose key starts with `prefix`, when given). The VM's env loader
-    /// map is not the same thing: it is the environment the process started
-    /// with, so a key the script deleted is still in it and a key the script
-    /// set is not.
-    fn process_env_snapshot(
-        global_this: &JSGlobalObject,
-        prefix: Option<&[u8]>,
-    ) -> JsResult<bun_dotenv::Map> {
+    /// Copy the own enumerable entries of `process.env` as it is now. The VM's
+    /// env loader map is not the same thing: it is the environment the process
+    /// started with, so a key the script deleted is still in it and a key the
+    /// script set is not.
+    fn process_env_snapshot(global_this: &JSGlobalObject) -> JsResult<bun_dotenv::Map> {
         let mut map = bun_dotenv::Map::init();
         let Some(process_env) = global_this.process_env()?.get_object() else {
             return Ok(map);
@@ -134,12 +130,8 @@ pub mod js_bundler {
             if value.is_undefined_or_null() || value.is_callable() {
                 continue;
             }
-            let key = key.to_utf8();
-            if prefix.is_some_and(|prefix| !key.starts_with(prefix)) {
-                continue;
-            }
             let value = value.to_bun_string(global_this)?;
-            map.put(&key, &value.to_utf8())?;
+            map.put(&key.to_utf8(), &value.to_utf8())?;
         }
 
         Ok(map)
@@ -192,8 +184,9 @@ pub mod js_bundler {
         pub(crate) throw_on_error: bool,
         pub(crate) env_behavior: api::DotEnvBehavior,
         pub(crate) env_prefix: OwnedString,
-        /// `process.env` as it was when `Bun.build` was called. `env: "inline"`
-        /// and `env: "PREFIX_*"` inline these values, not the environment the
+        /// `process.env` as it was when `Bun.build` was called, taken for
+        /// `env: "inline"` and `env: "PREFIX_*"`. Those inline these values (and
+        /// read `NODE_ENV` / `BUN_ENV` from them), not the environment the
         /// process started with.
         pub(crate) process_env: Option<bun_dotenv::Map>,
         pub(crate) compile: Option<CompileOptions>,
@@ -740,46 +733,39 @@ pub mod js_bundler {
 
             if let Some(env) = config.get(global_this, "env")? {
                 if !env.is_undefined() {
-                    if env == JSValue::NULL
+                    let behavior = if env == JSValue::NULL
                         || env == JSValue::FALSE
                         || (env.is_number() && env.as_number() == 0.0)
                     {
-                        this.env_behavior = api::DotEnvBehavior::Disable;
+                        api::DotEnvBehavior::Disable
                     } else if env == JSValue::TRUE || (env.is_number() && env.as_number() == 1.0) {
-                        this.env_behavior = api::DotEnvBehavior::LoadAll;
+                        api::DotEnvBehavior::LoadAll
                     } else if env.is_string() {
                         let slice = env.to_utf8(global_this)?;
                         match api::DotEnvBehavior::parse_str(slice.slice()) {
                             Ok((behavior, prefix)) => {
-                                this.env_behavior = behavior;
                                 if let Some(prefix) = prefix {
                                     this.env_prefix.append_slice_exact(prefix)?;
                                 }
+                                behavior
                             }
                             Err(()) => {
                                 return Err(global_this.throw_invalid_arguments(format_args!("env must be 'inline', 'disable', or a string with a '*' character")));
                             }
                         }
-                        drop(slice);
                     } else {
                         return Err(global_this.throw_invalid_arguments(format_args!(
                             "env must be 'inline', 'disable', or a string with a '*' character"
                         )));
+                    };
+                    this.env_behavior = behavior;
+                    if matches!(
+                        behavior,
+                        api::DotEnvBehavior::LoadAll | api::DotEnvBehavior::Prefix
+                    ) {
+                        this.process_env = Some(process_env_snapshot(global_this)?);
                     }
                 }
-            }
-
-            match this.env_behavior {
-                api::DotEnvBehavior::LoadAll => {
-                    this.process_env = Some(process_env_snapshot(global_this, None)?);
-                }
-                api::DotEnvBehavior::Prefix => {
-                    this.process_env = Some(process_env_snapshot(
-                        global_this,
-                        Some(this.env_prefix.list.as_slice()),
-                    )?);
-                }
-                _ => {}
             }
 
             if let Some(packages) = config.get_optional_enum_from_map(

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1079,7 +1079,9 @@ impl CompletionStruct for JSBundleCompletionTask {
         }
 
         transpiler.configure_linker();
-        transpiler.configure_defines()?;
+        transpiler.configure_defines_with_process_env(config.process_env.as_ref())?;
+        // The define table copied what it inlines.
+        config.process_env = None;
 
         // After configure_defines(): downloading the target reads proxy/TLS settings from the loaded env.
         transpiler.options.compile_target_builtins = match &config.compile {

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -1,35 +1,33 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 for (let backend of ["api", "cli"] as const) {
   describe(`bundler/${backend}`, () => {
-    // TODO: make this work as expected with process.env isntead of relying on the initial env vars.
-    if (backend === "cli")
-      itBundled("env/inline", {
-        env: {
-          FOO: "bar",
-          BAZ: "123",
-        },
-        backend: backend,
-        dotenv: "inline",
-        files: {
-          "/a.js": `
+    itBundled("env/inline", {
+      env: {
+        FOO: "bar",
+        BAZ: "123",
+      },
+      backend: backend,
+      dotenv: "inline",
+      files: {
+        "/a.js": `
         console.log(process.env.FOO);
         console.log(process.env.BAZ);
       `,
+      },
+      run: {
+        env: {
+          FOO: "barz",
+          BAZ: "123z",
         },
-        run: {
-          env: {
-            FOO: "barz",
-            BAZ: "123z",
-          },
-          stdout: "bar\n123\n",
-        },
-      });
+        stdout: "bar\n123\n",
+      },
+    });
 
-    // A variable from the process environment (not a .env file) is inlined at build time. It has to be one this
-    // process started with (the api backend builds in-process), spelled as the environment spells it (on Windows the
-    // inlined name is case-sensitive even though process.env is not: `Path`, not `PATH`).
+    // A variable from the process environment (not a .env file) is inlined at build time, spelled as the environment
+    // spells it (on Windows the inlined name is case-sensitive even though process.env is not: `Path`, not `PATH`).
     const systemKey = ["HOME", "OS", "NUMBER_OF_PROCESSORS", "COMPUTERNAME", "USER", "LANG"].find(
       key => process.env[key] && /^[\x20-\x7e]+$/.test(process.env[key]!) && !/["`$\\]/.test(process.env[key]!),
     )!;
@@ -72,56 +70,94 @@ for (let backend of ["api", "cli"] as const) {
       },
     });
 
-    // TODO: make this work as expected with process.env isntead of relying on the initial env vars.
     // Test pattern matching - only vars with prefix are inlined
-    if (backend === "cli")
-      itBundled("env/pattern-matching", {
-        env: {
-          PUBLIC_FOO: "public_value",
-          PUBLIC_BAR: "another_public",
-          PRIVATE_SECRET: "secret_value",
-        },
-        dotenv: "PUBLIC_*",
-        backend: backend,
-        files: {
-          "/a.js": `
+    itBundled("env/pattern-matching", {
+      env: {
+        PUBLIC_FOO: "public_value",
+        PUBLIC_BAR: "another_public",
+        PRIVATE_SECRET: "secret_value",
+      },
+      dotenv: "PUBLIC_*",
+      backend: backend,
+      files: {
+        "/a.js": `
         console.log(process.env.PUBLIC_FOO);
         console.log(process.env.PUBLIC_BAR);
         console.log(process.env.PRIVATE_SECRET);
       `,
-        },
-        run: {
-          env: {
-            PUBLIC_FOO: "BAD_FOO",
-            PUBLIC_BAR: "BAD_BAR",
-          },
-          stdout: "public_value\nanother_public\nundefined\n",
-        },
-      });
-
-    if (backend === "cli")
-      // Test nested environment variable references
-      itBundled("nested-refs", {
+      },
+      run: {
         env: {
-          BASE_URL: "https://api.example.com",
-          SHOULD_PRINT_BASE_URL: "process.env.BASE_URL",
-          SHOULD_PRINT_$BASE_URL: "$BASE_URL",
+          PUBLIC_FOO: "BAD_FOO",
+          PUBLIC_BAR: "BAD_BAR",
         },
-        dotenv: "inline",
-        backend: backend,
-        files: {
-          "/a.js": `
+        stdout: "public_value\nanother_public\nundefined\n",
+      },
+    });
+
+    // Test nested environment variable references
+    itBundled("nested-refs", {
+      env: {
+        BASE_URL: "https://api.example.com",
+        SHOULD_PRINT_BASE_URL: "process.env.BASE_URL",
+        SHOULD_PRINT_$BASE_URL: "$BASE_URL",
+      },
+      dotenv: "inline",
+      backend: backend,
+      files: {
+        "/a.js": `
       // Test nested references
       console.log(process.env.SHOULD_PRINT_BASE_URL);
       console.log(process.env.SHOULD_PRINT_$BASE_URL);
     `,
+      },
+      run: {
+        env: {
+          "BASE_URL": "https://api.example.com",
         },
-        run: {
-          env: {
-            "BASE_URL": "https://api.example.com",
-          },
-          stdout: "process.env.BASE_URL\n$BASE_URL",
-        },
-      });
+        stdout: "process.env.BASE_URL\n$BASE_URL",
+      },
+    });
   });
 }
+
+describe("Bun.build env", () => {
+  // `env: "inline"` and `env: "PREFIX_*"` inline process.env as it is when Bun.build() is called, not the environment
+  // the process started with: a variable the script deleted is not inlined, one it changed is inlined with the new
+  // value, and one it added is inlined.
+  test("inlines the live process.env", async () => {
+    using dir = tempDir("bun-build-live-env", {
+      "entry.ts": `console.log([process.env.BUN_TEST_ENV_SECRET, process.env.BUN_TEST_ENV_PUB, process.env.BUN_TEST_ENV_LATE, process.env.OTHER_TEST_ENV_LATE].join(","));`,
+      "build.ts": `
+        delete process.env.BUN_TEST_ENV_SECRET;
+        process.env.BUN_TEST_ENV_PUB = "changed-at-runtime";
+        process.env.BUN_TEST_ENV_LATE = "set-at-runtime";
+        process.env.OTHER_TEST_ENV_LATE = "other-set-at-runtime";
+        const results: Record<string, string | undefined> = {};
+        for (const env of ["inline", "BUN_TEST_ENV_*"] as const) {
+          const build = await Bun.build({ entrypoints: ["./entry.ts"], env });
+          if (!build.success) throw new AggregateError(build.logs, "build failed");
+          const output = await build.outputs[0].text();
+          results[env] = output.split("\\n").find(line => line.startsWith("console.log"));
+        }
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.ts"],
+      env: { ...bunEnv, BUN_TEST_ENV_SECRET: "hunter2", BUN_TEST_ENV_PUB: "startup-value" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      inline: `console.log([process.env.BUN_TEST_ENV_SECRET, "changed-at-runtime", "set-at-runtime", "other-set-at-runtime"].join(","));`,
+      "BUN_TEST_ENV_*": `console.log([process.env.BUN_TEST_ENV_SECRET, "changed-at-runtime", "set-at-runtime", process.env.OTHER_TEST_ENV_LATE].join(","));`,
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -124,15 +124,16 @@ for (let backend of ["api", "cli"] as const) {
 describe("Bun.build env", () => {
   // `env: "inline"` and `env: "PREFIX_*"` inline process.env as it is when Bun.build() is called, not the environment
   // the process started with: a variable the script deleted is not inlined, one it changed is inlined with the new
-  // value, and one it added is inlined.
+  // value, and one it added is inlined. The implicit `process.env.NODE_ENV` define reads the same environment.
   test("inlines the live process.env", async () => {
     using dir = tempDir("bun-build-live-env", {
-      "entry.ts": `console.log([process.env.BUN_TEST_ENV_SECRET, process.env.BUN_TEST_ENV_PUB, process.env.BUN_TEST_ENV_LATE, process.env.OTHER_TEST_ENV_LATE].join(","));`,
+      "entry.ts": `console.log([process.env.BUN_TEST_ENV_SECRET, process.env.BUN_TEST_ENV_PUB, process.env.BUN_TEST_ENV_LATE, process.env.OTHER_TEST_ENV_LATE, process.env.NODE_ENV].join(","));`,
       "build.ts": `
         delete process.env.BUN_TEST_ENV_SECRET;
         process.env.BUN_TEST_ENV_PUB = "changed-at-runtime";
         process.env.BUN_TEST_ENV_LATE = "set-at-runtime";
         process.env.OTHER_TEST_ENV_LATE = "other-set-at-runtime";
+        process.env.NODE_ENV = "production";
         const results: Record<string, string | undefined> = {};
         for (const env of ["inline", "BUN_TEST_ENV_*"] as const) {
           const build = await Bun.build({ entrypoints: ["./entry.ts"], env });
@@ -155,8 +156,8 @@ describe("Bun.build env", () => {
 
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({
-      inline: `console.log([process.env.BUN_TEST_ENV_SECRET, "changed-at-runtime", "set-at-runtime", "other-set-at-runtime"].join(","));`,
-      "BUN_TEST_ENV_*": `console.log([process.env.BUN_TEST_ENV_SECRET, "changed-at-runtime", "set-at-runtime", process.env.OTHER_TEST_ENV_LATE].join(","));`,
+      inline: `console.log([process.env.BUN_TEST_ENV_SECRET, "changed-at-runtime", "set-at-runtime", "other-set-at-runtime", "production"].join(","));`,
+      "BUN_TEST_ENV_*": `console.log([process.env.BUN_TEST_ENV_SECRET, "changed-at-runtime", "set-at-runtime", process.env.OTHER_TEST_ENV_LATE, "production"].join(","));`,
     });
     expect(exitCode).toBe(0);
   });

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -147,7 +147,13 @@ describe("Bun.build env", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "build.ts"],
-      env: { ...bunEnv, BUN_TEST_ENV_SECRET: "hunter2", BUN_TEST_ENV_PUB: "startup-value" },
+      env: {
+        ...bunEnv,
+        BUN_TEST_ENV_SECRET: "hunter2",
+        BUN_TEST_ENV_PUB: "startup-value",
+        NODE_ENV: undefined,
+        BUN_ENV: undefined,
+      },
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -1316,10 +1316,29 @@ for (const [key, blob] of build.outputs) {
         let build: BuildOutput;
         try {
           process.chdir(root);
+          // Bun.build reads the live process.env (for `env: "inline"` / `env: "PREFIX_*"`), so `env` is applied to
+          // it for the duration of the build, the same way the cli backend passes it to the subprocess.
+          const previousEnv: Record<string, string | undefined> = {};
+          for (const key in env) {
+            previousEnv[key] = process.env[key];
+            const value = env[key];
+            if (value === undefined) {
+              delete process.env[key];
+            } else {
+              process.env[key] = String(value).replaceAll("{{root}}", root);
+            }
+          }
           try {
             build = await Bun.build(buildConfig);
           } finally {
             process.chdir(originalCwd);
+            for (const key in previousEnv) {
+              if (previousEnv[key] === undefined) {
+                delete process.env[key];
+              } else {
+                process.env[key] = previousEnv[key];
+              }
+            }
           }
         } catch (e) {
           if (e instanceof AggregateError) {


### PR DESCRIPTION
### Problem
- `Bun.build({ env: "inline" })` and `Bun.build({ env: "PREFIX_*" })` inline the environment the process started with, not the live `process.env`. A build script that runs `delete process.env.SECRET; process.env.PUBLIC_URL = url` before `Bun.build()` still ships the startup value of `SECRET` and leaves `process.env.PUBLIC_URL` as a runtime reference. `bun build --env=inline` is unaffected: no JS runs before it.
- Cause: `copy_env_for_define` (`src/bundler/defines.rs`) builds the `process.env.*` defines from the VM's dotenv `Loader` map. That map is filled once from `environ` (and `.env` files) at startup. Writes to `process.env` go to the JS object (`JSEnvironmentVariableMap.cpp`) and never reach the map, apart from the six proxy variables.

### Fix
- For `"inline"` and prefix modes, `Bun.build` copies the own enumerable entries of the live `process.env` object on the JS thread while it parses its options (`process_env_snapshot`, `src/runtime/api/JSBundler.rs`). The bundle thread hands that map to the new `Transpiler::configure_defines_with_process_env`, which builds the `process.env.*` defines from it and also reads `NODE_ENV` / `BUN_ENV` from it (the implicit `process.env.NODE_ENV` define and production detection). Every other caller passes `None` and reads the loader as before, so the CLI, Workers, `Bun.serve` HTML routes and `Bun.build` without `env` are unchanged.
- `env_string_store_put` now copies each value into the define arena instead of pointing at the source map, so the snapshot is dropped right after the defines are built.
- New C++ export `JSGlobalObject__processEnv` / Rust `JSGlobalObject::process_env()` returns `globalObject->processEnvObject()`, the object `process.execve` and Worker `env` cloning already read. On Windows that is the `process.env` Proxy, which `JSPropertyIterator` already special-cases. The hunk is byte-identical to the one in #41869, so the two merge in either order.
- Self-reviewed: 4 concerns raised, 3 addressed (accessor unified with #41869, `NODE_ENV` / `BUN_ENV` read from the same snapshot, hermetic test env). Not taken: seating the snapshot in a per-build `bun_dotenv::Loader` (#37780 / #40571's shape) instead of passing it to `configure_defines`; see Notes.
- Verified: `test/bundler/bundler_env.test.ts`. The three api-backend cases that were gated to the CLI with a TODO for exactly this now run on both backends, and a new child-process test deletes, overrides and adds variables (and sets `NODE_ENV`) before building. 4 of the 11 fail on 1.4.3, all pass with this change. Also ran `bundler_edgecase.test.ts -t "ProcessEnv|NodeEnv"`, `bundler_jsx.test.ts`, `bun-build-api.test.ts` and `bun-serve-html-entry.test.ts`.

### Background
- `env: "inline"` is shorthand for a set of `define` entries: the bundler builds one `process.env.KEY` → string-literal define per variable before any file is parsed, on the bundle thread, in `Transpiler::configure_defines`. The same step adds an implicit `process.env.NODE_ENV` define in every mode.
- The dotenv `Loader` (`src/dotenv/env_loader.rs`) is Bun's native environment map. `process.env` is a JS object created lazily from that map with one getter per key. After that the two are independent, which is why `Bun.spawn`'s default `env` and a Worker's default `env` also see the startup environment (reported separately).
- `JSBundleCompletionTask` carries the parsed `Bun.build` config from the JS thread to the process-wide bundle thread. Anything the build needs from JS has to be copied into it first, which is what the snapshot is.

<details><summary>Notes</summary>

- Not changed, deliberately: `Bun.build` without `env` (or `env: "disable"`) still takes its implicit `NODE_ENV` define from the startup environment (#35952 is about whether `"disable"` should emit it at all), and `[serve.static] env` for `Bun.serve` HTML routes still reads the loader. `Bun.spawn` / Worker default `env` are separate reports.
- With a snapshot, an explicit live `NODE_ENV` / `BUN_ENV` wins in both directions. When the live environment has neither, the implicit define falls back to the transpiler's production mode, which `run_env_loader` still initializes from the startup environment (it also drives the JSX dev/prod runtime and the `development` export condition, so the build stays consistent with itself). Moving that initialization to the live environment is left for a separate change.
- Related open PRs on the same seam: #37784 makes the same copy in `env_string_store_put`, to fix a use-after-free when a proxy variable is assigned while a define table is alive. #37780 gives each `Bun.build` its own clone of the loader for that race, and #40571 folds it into a `process.env` write-through to the env map and `environ` on POSIX. A write-through map would make the startup loader live on POSIX, but not on Windows (the Proxy does not write the map), and the bundle thread would still need a copy taken on the JS thread; that copy is what this PR adds, taken from the JS object so it is the same on every platform. #41869 adds the same `process_env()` accessor for `Bun.redis`; #34972 wants it for `Bun.spawn`.
- Why the snapshot is passed to `configure_defines` instead of replacing the build's `Loader`: the build's loader pointer also reaches the macro VM a bundler thread creates on first use and keeps for the life of the thread (`Macro::init`), so a per-build loader needs the macro-VM clone that #37780 carries. If #37780 or #40571 lands first, the snapshot moves into their per-build loader (filled from `process_env_snapshot` instead of `Loader::snapshot()` for these two modes) and `configure_defines_with_process_env` goes away; if this lands first, they rebase over a `load_defines` that already takes the map to inline from.
- `define` still loses to an inlined env value of the same key (`Define::init` inserts env defines after user defines). That predates this change and is the same on the CLI.
- `test/bundler/expectBundled.ts`: the api backend now applies a test's `env` record to `process.env` around `Bun.build()` and restores it afterwards, mirroring how the cli backend passes `env` to the child. Tests without an explicit `backend` that set `env` still resolve to the cli backend, so only `bundler_env.test.ts` and `edgecase/ProcessEnvArbitrary` take that path.
- The snapshot is not filtered by prefix: `copy_env_for_define` already filters, and `NODE_ENV` / `BUN_ENV` have to be in it either way. It is a few kilobytes and is freed before the first file is parsed.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_env.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=s
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_env.test.ts:
runtime failed file: /tmp/bun-build-tests/bun-8h1pXH/env/inline/out.js
stdout output:
barz
123z
---
expected stdout:
bar
123
---
1932 |               console.log(`---`);
1933 |               console.log(`expected ${name}:`);
1934 |               console.log(expected);
1935 |               console.log(`---`);
1936 |             }
1937 |             expect(result).toBe(expected);
                                  ^
error: expect(received).toBe(expected)

- "bar
- 123"
+ "barz
+ 123z"

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1937:28)
(fail) bundler/api > env/inline [30.68ms]
(pass) bundler/api > env/inline system [9.72ms]
(pass) bundler/api > env/disable [8.95ms]
runtime failed file: /tmp/bun-build-tests/bun-8h1pXH/env/pattern-matching/out.js
stdout output:
BAD_FOO
BAD_BAR
undefined
---
expected stdout:
public_value
another_public
undefined
---
1932 |               console.log(`---`);
1933 |               console.log(`expected ${name}:`);
1934 |               console.log(expected);
1935 |               console.log(`---`);
1936 |           
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_env.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_env.test.ts:
(pass) bundler/api > env/inline [763.25ms]
(pass) bundler/api > env/inline system [426.21ms]
(pass) bundler/api > env/disable [350.69ms]
(pass) bundler/api > env/pattern-matching [349.31ms]
(pass) bundler/api > nested-refs [465.44ms]
(pass) bundler/cli > env/inline [541.37ms]
(pass) bundler/cli > env/inline system [516.22ms]
(pass) bundler/cli > env/disable [703.89ms]
(pass) bundler/cli > env/pattern-matching [587.10ms]
(pass) bundler/cli > nested-refs [558.51ms]
(pass) Bun.build env > inlines the live process.env [416.25ms]

 11 pass
 0 fail
 13 expect() calls
Ran 11 tests across 1 file. [8.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 678ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/pico
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/defines.rs                       |  13 +--
 src/bundler/options.rs                       |  39 +++----
 src/bundler/transpiler.rs                    |  21 +++-
 src/dotenv/env_loader.rs                     |   2 +-
 src/jsc/JSGlobalObject.rs                    |   7 ++
 src/jsc/bindings/ZigGlobalObject.cpp         |  11 ++
 src/runtime/api/JSBundler.rs                 |  49 +++++++-
 src/runtime/api/js_bundle_completion_task.rs |   4 +-
 test/bundler/bundler_env.test.ts             | 167 +++++++++++++++++----------
 test/bundler/expectBundled.ts                |  19 +++
 10 files changed, 226 insertions(+), 106 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/bundler/defines.rs                            2      6     15
src/bundler/options.rs                            8     13     15
src/bundler/transpiler.rs                         4      7     15
src/dotenv/env_loader.rs                          4      2     15
src/jsc/JSGlobalObject.rs                         4      3     15
src/jsc/bindings/ZigGlobalObject.cpp              1      1     15
src/runtime/api/JSBundler.rs                      9     12     15
src/runtime/api/js_bundle_completion_task.rs      3      2     15
test/bundler/bundler_env.test.ts                  4      5     15
test/bundler/expectBundled.ts                     3      2     21
```

</details>

**root cause** · written by the author bot

Bun.build read environment variables for `env: "inline"` and prefix-based defines from the env loader map, which is a snapshot captured at process startup, so any `process.env` writes or deletions performed by JS before the build were invisible to the bundler and stale values were inlined. The fix exposes the live `process.env` object through a new C binding and Rust accessor, and has `Bun.build` snapshot eligible values from it at call time, copying them into arena storage for the define configuration. Defines now reflect the environment as it exists when the build runs, and the bundler te…

<!-- robobun:evidence:end -->