### PR TITLE
install: make `bun pm untrusted`, `trust`, and `ls --trusted` read trustedDependencies from package.json

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -844,6 +844,67 @@ impl PackageManager {
         }
     }
 
+    /// `bun install` decides trust from the `trustedDependencies` in package.json
+    /// (the root and every workspace). `bun.lock` only records the set from its
+    /// last save, and `--frozen-lockfile` never rewrites it. Call this after
+    /// `load_lockfile_from_cwd` so `bun pm` sees the set the installer used.
+    pub fn load_trusted_dependencies_from_package_json(&mut self) -> Result<(), Error> {
+        use self::workspace_package_json_cache::{GetJSONOptions, GetResult};
+
+        let mut paths: Vec<Box<[u8]>> =
+            Vec::with_capacity(1 + self.lockfile.workspace_paths.count());
+        // SAFETY: `ROOT_PACKAGE_JSON_PATH` is written once in `init` on this
+        // thread and only read after.
+        paths.push(Box::from(
+            unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes(),
+        ));
+        let string_bytes = self.lockfile.buffers.string_bytes.as_slice();
+        for workspace_path in self.lockfile.workspace_paths.values() {
+            let mut path = bun_paths::AutoAbsPath::init_top_level_dir();
+            path.append(workspace_path.slice(string_bytes))?;
+            path.append(b"package.json")?;
+            paths.push(Box::from(path.slice()));
+        }
+
+        let log = self.log_mut();
+        let bump = bun_alloc::Arena::new();
+        let mut trusted: Option<crate::lockfile_real::TrustedDependenciesSet> = None;
+        for (i, path) in paths.iter().enumerate() {
+            let failed = match self.workspace_package_json_cache.get_with_path(
+                log,
+                path,
+                GetJSONOptions::default(),
+            ) {
+                GetResult::Entry(entry) => match Package::append_trusted_dependencies(
+                    &mut trusted,
+                    &bump,
+                    log,
+                    &entry.source,
+                    &entry.root,
+                ) {
+                    Ok(()) => continue,
+                    // `log` carries the message.
+                    Err(_) => None,
+                },
+                // A workspace that bun.lock lists can be gone from disk. The
+                // installer skips those too.
+                GetResult::ReadErr(Error::Sys(
+                    bun_errno::SystemErrno::ENOENT | bun_errno::SystemErrno::ENOTDIR,
+                )) if i > 0 => continue,
+                GetResult::ReadErr(err) => Some(("read", err)),
+                GetResult::ParseErr(err) => Some(("parse", err)),
+            };
+            let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+            if let Some((verb, err)) = failed {
+                Output::err(err, "failed to {} '{}'", (verb, bstr::BStr::new(&**path)));
+            }
+            Global::exit(1);
+        }
+
+        self.lockfile.trusted_dependencies = trusted;
+        Ok(())
+    }
+
     pub(crate) fn crash(&mut self) -> ! {
         if self.options.log_level != package_manager_options::LogLevel::Silent {
             // SAFETY: `self.log` points to a separate `bun_ast::Log` allocation (borrowed from

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -844,8 +844,10 @@ impl PackageManager {
         }
     }
 
-    /// Trust comes from package.json (root and workspaces), not from what `bun.lock` last saved.
-    pub fn load_trusted_dependencies_from_package_json(&mut self) -> Result<(), Error> {
+    /// Trust comes from package.json (root and workspaces). Returns the set `bun.lock` last saved.
+    pub fn load_trusted_dependencies_from_package_json(
+        &mut self,
+    ) -> Result<Option<lockfile::TrustedDependenciesSet>, Error> {
         use self::workspace_package_json_cache::{GetJSONOptions, GetResult};
 
         let mut paths: Vec<Box<[u8]>> =
@@ -865,7 +867,7 @@ impl PackageManager {
 
         let log = self.log_mut();
         let bump = bun_alloc::Arena::new();
-        let mut trusted: Option<crate::lockfile_real::TrustedDependenciesSet> = None;
+        let mut trusted: Option<lockfile::TrustedDependenciesSet> = None;
         for (i, path) in paths.iter().enumerate() {
             let failed = match self.workspace_package_json_cache.get_with_path(
                 log,
@@ -897,8 +899,10 @@ impl PackageManager {
             Global::exit(1);
         }
 
-        self.lockfile.trusted_dependencies = trusted;
-        Ok(())
+        Ok(core::mem::replace(
+            &mut self.lockfile.trusted_dependencies,
+            trusted,
+        ))
     }
 
     pub(crate) fn crash(&mut self) -> ! {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -844,10 +844,7 @@ impl PackageManager {
         }
     }
 
-    /// `bun install` decides trust from the `trustedDependencies` in package.json
-    /// (the root and every workspace). `bun.lock` only records the set from its
-    /// last save, and `--frozen-lockfile` never rewrites it. Call this after
-    /// `load_lockfile_from_cwd` so `bun pm` sees the set the installer used.
+    /// Trust comes from package.json (root and workspaces), not from what `bun.lock` last saved.
     pub fn load_trusted_dependencies_from_package_json(&mut self) -> Result<(), Error> {
         use self::workspace_package_json_cache::{GetJSONOptions, GetResult};
 
@@ -886,8 +883,7 @@ impl PackageManager {
                     // `log` carries the message.
                     Err(_) => None,
                 },
-                // A workspace that bun.lock lists can be gone from disk. The
-                // installer skips those too.
+                // The installer also skips a lockfile workspace that is missing on disk.
                 GetResult::ReadErr(Error::Sys(
                     bun_errno::SystemErrno::ENOENT | bun_errno::SystemErrno::ENOTDIR,
                 )) if i > 0 => continue,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -3275,7 +3275,23 @@ impl Lockfile {
         pkg_name: &[u8],
         resolution: &Resolution,
     ) -> bool {
-        if let Some(trusted_dependencies) = &self.trusted_dependencies {
+        self.has_trusted_dependency_in(
+            self.trusted_dependencies.as_ref(),
+            alias,
+            pkg_name,
+            resolution,
+        )
+    }
+
+    /// `has_trusted_dependency`, but against `trusted_dependencies` instead of the lockfile's own set.
+    pub fn has_trusted_dependency_in(
+        &self,
+        trusted_dependencies: Option<&TrustedDependenciesSet>,
+        alias: &[u8],
+        pkg_name: &[u8],
+        resolution: &Resolution,
+    ) -> bool {
+        if let Some(trusted_dependencies) = trusted_dependencies {
             let trusted_name = if resolution.tag == ResolutionTag::Npm {
                 pkg_name
             } else {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -116,7 +116,7 @@ pub(crate) type NameHashMap = ArrayHashMap<PackageNameHash, SemverString, ArrayI
 /// Value is the exact byte string the key hash was computed from; lookups must
 /// compare it since truncated hashes can collide. An empty value is the legacy
 /// `bun.lockb` sentinel ("name unknown, hash-only match").
-pub(crate) type TrustedDependenciesSet =
+pub type TrustedDependenciesSet =
     ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>, ArrayIdentityContext>;
 pub(crate) type VersionHashMap =
     ArrayHashMap<PackageNameHash, Semver::Version, ArrayIdentityContextU64>;

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -126,8 +126,7 @@ fn invalid_trusted_dependencies(
     crate::Error::InvalidPackageJSON
 }
 
-/// Adds the names from a package.json `"trustedDependencies"` array to `set`.
-/// `set` stays `None` when the key is absent, so the default list still applies.
+/// Appends a package.json `"trustedDependencies"` array to `set` (left `None` if the key is absent).
 pub(crate) fn append_trusted_dependencies(
     set: &mut Option<TrustedDependenciesSet>,
     bump: &bun_alloc::Arena,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -126,6 +126,39 @@ fn invalid_trusted_dependencies(
     crate::Error::InvalidPackageJSON
 }
 
+/// Adds the names from a package.json `"trustedDependencies"` array to `set`.
+/// `set` stays `None` when the key is absent, so the default list still applies.
+pub(crate) fn append_trusted_dependencies(
+    set: &mut Option<TrustedDependenciesSet>,
+    bump: &bun_alloc::Arena,
+    log: &mut bun_ast::Log,
+    source: &bun_ast::Source,
+    json: &Expr,
+) -> crate::Result<()> {
+    let Some(q) = json.as_property(b"trustedDependencies") else {
+        return Ok(());
+    };
+    let count = match &q.expr.data {
+        ExprData::EArray(arr) => arr.items.len_u32() as usize,
+        ExprData::EArrayJSON(arr) => arr.get().items().len(),
+        _ => return Err(invalid_trusted_dependencies(log, source, q.loc)),
+    };
+    let trusted = set.get_or_insert_with(Default::default);
+    trusted.ensure_unused_capacity(count)?;
+    if let Some(mut items) = q.expr.as_array() {
+        while let Some(item) = items.next() {
+            let Some(name) = item.as_string(bump) else {
+                return Err(invalid_trusted_dependencies(log, source, q.loc));
+            };
+            trusted.put_assume_capacity(
+                semver::string::Builder::string_hash(name) as TruncatedPackageNameHash,
+                Box::<[u8]>::from(name),
+            );
+        }
+    }
+    Ok(())
+}
+
 // `SemverIntType` defaults to `u64`, the only instantiation the lockfile/PM
 // call sites name unqualified.
 //
@@ -2523,29 +2556,13 @@ impl Package<u64> {
         }
 
         if FEATURES.trusted_dependencies {
-            if let Some(q) = json.as_property(b"trustedDependencies") {
-                let count = match &q.expr.data {
-                    ExprData::EArray(arr) => arr.items.len_u32() as usize,
-                    ExprData::EArrayJSON(arr) => arr.get().items().len(),
-                    _ => return Err(invalid_trusted_dependencies(log, source, q.loc)),
-                };
-                if lockfile.trusted_dependencies.is_none() {
-                    lockfile.trusted_dependencies = Some(Default::default());
-                }
-                let trusted = lockfile.trusted_dependencies.as_mut().unwrap();
-                trusted.ensure_unused_capacity(count)?;
-                if let Some(mut items) = q.expr.as_array() {
-                    while let Some(item) = items.next() {
-                        let Some(name) = item.as_string(&bump) else {
-                            return Err(invalid_trusted_dependencies(log, source, q.loc));
-                        };
-                        trusted.put_assume_capacity(
-                            semver::string::Builder::string_hash(name) as TruncatedPackageNameHash,
-                            Box::<[u8]>::from(name),
-                        );
-                    }
-                }
-            }
+            append_trusted_dependencies(
+                &mut lockfile.trusted_dependencies,
+                &bump,
+                log,
+                source,
+                &json,
+            )?;
         }
 
         if FEATURES.is_main {

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -559,6 +559,10 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             let log_level = pm.options.log_level;
             let load_lockfile = pm.load_lockfile_from_cwd::<true>();
             Self::handle_load_lockfile_errors_for(&load_lockfile, log_level, "list");
+            let trusted_only = strings::left_has_any_in_right(args, &[b"--trusted"]);
+            if trusted_only {
+                pm.load_trusted_dependencies_from_package_json()?;
+            }
 
             Output::flush();
             Output::disable_buffering();
@@ -598,8 +602,6 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             if first_directory.dependencies.len() > 1 {
                 more_packages[0] = true;
             }
-
-            let trusted_only = strings::left_has_any_in_right(args, &[b"--trusted"]);
 
             if strings::left_has_any_in_right(args, &[b"-A", b"-a", b"--all"]) {
                 if trusted_only {

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -6,7 +6,7 @@ use bun_collections::{ArrayHashMap, ArrayIdentityContext, StringArrayHashMap};
 use bun_core::strings;
 use bun_core::{Global, Output, Progress};
 use bun_install::lockfile::{
-    LoadResult, Lockfile,
+    LoadResult, Lockfile, TrustedDependenciesSet,
     package::PackageColumns as _,
     package::scripts::{List as ScriptsList, PrintFormat, Scripts},
     tree,
@@ -16,7 +16,7 @@ use bun_install::package_manager_real::{
 };
 use bun_install::{
     self as install, DEFAULT_TRUSTED_DEPENDENCIES_LIST, DependencyID, LifecycleScriptSubprocess,
-    PackageID, PackageManager, Resolution,
+    PackageID, PackageManager, Resolution, ResolutionTag,
 };
 use bun_paths::AutoAbsPath;
 
@@ -24,6 +24,31 @@ use crate::cli::Command;
 use crate::package_manager_command::PackageManagerCommand;
 
 type DepIdSet = ArrayHashMap<DependencyID, (), ArrayIdentityContext>;
+
+/// A dependency's scripts count as blocked when package.json does not trust it, or
+/// trusts it by name but no saved install has recorded that in `bun.lock` yet.
+fn scripts_blocked(
+    lockfile: &Lockfile,
+    recorded: &Option<TrustedDependenciesSet>,
+    alias: &[u8],
+    pkg_name: &[u8],
+    resolution: &Resolution,
+) -> bool {
+    if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
+        return true;
+    }
+    if lockfile.trusted_dependencies.is_none() {
+        // Trusted through the default list, which never reaches the lockfile.
+        return false;
+    }
+    let name = if resolution.tag == ResolutionTag::Npm {
+        pkg_name
+    } else {
+        alias
+    };
+    let hash = bun_semver::string::Builder::string_hash(name) as install::TruncatedPackageNameHash;
+    !recorded.as_ref().is_some_and(|set| set.contains(&hash))
+}
 
 pub(crate) struct DefaultTrustedCommand;
 
@@ -75,7 +100,7 @@ impl UntrustedCommand {
         // only path to the singleton for the rest of this fn (same as the
         // original `pm`).
         let pm: &mut PackageManager = unsafe { &mut *pm_raw };
-        pm.load_trusted_dependencies_from_package_json()?;
+        let recorded = pm.load_trusted_dependencies_from_package_json()?;
         let log: &mut bun_ast::Log = pm.log_mut();
         let lockfile: &Lockfile = &pm.lockfile;
 
@@ -98,7 +123,7 @@ impl UntrustedCommand {
             let alias = dep.name.slice(buf);
             let pkg_name = packages.items_name()[package_id as usize].slice(buf);
             let resolution = &resolutions[package_id as usize];
-            if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
+            if scripts_blocked(lockfile, &recorded, alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
         }
@@ -275,7 +300,7 @@ impl TrustCommand {
         }
         // SAFETY: `pm_raw` singleton; `load_lockfile` is not dereferenced
         // while this runs.
-        unsafe { (*pm_raw).load_trusted_dependencies_from_package_json()? };
+        let recorded = unsafe { (*pm_raw).load_trusted_dependencies_from_package_json()? };
 
         let mut packages_to_trust: Vec<&[u8]> = Vec::with_capacity(args[2..].len());
         for arg in &args[2..] {
@@ -322,7 +347,7 @@ impl TrustCommand {
             let alias = dep.name.slice(buf);
             let pkg_name = packages.items_name()[package_id as usize].slice(buf);
             let resolution = &resolutions[package_id as usize];
-            if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
+            if scripts_blocked(lockfile, &recorded, alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
         }
@@ -403,7 +428,9 @@ impl TrustCommand {
 
                         for package_name_from_cli in &packages_to_trust {
                             if strings::eql_long(package_name_from_cli, alias, true)
-                                && !lockfile.has_trusted_dependency(
+                                && scripts_blocked(
+                                    lockfile,
+                                    &recorded,
                                     alias,
                                     packages.items_name()[package_id as usize].slice(buf),
                                     resolution,

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -25,8 +25,7 @@ use crate::package_manager_command::PackageManagerCommand;
 
 type DepIdSet = ArrayHashMap<DependencyID, (), ArrayIdentityContext>;
 
-/// A dependency's scripts count as blocked when package.json does not trust it, or
-/// trusts it by name but no saved install has recorded that in `bun.lock` yet.
+/// Blocked: package.json does not trust it, or `bun.lock` has not recorded the trust yet.
 fn scripts_blocked(
     lockfile: &Lockfile,
     recorded: &Option<TrustedDependenciesSet>,

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -75,6 +75,7 @@ impl UntrustedCommand {
         // only path to the singleton for the rest of this fn (same as the
         // original `pm`).
         let pm: &mut PackageManager = unsafe { &mut *pm_raw };
+        pm.load_trusted_dependencies_from_package_json()?;
         let log: &mut bun_ast::Log = pm.log_mut();
         let lockfile: &Lockfile = &pm.lockfile;
 
@@ -272,6 +273,9 @@ impl TrustCommand {
                 meta.set_has_install_script(false);
             }
         }
+        // SAFETY: `pm_raw` singleton; `load_lockfile` is not dereferenced
+        // while this runs.
+        unsafe { (*pm_raw).load_trusted_dependencies_from_package_json()? };
 
         let mut packages_to_trust: Vec<&[u8]> = Vec::with_capacity(args[2..].len());
         for arg in &args[2..] {

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -16,7 +16,7 @@ use bun_install::package_manager_real::{
 };
 use bun_install::{
     self as install, DEFAULT_TRUSTED_DEPENDENCIES_LIST, DependencyID, LifecycleScriptSubprocess,
-    PackageID, PackageManager, Resolution, ResolutionTag,
+    PackageID, PackageManager, Resolution,
 };
 use bun_paths::AutoAbsPath;
 
@@ -25,7 +25,7 @@ use crate::package_manager_command::PackageManagerCommand;
 
 type DepIdSet = ArrayHashMap<DependencyID, (), ArrayIdentityContext>;
 
-/// Blocked: package.json does not trust it, or `bun.lock` has not recorded the trust yet.
+/// Blocked unless both package.json (now) and `bun.lock` (as of its last save) trust it.
 fn scripts_blocked(
     lockfile: &Lockfile,
     recorded: &Option<TrustedDependenciesSet>,
@@ -33,20 +33,8 @@ fn scripts_blocked(
     pkg_name: &[u8],
     resolution: &Resolution,
 ) -> bool {
-    if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
-        return true;
-    }
-    if lockfile.trusted_dependencies.is_none() {
-        // Trusted through the default list, which never reaches the lockfile.
-        return false;
-    }
-    let name = if resolution.tag == ResolutionTag::Npm {
-        pkg_name
-    } else {
-        alias
-    };
-    let hash = bun_semver::string::Builder::string_hash(name) as install::TruncatedPackageNameHash;
-    !recorded.as_ref().is_some_and(|set| set.contains(&hash))
+    !lockfile.has_trusted_dependency(alias, pkg_name, resolution)
+        || !lockfile.has_trusted_dependency_in(recorded.as_ref(), alias, pkg_name, resolution)
 }
 
 pub(crate) struct DefaultTrustedCommand;

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -594,8 +594,7 @@ impl TrustCommand {
         // now add the package names to lockfile.trustedDependencies and package.json `trustedDependencies`
         debug_assert!(!package_names_to_add.keys().is_empty());
 
-        // Save what bun.lock recorded plus the names whose scripts just ran. A name that
-        // package.json lists but whose scripts never ran stays unrecorded.
+        // Record only what bun.lock had plus the scripts that just ran.
         // SAFETY: `pm_raw` singleton; mutates `lockfile.trusted_dependencies`.
         unsafe {
             (*pm_raw).lockfile.trusted_dependencies = Some(recorded.unwrap_or_default());

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -594,12 +594,11 @@ impl TrustCommand {
         // now add the package names to lockfile.trustedDependencies and package.json `trustedDependencies`
         debug_assert!(!package_names_to_add.keys().is_empty());
 
-        // could be null if these are the first packages to be trusted
+        // Save what bun.lock recorded plus the names whose scripts just ran. A name that
+        // package.json lists but whose scripts never ran stays unrecorded.
         // SAFETY: `pm_raw` singleton; mutates `lockfile.trusted_dependencies`.
         unsafe {
-            if (*pm_raw).lockfile.trusted_dependencies.is_none() {
-                (*pm_raw).lockfile.trusted_dependencies = Some(Default::default());
-            }
+            (*pm_raw).lockfile.trusted_dependencies = Some(recorded.unwrap_or_default());
         }
 
         let mut total_scripts_ran: usize = 0;

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -853,6 +853,30 @@ describe.concurrent("bun pm reads trustedDependencies from package.json, not a s
     expect(exitCode).toBe(0);
   });
 
+  // A default-list package ran its scripts at install. Naming it in package.json
+  // afterwards does not make it blocked, even though bun.lock never listed it.
+  test("default trust made explicit after install", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const dependencies = { electron: "1.0.0" };
+
+    await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies }));
+    let { out, err, exitCode } = await run(ctx, ["install"]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).not.toContain("Blocked");
+    expect(exitCode).toBe(0);
+    expect(await exists(join(packageDir, "node_modules", "electron", "preinstall.txt"))).toBeTrue();
+    expect(await file(join(packageDir, "bun.lock")).text()).not.toContain('"trustedDependencies"');
+
+    await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies, trustedDependencies: ["electron"] }));
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Found 0 untrusted dependencies with scripts");
+    expect(exitCode).toBe(0);
+  });
+
   // Workspace package.json files count too, like they do for `bun install`.
   test("trust declared by a workspace package.json", async () => {
     using ctx = await setupTest();

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -817,35 +817,59 @@ describe.concurrent("bun pm reads trustedDependencies from package.json, not a s
     using ctx = await setupTest();
     const { packageDir, packageJson } = ctx;
     const marker = join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt");
-    const dependencies = { "uses-what-bin": "1.0.0" };
+    const dependencies = { "uses-what-bin": "1.0.0", "all-lifecycle-scripts": "1.0.0" };
+    const lockfileTrusted = async () =>
+      (await file(join(packageDir, "bun.lock")).text()).match(/"trustedDependencies": \[([^\]]*)\]/)?.[1] ?? null;
 
     await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies }));
     let { out, err, exitCode } = await run(ctx, ["install"]);
     expect(err).toContain("Saved lockfile");
     expect(err).not.toContain("error:");
-    expect(out).toContain("Blocked 1 postinstall");
+    expect(out).toContain("Blocked 4 postinstalls");
     expect(exitCode).toBe(0);
 
     await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies, trustedDependencies: ["uses-what-bin"] }));
-    expect(await file(join(packageDir, "bun.lock")).text()).not.toContain('"trustedDependencies"');
+    expect(await lockfileTrusted()).toBeNull();
 
     ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--trusted"]));
     expect(err).not.toContain("error:");
     expect(out).toContain("uses-what-bin@1.0.0");
+    expect(out).not.toContain("all-lifecycle-scripts");
     expect(exitCode).toBe(0);
 
     ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
     expect(err).not.toContain("error:");
     expect(out).toContain("uses-what-bin @1.0.0\n");
+    expect(out).toContain("all-lifecycle-scripts @1.0.0\n");
     expect(exitCode).toBe(0);
     expect(await exists(marker)).toBeFalse();
+
+    // Trusting another package records only that package: uses-what-bin is in
+    // package.json but its script still has not run.
+    ({ out, err, exitCode } = await run(ctx, ["pm", "trust", "all-lifecycle-scripts"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("3 scripts ran across 1 package");
+    expect(exitCode).toBe(0);
+    expect(await lockfileTrusted()).toContain('"all-lifecycle-scripts"');
+    expect(await lockfileTrusted()).not.toContain('"uses-what-bin"');
+    expect(await file(packageJson).json()).toEqual({
+      name: "foo",
+      dependencies,
+      trustedDependencies: ["all-lifecycle-scripts", "uses-what-bin"],
+    });
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("uses-what-bin @1.0.0\n");
+    expect(out).not.toContain("all-lifecycle-scripts @1.0.0\n");
+    expect(exitCode).toBe(0);
 
     ({ out, err, exitCode } = await run(ctx, ["pm", "trust", "uses-what-bin"]));
     expect(err).not.toContain("error:");
     expect(out).toContain("1 script ran across 1 package");
     expect(exitCode).toBe(0);
     expect(await exists(marker)).toBeTrue();
-    expect(await file(join(packageDir, "bun.lock")).text()).toContain('"trustedDependencies"');
+    expect(await lockfileTrusted()).toContain('"uses-what-bin"');
 
     ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
     expect(err).not.toContain("error:");

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -877,6 +877,39 @@ describe.concurrent("bun pm reads trustedDependencies from package.json, not a s
     expect(exitCode).toBe(0);
   });
 
+  // The other way around: an explicit list blocked a default-list package at
+  // install. Dropping the list from package.json does not mark its scripts as run.
+  test("default-list package blocked by an explicit list stays blocked after the list is removed", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const marker = join(packageDir, "node_modules", "electron", "preinstall.txt");
+    const dependencies = { electron: "1.0.0", "uses-what-bin": "1.0.0" };
+
+    await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies, trustedDependencies: ["uses-what-bin"] }));
+    let { out, err, exitCode } = await run(ctx, ["install"]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Blocked 1 postinstall");
+    expect(exitCode).toBe(0);
+    expect(await exists(marker)).toBeFalse();
+
+    // Without the key, electron falls back to the default list, and uses-what-bin
+    // loses its trust.
+    await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies }));
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("electron @1.0.0\n");
+    expect(out).toContain("uses-what-bin @1.0.0\n");
+    expect(exitCode).toBe(0);
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "trust", "electron"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 script ran across 1 package");
+    expect(exitCode).toBe(0);
+    expect(await exists(marker)).toBeTrue();
+  });
+
   // Workspace package.json files count too, like they do for `bun install`.
   test("trust declared by a workspace package.json", async () => {
     using ctx = await setupTest();

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -732,6 +732,147 @@ test.concurrent(
   },
 );
 
+describe.concurrent("bun pm reads trustedDependencies from package.json, not a stale bun.lock", () => {
+  async function run(ctx: TestCtx, cmd: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...cmd],
+      cwd: ctx.packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+      env: ctx.env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  for (const linker of ["hoisted", "isolated"] as const) {
+    // A `--frozen-lockfile` install after removing a name from package.json
+    // `trustedDependencies` blocks the scripts but leaves the name in bun.lock.
+    test(`trust removed from package.json, frozen install (${linker})`, async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson } = ctx;
+      await verdaccio.writeBunfig(packageDir, { linker });
+      const marker = join(packageDir, "node_modules", "all-lifecycle-scripts", "postinstall.txt");
+      const dependencies = { "all-lifecycle-scripts": "1.0.0" };
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({ name: "foo", dependencies, trustedDependencies: ["all-lifecycle-scripts"] }),
+      );
+      let { out, err, exitCode } = await run(ctx, ["install"]);
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(await exists(marker)).toBeTrue();
+      expect(exitCode).toBe(0);
+
+      await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies }));
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      ({ out, err, exitCode } = await run(ctx, ["install", "--frozen-lockfile"]));
+      expect(err).not.toContain("error:");
+      expect(await exists(marker)).toBeFalse();
+      expect(await file(join(packageDir, "bun.lock")).text()).toContain('"trustedDependencies"');
+      expect(exitCode).toBe(0);
+
+      ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+      expect(err).not.toContain("error:");
+      expect(out).toContain("./node_modules/all-lifecycle-scripts @1.0.0".replaceAll("/", sep));
+      expect(exitCode).toBe(0);
+
+      ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--trusted"]));
+      expect(err).not.toContain("error:");
+      expect(out).not.toContain("all-lifecycle-scripts");
+      expect(exitCode).toBe(0);
+
+      ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--all", "--trusted"]));
+      expect(err).not.toContain("error:");
+      expect(out).not.toContain("all-lifecycle-scripts");
+      expect(exitCode).toBe(0);
+
+      ({ out, err, exitCode } = await run(ctx, ["pm", "trust", "all-lifecycle-scripts"]));
+      expect(err).not.toContain("error:");
+      expect(out).toContain("3 scripts ran across 1 package");
+      expect(exitCode).toBe(0);
+      expect(await exists(marker)).toBeTrue();
+      expect(await file(packageJson).json()).toEqual({
+        name: "foo",
+        dependencies,
+        trustedDependencies: ["all-lifecycle-scripts"],
+      });
+
+      ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--trusted"]));
+      expect(err).not.toContain("error:");
+      expect(out).toContain("all-lifecycle-scripts@1.0.0");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  // The reverse: package.json trusts a name that bun.lock does not list.
+  test("trust added to package.json after install", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const dependencies = { "uses-what-bin": "1.0.0" };
+
+    await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies }));
+    let { out, err, exitCode } = await run(ctx, ["install"]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Blocked 1 postinstall");
+    expect(exitCode).toBe(0);
+
+    await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies, trustedDependencies: ["uses-what-bin"] }));
+    expect(await file(join(packageDir, "bun.lock")).text()).not.toContain('"trustedDependencies"');
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Found 0 untrusted dependencies with scripts");
+    expect(exitCode).toBe(0);
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--trusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("uses-what-bin@1.0.0");
+    expect(exitCode).toBe(0);
+  });
+
+  // Workspace package.json files count too, like they do for `bun install`.
+  test("trust declared by a workspace package.json", async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson } = ctx;
+    const marker = join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt");
+    const workspaceJson = join(packageDir, "packages", "a", "package.json");
+    await mkdir(join(packageDir, "packages", "a"), { recursive: true });
+
+    await writeFile(packageJson, JSON.stringify({ name: "foo", workspaces: ["packages/*"] }));
+    await writeFile(
+      workspaceJson,
+      JSON.stringify({ name: "a", dependencies: { "uses-what-bin": "1.0.0" }, trustedDependencies: ["uses-what-bin"] }),
+    );
+    let { out, err, exitCode } = await run(ctx, ["install"]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(await exists(marker)).toBeTrue();
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain('"trustedDependencies"');
+    expect(exitCode).toBe(0);
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--all", "--trusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("uses-what-bin@1.0.0");
+    expect(exitCode).toBe(0);
+
+    await writeFile(workspaceJson, JSON.stringify({ name: "a", dependencies: { "uses-what-bin": "1.0.0" } }));
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("./node_modules/uses-what-bin @1.0.0".replaceAll("/", sep));
+    expect(exitCode).toBe(0);
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--all", "--trusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).not.toContain("uses-what-bin");
+    expect(exitCode).toBe(0);
+  });
+});
+
 // waiter thread is only a thing on Linux.
 for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
   describe.concurrent("lifecycle scripts" + (forceWaiterThread ? " (waiter thread)" : ""), async () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -776,7 +776,10 @@ describe.concurrent("bun pm reads trustedDependencies from package.json, not a s
 
       ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
       expect(err).not.toContain("error:");
-      expect(out).toContain("./node_modules/all-lifecycle-scripts @1.0.0".replaceAll("/", sep));
+      // On Windows the isolated linker reports the store path, so match the
+      // package and its scripts rather than the folder.
+      expect(out).toContain("all-lifecycle-scripts @1.0.0\n");
+      expect(out).toContain("[postinstall]: bun postinstall.js");
       expect(exitCode).toBe(0);
 
       ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--trusted"]));

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -810,10 +810,13 @@ describe.concurrent("bun pm reads trustedDependencies from package.json, not a s
     });
   }
 
-  // The reverse: package.json trusts a name that bun.lock does not list.
+  // The reverse: package.json trusts a name by hand after an install that blocked
+  // its scripts. bun.lock has not recorded the trust, so the scripts still count
+  // as blocked until `bun pm trust` (or an install) runs them.
   test("trust added to package.json after install", async () => {
     using ctx = await setupTest();
     const { packageDir, packageJson } = ctx;
+    const marker = join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt");
     const dependencies = { "uses-what-bin": "1.0.0" };
 
     await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies }));
@@ -826,14 +829,27 @@ describe.concurrent("bun pm reads trustedDependencies from package.json, not a s
     await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies, trustedDependencies: ["uses-what-bin"] }));
     expect(await file(join(packageDir, "bun.lock")).text()).not.toContain('"trustedDependencies"');
 
-    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
-    expect(err).not.toContain("error:");
-    expect(out).toContain("Found 0 untrusted dependencies with scripts");
-    expect(exitCode).toBe(0);
-
     ({ out, err, exitCode } = await run(ctx, ["pm", "ls", "--trusted"]));
     expect(err).not.toContain("error:");
     expect(out).toContain("uses-what-bin@1.0.0");
+    expect(exitCode).toBe(0);
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("uses-what-bin @1.0.0\n");
+    expect(exitCode).toBe(0);
+    expect(await exists(marker)).toBeFalse();
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "trust", "uses-what-bin"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 script ran across 1 package");
+    expect(exitCode).toBe(0);
+    expect(await exists(marker)).toBeTrue();
+    expect(await file(join(packageDir, "bun.lock")).text()).toContain('"trustedDependencies"');
+
+    ({ out, err, exitCode } = await run(ctx, ["pm", "untrusted"]));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Found 0 untrusted dependencies with scripts");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Problem
- Remove a package from package.json `trustedDependencies`, then run `bun install --frozen-lockfile` (or `bun ci`). The installer blocks the scripts. But `bun pm untrusted` prints `Found 0 untrusted dependencies with scripts`, `bun pm trust <pkg>` fails with `0 scripts ran. The following packages are already trusted`, and `bun pm ls --trusted` lists the package.
- Cause: `bun install` decides trust from package.json and copies that set over the loaded lockfile (`install_with_manager.rs:358`). A frozen install never rewrites `bun.lock`, so its `"trustedDependencies"` goes stale. The three `pm` commands only loaded the lockfile and checked `has_trusted_dependency` against the stale set.

### Fix
- New `PackageManager::load_trusted_dependencies_from_package_json` reads `trustedDependencies` from the root package.json and each workspace in the lockfile and replaces `lockfile.trusted_dependencies`. `pm untrusted`, `pm trust` and `pm ls --trusted` call it after the lockfile load.
- `pm untrusted` and `pm trust` count a dependency as blocked unless both package.json (now) and the set `bun.lock` last saved trust it. Both sides use the same check (`has_trusted_dependency_in`, default list included). So a revoked name is blocked, and a name added by hand after a blocked install stays runnable by `bun pm trust`, which then saves the lockfile.
- The array parsing moves out of `Package::parse_with_json` into `append_trusted_dependencies`, one parser for the installer and `pm`.
- Verified: `test/cli/install/bun-install-lifecycle-scripts.test.ts`, six new cases, five of which fail on stock bun. Also ran the rest of that file and `bun-pm.test.ts`.

### Background
- `trustedDependencies` lists the dependencies whose lifecycle scripts may run. Others (outside the built-in default list) are blocked.
- `bun.lock` records a `"trustedDependencies"` array at save time so the next install's differ sees additions and removals. It is not the source of truth.
- `--frozen-lockfile` disables lockfile saving, so `bun.lock` stays behind package.json until the next normal install.

<details><summary>Notes</summary>

- Trust set semantics match the installer: `None` when no manifest has the key (the default list applies), else the union of root and workspace entries. `pm ls --trusted` shows that package.json view.
- Why both sides: a name can be added to package.json after an install that blocked its scripts. Reading package.json alone would make `pm trust` refuse with "already trusted" while the scripts never ran (and under the isolated linker a later `bun install` does not run them either). Reading `bun.lock` alone is the old behavior and misses revocations. The `bun.lock` side is evaluated with the default list when the lockfile has no `trustedDependencies`, so a default-list package whose trust is later made explicit in package.json is not reported as blocked.
- `bun pm trust` writes to `bun.lock` only what it had recorded plus the names whose scripts it just ran. A name the user added to package.json by hand, whose scripts never ran, stays unrecorded until `pm trust <name>` or a saving install runs it.
- Known limit: `bun.lock` cannot see installs that did not save it. After `bun ci` with a name that package.json trusts but `bun.lock` does not, the scripts ran, yet `pm untrusted` still lists the package until a saving install or `bun pm trust` records it (same as before this change).
- The `Blocked N postinstalls` summary line is also missing in the frozen scenario, but that is a separate, broader gap: it is missing on every reinstall from `bun.lock` (the hoisted linker gates it on `meta.has_install_script`, which `bun.lock` does not store, and the isolated linker never counts blocked scripts). Not changed here.
- `bun install` itself ignores a `trustedDependencies` edit made only in a workspace package.json after the first install (the nested workspace diff is dropped). Tracked separately. The `pm` commands here read workspace manifests the way a fresh resolve does.
- With a legacy `bun.lockb`, which stores only name hashes, `bun pm ls --trusted` now lists what package.json trusts. `pm untrusted`/`pm trust` still see the hash-only entries as unrecorded, as before (#34327 covers that sentinel).
- `bun pm ls` without `--trusted` does not read package.json.
- A workspace listed in `bun.lock` but missing on disk is skipped, like the installer's pruned-workspace tolerance. Read or parse errors print the log and `failed to read/parse '<path>'`, like `bun install`.
- The new tests: frozen-install drift on hoisted and isolated (untrusted, `ls --trusted`, `ls --all --trusted`, then `pm trust` runs all three scripts and rewrites package.json); trust added to package.json by hand after a blocked install (`ls --trusted` lists it, `pm untrusted` still lists it, `pm trust` runs the script and records it, then `pm untrusted` reports 0); default-list trust (electron) made explicit after install is not reported as blocked (regression guard, passes on stock too); a default-list package blocked by an explicit list stays blocked after the list is removed from package.json, while the formerly listed package becomes untrusted; trust declared then removed in a workspace package.json.

</details>
