### PR TITLE
Resolve relative imports of a module imported with a ?query that contains a slash

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4517,9 +4517,7 @@ impl VirtualMachine {
         let top_level_dir = self.top_level_dir();
         let source_to_use: &[u8] = if !is_special_source {
             if is_a_file_path {
-                // `source` is the referrer's module key, `<path>?query` when the
-                // referrer was imported with a query. The directory is that of
-                // `<path>`: a `/` inside the query is not a path separator.
+                // `source` is the referrer's module key, which may be `<path>?query`.
                 let mut source_query: &[u8] = b"";
                 let source_path = normalize_specifier_for_resolution(source, &mut source_query);
                 // SAFETY: PORT — `dir_with_trailing_slash()` returns a

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4517,13 +4517,18 @@ impl VirtualMachine {
         let top_level_dir = self.top_level_dir();
         let source_to_use: &[u8] = if !is_special_source {
             if is_a_file_path {
+                // `source` is the referrer's module key, `<path>?query` when the
+                // referrer was imported with a query. The directory is that of
+                // `<path>`: a `/` inside the query is not a path separator.
+                let mut source_query: &[u8] = b"";
+                let source_path = normalize_specifier_for_resolution(source, &mut source_query);
                 // SAFETY: PORT — `dir_with_trailing_slash()` returns a
                 // re-slice of `source`, which the caller guarantees outlives
                 // the resolve call (and the resolver only borrows it for the
                 // synchronous `resolve_and_auto_install`).
                 unsafe {
                     bun_ptr::detach_lifetime(
-                        bun_resolver::fs::PathName::init(source).dir_with_trailing_slash(),
+                        bun_resolver::fs::PathName::init(source_path).dir_with_trailing_slash(),
                     )
                 }
             } else {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4518,8 +4518,7 @@ impl VirtualMachine {
         let source_to_use: &[u8] = if !is_special_source {
             if is_a_file_path {
                 // `source` is the referrer's module key, which may be `<path>?query`.
-                let mut source_query: &[u8] = b"";
-                let source_path = normalize_specifier_for_resolution(source, &mut source_query);
+                let source_path = crate::resolver_jsc::module_key_without_query(source);
                 // SAFETY: PORT — `dir_with_trailing_slash()` returns a
                 // re-slice of `source`, which the caller guarantees outlives
                 // the resolve call (and the resolver only borrows it for the

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -917,7 +917,9 @@ JSCommonJSModule* JSCommonJSModule::create(
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto key = requireMapKey->value(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    auto index = key->reverseFind(PLATFORM_SEP, key->length());
+    // The key may be `<path>?query`; the directory is that of `<path>`.
+    auto queryStart = key->find('?');
+    auto index = key->reverseFind(PLATFORM_SEP, queryStart == WTF::notFound ? key->length() : queryStart);
 
     JSString* dirname;
     if (index != WTF::notFound) {

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -917,9 +917,7 @@ JSCommonJSModule* JSCommonJSModule::create(
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto key = requireMapKey->value(globalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    // The key may be `<path>?query`; the directory is that of `<path>`.
-    auto queryStart = key->find('?');
-    auto index = key->reverseFind(PLATFORM_SEP, queryStart == WTF::notFound ? key->length() : queryStart);
+    auto index = key->reverseFind(PLATFORM_SEP, moduleKeyPathLength(key));
 
     JSString* dirname;
     if (index != WTF::notFound) {

--- a/src/jsc/bindings/PathInlines.h
+++ b/src/jsc/bindings/PathInlines.h
@@ -52,6 +52,20 @@ ALWAYS_INLINE bool isAbsolutePath(WTF::String input)
 #endif
 }
 
+/// Length of the `<path>` of a module key, which is `<path>?query` when the
+/// module was imported with a query. A Windows `\\?\` or `\\.\` device prefix
+/// is path. Keep in sync with `module_key_without_query` (resolver_jsc.rs).
+ALWAYS_INLINE unsigned moduleKeyPathLength(const WTF::String& key)
+{
+    unsigned start = 0;
+#if OS(WINDOWS)
+    if (key.length() >= 4 && IS_SLASH(key[0]) && IS_SLASH(key[1]) && (key[2] == '?' || key[2] == '.') && IS_SLASH(key[3]))
+        start = 4;
+#endif
+    size_t queryStart = key.find('?', start);
+    return queryStart == WTF::notFound ? key.length() : static_cast<unsigned>(queryStart);
+}
+
 #undef IS_LETTER
 #undef IS_SLASH
 

--- a/src/jsc/bindings/PathInlines.h
+++ b/src/jsc/bindings/PathInlines.h
@@ -52,16 +52,16 @@ ALWAYS_INLINE bool isAbsolutePath(WTF::String input)
 #endif
 }
 
-/// Length of the `<path>` of a `<path>?query` module key. A Windows `\\?\` or `\\.\` device
-/// prefix is path. Keep in sync with `module_key_without_query` (resolver_jsc.rs).
+/// Length of the `<path>` of a `<path>?query` module key. Twin of `module_key_without_query` (resolver_jsc.rs).
 ALWAYS_INLINE unsigned moduleKeyPathLength(const WTF::String& key)
 {
-    unsigned start = 0;
+    unsigned devicePrefixLength = 0;
 #if OS(WINDOWS)
+    // `\\?\C:\...` and `\\.\...` are paths, not queries.
     if (key.length() >= 4 && IS_SLASH(key[0]) && IS_SLASH(key[1]) && (key[2] == '?' || key[2] == '.') && IS_SLASH(key[3]))
-        start = 4;
+        devicePrefixLength = 4;
 #endif
-    size_t queryStart = key.find('?', start);
+    size_t queryStart = key.find('?', devicePrefixLength);
     return queryStart == WTF::notFound ? key.length() : static_cast<unsigned>(queryStart);
 }
 

--- a/src/jsc/bindings/PathInlines.h
+++ b/src/jsc/bindings/PathInlines.h
@@ -52,9 +52,8 @@ ALWAYS_INLINE bool isAbsolutePath(WTF::String input)
 #endif
 }
 
-/// Length of the `<path>` of a module key, which is `<path>?query` when the
-/// module was imported with a query. A Windows `\\?\` or `\\.\` device prefix
-/// is path. Keep in sync with `module_key_without_query` (resolver_jsc.rs).
+/// Length of the `<path>` of a `<path>?query` module key. A Windows `\\?\` or `\\.\` device
+/// prefix is path. Keep in sync with `module_key_without_query` (resolver_jsc.rs).
 ALWAYS_INLINE unsigned moduleKeyPathLength(const WTF::String& key)
 {
     unsigned start = 0;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -529,12 +529,11 @@ JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String reques
     JSValue dirname;
     if (parent.filename) {
         JSString* filename = parent.filename;
-        // The filename is a module key, which may be `<path>?query`.
-        auto filenameView = filename->value(globalObject);
+        auto filenameValue = filename->value(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        auto queryStart = filenameView->find('?');
-        if (queryStart != WTF::notFound) {
-            filename = JSC::jsSubstring(globalObject, filename, 0, queryStart);
+        unsigned pathLength = moduleKeyPathLength(filenameValue);
+        if (pathLength != filenameValue->length()) {
+            filename = JSC::jsSubstring(globalObject, filename, 0, pathLength);
             RETURN_IF_EXCEPTION(scope, {});
         }
         EncodedJSValue encodedFilename = JSValue::encode(filename);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -528,7 +528,16 @@ JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String reques
 
     JSValue dirname;
     if (parent.filename) {
-        EncodedJSValue encodedFilename = JSValue::encode(parent.filename);
+        JSString* filename = parent.filename;
+        // The filename is a module key, which may be `<path>?query`.
+        auto filenameView = filename->value(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto queryStart = filenameView->find('?');
+        if (queryStart != WTF::notFound) {
+            filename = JSC::jsSubstring(globalObject, filename, 0, queryStart);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+        EncodedJSValue encodedFilename = JSValue::encode(filename);
 #if OS(WINDOWS)
         dirname = JSValue::decode(
             Bun__Path__dirname(globalObject, true, &encodedFilename, 1));

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -29,9 +29,8 @@ extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObject) -> JSVa
     node_module_paths_js_value(&BunString::static_("."), global, false)
 }
 
-/// The `<path>` of a module key, which is `<path>?query` when the module was
-/// imported with a query. A Windows `\\?\` or `\\.\` device prefix is path.
-/// Keep in sync with `moduleKeyPathLength` (PathInlines.h).
+/// The `<path>` of a `<path>?query` module key. A Windows `\\?\` or `\\.\` device
+/// prefix is path. Keep in sync with `moduleKeyPathLength` (PathInlines.h).
 pub fn module_key_without_query(key: &[u8]) -> &[u8] {
     let start = if cfg!(windows)
         && key.len() >= 4

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -40,7 +40,12 @@ extern "C" fn node_module_paths_js_value(
 
     let utf8 = in_str.to_utf8();
     let base_path: &[u8] = if use_dirname {
-        resolve_path::dirname::<bun_paths::platform::Auto>(utf8.slice())
+        // `in_str` is a module key, which may be `<path>?query`.
+        let path = match strings::index_of_char_usize(utf8.slice(), b'?') {
+            Some(query_start) => &utf8.slice()[..query_start],
+            None => utf8.slice(),
+        };
+        resolve_path::dirname::<bun_paths::platform::Auto>(path)
     } else {
         utf8.slice()
     };

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -29,6 +29,27 @@ extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObject) -> JSVa
     node_module_paths_js_value(&BunString::static_("."), global, false)
 }
 
+/// The `<path>` of a module key, which is `<path>?query` when the module was
+/// imported with a query. A Windows `\\?\` or `\\.\` device prefix is path.
+/// Keep in sync with `moduleKeyPathLength` (PathInlines.h).
+pub fn module_key_without_query(key: &[u8]) -> &[u8] {
+    let start = if cfg!(windows)
+        && key.len() >= 4
+        && bun_paths::is_sep_any(key[0])
+        && bun_paths::is_sep_any(key[1])
+        && (key[2] == b'?' || key[2] == b'.')
+        && bun_paths::is_sep_any(key[3])
+    {
+        4
+    } else {
+        0
+    };
+    match strings::index_of_char_usize(&key[start..], b'?') {
+        Some(query_start) => &key[..start + query_start],
+        None => key,
+    }
+}
+
 // C++ callers pass a borrowed `const BunString*` (`Bun::toString`).
 #[unsafe(export_name = "Resolver__nodeModulePathsJSValue")]
 extern "C" fn node_module_paths_js_value(
@@ -40,12 +61,7 @@ extern "C" fn node_module_paths_js_value(
 
     let utf8 = in_str.to_utf8();
     let base_path: &[u8] = if use_dirname {
-        // `in_str` is a module key, which may be `<path>?query`.
-        let path = match strings::index_of_char_usize(utf8.slice(), b'?') {
-            Some(query_start) => &utf8.slice()[..query_start],
-            None => utf8.slice(),
-        };
-        resolve_path::dirname::<bun_paths::platform::Auto>(path)
+        resolve_path::dirname::<bun_paths::platform::Auto>(module_key_without_query(utf8.slice()))
     } else {
         utf8.slice()
     };

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -29,10 +29,10 @@ extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObject) -> JSVa
     node_module_paths_js_value(&BunString::static_("."), global, false)
 }
 
-/// The `<path>` of a `<path>?query` module key. A Windows `\\?\` or `\\.\` device
-/// prefix is path. Keep in sync with `moduleKeyPathLength` (PathInlines.h).
+/// The `<path>` of a `<path>?query` module key. Twin of `moduleKeyPathLength` (PathInlines.h).
 pub fn module_key_without_query(key: &[u8]) -> &[u8] {
-    let start = if cfg!(windows)
+    // `\\?\C:\...` and `\\.\...` are paths, not queries.
+    let device_prefix_len = if cfg!(windows)
         && key.len() >= 4
         && bun_paths::is_sep_any(key[0])
         && bun_paths::is_sep_any(key[1])
@@ -43,8 +43,8 @@ pub fn module_key_without_query(key: &[u8]) -> &[u8] {
     } else {
         0
     };
-    match strings::index_of_char_usize(&key[start..], b'?') {
-        Some(query_start) => &key[..start + query_start],
+    match strings::index_of_char_usize(&key[device_prefix_len..], b'?') {
+        Some(query_start) => &key[..device_prefix_len + query_start],
         None => key,
     }
 }

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -274,39 +274,24 @@ test.concurrent("static imports inside a module imported with a ?query containin
 
 // Same for a CommonJS module: its key is the referrer for `require()`, and
 // `__dirname`, `module.paths` and `require.resolve.paths()` derive from it.
-test.concurrent("require() inside a CommonJS module loaded with a ?query containing / resolves", async () => {
-  using dir = tempDir("import-query-slash-referrer-cjs", {
-    "sub/b.cjs": `module.exports = { b: 42 };`,
-    "a.cjs": `
-      const path = require("node:path");
-      module.exports = {
-        b: require("./sub/b.cjs").b,
-        resolved: path.relative(__dirname, require.resolve("./sub/b.cjs")).replaceAll(path.sep, "/"),
-        dirname: path.basename(__dirname),
-        paths0: path.basename(path.dirname(module.paths[0])) + "/" + path.basename(module.paths[0]),
-        lookupRelative: path.basename(require.resolve.paths("./sub/b.cjs")[0]),
-        lookupBare: path.basename(path.dirname(require.resolve.paths("pkg")[0])) + "/" + path.basename(require.resolve.paths("pkg")[0]),
-      };
-    `,
-    "entry.mjs": `
-      const viaImport = (await import("./a.cjs?path=/x/y")).default;
-      console.log(JSON.stringify({ viaImport }));
-    `,
-    "entry.cjs": `
-      const viaRequire = require("./a.cjs?path=/x/y");
-      console.log(JSON.stringify({ viaRequire }));
-    `,
-  });
-  const dirName = basename(String(dir));
-  const expected = {
-    b: 42,
-    resolved: "sub/b.cjs",
-    dirname: dirName,
-    paths0: dirName + "/node_modules",
-    lookupRelative: dirName,
-    lookupBare: dirName + "/node_modules",
-  };
-  for (const entry of ["entry.mjs", "entry.cjs"]) {
+for (const entry of ["entry.mjs", "entry.cjs"]) {
+  test.concurrent(`require() inside a CommonJS module loaded with a ?query containing / resolves (${entry})`, async () => {
+    using dir = tempDir("import-query-slash-referrer-cjs", {
+      "sub/b.cjs": `module.exports = { b: 42 };`,
+      "a.cjs": `
+        const path = require("node:path");
+        module.exports = {
+          b: require("./sub/b.cjs").b,
+          resolved: path.relative(__dirname, require.resolve("./sub/b.cjs")).replaceAll(path.sep, "/"),
+          dirname: path.basename(__dirname),
+          paths0: path.basename(path.dirname(module.paths[0])) + "/" + path.basename(module.paths[0]),
+          lookupRelative: path.basename(require.resolve.paths("./sub/b.cjs")[0]),
+          lookupBare: path.basename(path.dirname(require.resolve.paths("pkg")[0])) + "/" + path.basename(require.resolve.paths("pkg")[0]),
+        };
+      `,
+      "entry.mjs": `console.log(JSON.stringify((await import("./a.cjs?path=/x/y")).default));`,
+      "entry.cjs": `console.log(JSON.stringify(require("./a.cjs?path=/x/y")));`,
+    });
     await using proc = Bun.spawn({
       cmd: [bunExe(), entry],
       env: bunEnv,
@@ -316,7 +301,15 @@ test.concurrent("require() inside a CommonJS module loaded with a ?query contain
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ [entry === "entry.mjs" ? "viaImport" : "viaRequire"]: expected });
+    const dirName = basename(String(dir));
+    expect(JSON.parse(stdout.trim())).toEqual({
+      b: 42,
+      resolved: "sub/b.cjs",
+      dirname: dirName,
+      paths0: dirName + "/node_modules",
+      lookupRelative: dirName,
+      lookupBare: dirName + "/node_modules",
+    });
     expect(exitCode).toBe(0);
-  }
-});
+  });
+}

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -273,7 +273,7 @@ test.concurrent("static imports inside a module imported with a ?query containin
 });
 
 // Same for a CommonJS module: its key is the referrer for `require()`, and
-// `__dirname` / `module.paths` derive from it.
+// `__dirname`, `module.paths` and `require.resolve.paths()` derive from it.
 test.concurrent("require() inside a CommonJS module loaded with a ?query containing / resolves", async () => {
   using dir = tempDir("import-query-slash-referrer-cjs", {
     "sub/b.cjs": `module.exports = { b: 42 };`,
@@ -283,7 +283,9 @@ test.concurrent("require() inside a CommonJS module loaded with a ?query contain
         b: require("./sub/b.cjs").b,
         resolved: path.relative(__dirname, require.resolve("./sub/b.cjs")).replaceAll(path.sep, "/"),
         dirname: path.basename(__dirname),
-        paths0: path.relative(__dirname, module.paths[0]),
+        paths0: path.basename(path.dirname(module.paths[0])) + "/" + path.basename(module.paths[0]),
+        lookupRelative: path.basename(require.resolve.paths("./sub/b.cjs")[0]),
+        lookupBare: path.basename(path.dirname(require.resolve.paths("pkg")[0])) + "/" + path.basename(require.resolve.paths("pkg")[0]),
       };
     `,
     "entry.mjs": `
@@ -295,7 +297,15 @@ test.concurrent("require() inside a CommonJS module loaded with a ?query contain
       console.log(JSON.stringify({ viaRequire }));
     `,
   });
-  const expected = { b: 42, resolved: "sub/b.cjs", dirname: basename(String(dir)), paths0: "node_modules" };
+  const dirName = basename(String(dir));
+  const expected = {
+    b: 42,
+    resolved: "sub/b.cjs",
+    dirname: dirName,
+    paths0: dirName + "/node_modules",
+    lookupRelative: dirName,
+    lookupBare: dirName + "/node_modules",
+  };
   for (const entry of ["entry.mjs", "entry.cjs"]) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), entry],

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -275,10 +275,12 @@ test.concurrent("static imports inside a module imported with a ?query containin
 // Same for a CommonJS module: its key is the referrer for `require()`, and
 // `__dirname`, `module.paths` and `require.resolve.paths()` derive from it.
 for (const entry of ["entry.mjs", "entry.cjs"]) {
-  test.concurrent(`require() inside a CommonJS module loaded with a ?query containing / resolves (${entry})`, async () => {
-    using dir = tempDir("import-query-slash-referrer-cjs", {
-      "sub/b.cjs": `module.exports = { b: 42 };`,
-      "a.cjs": `
+  test.concurrent(
+    `require() inside a CommonJS module loaded with a ?query containing / resolves (${entry})`,
+    async () => {
+      using dir = tempDir("import-query-slash-referrer-cjs", {
+        "sub/b.cjs": `module.exports = { b: 42 };`,
+        "a.cjs": `
         const path = require("node:path");
         module.exports = {
           b: require("./sub/b.cjs").b,
@@ -289,27 +291,28 @@ for (const entry of ["entry.mjs", "entry.cjs"]) {
           lookupBare: path.basename(path.dirname(require.resolve.paths("pkg")[0])) + "/" + path.basename(require.resolve.paths("pkg")[0]),
         };
       `,
-      "entry.mjs": `console.log(JSON.stringify((await import("./a.cjs?path=/x/y")).default));`,
-      "entry.cjs": `console.log(JSON.stringify(require("./a.cjs?path=/x/y")));`,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), entry],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const dirName = basename(String(dir));
-    expect(JSON.parse(stdout.trim())).toEqual({
-      b: 42,
-      resolved: "sub/b.cjs",
-      dirname: dirName,
-      paths0: dirName + "/node_modules",
-      lookupRelative: dirName,
-      lookupBare: dirName + "/node_modules",
-    });
-    expect(exitCode).toBe(0);
-  });
+        "entry.mjs": `console.log(JSON.stringify((await import("./a.cjs?path=/x/y")).default));`,
+        "entry.cjs": `console.log(JSON.stringify(require("./a.cjs?path=/x/y")));`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), entry],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const dirName = basename(String(dir));
+      expect(JSON.parse(stdout.trim())).toEqual({
+        b: 42,
+        resolved: "sub/b.cjs",
+        dirname: dirName,
+        paths0: dirName + "/node_modules",
+        lookupRelative: dirName,
+        lookupBare: dirName + "/node_modules",
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
 }

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { basename } from "node:path";
 globalThis.importQueryFixtureOrder = [];
 const resolvedPath = require.resolve("./import-query-fixture.ts");
 const resolvedURL = Bun.pathToFileURL(resolvedPath).href;
@@ -233,4 +234,79 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
   const resolved = JSON.parse(stdout.trim());
   expect(resolved).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
   expect(exitCode).toBe(0);
+});
+
+// The module key of a module imported with a `?query` is `<abs path>?query`, and
+// that key is the referrer for the module's own imports. A `/` inside the query
+// must not be taken as the last path separator of the referrer.
+test.concurrent("static imports inside a module imported with a ?query containing / resolve", async () => {
+  using dir = tempDir("import-query-slash-referrer-esm", {
+    "sub/b.mjs": `export const b = 42;`,
+    "a.mjs": `import { b } from "./sub/b.mjs"; export const a = b; export const url = import.meta.url;`,
+    "entry.mjs": `
+      import { a as viaStatic, url as staticUrl } from "./a.mjs?path=/x/y";
+      const dyn = await import("./a.mjs?dir=/x/y/&flag");
+      console.log(JSON.stringify({
+        viaStatic,
+        staticUrl: staticUrl.slice(staticUrl.lastIndexOf("/a.mjs") + 1),
+        viaDynamic: dyn.a,
+        dynamicUrl: dyn.url.slice(dyn.url.lastIndexOf("/a.mjs") + 1),
+      }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    viaStatic: 42,
+    staticUrl: "a.mjs?path=/x/y",
+    viaDynamic: 42,
+    dynamicUrl: "a.mjs?dir=/x/y/&flag",
+  });
+  expect(exitCode).toBe(0);
+});
+
+// Same for a CommonJS module: its key is the referrer for `require()`, and
+// `__dirname` / `module.paths` derive from it.
+test.concurrent("require() inside a CommonJS module loaded with a ?query containing / resolves", async () => {
+  using dir = tempDir("import-query-slash-referrer-cjs", {
+    "sub/b.cjs": `module.exports = { b: 42 };`,
+    "a.cjs": `
+      const path = require("node:path");
+      module.exports = {
+        b: require("./sub/b.cjs").b,
+        resolved: path.relative(__dirname, require.resolve("./sub/b.cjs")).replaceAll(path.sep, "/"),
+        dirname: path.basename(__dirname),
+        paths0: path.relative(__dirname, module.paths[0]),
+      };
+    `,
+    "entry.mjs": `
+      const viaImport = (await import("./a.cjs?path=/x/y")).default;
+      console.log(JSON.stringify({ viaImport }));
+    `,
+    "entry.cjs": `
+      const viaRequire = require("./a.cjs?path=/x/y");
+      console.log(JSON.stringify({ viaRequire }));
+    `,
+  });
+  const expected = { b: 42, resolved: "sub/b.cjs", dirname: basename(String(dir)), paths0: "node_modules" };
+  for (const entry of ["entry.mjs", "entry.cjs"]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ [entry === "entry.mjs" ? "viaImport" : "viaRequire"]: expected });
+    expect(exitCode).toBe(0);
+  }
 });


### PR DESCRIPTION
### Problem
- A module imported with a `?query` that contains a `/` cannot resolve its own relative imports: `error: Cannot find module './sub/b.mjs' from '/tmp/refq/a.mjs?path=/x/y'`. Node loads it. With `?q=1` Bun loads it too.
- The referrer that reaches `VirtualMachine::_resolve` is the module key, `<abs path>?query`. `_resolve` took its directory with `PathName::init` over the whole key (`VirtualMachine.rs:4526`), so the last `/` inside the query won.
- Three CommonJS sites split the same key the same way: `__dirname` of a `require()`d module (`JSCommonJSModule.cpp:920`), `module.paths` (`resolver_jsc.rs:43`), and `require.resolve.paths("./rel")` (`NodeModuleModule.cpp:530`).

### Fix
- All four sites cut the key at the first `?` before they take the directory, through `module_key_without_query` (Rust) and `moduleKeyPathLength` (C++). This is the rule the loader already applies to every key and specifier. On Windows a leading `\\?\` or `\\.\` device prefix is skipped first.
- Correct because the key is always `<resolved filesystem path>` plus the query the loader appended, and the query never names a directory. A literal `?` in a POSIX directory name is already unloadable on main (#7928), so no loadable case changes.
- Verified: `test/js/bun/resolve/import-query.test.ts` (three new tests, stock bun fails all), plus the resolver, `node:module` and Node `test-module-*` / `test-require-resolve` suites.
- Self-reviewed, then review found the fourth site and the Windows prefix, both fixed. One concern declined (resolve-only output for an unloadable `?` directory), see Notes.

### Background
- Bun keys the ESM registry and `require.cache` on the resolved absolute path plus the import's `?query`, so `./a.mjs?v=1` and `./a.mjs?v=2` are two module instances, as in Node.
- When a module imports something, JSC hands the importing module's key back as the referrer. Bun resolves the specifier against the referrer's directory.
- `PathName::init` splits a path into dir, base, and ext at the last separator. It knows nothing about queries.

<details><summary>Notes</summary>

- A CommonJS module reached through `import()` already got the right `__dirname`: that path (`createCommonJSModule` in `JSCommonJSModule.cpp`) searches `source_url`, which is the query-free `path.text`. Only the `require()` path (`$createCommonJSModule` from `CommonJS.ts`, which lands in `JSCommonJSModule::create(globalObject, requireMapKey, ...)`) searched the key itself.
- `import.meta.dir`, `import.meta.path`, `import.meta.resolve`, `createRequire(import.meta.url)` and dynamic `import()` from inside such a module were already correct on main. Static `import`, `require()`, `require.resolve()`, `require.resolve.paths()`, `__dirname` (via `require()`), and `module.paths` were not.
- `Module._nodeModulePaths(dir)` (the user-facing API, `use_dirname == false`), `new Module(id)` and `Bun.resolveSync(specifier, dir)` take user-supplied paths, not module keys, and are unchanged.
- Declined review concern: a literal `?` in a POSIX directory name. `createRequire("/tmp/q?d/a.cjs").resolve("./sub/b.cjs")` returned `/tmp/q?d/sub/b.cjs` on main and now throws `Cannot find module`. But main cannot load anything under such a directory (`createRequire("/tmp/q?d/a.cjs")("./sub/b.cjs")` fails with `ENOENT reading "/tmp/q"`, `bun /tmp/q?d/a.cjs` fails with `Module not found`), because the loader splits every key and specifier at the first `?`. That is #7928, and #36627 / #36048 change the split rule at all sites together. The two helpers added here are the place to do that for the directory sites.
- Other suites run locally on the debug ASAN build: `import-meta`, `import-meta-resolve`, `resolve.test.ts`, `esModule`, `node-module-module`, `module-resolve-filename-paths`, and Node's `test-module-nodemodulepaths`, `test-module-create-require`, `test-require-resolve`, `test-module-relative-lookup`, `test-require-cache`, `test-require-dot`.
- Related open PRs in this area: #35703 (adds `#fragment` splitting, and strips the referrer query in `normalize_source` as part of that larger change), #36627 and #36048 (`?` inside real file names), #35601 (`file://` URLs with a query). This PR is the standalone fix for the referrer directory and also covers the CommonJS sites, which #35703 does not touch.

</details>
