### PR TITLE
worker: resolve fetch() proxy env (and the rest of the env loader) from the worker's own environment

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,10 +595,8 @@ impl Loader {
         }
     }
 
-    /// A `Worker`'s loader: a copy of the map. Whatever this loader already read
-    /// (the process environment, `.env` files, explicit `--env-file` entries) counts
-    /// as loaded in the copy too, so the worker thread neither reads a pipe twice
-    /// nor overlays the copied map with `environ` again.
+    /// A `Worker`'s copy: the map plus what was already loaded, so the worker thread
+    /// does not read `environ`, `.env` files or an `--env-file` pipe a second time.
     pub fn clone_for_worker(&self) -> Result<Loader, AllocError> {
         Ok(Loader {
             map: self.map.clone_with_allocator()?,
@@ -611,10 +609,8 @@ impl Loader {
         })
     }
 
-    /// A `Worker`'s loader when `new Worker(url, { env })` gave it an environment:
-    /// an empty map for the caller to fill with exactly those entries. The process
-    /// environment and every `.env` source count as loaded, so
-    /// `Transpiler::configure_defines` on the worker thread overlays nothing.
+    /// An empty loader for a `Worker` given `{ env }`: the caller fills the map, and
+    /// every env source counts as loaded so nothing overlays it later.
     pub fn for_worker_env(&self, capacity: usize) -> Result<Loader, AllocError> {
         let mut map = Map::init();
         map.ensure_unused_capacity(capacity)?;

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,14 +595,17 @@ impl Loader {
         }
     }
 
-    /// A `Worker`'s loader: the map, with the explicit entries marked loaded so a pipe is not read twice.
+    /// A `Worker`'s loader: a copy of the map. Whatever this loader already read
+    /// (the process environment, `.env` files, explicit `--env-file` entries) counts
+    /// as loaded in the copy too, so the worker thread neither reads a pipe twice
+    /// nor overlays the copied map with `environ` again.
     pub fn clone_for_worker(&self) -> Result<Loader, AllocError> {
         Ok(Loader {
             map: self.map.clone_with_allocator()?,
-            default_files_loaded: EnumSet::empty(),
+            default_files_loaded: self.default_files_loaded,
             custom_files_loaded: self.custom_files_loaded.clone()?,
             quiet: false,
-            did_load_process: false,
+            did_load_process: self.did_load_process,
             reject_unauthorized: Cell::new(None),
             aws_credentials: None,
         })

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -608,6 +608,24 @@ impl Loader {
         })
     }
 
+    /// A `Worker`'s loader when `new Worker(url, { env })` gave it an environment:
+    /// an empty map for the caller to fill with exactly those entries. The process
+    /// environment and every `.env` source count as loaded, so
+    /// `Transpiler::configure_defines` on the worker thread overlays nothing.
+    pub fn for_worker_env(&self, capacity: usize) -> Result<Loader, AllocError> {
+        let mut map = Map::init();
+        map.ensure_unused_capacity(capacity)?;
+        Ok(Loader {
+            map,
+            default_files_loaded: EnumSet::all(),
+            custom_files_loaded: self.custom_files_loaded.clone()?,
+            quiet: false,
+            did_load_process: true,
+            reject_unauthorized: Cell::new(None),
+            aws_credentials: None,
+        })
+    }
+
     pub fn load_process(&mut self) -> Result<(), AllocError> {
         if self.did_load_process {
             return Ok(());

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3687,22 +3687,25 @@ impl VirtualMachine {
             self.transpiler_store.enabled = false;
         }
 
-        if let Some(idx) = map.map.get_index(b"NODE_CHANNEL_FD") {
-            let (_, kv) = map.map.swap_remove_at(idx);
-            let fd_s = kv.value;
-            let advanced = map
-                .map
-                .get_index(b"NODE_CHANNEL_SERIALIZATION_MODE")
-                .map(|i| map.map.swap_remove_at(i).1)
-                .is_some_and(|v| &v.value[..] == b"advanced");
-            // Accept only
-            // non-negative values that fit in i31 (i.e. `0..=i32::MAX`).
-            // Parsing as `u32` then `as i32` would silently wrap values in
-            // `2^31..2^32` to a negative fd instead of taking the warn branch.
-            // The channel belongs to the process (its main thread). A worker
-            // sees the same inherited variables but must not open a second
-            // endpoint over the same fd (Node: no process.send() in workers).
-            if self.is_main_thread() {
+        // The channel belongs to the process: its main thread adopts it from the
+        // inherited environment and drops the variables, as Node does. A worker's
+        // map is a copy of its parent's (taken after this ran there) or exactly
+        // `options.env`, so it is left as given; node:worker_threads reads
+        // `process.env.NODE_CHANNEL_FD` in the worker to decide whether
+        // `process.send` is a disabled stub, like Node.
+        if self.is_main_thread() {
+            if let Some(idx) = map.map.get_index(b"NODE_CHANNEL_FD") {
+                let (_, kv) = map.map.swap_remove_at(idx);
+                let fd_s = kv.value;
+                let advanced = map
+                    .map
+                    .get_index(b"NODE_CHANNEL_SERIALIZATION_MODE")
+                    .map(|i| map.map.swap_remove_at(i).1)
+                    .is_some_and(|v| &v.value[..] == b"advanced");
+                // Accept only
+                // non-negative values that fit in i31 (i.e. `0..=i32::MAX`).
+                // Parsing as `u32` then `as i32` would silently wrap values in
+                // `2^31..2^32` to a negative fd instead of taking the warn branch.
                 match bun_core::fmt::parse_int::<i32>(&fd_s, 10)
                     .ok()
                     .filter(|&n| n >= 0)

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3687,12 +3687,9 @@ impl VirtualMachine {
             self.transpiler_store.enabled = false;
         }
 
-        // The channel belongs to the process: its main thread adopts it from the
-        // inherited environment and drops the variables, as Node does. A worker's
-        // map is a copy of its parent's (taken after this ran there) or exactly
-        // `options.env`, so it is left as given; node:worker_threads reads
-        // `process.env.NODE_CHANNEL_FD` in the worker to decide whether
-        // `process.send` is a disabled stub, like Node.
+        // Only the main thread adopts the process's IPC channel and drops the
+        // variables (as Node does). A worker keeps what its env gave it;
+        // node:worker_threads reads `process.env.NODE_CHANNEL_FD` to stub `process.send`.
         if self.is_main_thread() {
             if let Some(idx) = map.map.get_index(b"NODE_CHANNEL_FD") {
                 let (_, kv) = map.map.swap_remove_at(idx);
@@ -3702,10 +3699,8 @@ impl VirtualMachine {
                     .get_index(b"NODE_CHANNEL_SERIALIZATION_MODE")
                     .map(|i| map.map.swap_remove_at(i).1)
                     .is_some_and(|v| &v.value[..] == b"advanced");
-                // Accept only
-                // non-negative values that fit in i31 (i.e. `0..=i32::MAX`).
-                // Parsing as `u32` then `as i32` would silently wrap values in
-                // `2^31..2^32` to a negative fd instead of taking the warn branch.
+                // Non-negative i31 only: `u32` then `as i32` would wrap `2^31..` to a
+                // negative fd instead of warning.
                 match bun_core::fmt::parse_int::<i32>(&fd_s, 10)
                     .ok()
                     .filter(|&n| n >= 0)

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -516,6 +516,11 @@ JSC_DEFINE_HOST_FUNCTION(jsEditWindowsEnvVar, (JSGlobalObject * global, JSC::Cal
     auto scope = DECLARE_THROW_SCOPE(global->vm());
     ASSERT(callFrame->argumentCount() == 2);
     ASSERT(callFrame->uncheckedArgument(0).isString());
+    // A worker's environment is its own env map (Node: a MapKVStore); only the
+    // main thread's process.env writes through to the OS environment block.
+    auto* context = defaultGlobalObject(global)->scriptExecutionContext();
+    if (context && !context->isMainThread())
+        return JSValue::encode(jsUndefined());
     WTF::String string1 = callFrame->uncheckedArgument(0).toWTFString(global);
     RETURN_IF_EXCEPTION(scope, {});
     JSValue arg2 = callFrame->uncheckedArgument(1);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -516,8 +516,7 @@ JSC_DEFINE_HOST_FUNCTION(jsEditWindowsEnvVar, (JSGlobalObject * global, JSC::Cal
     auto scope = DECLARE_THROW_SCOPE(global->vm());
     ASSERT(callFrame->argumentCount() == 2);
     ASSERT(callFrame->uncheckedArgument(0).isString());
-    // A worker's environment is its own env map (Node: a MapKVStore); only the
-    // main thread's process.env writes through to the OS environment block.
+    // Only the main thread writes through to the OS environment (Node: a worker env is a MapKVStore).
     auto* context = defaultGlobalObject(global)->scriptExecutionContext();
     if (context && !context->isMainThread())
         return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -571,14 +571,11 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
         const auto initializeWorker = [&](WebCore::WorkerMessagingProxy& worker) -> void {
             auto& options = worker.options();
 
-            // An explicit `options.env` (or the parent's process.env snapshot) was
-            // already seeded into this worker VM's env loader by WebWorker__create,
-            // so process.env is built lazily from it by createEnvironmentVariablesMap,
-            // exactly as on the main thread.
+            // options.env already seeded this VM's env loader (WebWorker__create); process.env
+            // is built lazily from it by createEnvironmentVariablesMap, as on the main thread.
             if (options.sharedEnvStore) {
-                // worker_threads SHARE_ENV: join the env tree the spawning thread
-                // resolved. Consumed here, and published on the context before the
-                // view, which resolves its store through the context.
+                // worker_threads SHARE_ENV: join the env tree the spawning thread resolved.
+                // Published on the context before the view, which resolves its store through it.
                 RefPtr<Bun::SharedEnvStore> store = std::exchange(options.sharedEnvStore, nullptr);
                 globalObject->scriptExecutionContext()->setSharedEnvStore(*store);
                 globalObject->m_processEnvObject.set(vm, globalObject, Bun::createSharedEnvironmentVariablesMap(globalObject).getObject());

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -571,44 +571,14 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
         const auto initializeWorker = [&](WebCore::WorkerMessagingProxy& worker) -> void {
             auto& options = worker.options();
 
-            if (options.env.has_value()) {
-                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-                HashMap<String, String> map = *std::exchange(options.env, std::nullopt);
-                auto size = map.size();
-
-                // In theory, a GC could happen before we finish putting all the properties on the object.
-                // So we use a MarkedArgumentBuffer to ensure that the strings are not collected and we immediately put them on the object.
-                MarkedArgumentBuffer strings;
-                strings.ensureCapacity(size);
-                for (const auto& value : map.values()) {
-                    strings.append(jsString(vm, value));
-                }
-
-#if OS(WINDOWS)
-                JSC::JSObject* env = size
-                    ? JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), size >= JSFinalObject::maxInlineCapacity ? JSFinalObject::maxInlineCapacity : size)
-                    : JSC::constructEmptyObject(globalObject);
-#else
-                // Same exotic object as the main thread so writes inside the
-                // worker coerce to string, reject symbol keys, and validate
-                // defineProperty like Node's EnvSetter/EnvDefiner.
-                auto* envStructure = Bun::JSEnvironmentVariableMap::createStructure(vm, globalObject, globalObject->objectPrototype());
-                JSC::JSObject* env = Bun::JSEnvironmentVariableMap::create(vm, envStructure);
-#endif
-                size_t i = 0;
-                for (auto k : map) {
-                    // Numeric env keys hit putDirectIndex → defineOwnProperty (declares a
-                    // ThrowScope). Seeded values are JSStrings, so this throws only on OOM
-                    // or under a termination already requested for this starting worker.
-                    env->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, WTF::move(k.key)), strings.at(i++));
-                    if (scope.exception()) [[unlikely]]
-                        break;
-                }
-                globalObject->m_processEnvObject.set(vm, globalObject, env);
-            } else if (options.sharedEnvStore) {
+            // An explicit `options.env` (or the parent's process.env snapshot) was
+            // already seeded into this worker VM's env loader by WebWorker__create,
+            // so process.env is built lazily from it by createEnvironmentVariablesMap,
+            // exactly as on the main thread.
+            if (options.sharedEnvStore) {
                 // worker_threads SHARE_ENV: join the env tree the spawning thread
-                // resolved. Consumed like options.env, and published on the context
-                // before the view, which resolves its store through the context.
+                // resolved. Consumed here, and published on the context before the
+                // view, which resolves its store through the context.
                 RefPtr<Bun::SharedEnvStore> store = std::exchange(options.sharedEnvStore, nullptr);
                 globalObject->scriptExecutionContext()->setSharedEnvStore(*store);
                 globalObject->m_processEnvObject.set(vm, globalObject, Bun::createSharedEnvironmentVariablesMap(globalObject).getObject());

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -285,14 +285,15 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
                 envObject->methodTable()->getOwnPropertyNames(envObject, lexicalGlobalObject, keys, JSC::DontEnumPropertiesMode::Exclude);
                 RETURN_IF_EXCEPTION(throwScope, {});
 
-                HashMap<String, String> env;
+                Vector<std::pair<String, String>> env;
+                env.reserveInitialCapacity(keys.size());
 
                 for (const auto& key : keys) {
                     JSValue value = envObject->get(lexicalGlobalObject, key);
                     RETURN_IF_EXCEPTION(throwScope, {});
-                    String str = value.toWTFString(lexicalGlobalObject).isolatedCopy();
+                    String str = value.toWTFString(lexicalGlobalObject);
                     RETURN_IF_EXCEPTION(throwScope, {});
-                    env.add(key.impl()->isolatedCopy(), str);
+                    env.append({ key.string(), WTF::move(str) });
                 }
 
                 options.env.emplace(WTF::move(env));

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -143,8 +143,7 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
                                                })
                                                .value_or(std::span<WTF::StringImpl*> {});
 
-    // [key, value, key, value, ...]; WebWorker__create copies the bytes into the
-    // worker's env loader, so the strings only need to live across the call.
+    // [key, value, ...]; WebWorker__create copies the bytes, so these only live across the call.
     Vector<BunString> envPairs;
     bool hasEnv = m_options.env.has_value();
     if (hasEnv) {

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -68,7 +68,10 @@ void* WebWorker__create(
     StringImpl** execArgvPtr,
     size_t execArgvLen,
     BunString* preloadModulesPtr,
-    size_t preloadModulesLen);
+    size_t preloadModulesLen,
+    bool hasEnv,
+    const BunString* envPairsPtr,
+    size_t envPairsLen);
 // Raise a TerminationException in the worker VM at its next safepoint and wake its loop. Any thread.
 void WebWorker__requestTermination(void*);
 // Toggle the keep-alive this worker holds on the parent event loop. Parent thread.
@@ -140,6 +143,18 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
                                                })
                                                .value_or(std::span<WTF::StringImpl*> {});
 
+    // [key, value, key, value, ...]; WebWorker__create copies the bytes into the
+    // worker's env loader, so the strings only need to live across the call.
+    Vector<BunString> envPairs;
+    bool hasEnv = m_options.env.has_value();
+    if (hasEnv) {
+        envPairs.reserveInitialCapacity(m_options.env->size() * 2);
+        for (auto& [key, value] : *m_options.env) {
+            envPairs.append(Bun::toString(key));
+            envPairs.append(Bun::toString(value));
+        }
+    }
+
     // The thread holds a ref on the proxy until releaseWorkerThread().
     ref();
     BunString errorMessage = BunStringEmpty;
@@ -163,8 +178,12 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
         execArgv.data(),
         execArgv.size(),
         preloadModules.begin(),
-        preloadModules.size());
+        preloadModules.size(),
+        hasEnv,
+        envPairs.begin(),
+        envPairs.size() / 2);
     m_options.preloadModules.clear();
+    m_options.env = std::nullopt;
 
     if (!m_workerThread) {
         m_state.store(State::Closed);

--- a/src/jsc/bindings/webcore/WorkerOptions.h
+++ b/src/jsc/bindings/webcore/WorkerOptions.h
@@ -34,10 +34,8 @@ struct WorkerOptions {
     // Objects transferred for either data or environmentData in the transferList
     Vector<TransferredMessagePort> dataMessagePorts;
     Vector<String> preloadModules;
-    // The worker's whole initial environment (`options.env`, or a snapshot of the
-    // parent's `process.env`), in enumeration order. Consumed on the parent thread
-    // by WebWorker__create, which seeds the worker VM's env loader from it. nullopt
-    // means the worker clones the parent's env loader instead.
+    // The worker's whole initial environment in enumeration order, consumed on the parent
+    // thread by WebWorker__create. If nullopt, the worker clones the parent's env loader.
     std::optional<Vector<std::pair<String, String>>> env;
     Vector<String> argv;
     // If nullopt, inherit execArgv from the parent thread

--- a/src/jsc/bindings/webcore/WorkerOptions.h
+++ b/src/jsc/bindings/webcore/WorkerOptions.h
@@ -34,7 +34,11 @@ struct WorkerOptions {
     // Objects transferred for either data or environmentData in the transferList
     Vector<TransferredMessagePort> dataMessagePorts;
     Vector<String> preloadModules;
-    std::optional<HashMap<String, String>> env;
+    // The worker's whole initial environment (`options.env`, or a snapshot of the
+    // parent's `process.env`), in enumeration order. Consumed on the parent thread
+    // by WebWorker__create, which seeds the worker VM's env loader from it. nullopt
+    // means the worker clones the parent's env loader instead.
+    std::optional<Vector<std::pair<String, String>>> env;
     Vector<String> argv;
     // If nullopt, inherit execArgv from the parent thread
     std::optional<Vector<String>> execArgv;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -132,9 +132,8 @@ struct WorkerVmInit {
     proxy_env_slots: jsc::rare_data::ProxyEnvSlots,
 }
 
-/// Build the loader for a worker that was given its environment: `pairs` is
-/// `[key, value, key, value, ...]` in the order the worker's `process.env`
-/// should enumerate.
+/// The loader for a worker given its environment as `[key, value, ...]` pairs,
+/// in `process.env` enumeration order.
 fn worker_env_loader(
     parent: &bun_dotenv::Loader,
     pairs: &[BunString],
@@ -299,10 +298,8 @@ impl WebWorker {
     /// and spawn the thread. On any failure returns null with `error_message`
     /// set and nothing to clean up.
     ///
-    /// `env_ptr` holds `env_pairs_len` key/value pairs, interleaved. With
-    /// `has_env` they become the worker's whole environment (`options.env`, or
-    /// the parent's current `process.env`); without it the worker starts from
-    /// a clone of the parent's env loader.
+    /// With `has_env`, the `env_pairs_len` interleaved key/value pairs at `env_ptr`
+    /// are the worker's whole environment; otherwise the parent's loader is cloned.
     #[unsafe(export_name = "WebWorker__create")]
     pub(crate) unsafe extern "C" fn create(
         proxy: *mut c_void,
@@ -397,13 +394,10 @@ impl WebWorker {
                 transform_options.allow_ffi_cc = Some(parent_allows_ffi_cc && flags.allow_ffi_cc);
             }
         }
-        // The worker's env loader is what its `process.env`, `fetch()` proxy
-        // resolution, TLS defaults and `Bun.spawn` inheritance read. With an
-        // explicit environment it holds exactly those entries; otherwise it
-        // starts as a copy of the parent's now (as in Node). In the copy case
-        // proxy-env values may be RefCountedEnvValue bytes owned by the
-        // parent's proxy_env_storage: snapshot slots + map under its lock so
-        // every slice copied is backed by a ref the snapshot holds.
+        // The worker's env loader (what its `process.env`, fetch() and Bun.spawn
+        // read): exactly the given environment, or a copy of the parent's now (as
+        // in Node), taken under the parent's proxy-env lock so every
+        // RefCountedEnvValue slice in the copy is backed by a ref the snapshot holds.
         let mut proxy_env_slots = jsc::rare_data::ProxyEnvSlots::default();
         let env_loader = if has_env {
             // SAFETY: caller passed `2 * env_pairs_len` valid strings (or `(null,0)`);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -132,6 +132,25 @@ struct WorkerVmInit {
     proxy_env_slots: jsc::rare_data::ProxyEnvSlots,
 }
 
+/// Build the loader for a worker that was given its environment: `pairs` is
+/// `[key, value, key, value, ...]` in the order the worker's `process.env`
+/// should enumerate.
+fn worker_env_loader(
+    parent: &bun_dotenv::Loader,
+    pairs: &[BunString],
+) -> Result<bun_dotenv::Loader, bun_alloc::AllocError> {
+    let mut loader = parent.for_worker_env(pairs.len() / 2)?;
+    for pair in pairs.chunks_exact(2) {
+        let key = pair[0].to_utf8();
+        if key.is_empty() {
+            continue;
+        }
+        let value = pair[1].to_utf8();
+        loader.map.put(&key, &value)?;
+    }
+    Ok(loader)
+}
+
 enum EntryOutcome {
     Continue,
     /// The entry module rejected and no handler took it: the worker exits.
@@ -279,6 +298,11 @@ impl WebWorker {
     /// keep-alive on the parent event loop, register as a child of the parent VM,
     /// and spawn the thread. On any failure returns null with `error_message`
     /// set and nothing to clean up.
+    ///
+    /// `env_ptr` holds `env_pairs_len` key/value pairs, interleaved. With
+    /// `has_env` they become the worker's whole environment (`options.env`, or
+    /// the parent's current `process.env`); without it the worker starts from
+    /// a clone of the parent's env loader.
     #[unsafe(export_name = "WebWorker__create")]
     pub(crate) unsafe extern "C" fn create(
         proxy: *mut c_void,
@@ -299,6 +323,9 @@ impl WebWorker {
         exec_argv_len: usize,
         preload_modules_ptr: *const BunString,
         preload_modules_len: usize,
+        has_env: bool,
+        env_ptr: *const BunString,
+        env_pairs_len: usize,
     ) -> *mut WebWorker {
         jsc::mark_binding();
         log!("[{}] create", this_context_id);
@@ -370,23 +397,38 @@ impl WebWorker {
                 transform_options.allow_ffi_cc = Some(parent_allows_ffi_cc && flags.allow_ffi_cc);
             }
         }
-        // The worker's `process.env` starts as a copy of the parent's now (as in
-        // Node). Proxy-env values may be RefCountedEnvValue bytes owned by the
+        // The worker's env loader is what its `process.env`, `fetch()` proxy
+        // resolution, TLS defaults and `Bun.spawn` inheritance read. With an
+        // explicit environment it holds exactly those entries; otherwise it
+        // starts as a copy of the parent's now (as in Node). In the copy case
+        // proxy-env values may be RefCountedEnvValue bytes owned by the
         // parent's proxy_env_storage: snapshot slots + map under its lock so
         // every slice copied is backed by a ref the snapshot holds.
         let mut proxy_env_slots = jsc::rare_data::ProxyEnvSlots::default();
-        let mut env_loader = {
-            let parent_slots = parent_ref.proxy_env_storage.lock();
-            proxy_env_slots.clone_from(&parent_slots);
-            match parent_ref.env_loader().clone_for_worker() {
+        let env_loader = if has_env {
+            // SAFETY: caller passed `2 * env_pairs_len` valid strings (or `(null,0)`);
+            // slice borrowed from C++ for the duration of this call.
+            let pairs: &[BunString] = unsafe { bun_core::ffi::slice(env_ptr, env_pairs_len * 2) };
+            match worker_env_loader(parent_ref.env_loader(), pairs) {
                 Ok(loader) => loader,
                 Err(_) => {
                     *error_message = BunString::static_("Out of memory");
                     return core::ptr::null_mut();
                 }
             }
+        } else {
+            let parent_slots = parent_ref.proxy_env_storage.lock();
+            proxy_env_slots.clone_from(&parent_slots);
+            let mut loader = match parent_ref.env_loader().clone_for_worker() {
+                Ok(loader) => loader,
+                Err(_) => {
+                    *error_message = BunString::static_("Out of memory");
+                    return core::ptr::null_mut();
+                }
+            };
+            proxy_env_slots.sync_into(&mut loader.map);
+            loader
         };
-        proxy_env_slots.sync_into(&mut env_loader.map);
         let init = WorkerVmInit {
             transform_options,
             env_loader,

--- a/test/js/web/workers/worker-env-proxy-fixture.mjs
+++ b/test/js/web/workers/worker-env-proxy-fixture.mjs
@@ -1,0 +1,68 @@
+// Runs fetch() inside workers whose proxy environment differs from the main
+// thread's, and prints which requests went through the proxy. argv[2] picks
+// the Worker constructor: "node" (node:worker_threads) or "web" (globalThis.Worker).
+import { isMainThread, parentPort, Worker as NodeWorker, workerData } from "node:worker_threads";
+
+async function workerBody(data, reply) {
+  for (const [key, value] of Object.entries(data.assign ?? {})) process.env[key] = value;
+  const res = await fetch(data.url);
+  reply(await res.text());
+}
+
+if (!isMainThread) {
+  if (workerData) {
+    await workerBody(workerData, msg => parentPort.postMessage(msg));
+  } else {
+    // Web Worker: the scenario arrives as the first message.
+    self.onmessage = e => workerBody(e.data, msg => postMessage(msg));
+  }
+} else {
+  const kind = process.argv[2];
+  // Any request that reaches this server was sent to the proxy (absolute-form).
+  const proxy = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("VIA-PROXY") });
+  const origin = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("DIRECT") });
+  const url = `http://127.0.0.1:${origin.port}/`;
+  const P = `http://127.0.0.1:${proxy.port}`;
+  const file = new URL(import.meta.url);
+
+  function run(env, assign) {
+    const data = { url, assign };
+    return new Promise((resolve, reject) => {
+      if (kind === "node") {
+        const w = new NodeWorker(file, { env, workerData: data });
+        w.once("message", resolve);
+        w.once("error", reject);
+      } else {
+        const w = new Worker(file.href, { env });
+        w.onmessage = e => {
+          resolve(e.data);
+          w.terminate();
+        };
+        w.onerror = e => reject(e.error ?? new Error(e.message));
+        w.postMessage(data);
+      }
+    });
+  }
+
+  // A worker's environment is captured when it is constructed, so all five run
+  // at once; only the construction order relative to the main-thread write matters.
+  const pending = {};
+  // The worker's own env names a proxy; the main thread has none.
+  pending.workerEnvProxy = run({ HTTP_PROXY: P });
+  // The worker's env also excludes the origin with NO_PROXY.
+  pending.workerEnvNoProxy = run({ HTTP_PROXY: P, NO_PROXY: "127.0.0.1,localhost" });
+  // The worker assigns process.env.HTTP_PROXY at runtime before it fetches.
+  pending.workerRuntimeProxy = run({}, { HTTP_PROXY: P });
+  // The main thread sets a proxy at runtime; the worker's env has none.
+  process.env.HTTP_PROXY = P;
+  pending.mainProxyWorkerEnvEmpty = run({});
+  // ...and a worker env that names the proxy but excludes the origin.
+  pending.mainProxyWorkerNoProxy = run({ HTTP_PROXY: P, NO_PROXY: "127.0.0.1" });
+
+  const results = {};
+  for (const [name, promise] of Object.entries(pending)) results[name] = await promise;
+  console.log(JSON.stringify(results));
+  proxy.stop(true);
+  origin.stop(true);
+  process.exit(0);
+}

--- a/test/js/web/workers/worker-env.test.ts
+++ b/test/js/web/workers/worker-env.test.ts
@@ -69,6 +69,46 @@ describe.concurrent("worker env", () => {
     });
   });
 
+  test("a nested worker started without env from a worker with env inherits exactly that env", async () => {
+    using dir = tempDir("worker-env-nested", {
+      "main.mjs": `
+        const outer = new Worker(new URL("./outer.mjs", import.meta.url).href, {
+          env: { ONLY_IN_OUTER: "outer" },
+        });
+        outer.onmessage = e => {
+          console.log(JSON.stringify(e.data));
+          outer.terminate();
+        };
+        outer.onerror = e => { console.error(e.message); process.exit(1); };
+      `,
+      // Starts the inner worker before anything reads process.env here.
+      "outer.mjs": `
+        const inner = new Worker(new URL("./inner.mjs", import.meta.url).href, { type: "module" });
+        inner.onmessage = e => postMessage(e.data);
+        inner.onerror = e => { throw e.error ?? new Error(e.message); };
+      `,
+      "inner.mjs": `
+        postMessage({
+          keys: Object.keys(process.env).filter(k => k === "ONLY_IN_OUTER" || k === "SET_AT_LAUNCH"),
+          only: process.env.ONLY_IN_OUTER,
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: { ...cleanEnv, SET_AT_LAUNCH: "launch" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ result: stdout ? JSON.parse(stdout) : stdout, stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+      result: { keys: ["ONLY_IN_OUTER"], only: "outer" },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   test("NODE_TLS_REJECT_UNAUTHORIZED in the worker's env applies to the worker's fetch()", async () => {
     using dir = tempDir("worker-env-tls", {
       "cert.pem": tls.cert,

--- a/test/js/web/workers/worker-env.test.ts
+++ b/test/js/web/workers/worker-env.test.ts
@@ -1,0 +1,111 @@
+// A Worker given `env` (or started after the parent touched process.env) owns
+// that environment natively: fetch()'s proxy and TLS defaults, and the env a
+// child process inherits, come from the worker's environment rather than the
+// main thread's.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tls } from "harness";
+import { join } from "node:path";
+
+// CI containers can carry ambient proxy variables; each case spawns a process
+// whose environment has none so only the values under test apply.
+const cleanEnv: Record<string, string | undefined> = { ...bunEnv };
+for (const key of ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy"]) {
+  delete cleanEnv[key];
+}
+
+async function run(cmd: string[], cwd?: string) {
+  await using proc = Bun.spawn({ cmd, env: cleanEnv, cwd, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode };
+}
+
+describe.concurrent("worker env", () => {
+  describe.each(["node", "web"])("%s Worker", kind => {
+    test("fetch() resolves HTTP_PROXY / NO_PROXY from the worker's own environment", async () => {
+      const { stdout, stderr, exitCode } = await run([
+        bunExe(),
+        join(import.meta.dirname, "worker-env-proxy-fixture.mjs"),
+        kind,
+      ]);
+      expect({ result: stdout ? JSON.parse(stdout) : stdout, stderr, exitCode }).toEqual({
+        result: {
+          workerEnvProxy: "VIA-PROXY",
+          workerEnvNoProxy: "DIRECT",
+          workerRuntimeProxy: "VIA-PROXY",
+          mainProxyWorkerEnvEmpty: "DIRECT",
+          mainProxyWorkerNoProxy: "DIRECT",
+        },
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
+  test("a child process spawned from the worker inherits the worker's environment", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      bunExe(),
+      "-e",
+      `const { Worker } = require("node:worker_threads");
+       const env = { ...process.env, FROM_WORKER_OPTION: "worker" };
+       process.env.SET_IN_PARENT = "parent";
+       const w = new Worker(
+         \`const { parentPort } = require("node:worker_threads");
+          // No env option: Bun.spawnSync passes the spawning thread's environment.
+          const { stdout } = Bun.spawnSync({
+            cmd: [process.execPath, "-e", "console.log(JSON.stringify([process.env.FROM_WORKER_OPTION, process.env.SET_IN_PARENT]))"],
+          });
+          parentPort.postMessage({
+            child: JSON.parse(stdout.toString()),
+            worker: [process.env.FROM_WORKER_OPTION, process.env.SET_IN_PARENT],
+          });\`,
+         { eval: true, env },
+       );
+       w.once("message", msg => console.log(JSON.stringify(msg)));`,
+    ]);
+    expect({ result: stdout ? JSON.parse(stdout) : stdout, stderr, exitCode }).toEqual({
+      result: { child: ["worker", null], worker: ["worker", null] },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("NODE_TLS_REJECT_UNAUTHORIZED in the worker's env applies to the worker's fetch()", async () => {
+    using dir = tempDir("worker-env-tls", {
+      "cert.pem": tls.cert,
+      "key.pem": tls.key,
+      "main.mjs": `
+        import { Worker } from "node:worker_threads";
+        import { readFileSync } from "node:fs";
+        const server = Bun.serve({
+          port: 0,
+          tls: { cert: readFileSync("cert.pem", "utf8"), key: readFileSync("key.pem", "utf8") },
+          fetch: () => new Response("ok"),
+        });
+        const url = "https://localhost:" + server.port + "/";
+        const run = env =>
+          new Promise((resolve, reject) => {
+            const w = new Worker(new URL("./worker.mjs", import.meta.url), { env, workerData: url });
+            w.once("message", resolve);
+            w.once("error", reject);
+          });
+        const results = {
+          rejecting: await run({}),
+          accepting: await run({ NODE_TLS_REJECT_UNAUTHORIZED: "0" }),
+        };
+        console.log(JSON.stringify(results));
+        server.stop(true);
+        process.exit(0);
+      `,
+      "worker.mjs": `
+        import { parentPort, workerData } from "node:worker_threads";
+        parentPort.postMessage(await fetch(workerData).then(res => res.text(), err => err.code));
+      `,
+    });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "main.mjs"], String(dir));
+    expect({ result: stdout ? JSON.parse(stdout) : stdout, stderr, exitCode }).toEqual({
+      result: { rejecting: "DEPTH_ZERO_SELF_SIGNED_CERT", accepting: "ok" },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `fetch()` inside a Worker ignores that worker's proxy environment. `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` from `new Worker(f, { env })`, or assigned to `process.env` inside the worker, never apply, while the main thread's values apply to every worker's fetch. Same for `NODE_TLS_REJECT_UNAUTHORIZED` and the env `Bun.spawn` passes on from a worker. Both Worker kinds.
- Cause: `options.env` only became the worker's `process.env` JS object (`ZigGlobalObject.cpp:574`). The worker VM's env loader, which `FetchTasklet.rs:1900`, `get_tls_reject_unauthorized` and `Bun.spawn` read, stayed a clone of the parent's (`web_worker.rs:381`), overlaid again with the launch environment.

### Fix
- `WebWorker__create` receives the `options.env` pairs and builds the worker's loader from exactly those entries (`Loader::for_worker_env`). Without `options.env` the worker clones the parent's loader as before; the clone keeps its loaded state instead of re-reading `environ` and `.env` files.
- The worker's `process.env` is built lazily from that loader by `createEnvironmentVariablesMap`, as on the main thread, so the proxy accessors write the worker's own map. Only the main thread adopts and strips `NODE_CHANNEL_FD`, and on Windows only its writes reach the OS environment.
- Correct because the worker's loader now holds what its `process.env` shows, and nothing else read `options.env`. Node (`NODE_USE_ENV_PROXY=1`) also lets the worker's own env decide.
- Verified: `test/js/web/workers/worker-env.test.ts` (5 tests, 4 fail on 1.4.3), plus the worker, worker_threads, process.env and `--env-file` suites, on Linux and Windows.

### Background
- Each `VirtualMachine` owns a `bun_dotenv::Loader` (`vm.transpiler.env`): an insertion-ordered map filled from `environ` and `.env` files at startup. fetch proxy resolution, the TLS-reject default and `Bun.spawn`'s default env read it.
- The main thread builds `process.env` lazily from that map. The six proxy keys are accessors whose setter writes the map; that is how a runtime `process.env.HTTP_PROXY = ...` reaches fetch.
- `new Worker(url, { env })` (or any options object once the parent touched `process.env`) snapshots the env into `WorkerOptions.env` on the parent thread. `SHARE_ENV` workers use `JSSharedEnvMap` and are unchanged.

<details><summary>Notes</summary>

- Found by an internal audit of per-worker env handling, not a user issue. Repro on bun 1.4.3 with a loopback origin and a loopback proxy: worker env `{HTTP_PROXY:P}` went DIRECT, main `HTTP_PROXY=P` with worker env `{}` went VIA-PROXY, and a worker `NO_PROXY` was ignored. With this change: VIA-PROXY, DIRECT, DIRECT.
- Decisions for the reviewer: (1) a worker's `process.env` writes no longer reach the OS environment block on Windows (`jsEditWindowsEnvVar` is main-thread only), where before an explicit-env worker had a plain object that never wrote through and a default-env worker wrote through; (2) `Bun.which()` and the executable lookup of `Bun.spawn` inside a worker now use the worker's own `PATH`, so a worker given `env: { FOO }` with no `PATH` resolves nothing through `PATH` (spawning `ls` still works, `Bun.which("ls")` returns null), as its `process.env` already suggested.
- Overlapping open PRs: #39677 (default env for `new Worker(url)` with no options) is a hoist of the same `JSWorker.cpp` snapshot block and rebases on this in a few lines. #34654 and #34424 extend `WebWorker__create` / `initializeWorker` for per-worker flags; with the worker's loader seeded here, a per-worker `NODE_USE_SYSTEM_CA` can read `env_loader.get()` in `create()` instead of a new parameter. #40420 rewrites `web_worker.rs`; whichever lands second takes a small rebase in `create()`.
- A second symptom of the same cause: with `HTTP_PROXY=launch` in the launch env and `process.env.HTTP_PROXY = runtime` on the main thread, a worker's `process.env.HTTP_PROXY` read `runtime` while its fetch and its child processes used `launch`, because `clone_for_worker` left `did_load_process` false and the worker re-read `environ` over the cloned map. Neither worker path runs that reload now. Which env a `new Worker(url)` with no options object starts from is #39677's question and is unchanged here.
- `NODE_CHANNEL_FD`: the first revision stripped it from every VM's map, which broke `test-worker-unsupported-things.js` once the worker's `process.env` came from the map. The main thread adopts the channel and strips the variables before its `process.env` exists, so a snapshot or clone taken from it never carries them; a worker only sees the key when its parent put it in the env on purpose, as in that test. A worker inside a forked child still has no `process.send` (`worker_threads.test.ts` covers it).
- `WorkerOptions.env` is now a `Vector<std::pair<String, String>>` so the worker's `process.env` enumerates in the parent's order, and the strings are no longer `isolatedCopy()`'d because they are consumed on the parent thread.
- A worker env containing `NODE_ENV=production` now also makes the worker's transpiler treat the worker as production (export conditions), consistent with launching bun with that env.
- Self-reviewed: the one blocking concern (a nested worker without `env` re-reading `environ` over the outer worker's map) is fixed in 2d4f6db551 and tested; the remaining notes were about this body and PR ordering, addressed above.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/workers/worker-env.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/usr/local/bun/bin/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=stati
... (truncated)

release without fix: 4 FAILED
bun test v1.4.2 (744846f84)

test/js/web/workers/worker-env.test.ts:
(pass) worker env > a nested worker started without env from a worker with env inherits exactly that env [16.78ms]
25 |       const { stdout, stderr, exitCode } = await run([
26 |         bunExe(),
27 |         join(import.meta.dirname, "worker-env-proxy-fixture.mjs"),
28 |         kind,
29 |       ]);
30 |       expect({ result: stdout ? JSON.parse(stdout) : stdout, stderr, exitCode }).toEqual({
                                                                                      ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "result": {
-     "mainProxyWorkerEnvEmpty": "DIRECT",
-     "mainProxyWorkerNoProxy": "DIRECT",
+     "mainProxyWorkerEnvEmpty": "VIA-PROXY",
+     "mainProxyWorkerNoProxy": "VIA-PROXY",
      "workerEnvNoProxy": "DIRECT",
-     "workerEnvProxy": "VIA-PROXY",
-     "workerRuntimeProxy": "VIA-PROXY",
+     "workerEnvProxy": "DIRECT",
+     "workerRuntimeProxy": "DIRECT",
    },
    "stderr": "",
  }

- Expected  - 4
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/web/workers/worker-env.test.ts:30:82)
(fail) worker env > web Worker > fetc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/workers/worker-env.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/workers/worker-env.test.ts:
(pass) worker env > a nested worker started without env from a worker with env inherits exactly that env [753.27ms]
(pass) worker env > web Worker > fetch() resolves HTTP_PROXY / NO_PROXY from the worker's own environment [1290.89ms]
(pass) worker env > node Worker > fetch() resolves HTTP_PROXY / NO_PROXY from the worker's own environment [2601.49ms]
(pass) worker env > a child process spawned from the worker inherits the worker's environment [2795.16ms]
(pass) worker env > NODE_TLS_REJECT_UNAUTHORIZED in the worker's env applies to the worker's fetch() [3346.35ms]

 5 pass
 0 fail
 5 expect() calls
Ran 5 tests across 1 file. [5.89s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     71b733f891
  features     baseline

23 deps, 131 codegen, 1172 objects in 657ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] mkdir stamps
[2/1248] mkdir codegen
[3/1248] mkdir obj
[4/1248] mkdir pch
[5/1248] install /workspace/bun
bun install v1.4.2 (744846f84)

Checked 22 installs across 61 packages (no changes) [35.00ms]
[6/1248] gen ErrorCode+*.h
[7/1248] fetch zlib
[zlib] up to date
[8/1248] install /workspace/bun/packages/bun-error
bun install v1.4.2 (744846f84)

Checked 1 install across 2 packages (no changes) [4.00ms]
[9/1248] fetch tinycc
[tinycc] up to date
[10/1248] fetch picohttpparser
[picohttpparser] up to date
[11/1248] gen bindgenv2
[12/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.2 (744846f84)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[13/1248] gen .bind.ts → GeneratedBindings.cpp
[14/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[15/1248] gen node-fallbacks/react-refresh.js
Bundled 1 module in 15ms
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/dotenv/env_loader.rs                          |  23 +++-
 src/jsc/VirtualMachine.rs                         |  30 ++---
 src/jsc/bindings/JSEnvironmentVariableMap.cpp     |   4 +
 src/jsc/bindings/ZigGlobalObject.cpp              |  43 +-----
 src/jsc/bindings/webcore/JSWorker.cpp             |   7 +-
 src/jsc/bindings/webcore/WorkerMessagingProxy.cpp |  22 +++-
 src/jsc/bindings/webcore/WorkerOptions.h          |   4 +-
 src/jsc/web_worker.rs                             |  52 ++++++--
 test/js/web/workers/worker-env-proxy-fixture.mjs  |  68 ++++++++++
 test/js/web/workers/worker-env.test.ts            | 151 ++++++++++++++++++++++
 10 files changed, 333 insertions(+), 71 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/dotenv/env_loader.rs                               5      6      9
src/jsc/VirtualMachine.rs                              3      2      9
src/jsc/bindings/JSEnvironmentVariableMap.cpp          5      3      9
src/jsc/bindings/ZigGlobalObject.cpp                   4      3      9
src/jsc/bindings/webcore/JSWorker.cpp                  1      1     10
src/jsc/bindings/webcore/WorkerMessagingProxy.cpp      2      4      9
src/jsc/bindings/webcore/WorkerOptions.h               2      2      9
src/jsc/web_worker.rs                                  7      6      9
test/js/web/workers/worker-env-proxy-fixture.mjs       0      3     10
test/js/web/workers/worker-env.test.ts                 1      5      9
```

</details>

<!-- robobun:evidence:end -->