### PR TITLE
Glob.scan: accept a file URL as cwd, reject a Buffer or array in the cwd slot

### DIFF
--- a/docs/runtime/glob.mdx
+++ b/docs/runtime/glob.mdx
@@ -33,8 +33,8 @@ The `Glob` class implements the following interface:
 
 ```ts
 class Glob {
-  scan(root: string | URL | ScanOptions): AsyncIterable<string>;
-  scanSync(root: string | URL | ScanOptions): Iterable<string>;
+  scan(root?: string | URL | ScanOptions): AsyncIterable<string>;
+  scanSync(root?: string | URL | ScanOptions): Iterable<string>;
 
   match(path: string): boolean;
 }

--- a/docs/runtime/glob.mdx
+++ b/docs/runtime/glob.mdx
@@ -33,17 +33,18 @@ The `Glob` class implements the following interface:
 
 ```ts
 class Glob {
-  scan(root: string | ScanOptions): AsyncIterable<string>;
-  scanSync(root: string | ScanOptions): Iterable<string>;
+  scan(root: string | URL | ScanOptions): AsyncIterable<string>;
+  scanSync(root: string | URL | ScanOptions): Iterable<string>;
 
   match(path: string): boolean;
 }
 
 interface ScanOptions {
   /**
-   * The root directory to start matching from. Defaults to `process.cwd()`
+   * The root directory to start matching from, as a path or a `file:` URL.
+   * Defaults to `process.cwd()`
    */
-  cwd?: string;
+  cwd?: string | URL;
 
   /**
    * Allow patterns to match entries that begin with a period (`.`).

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8815,9 +8815,10 @@ declare module "bun" {
 
   interface GlobScanOptions {
     /**
-     * The root directory to start matching from. Defaults to `process.cwd()`
+     * The root directory to start matching from, as a path or a `file:` URL.
+     * Defaults to `process.cwd()`
      */
-    cwd?: string;
+    cwd?: string | URL;
 
     /**
      * Allow patterns to match entries that begin with a period (`.`).
@@ -8911,7 +8912,7 @@ declare module "bun" {
      * }
      * ```
      */
-    scan(optionsOrCwd?: string | GlobScanOptions): AsyncIterableIterator<string>;
+    scan(optionsOrCwd?: string | URL | GlobScanOptions): AsyncIterableIterator<string>;
 
     /**
      * Synchronously scan a root directory recursively for files that match this glob pattern. Returns an iterator.
@@ -8932,7 +8933,7 @@ declare module "bun" {
      * }
      * ```
      */
-    scanSync(optionsOrCwd?: string | GlobScanOptions): IterableIterator<string>;
+    scanSync(optionsOrCwd?: string | URL | GlobScanOptions): IterableIterator<string>;
 
     /**
      * Match the glob against a string

--- a/src/jsc/DOMURL.rs
+++ b/src/jsc/DOMURL.rs
@@ -58,10 +58,7 @@ impl DOMURL {
         Ok(path)
     }
 
-    /// [`file_system_path`](Self::file_system_path) for a path argument: a URL
-    /// that is not a non-empty `file:` path throws `ERR_INVALID_URL_SCHEME` /
-    /// `ERR_INVALID_FILE_URL_PATH` / `ERR_INVALID_FILE_URL_HOST` /
-    /// `ERR_INVALID_ARG_VALUE`, like `fileURLToPath()`.
+    /// [`file_system_path`](Self::file_system_path) that throws `fileURLToPath()`'s errors for a non-`file:` or empty path.
     pub fn file_system_path_for_js(&mut self, global: &JSGlobalObject) -> JsResult<bstr::String> {
         let code = match self.file_system_path() {
             Ok(path) if !path.is_empty() => return Ok(path),

--- a/src/jsc/DOMURL.rs
+++ b/src/jsc/DOMURL.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_int;
 
-use crate::{JSValue, VM};
+use crate::{ErrorCode, JSGlobalObject, JSValue, JsResult, VM};
 use bun_core as bstr;
 
 bun_opaque::opaque_ffi! {
@@ -56,5 +56,22 @@ impl DOMURL {
         }
         debug_assert!(path.tag() != bun_core::Tag::Dead);
         Ok(path)
+    }
+
+    /// [`file_system_path`](Self::file_system_path) for a path argument: a URL
+    /// that is not a non-empty `file:` path throws `ERR_INVALID_URL_SCHEME` /
+    /// `ERR_INVALID_FILE_URL_PATH` / `ERR_INVALID_FILE_URL_HOST` /
+    /// `ERR_INVALID_ARG_VALUE`, like `fileURLToPath()`.
+    pub fn file_system_path_for_js(&mut self, global: &JSGlobalObject) -> JsResult<bstr::String> {
+        let code = match self.file_system_path() {
+            Ok(path) if !path.is_empty() => return Ok(path),
+            Ok(_) => ErrorCode::INVALID_ARG_VALUE,
+            Err(ToFileSystemPathError::NotFileUrl) => ErrorCode::INVALID_URL_SCHEME,
+            Err(ToFileSystemPathError::InvalidPath) => ErrorCode::INVALID_FILE_URL_PATH,
+            Err(ToFileSystemPathError::InvalidHost) => ErrorCode::INVALID_FILE_URL_HOST,
+        };
+        Err(global
+            .err(code, format_args!("URL must be a non-empty \"file:\" path"))
+            .throw())
     }
 }

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -12,6 +12,9 @@ use bun_jsc::{
 use bun_paths::resolve_path::join_string_buf;
 use bun_paths::{self as resolve_path, MAX_PATH_BYTES, platform};
 use bun_sys as syscall;
+use bun_sys_jsc::SystemErrorJsc as _;
+
+use crate::node::types::Valid;
 
 // Codegen hooks (JSGlob): toJS / fromJS / fromJSDirect are provided by the
 // generated C++ wrapper. See PORTING.md §JSC ".classes.ts-backed types".
@@ -52,30 +55,36 @@ impl ScanOpts {
             return Ok(Box::default());
         }
 
-        let cwd_str: Box<[u8]> = 'cwd_str: {
-            let cwd_utf8 = cwd_string.to_utf8();
+        let cwd_utf8 = cwd_string.to_utf8();
+        let cwd = cwd_utf8.slice();
+        // The walker opens `cwd` as a C string; an interior NUL would scan a different directory.
+        if bun_core::strings::contains_char(cwd, 0) {
+            return Err(global_this
+                .err(
+                    bun_jsc::ErrorCode::INVALID_ARG_VALUE,
+                    format_args!(
+                        "The argument 'cwd' must be a string or URL without null bytes. Received {}",
+                        bun_core::fmt::quote(cwd)
+                    ),
+                )
+                .throw());
+        }
+        let too_long = |path: &[u8]| {
+            Valid::path_too_long(path)
+                .map(|err| global_this.throw_value(err.to_error_instance(global_this)))
+        };
+        if let Some(err) = too_long(cwd) {
+            return Err(err);
+        }
 
-            if cwd_utf8.slice().len() > MAX_PATH_BYTES {
-                return Err(global_this.throw(format_args!(
-                    "{}: invalid `cwd`, longer than {} bytes",
-                    fn_name, MAX_PATH_BYTES
-                )));
-            }
+        if resolve_path::Platform::AUTO.is_absolute(cwd) {
+            return Ok(Box::from(cwd));
+        }
 
-            // If its absolute return as is
-            if resolve_path::Platform::AUTO.is_absolute(cwd_utf8.slice()) {
-                break 'cwd_str Box::<[u8]>::from(cwd_utf8.slice());
-            }
-
-            // `cwd_utf8` drops at scope exit.
-            let mut path_buf2 = [0u8; MAX_PATH_BYTES * 2];
-
-            if !absolute {
-                let parts: &[&[u8]] = &[cwd_utf8.slice()];
-                let cwd_str = join_string_buf::<platform::Auto>(&mut path_buf2, parts);
-                break 'cwd_str Box::<[u8]>::from(cwd_str);
-            }
-
+        let mut path_buf2 = [0u8; MAX_PATH_BYTES * 2];
+        let cwd_str = if !absolute {
+            join_string_buf::<platform::Auto>(&mut path_buf2, &[cwd])
+        } else {
             // Convert to an absolute path
             let mut path_buf = bun_paths::path_buffer_pool::get();
             let cwd_len = match bun_sys::getcwd(&mut path_buf[..]) {
@@ -85,22 +94,12 @@ impl ScanOpts {
                     return Err(global_this.throw_value(err_js));
                 }
             };
-
-            let cwd_str = join_string_buf::<platform::Auto>(
-                &mut path_buf2,
-                &[&path_buf[..cwd_len], cwd_utf8.slice()],
-            );
-            break 'cwd_str Box::<[u8]>::from(cwd_str);
+            join_string_buf::<platform::Auto>(&mut path_buf2, &[&path_buf[..cwd_len], cwd])
         };
-
-        if cwd_str.len() > MAX_PATH_BYTES {
-            return Err(global_this.throw(format_args!(
-                "{}: invalid `cwd`, longer than {} bytes",
-                fn_name, MAX_PATH_BYTES
-            )));
+        if let Some(err) = too_long(cwd_str) {
+            return Err(err);
         }
-
-        Ok(cwd_str)
+        Ok(Box::from(cwd_str))
     }
 
     fn from_js(
@@ -131,9 +130,10 @@ impl ScanOpts {
             }
             return Ok(Some(out));
         }
-        // A Buffer or an array is an object too, but never an options bag. Taking
-        // it as one would silently scan `process.cwd()`.
-        if !opts_obj.is_object() || opts_obj.js_type().is_array_like() {
+        // A Buffer, DataView or array is an object too, but never an options bag.
+        // Taking it as one would silently scan `process.cwd()`.
+        let ty = opts_obj.js_type();
+        if !ty.is_object() || ty.is_array_like() || ty == bun_jsc::JSType::DataView {
             return Err(global_this.throw(format_args!(
                 "{}: expected first argument to be a string, URL, or options object",
                 fn_name

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -6,8 +6,8 @@ use bun_glob::BunGlobWalker as GlobWalker;
 use bun_glob::walk;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{
-    ArgumentsSlice, CallFrame, JSGlobalObject, JSPromiseStrong, JSValue, Job, JobContext, JsPtr,
-    JsResult, JsThread, StringJsc as _, SysErrorJsc as _,
+    ArgumentsSlice, CallFrame, DOMURL, JSGlobalObject, JSPromiseStrong, JSValue, Job, JobContext,
+    JsPtr, JsResult, JsThread, StringJsc as _, SysErrorJsc as _,
 };
 use bun_paths::resolve_path::join_string_buf;
 use bun_paths::{self as resolve_path, MAX_PATH_BYTES, platform};
@@ -38,7 +38,16 @@ impl ScanOpts {
         absolute: bool,
         fn_name: &'static str,
     ) -> JsResult<Box<[u8]>> {
-        let cwd_string = BunString::from_js(cwd_val, global_this)?;
+        let cwd_string = if let Some(url) = DOMURL::cast(cwd_val) {
+            url.file_system_path_for_js(global_this)?
+        } else if cwd_val.is_string() {
+            BunString::from_js(cwd_val, global_this)?
+        } else {
+            return Err(global_this.throw(format_args!(
+                "{}: invalid `cwd`, not a string or URL",
+                fn_name
+            )));
+        };
         if cwd_string.is_empty() {
             return Ok(Box::default());
         }
@@ -114,19 +123,19 @@ impl ScanOpts {
         if opts_obj.is_undefined_or_null() {
             return Ok(Some(out));
         }
-        if !opts_obj.is_object() {
-            if opts_obj.is_string() {
-                {
-                    let result =
-                        Self::parse_cwd(global_this, arena, opts_obj, out.absolute, fn_name)?;
-                    if !result.is_empty() {
-                        out.cwd = Some(result);
-                    }
-                }
-                return Ok(Some(out));
+        // `scan(cwd)`: a string or a `file:` URL in the options slot is the cwd.
+        if opts_obj.is_string() || DOMURL::cast(opts_obj).is_some() {
+            let result = Self::parse_cwd(global_this, arena, opts_obj, out.absolute, fn_name)?;
+            if !result.is_empty() {
+                out.cwd = Some(result);
             }
+            return Ok(Some(out));
+        }
+        // A Buffer or an array is an object too, but never an options bag. Taking
+        // it as one would silently scan `process.cwd()`.
+        if !opts_obj.is_object() || opts_obj.js_type().is_array_like() {
             return Err(global_this.throw(format_args!(
-                "{}: expected first argument to be an object",
+                "{}: expected first argument to be a string, URL, or options object",
                 fn_name
             )));
         }
@@ -166,17 +175,9 @@ impl ScanOpts {
         }
 
         if let Some(cwd_val) = opts_obj.get_truthy(global_this, "cwd")? {
-            if !cwd_val.is_string() {
-                return Err(
-                    global_this.throw(format_args!("{}: invalid `cwd`, not a string", fn_name))
-                );
-            }
-
-            {
-                let result = Self::parse_cwd(global_this, arena, cwd_val, out.absolute, fn_name)?;
-                if !result.is_empty() {
-                    out.cwd = Some(result);
-                }
+            let result = Self::parse_cwd(global_this, arena, cwd_val, out.absolute, fn_name)?;
+            if !result.is_empty() {
+                out.cwd = Some(result);
             }
         }
 

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -130,8 +130,7 @@ impl ScanOpts {
             }
             return Ok(Some(out));
         }
-        // A Buffer, DataView or array is an object too, but never an options bag.
-        // Taking it as one would silently scan `process.cwd()`.
+        // A Buffer, DataView or array is never an options bag; reading it as one would scan `process.cwd()`.
         let ty = opts_obj.js_type();
         if !ty.is_object() || ty.is_array_like() || ty == bun_jsc::JSType::DataView {
             return Err(global_this.throw(format_args!(

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1128,42 +1128,7 @@ impl PathLikeExt for PathLike<'_> {
             }
             _ => {
                 if let Some(domurl) = jsc::DOMURL::cast(arg) {
-                    use jsc::dom_url::ToFileSystemPathError;
-                    let str = match domurl.file_system_path() {
-                        Ok(s) => s,
-                        Err(ToFileSystemPathError::NotFileUrl) => {
-                            return Err(ctx
-                                .err(
-                                    jsc::ErrorCode::INVALID_URL_SCHEME,
-                                    format_args!("URL must be a non-empty \"file:\" path"),
-                                )
-                                .throw());
-                        }
-                        Err(ToFileSystemPathError::InvalidPath) => {
-                            return Err(ctx
-                                .err(
-                                    jsc::ErrorCode::INVALID_FILE_URL_PATH,
-                                    format_args!("URL must be a non-empty \"file:\" path"),
-                                )
-                                .throw());
-                        }
-                        Err(ToFileSystemPathError::InvalidHost) => {
-                            return Err(ctx
-                                .err(
-                                    jsc::ErrorCode::INVALID_FILE_URL_HOST,
-                                    format_args!("URL must be a non-empty \"file:\" path"),
-                                )
-                                .throw());
-                        }
-                    };
-                    if str.is_empty() {
-                        return Err(ctx
-                            .err(
-                                jsc::ErrorCode::INVALID_ARG_VALUE,
-                                format_args!("URL must be a non-empty \"file:\" path"),
-                            )
-                            .throw());
-                    }
+                    let str = domurl.file_system_path_for_js(ctx)?;
                     arguments.eat();
                     path_like_from_string(ctx, str, arguments.will_be_async)?
                 } else {

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -190,6 +190,73 @@ describe("glob.match", async () => {
     }
   });
 
+  test("cwd accepts a file URL, and a non-options object in the cwd slot throws", async () => {
+    using dir = tempDir("glob-scan-url-cwd", {
+      "real/REAL.txt": "",
+      "real/sub/INNER.txt": "",
+      "other/OTHER.txt": "",
+    });
+    const real = path.join(String(dir), "real");
+
+    // Run from a sibling directory so that a silently ignored cwd shows up as
+    // ["OTHER.txt"]. Both URL spellings (with and without the trailing slash
+    // that `new URL("./real/", import.meta.url)` produces) must work.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const real = process.argv[1];
+          const urls = [Bun.pathToFileURL(real), Bun.pathToFileURL(real + ${JSON.stringify(path.sep)})];
+          const results = {};
+          const attempt = async (label, fn) => {
+            try {
+              results[label] = (await fn()).sort();
+            } catch (e) {
+              results[label] = "throw: " + e.message;
+            }
+          };
+          for (const [i, u] of urls.entries()) {
+            await attempt("scanSync(URL" + i + ")", () => [...new Bun.Glob("**/*.txt").scanSync(u)]);
+            await attempt("scan(URL" + i + ")", () => Array.fromAsync(new Bun.Glob("**/*.txt").scan(u)));
+            await attempt("scanSync({cwd: URL" + i + "})", () => [...new Bun.Glob("**/*.txt").scanSync({ cwd: u })]);
+            await attempt("scan({cwd: URL" + i + "})", () => Array.fromAsync(new Bun.Glob("**/*.txt").scan({ cwd: u })));
+          }
+          await attempt("scanSync(string)", () => [...new Bun.Glob("**/*.txt").scanSync(real)]);
+          await attempt("scanSync(Buffer)", () => [...new Bun.Glob("*").scanSync(Buffer.from(real))]);
+          await attempt("scanSync([real])", () => [...new Bun.Glob("*").scanSync([real])]);
+          await attempt("scanSync({cwd: Buffer})", () => [...new Bun.Glob("*").scanSync({ cwd: Buffer.from(real) })]);
+          await attempt("scanSync(http URL)", () => [...new Bun.Glob("*").scanSync(new URL("http://example.com/real"))]);
+          await attempt("scanSync({cwd: http URL})", () => [...new Bun.Glob("*").scanSync({ cwd: new URL("http://example.com/real") })]);
+          console.log(JSON.stringify(results));
+        `,
+        real,
+      ],
+      env: bunEnv,
+      cwd: path.join(String(dir), "other"),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const found = ["REAL.txt", path.join("sub", "INNER.txt")].sort();
+    expect(JSON.parse(await proc.stdout.text())).toEqual({
+      "scanSync(URL0)": found,
+      "scan(URL0)": found,
+      "scanSync({cwd: URL0})": found,
+      "scan({cwd: URL0})": found,
+      "scanSync(URL1)": found,
+      "scan(URL1)": found,
+      "scanSync({cwd: URL1})": found,
+      "scan({cwd: URL1})": found,
+      "scanSync(string)": found,
+      "scanSync(Buffer)": "throw: scanSync: expected first argument to be a string, URL, or options object",
+      "scanSync([real])": "throw: scanSync: expected first argument to be a string, URL, or options object",
+      "scanSync({cwd: Buffer})": "throw: scanSync: invalid `cwd`, not a string or URL",
+      "scanSync(http URL)": 'throw: URL must be a non-empty "file:" path',
+      "scanSync({cwd: http URL})": 'throw: URL must be a non-empty "file:" path',
+    });
+    expect(await proc.exited).toBe(0);
+  });
+
   test("oversized cwd throws instead of crashing", async () => {
     const glob = new Glob("*.ts");
     const tooLong = Buffer.alloc(100_000, "x").toString();

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -228,6 +228,10 @@ describe("glob.match", async () => {
           await attempt("scanSync({cwd: Buffer})", () => [...new Bun.Glob("*").scanSync({ cwd: Buffer.from(real) })]);
           await attempt("scanSync(http URL)", () => [...new Bun.Glob("*").scanSync(new URL("http://example.com/real"))]);
           await attempt("scanSync({cwd: http URL})", () => [...new Bun.Glob("*").scanSync({ cwd: new URL("http://example.com/real") })]);
+          await attempt("scanSync(DataView)", () => [...new Bun.Glob("*").scanSync(new DataView(new ArrayBuffer(1)))]);
+          // The native walker opens cwd as a C string, so an interior NUL would scan "real" instead.
+          await attempt("scanSync(real + NUL)", () => [...new Bun.Glob("*").scanSync(real + "\\0ignored")]);
+          await attempt("scanSync({cwd: real + NUL})", () => [...new Bun.Glob("*").scanSync({ cwd: real + "\\0ignored" })]);
           console.log(JSON.stringify(results));
         `,
         real,
@@ -253,6 +257,13 @@ describe("glob.match", async () => {
       "scanSync({cwd: Buffer})": "throw: scanSync: invalid `cwd`, not a string or URL",
       "scanSync(http URL)": 'throw: URL must be a non-empty "file:" path',
       "scanSync({cwd: http URL})": 'throw: URL must be a non-empty "file:" path',
+      "scanSync(DataView)": "throw: scanSync: expected first argument to be a string, URL, or options object",
+      "scanSync(real + NUL)": expect.stringContaining(
+        "throw: The argument 'cwd' must be a string or URL without null bytes. Received ",
+      ),
+      "scanSync({cwd: real + NUL})": expect.stringContaining(
+        "throw: The argument 'cwd' must be a string or URL without null bytes. Received ",
+      ),
     });
     expect(await proc.exited).toBe(0);
   });


### PR DESCRIPTION
### Problem
- `new Bun.Glob("*").scanSync(new URL("./real/", import.meta.url))` and `scanSync(Buffer.from(dir))` scan `process.cwd()` instead of `dir`, with no error. `scanSync({ cwd: url })` throws `scanSync: invalid \`cwd\`, not a string`, while `fs.globSync("*", { cwd: url })` honors the URL.
- The cause is `ScanOpts::from_js` (`src/runtime/api/glob.rs:117`). It treats every non-string object in the `optionsOrCwd` slot as an options bag. A `URL` or a `Buffer` has no `cwd` property, so the scan falls back to the process cwd. A `cwd` string with an interior NUL byte had the same effect: the walker opens it as a C string and scans the truncated path.

### Fix
- A `file:` URL is now a valid `cwd`, both as `scan(url)` / `scanSync(url)` and as `{ cwd: url }`. It resolves through `DOMURL::file_system_path`, the same path `Bun.file(url)` and `node:fs` use, so a non-`file:` URL throws `ERR_INVALID_URL_SCHEME`. The URL-to-path error mapping that `PathLike::from_js` had inline moves to `DOMURL::file_system_path_for_js` so both callers share it.
- An array-like object (Buffer, typed array, ArrayBuffer, DataView, array) in the positional slot now throws `expected first argument to be a string, URL, or options object` instead of scanning the wrong directory. `{ cwd }` with any other type still throws, now worded `not a string or URL`. A `cwd` with a NUL byte throws `ERR_INVALID_ARG_VALUE`, and an over-long one throws the same `ENAMETOOLONG` error as `node:fs` (`Valid::path_too_long`) instead of a bespoke message.
- Self-reviewed: 4 concerns raised, 3 addressed (DataView, the NUL/length checks through the shared validator, the justification below). Not taken: accepting a Buffer `cwd` through `PathLike`. No glob API (node `fs.glob`, fast-glob) takes a Buffer cwd, and `string | URL` can widen later without a break.
- Verified: `test/js/bun/glob/scan.test.ts` (`cwd accepts a file URL, ...`, fails on canary). Also `match.test.ts`, `path-length.test.ts`, `proto.test.ts`, `test/js/node/fs/glob.test.ts`, and `bun-types.test.ts`.

### Background
- `Glob#scan(optionsOrCwd?: string | GlobScanOptions)` takes either the root directory as a string or an options object whose `cwd` defaults to `process.cwd()`. The native parser dispatches on the JS type of that one argument.
- `DOMURL` is the C++ `URL` object. `DOMURL::cast` checks whether a `JSValue` is one, and `file_system_path` is `fileURLToPath()`.
- Nobody asked for URL support here; the motivation is the silent wrong-directory scan plus parity. Node documents `fs.glob`'s `cwd` as `string | URL`, Bun's `node:fs` glob honors it, and `Bun.file`, `Bun.write` and `node:fs` paths all take a `file:` URL. `bun.d.ts` and `docs/runtime/glob.mdx` now say `string | URL`.

<details><summary>Notes</summary>

The alternative shape is to keep `cwd` string-only and throw for a URL in either slot. That is a two-line change on top of this one (drop the `DOMURL::cast` arms) if preferred.

Before (canary `f42e98025`), from a sibling directory `other/` of `real/`:

```
scanSync(string path)    -> ["REAL.txt"]
scanSync(URL)            -> ["OTHER.txt"]      (wrong directory, no error)
scanSync(Buffer)         -> ["OTHER.txt"]      (wrong directory, no error)
scanSync(real + "\0x")   -> scans real         (NUL truncates the C path)
scanSync({cwd: URL})     -> THROW scanSync: invalid `cwd`, not a string
fs.globSync(*,{cwd:URL}) -> ["REAL.txt"]
scanSync(5)              -> THROW expected first argument to be an object
```

After: the URL forms return `["REAL.txt"]`, the Buffer/DataView/array forms throw, the NUL form throws `ERR_INVALID_ARG_VALUE`, and the `scanSync(5)` message lists the accepted types.

`{ cwd: false }` / `{ cwd: 0 }` are still ignored (`get_truthy`), unchanged here. #33181 adds a NUL check to the same function with a generalized `Valid::no_null_bytes`; whichever lands second drops its hunk.

</details>
