### PR TITLE
node:fs: reject a non-string, non-object options argument like node

### DIFF
--- a/src/js/internal/fs/watch.ts
+++ b/src/js/internal/fs/watch.ts
@@ -149,6 +149,8 @@ class FSWatcher extends EventEmitter {
       options = {};
     } else if (typeof options === "string") {
       options = { encoding: options };
+    } else if (options != null && typeof options !== "object") {
+      throw $ERR_INVALID_ARG_TYPE("options", ["string", "Object"], options);
     }
 
     if (typeof listener !== "function") {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -457,9 +457,11 @@ function asyncWrap(fn: any, name: string) {
       if (options == null || typeof options === "function") {
       } else if (typeof options === "string") {
         encoding = options;
+      } else if (typeof options === "object") {
+        encoding = options.encoding ?? encoding;
+        flush = options.flush ?? flush;
       } else {
-        encoding = options?.encoding ?? encoding;
-        flush = options?.flush ?? flush;
+        throw $ERR_INVALID_ARG_TYPE("options", ["string", "Object"], options);
       }
 
       try {
@@ -686,9 +688,11 @@ function asyncWrap(fn: any, name: string) {
       if (options == null || typeof options === "function") {
       } else if (typeof options === "string") {
         encoding = options;
+      } else if (typeof options === "object") {
+        encoding = options.encoding ?? encoding;
+        signal = options.signal ?? undefined;
       } else {
-        encoding = options?.encoding ?? encoding;
-        signal = options?.signal ?? undefined;
+        throw $ERR_INVALID_ARG_TYPE("options", ["string", "Object"], options);
       }
 
       try {
@@ -1614,10 +1618,16 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
     if (signal?.aborted) {
       throw $makeAbortError(undefined, { cause: signal.reason });
     }
-  } else if (typeof optionsOrEncoding === "string" || optionsOrEncoding == null) {
-    encoding = optionsOrEncoding || "utf8";
+  } else if (
+    typeof optionsOrEncoding === "string" ||
+    optionsOrEncoding == null ||
+    typeof optionsOrEncoding === "function"
+  ) {
+    encoding = (typeof optionsOrEncoding === "string" && optionsOrEncoding) || "utf8";
     flag ??= "w";
     mode ??= 0o666;
+  } else {
+    throw $ERR_INVALID_ARG_TYPE("options", ["string", "Object"], optionsOrEncoding);
   }
 
   if (!Buffer.isEncoding(encoding)) {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -690,20 +690,23 @@ function encodeRealpathResult(result, encoding) {
 }
 
 let assertEncodingForWindows: any = undefined;
+/** `getOptions(options).encoding` for the win32 JS ports of realpath below. */
+function realpathEncodingOption(options): string | undefined {
+  let encoding;
+  if (options == null || typeof options === "function") return undefined;
+  if (typeof options === "string") encoding = options;
+  else if (typeof options === "object") encoding = options.encoding;
+  else throw $ERR_INVALID_ARG_TYPE("options", ["string", "Object"], options);
+  if (encoding) {
+    (assertEncodingForWindows ??= $newRustFunction("runtime/node/types.rs", "jsAssertEncodingValid", 1))(encoding);
+  }
+  return encoding;
+}
 const realpathSync: typeof import("node:fs").realpathSync =
   process.platform !== "win32"
     ? (fs.realpathSync.bind(fs) as any)
     : function realpathSync(p, options) {
-        let encoding;
-        if (options) {
-          if (typeof options === "string") encoding = options;
-          else encoding = options?.encoding;
-          if (encoding) {
-            (assertEncodingForWindows ?? $newRustFunction("runtime/node/types.rs", "jsAssertEncodingValid", 1))(
-              encoding,
-            );
-          }
-        }
+        const encoding = realpathEncodingOption(options);
         // This function is ported 1:1 from node.js, to emulate how it is unable to
         // resolve subst drives to their underlying location. The native call is
         // able to see through that.
@@ -817,16 +820,7 @@ const realpath: typeof import("node:fs").realpath =
           options = undefined;
         }
         callback = ensureCallback(callback);
-        let encoding;
-        if (options) {
-          if (typeof options === "string") encoding = options;
-          else encoding = options?.encoding;
-          if (encoding) {
-            (assertEncodingForWindows ?? $newRustFunction("runtime/node/types.rs", "jsAssertEncodingValid", 1))(
-              encoding,
-            );
-          }
-        }
+        const encoding = realpathEncodingOption(options);
         if (p instanceof URL) {
           const pathname = p.pathname;
           if (pathname.indexOf("%00") != -1) {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -1079,11 +1079,10 @@ class Dir {
   constructor(handle, path: PathLike, options, validated?) {
     if ($isUndefinedOrNull(handle)) throw $ERR_MISSING_ARGS("handle");
     validateInteger(handle, "handle", 0);
-    if (options != null && typeof options !== "object" && typeof options !== "string") {
-      throw $ERR_INVALID_ARG_TYPE("options", "object", options);
-    }
-    // node's getOptions: a string is encoding shorthand
-    if (typeof options === "string") options = { encoding: options };
+    // node's getOptions: a string is encoding shorthand, a function means no options
+    if (options == null || typeof options === "function") options = undefined;
+    else if (typeof options === "string") options = { encoding: options };
+    else if (typeof options !== "object") throw $ERR_INVALID_ARG_TYPE("options", ["string", "Object"], options);
     const encoding = options?.encoding;
     if (encoding != null && encoding !== "buffer" && !Buffer.isEncoding(encoding)) {
       throw $ERR_INVALID_ARG_VALUE("encoding", encoding, "is invalid encoding");

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3131,10 +3131,16 @@ pub mod args {
         Ok(default)
     }
 
+    /// Node's `getOptions()`: the `options` slot takes a string (encoding
+    /// shorthand), an object, `null`/`undefined`, or a function (a callback that
+    /// the JS wrapper already peeled off). Anything else is `ERR_INVALID_ARG_TYPE`.
+    fn throw_invalid_options_type(ctx: &JSGlobalObject, value: JSValue) -> bun_jsc::JsError {
+        ctx.throw_invalid_argument_type_value_one_of(b"options", b"string or object", value)
+    }
+
     /// Consume the next positional argument as a Node.js fs `encoding` option.
     /// Accepts either an encoding string (`"utf8"`, `"buffer"`, ...) or an options
-    /// object with an `.encoding` property. Any other value (including `undefined`
-    /// / `null` / numbers / functions) is silently ignored and `default` is returned.
+    /// object with an `.encoding` property, per `getOptions()`.
     /// Shared by `Readlink`/`Realpath`/`MkdirTemp::from_js`.
     fn parse_encoding_arg(
         ctx: &JSGlobalObject,
@@ -3153,6 +3159,8 @@ pub mod args {
                 _ => {
                     if val.is_object() {
                         encoding = get_encoding(val, ctx, encoding)?;
+                    } else if !val.is_undefined_or_null() {
+                        return Err(throw_invalid_options_type(ctx, val));
                     }
                 }
             }
@@ -3403,6 +3411,8 @@ pub mod args {
                             if let Some(w) = val.get_boolean_strict(ctx, "withFileTypes")? {
                                 with_file_types = w;
                             }
+                        } else if !val.is_undefined_or_null() {
+                            return Err(throw_invalid_options_type(ctx, val));
                         }
                     }
                 }
@@ -3961,6 +3971,8 @@ pub mod args {
                             ));
                         }
                     }
+                } else if !arg.is_undefined_or_null() {
+                    return Err(throw_invalid_options_type(ctx, arg));
                 }
             }
             let abort_signal = scopeguard::ScopeGuard::into_inner(abort_signal);
@@ -4065,6 +4077,8 @@ pub mod args {
                             );
                         }
                     }
+                } else if !arg.is_undefined_or_null() {
+                    return Err(throw_invalid_options_type(ctx, arg));
                 }
             }
             let flavor = if arguments.will_be_async {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3131,9 +3131,7 @@ pub mod args {
         Ok(default)
     }
 
-    /// Node's `getOptions()`: the `options` slot takes a string (encoding
-    /// shorthand), an object, `null`/`undefined`, or a function (a callback that
-    /// the JS wrapper already peeled off). Anything else is `ERR_INVALID_ARG_TYPE`.
+    /// Node's `getOptions()` rejects an `options` value that is not a string, object, nullish, or function.
     fn throw_invalid_options_type(ctx: &JSGlobalObject, value: JSValue) -> bun_jsc::JsError {
         ctx.throw_invalid_argument_type_value_one_of(b"options", b"string or object", value)
     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3155,6 +3155,95 @@ describe("writeFile/appendFile data argument", () => {
   });
 });
 
+describe("fs options argument", () => {
+  // Node's getOptions(): the `options` slot is a string (encoding shorthand), an
+  // object, null/undefined, or a function (a callback). Anything else throws.
+  // A positional mode like `writeFileSync(p, data, 0o600)` must not silently
+  // write a 0o644 file.
+  const message = (received: string) =>
+    `The "options" argument must be one of type string or object. Received ${received}`;
+  const bad: [unknown, string][] = [
+    [0o600, "type number (384)"],
+    [0, "type number (0)"],
+    [true, "type boolean (true)"],
+    [false, "type boolean (false)"],
+    [Symbol("s"), "type symbol (Symbol(s))"],
+    [5n, "type bigint (5n)"],
+  ];
+
+  it("sync and callback forms throw ERR_INVALID_ARG_TYPE for a non-string, non-object options value", () => {
+    using dir = tempDir("fs-options-type", { "existing.txt": "x" });
+    const file = (name: string) => join(String(dir), name);
+    const existing = file("existing.txt");
+    const cb = () => {};
+
+    for (const [value, received] of bad) {
+      const opts = value as any;
+      const expected = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message: message(received) });
+      expect(() => writeFileSync(file("write-sync.txt"), "KEY", opts)).toThrow(expected);
+      expect(() => fs.appendFileSync(file("append-sync.txt"), "KEY", opts)).toThrow(expected);
+      expect(() => fs.writeFile(file("write-cb.txt"), "KEY", opts, cb)).toThrow(expected);
+      expect(() => fs.appendFile(file("append-cb.txt"), "KEY", opts, cb)).toThrow(expected);
+      expect(() => readFileSync(existing, opts)).toThrow(expected);
+      expect(() => fs.readFile(existing, opts, cb)).toThrow(expected);
+      expect(() => readdirSync(String(dir), opts)).toThrow(expected);
+      expect(() => fs.readdir(String(dir), opts, cb)).toThrow(expected);
+      expect(() => readlinkSync(existing, opts)).toThrow(expected);
+      expect(() => fs.readlink(existing, opts, cb)).toThrow(expected);
+      expect(() => realpathSync(existing, opts)).toThrow(expected);
+      expect(() => fs.realpath(existing, opts, cb)).toThrow(expected);
+      expect(() => realpathSync.native(existing, opts)).toThrow(expected);
+      expect(() => fs.realpath.native(existing, opts, cb)).toThrow(expected);
+      expect(() => mkdtempSync(file("mkdtemp-"), opts)).toThrow(expected);
+      expect(() => fs.mkdtemp(file("mkdtemp-"), opts, cb)).toThrow(expected);
+      expect(() => fs.watch(String(dir), opts)).toThrow(expected);
+    }
+
+    // Nothing got written, and the valid forms still work.
+    expect(readdirSync(String(dir)).sort()).toEqual(["existing.txt"]);
+    writeFileSync(file("null.txt"), "a", null);
+    writeFileSync(file("undefined.txt"), "b", undefined);
+    writeFileSync(file("string.txt"), "c", "utf8");
+    writeFileSync(file("object.txt"), "d", { mode: 0o600 });
+    expect(readFileSync(file("null.txt"), null)).toEqual(Buffer.from("a"));
+    expect(readFileSync(file("string.txt"), "utf8")).toBe("c");
+    expect(readFileSync(file("object.txt"), { encoding: "utf8" })).toBe("d");
+    if (!isWindows) {
+      expect(statSync(file("object.txt")).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("fs.promises and FileHandle forms reject with ERR_INVALID_ARG_TYPE", async () => {
+    using dir = tempDir("fs-options-type-promises", { "existing.txt": "x" });
+    const file = (name: string) => join(String(dir), name);
+    const existing = file("existing.txt");
+
+    const fh = await _promises.open(existing, "r+");
+    try {
+      for (const [value, received] of bad) {
+        const opts = value as any;
+        const expected = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message: message(received) });
+        // These are async functions, so the error is a rejection, like node.
+        await expect(_promises.writeFile(file("write.txt"), "KEY", opts)).rejects.toThrow(expected);
+        await expect(_promises.writeFile(file("write-iter.txt"), ["KEY"], opts)).rejects.toThrow(expected);
+        await expect(_promises.appendFile(file("append.txt"), "KEY", opts)).rejects.toThrow(expected);
+        await expect(_promises.readFile(existing, opts)).rejects.toThrow(expected);
+        await expect(_promises.readdir(String(dir), opts)).rejects.toThrow(expected);
+        await expect(_promises.readlink(existing, opts)).rejects.toThrow(expected);
+        await expect(_promises.realpath(existing, opts)).rejects.toThrow(expected);
+        await expect(_promises.mkdtemp(file("mkdtemp-"), opts)).rejects.toThrow(expected);
+        await expect(fh.readFile(opts)).rejects.toThrow(expected);
+        await expect(fh.writeFile("KEY", opts)).rejects.toThrow(expected);
+        await expect(fh.appendFile("KEY", opts)).rejects.toThrow(expected);
+      }
+    } finally {
+      await fh.close();
+    }
+    expect(readdirSync(String(dir)).sort()).toEqual(["existing.txt"]);
+    expect(readFileSync(existing, "utf8")).toBe("x");
+  });
+});
+
 function triggerDOMJIT(target: fs.Stats, fn: (..._: any[]) => any, result: any) {
   for (let i = 0; i < 9999; i++) {
     if (fn.apply(target) !== result) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3197,6 +3197,8 @@ describe("fs options argument", () => {
       expect(() => mkdtempSync(file("mkdtemp-"), opts)).toThrow(expected);
       expect(() => fs.mkdtemp(file("mkdtemp-"), opts, cb)).toThrow(expected);
       expect(() => fs.watch(String(dir), opts)).toThrow(expected);
+      expect(() => fs.opendirSync(String(dir), opts)).toThrow(expected);
+      expect(() => fs.opendir(String(dir), opts, cb)).toThrow(expected);
     }
 
     // Nothing got written, and the valid forms still work.
@@ -3211,6 +3213,9 @@ describe("fs options argument", () => {
     if (!isWindows) {
       expect(statSync(file("object.txt")).mode & 0o777).toBe(0o600);
     }
+    // A function in the options slot means "no options", like in node's getOptions().
+    expect(readFileSync(file("string.txt"), cb as any)).toEqual(Buffer.from("c"));
+    fs.opendirSync(String(dir), cb as any).closeSync();
   });
 
   it("fs.promises and FileHandle forms reject with ERR_INVALID_ARG_TYPE", async () => {
@@ -3235,6 +3240,7 @@ describe("fs options argument", () => {
         await expect(fh.readFile(opts)).rejects.toThrow(expected);
         await expect(fh.writeFile("KEY", opts)).rejects.toThrow(expected);
         await expect(fh.appendFile("KEY", opts)).rejects.toThrow(expected);
+        await expect(_promises.opendir(String(dir), opts)).rejects.toThrow(expected);
       }
     } finally {
       await fh.close();


### PR DESCRIPTION
### Problem
- `fs.writeFileSync(path, "KEY", 0o600)` writes a `0o644` file. Bun treats any `options` value that is not a string or an object as "no options". Node throws `ERR_INVALID_ARG_TYPE: The "options" argument must be one of type string or object. Received type number (384)` from `getOptions()` (`lib/internal/fs/utils.js`).
- The same hole exists in every fs entry point that takes `options: string | object`: `readFile`, `writeFile`, `appendFile`, `readdir`, `readlink`, `realpath`, `mkdtemp`, `watch` (sync, callback and `fs.promises` forms) and `FileHandle#readFile/writeFile/appendFile`. The native parsers in `src/runtime/node/node_fs.rs` (`parse_encoding_arg`, `Readdir::from_js`, `ReadFile::from_js`, `WriteFile::from_js_with_default_flag`) had no `else` branch for a non-object, and the JS wrappers in `fs.promises.ts`, `internal/fs/watch.ts` and the win32 `realpath` port swallowed it too.

### Fix
- Each of those parsers now throws `ERR_INVALID_ARG_TYPE` with node's message when `options` is not a string, an object, `null`/`undefined`, or a function. A function stays accepted because the callback wrappers (`fs.readFile(path, cb)`) leave the callback in that slot, as node's `getOptions()` does. `opendir`/`opendirSync`/`Dir` get the same contract: they already threw, but with a different message, and rejected a function.
- `fs.promises.writeFile` with iterable data and a bad `options` now rejects with the same error instead of `Unknown encoding: undefined`.
- Self-reviewed: 2 concerns raised, 2 addressed (the `opendir` contract above, and the notes below no longer claim it already matched).
- Verified: `test/js/node/fs/fs.test.ts` (`fs options argument`, two tests, both fail on canary). Also the rest of `fs.test.ts`, `promises.test.js`, `dir.test.ts`, `fs.watch.test.ts`, `fs-promises-writeFile-async-iterator.test.ts` and 54 `test-fs-*` node parallel tests.

### Background
- Node routes the `options` argument of these functions through one helper, `getOptions(options, defaults)`. It returns the defaults for `null`, `undefined` or a function, turns a string into `{ encoding }`, uses an object as is, and throws for anything else. So `fs.mkdirSync(p, 0o700)` and `fs.openSync(p, "w", 0o600)` take a positional mode, but `writeFileSync(p, data, 0o600)` does not. Under Bun that last call silently produced a world-readable file.
- Bun already enforced this contract on `rm`, `cp`, `createReadStream`/`createWriteStream` (`getStreamOptions`) and `glob`. The functions above were the remaining lenient ones.
- In `node_fs.rs`, `JSValue::is_object()` is true for functions (`JSType >= Object`), so the new `else` branches only see primitives: numbers, booleans, symbols and bigints.

<details><summary>Notes</summary>

Repro matrix (bun canary `f42e98025` before, this branch after, node v26.3.0):

```
writeFileSync(p,'KEY',0o600)        before: ACCEPTED, mode 644   after/node: ERR_INVALID_ARG_TYPE
appendFileSync(p,'KEY',0o600)       before: ACCEPTED, mode 644   after/node: ERR_INVALID_ARG_TYPE
promises.writeFile(p,'KEY',0o600)   before: ACCEPTED, mode 644   after/node: ERR_INVALID_ARG_TYPE (rejection)
promises.appendFile(p,'KEY',0o600)  before: ACCEPTED, mode 644   after/node: ERR_INVALID_ARG_TYPE (rejection)
writeFile(p,'KEY',0o600,cb)         before: ACCEPTED, mode 644   after/node: ERR_INVALID_ARG_TYPE (sync throw)
appendFile(p,'KEY',0o600,cb)        before: ACCEPTED, mode 644   after/node: ERR_INVALID_ARG_TYPE (sync throw)
writeFileSync(p,'KEY',true|Symbol()|5n)  before: ACCEPTED        after/node: ERR_INVALID_ARG_TYPE
writeFileSync(p,'KEY',null|undefined|'utf8'|()=>{})  ACCEPTED everywhere
readFileSync(p|fd, 5), readFile(p, 5, cb), promises.readFile(p, 5)  before: Buffer  after/node: ERR_INVALID_ARG_TYPE
fh.readFile(5), fh.writeFile('X', 5), fh.appendFile('X', 5)          before: ok      after/node: ERR_INVALID_ARG_TYPE
readdirSync(D, 5|true), realpathSync(D, 5), mkdtempSync(D+'/x-', 5)  before: ok      after/node: ERR_INVALID_ARG_TYPE
readlinkSync(f, 5)                  before: EINVAL               after/node: ERR_INVALID_ARG_TYPE
watch(D, 5)                         before: TypeError 'Expected "listener" callback to be a function'  after/node: ERR_INVALID_ARG_TYPE
opendirSync(D, 5)                   before: ERR_INVALID_ARG_TYPE 'must be of type object'  after/node: 'must be one of type string or object'
opendirSync(D, ()=>{})              before: ERR_INVALID_ARG_TYPE  after/node: accepted (defaults)
```

Not changed: `fs.promises.watch`. Node uses `validateObject` there (a string is rejected too), which is a different contract from `getOptions`; Bun throws a `TypeError` about the listener for a number today. `createReadStream`/`createWriteStream` already match node through `getStreamOptions`.

The JS side now has the `getOptions` discrimination in a handful of places (`getStreamOptions`, `FSWatcher`, `Dir`, the two `FileHandle` writers, the iterable `writeFile` path, the win32 `realpath` helper). Folding them into one `getOptions(options, defaults)` in `internal/validators` is a reasonable follow-up. It is not in this PR to keep the diff to the behavior change.

Two pre-existing slow tests in `fs.test.ts` (`stat > async calls do not keep a Buffer path alive`, `readdirSync(path, {recursive: true}) x 100`) time out under the full debug+ASAN run in this container and pass in isolation. `abort-signal-leak-read-write-file.test.ts` (100k iterations) also exceeds its 300 s budget under debug+ASAN here; a 5k-iteration copy of the fixture passes.

</details>
