### PR TITLE
bundler: compose source maps through an input file's sourceMappingURL map

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -54,6 +54,9 @@ pub struct Ast<'a> {
     // them under the same lifetime-erased contract as `StoreRef`.
     pub hashbang: StoreStr,
     pub directive: Option<StoreStr>,
+    /// The last `//# sourceMappingURL=` (or `//@`, `/*# */`) comment in the
+    /// file: the URL text and where it is.
+    pub source_mapping_url: Option<crate::Span>,
     /// `export default X` where `X` is an import binding in this file. When
     /// `X` resolves to a module namespace the linker binds importers of
     /// `default` through `X` (a namespace never changes identity, so the
@@ -125,6 +128,7 @@ impl<'a> Ast<'a> {
             import_records: ImportRecordList::new_in(arena),
             hashbang: StoreStr::EMPTY,
             directive: None,
+            source_mapping_url: None,
             export_default_alias_of_import: Ref::NONE,
             parts: PartList::new_in(arena),
             symbols: SymbolList::new_in(arena),

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -54,8 +54,7 @@ pub struct Ast<'a> {
     // them under the same lifetime-erased contract as `StoreRef`.
     pub hashbang: StoreStr,
     pub directive: Option<StoreStr>,
-    /// The last `//# sourceMappingURL=` (or `//@`, `/*# */`) comment in the
-    /// file: the URL text and where it is.
+    /// URL text and location of the file's last `sourceMappingURL` comment.
     pub source_mapping_url: Option<crate::Span>,
     /// `export default X` where `X` is an import binding in this file. When
     /// `X` resolves to a module namespace the linker binds importers of

--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -112,6 +112,10 @@ pub struct InputFile {
     pub unique_key_for_additional_file: Box<[u8], AstAlloc>,
     pub content_hash_for_additional_file: u64,
     pub flags: InputFileFlags,
+    /// The source map the file names in its `sourceMappingURL` comment, when
+    /// source maps are on and it could be loaded. Global-heap; drained in
+    /// `BundleV2::deinit_without_freeing_arena`.
+    pub input_source_map: Option<Box<bun_sourcemap::InputSourceMap>>,
 }
 
 impl Default for InputFile {
@@ -125,6 +129,7 @@ impl Default for InputFile {
             unique_key_for_additional_file: AstAlloc::vec().into_boxed_slice(),
             content_hash_for_additional_file: 0,
             flags: InputFileFlags::default(),
+            input_source_map: None,
         }
     }
 }
@@ -142,6 +147,7 @@ bun_collections::multi_array_columns! {
         unique_key_for_additional_file: Box<[u8], AstAlloc>,
         content_hash_for_additional_file: u64,
         flags: InputFileFlags,
+        input_source_map: Option<Box<bun_sourcemap::InputSourceMap>>,
     }
 }
 

--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -112,9 +112,7 @@ pub struct InputFile {
     pub unique_key_for_additional_file: Box<[u8], AstAlloc>,
     pub content_hash_for_additional_file: u64,
     pub flags: InputFileFlags,
-    /// The source map the file names in its `sourceMappingURL` comment, when
-    /// source maps are on and it could be loaded. Global-heap; drained in
-    /// `BundleV2::deinit_without_freeing_arena`.
+    /// From the file's `sourceMappingURL` comment. Global heap: drained in `deinit_without_freeing_arena`.
     pub input_source_map: Option<Box<bun_sourcemap::InputSourceMap>>,
 }
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1188,8 +1188,7 @@ impl<'a> LinkerContext<'a> {
         //   -->
         //    Which source index in the generated sourcemap, referred to
         //    as the "mapping source index" within this function to be distinct.
-        //    A file with an input source map takes one slot per source of that
-        //    map, starting here; its chunks carry slot offsets relative to it.
+        //    A file with an input source map takes one slot per source of that map.
         let mut source_id_map: ArrayHashMap<u32, i32> = ArrayHashMap::new();
 
         let source_indices = results.items_source_index();
@@ -1289,8 +1288,7 @@ impl<'a> LinkerContext<'a> {
             )?;
 
             prev_end_state = chunk.end_state;
-            // A chunk's own source indices count from 0 (and stay 0 unless the
-            // file had an input source map with several sources).
+            // Chunk-local source indices count from 0: rebase onto the file's first slot.
             prev_end_state.source_index += mapping_source_index;
             prev_column_offset = chunk.final_generated_column;
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1176,6 +1176,7 @@ impl<'a> LinkerContext<'a> {
         let mut j = StringJoiner::default();
 
         let sources = self.parse_graph().input_files.items_source();
+        let input_source_maps = self.parse_graph().input_files.items_input_source_map();
         let quoted_source_map_contents = self.graph.files.items_quoted_source_contents();
 
         // Entries in `results` do not 1:1 map to source files, the mapping
@@ -1187,80 +1188,69 @@ impl<'a> LinkerContext<'a> {
         //   -->
         //    Which source index in the generated sourcemap, referred to
         //    as the "mapping source index" within this function to be distinct.
+        //    A file with an input source map takes one slot per source of that
+        //    map, starting here; its chunks carry slot offsets relative to it.
         let mut source_id_map: ArrayHashMap<u32, i32> = ArrayHashMap::new();
 
         let source_indices = results.items_source_index();
 
         j.push_static(b"{\n  \"version\": 3,\n  \"sources\": [");
-        if !source_indices.is_empty() {
-            {
-                let index = source_indices[0];
-                let path = &sources[index as usize].path;
-                source_id_map.put_no_clobber(index, 0)?;
+        let mut next_mapping_source_index: i32 = 0;
+        for &index in source_indices {
+            let gop = source_id_map.get_or_put(index)?;
+            if gop.found_existing {
+                continue;
+            }
+            *gop.value_ptr = next_mapping_source_index;
 
-                // Note: the relative path lives in a local owned buffer
-                // (drops at scope exit).
+            let mut push_source = |j: &mut StringJoiner, abs_path_or_name: &[u8], is_file: bool| {
                 let rel_path_storage;
-                let pretty: &[u8] = if path.is_file() {
-                    rel_path_storage = Self::source_map_relative_path(chunk_abs_dir, path.text)?;
+                let name: &[u8] = if is_file {
+                    rel_path_storage =
+                        Self::source_map_relative_path(chunk_abs_dir, abs_path_or_name)?;
                     &rel_path_storage
                 } else {
-                    path.pretty
+                    abs_path_or_name
                 };
-
-                let mut quote_buf = MutableString::init(pretty.len() + 2)?;
-                js_printer::quote_for_json(pretty, &mut quote_buf, false)?;
+                let mut quote_buf = MutableString::init(name.len() + ", ".len() + 2)?;
+                if next_mapping_source_index > 0 {
+                    quote_buf.append_assume_capacity(b", ");
+                }
+                js_printer::quote_for_json(name, &mut quote_buf, false)?;
                 // `to_default_owned` moves the buffer into the joiner
                 // (joiner owns it until `done`).
                 j.push_owned(quote_buf.to_default_owned());
-            }
-
-            let mut next_mapping_source_index: i32 = 1;
-            for &index in &source_indices[1..] {
-                let gop = source_id_map.get_or_put(index)?;
-                if gop.found_existing {
-                    continue;
-                }
-
-                *gop.value_ptr = next_mapping_source_index;
                 next_mapping_source_index += 1;
+                Ok::<(), BunError>(())
+            };
 
-                let path = &sources[index as usize].path;
-
-                let rel_path_storage;
-                let pretty: &[u8] = if path.is_file() {
-                    rel_path_storage = Self::source_map_relative_path(chunk_abs_dir, path.text)?;
-                    &rel_path_storage
-                } else {
-                    path.pretty
-                };
-
-                let mut quote_buf = MutableString::init(pretty.len() + ", ".len() + 2)?;
-                quote_buf.append_assume_capacity(b", ");
-                js_printer::quote_for_json(pretty, &mut quote_buf, false)?;
-                j.push_owned(quote_buf.to_default_owned());
+            match input_source_maps[index as usize].as_deref() {
+                None => {
+                    let path = &sources[index as usize].path;
+                    if path.is_file() {
+                        push_source(&mut j, path.text, true)?;
+                    } else {
+                        push_source(&mut j, path.pretty, false)?;
+                    }
+                }
+                Some(input_source_map) => {
+                    for source in input_source_map.sources.iter() {
+                        push_source(&mut j, &source.path, source.is_file)?;
+                    }
+                }
             }
         }
 
         j.push_static(b"],\n  \"sourcesContent\": [");
 
-        let source_indices_for_contents = source_id_map.keys();
-        if !source_indices_for_contents.is_empty() {
-            j.push_static(b"\n    ");
-            j.push_static(
-                quoted_source_map_contents[source_indices_for_contents[0] as usize]
+        for (i, &index) in source_id_map.keys().iter().enumerate() {
+            j.push_static(if i == 0 { b"\n    " } else { b",\n    " });
+            j.push_static(match input_source_maps[index as usize].as_deref() {
+                None => quoted_source_map_contents[index as usize]
                     .as_deref()
                     .unwrap_or(b""),
-            );
-
-            for &index in &source_indices_for_contents[1..] {
-                j.push_static(b",\n    ");
-                j.push_static(
-                    quoted_source_map_contents[index as usize]
-                        .as_deref()
-                        .unwrap_or(b""),
-                );
-            }
+                Some(input_source_map) => &input_source_map.quoted_sources_content,
+            });
         }
         j.push_static(b"\n  ],\n  \"mappings\": \"");
 
@@ -1299,7 +1289,9 @@ impl<'a> LinkerContext<'a> {
             )?;
 
             prev_end_state = chunk.end_state;
-            prev_end_state.source_index = mapping_source_index;
+            // A chunk's own source indices count from 0 (and stay 0 unless the
+            // file had an input source map with several sources).
+            prev_end_state.source_index += mapping_source_index;
             prev_column_offset = chunk.final_generated_column;
 
             if prev_end_state.generated_line == 0 {
@@ -1677,6 +1669,10 @@ impl SourceMapData {
         let parse_graph = this.parse_graph();
         let loader: Loader = parse_graph.input_files.items_loader()[source_index as usize];
         if !loader.can_have_source_map() {
+            return;
+        }
+        // The output map carries the input map's `sourcesContent` instead.
+        if parse_graph.input_files.items_input_source_map()[source_index as usize].is_some() {
             return;
         }
 
@@ -2360,6 +2356,9 @@ impl<'a> LinkerContext<'a> {
             // SAFETY: `self.mangled_props` is not mutated during printing; detached borrow
             // outlives only this call (see above).
             unsafe { bun_ptr::detach_lifetime_ref(&self.mangled_props) };
+        let input_source_map: Option<&bun_sourcemap::InputSourceMap> =
+            parse_graph.input_files.items_input_source_map()[source_index.get() as usize]
+                .as_deref();
 
         let print_options = js_printer::Options {
             bundling: true,
@@ -2406,6 +2405,7 @@ impl<'a> LinkerContext<'a> {
             require_or_import_meta_for_source_callback:
                 js_printer::RequireOrImportMetaCallback::init(self),
             line_offset_tables: Some(line_offset_table),
+            input_source_map,
             target: self.options.target,
 
             hmr_ref: if self.options.output_format == Format::InternalBakeDev {

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2670,8 +2670,7 @@ pub mod parse_worker {
         // SAFETY: task.ctx backref valid for the bundle pass (outlives `'r`).
         let task_ctx = unsafe { task.ctx() };
         let module_type = opts.module_type;
-        // The dev server joins per-file maps itself (`SourceMapStore`) and
-        // assumes one `sources` entry per file, so it gets no input maps.
+        // The dev server's `SourceMapStore` assumes one `sources` entry per file: no input maps there.
         let use_input_source_maps =
             topts.source_map != options::SourceMapOption::None && !topts.has_dev_server();
         // `topts` (a `&BundleOptions`) is dead past this point; the callees take

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -186,6 +186,9 @@ pub(crate) struct Success {
 
     /// The package name from package.json, used for barrel optimization.
     pub(crate) package_name: ast::StoreStr,
+
+    /// See `InputFile::input_source_map`, where this moves on completion.
+    pub(crate) input_source_map: Option<Box<bun_sourcemap::InputSourceMap>>,
 }
 
 pub(crate) struct ResultError {
@@ -803,6 +806,7 @@ pub mod parse_worker {
         unique_key_prefix: u64,
         unique_key_for_additional_file: &mut FileLoaderHash,
         has_any_css_locals: &AtomicU32,
+        source_mapping_url: &mut Option<bun_ast::Span>,
     ) -> core::result::Result<JSAst<'static>, AnyError> {
         use core::fmt::Write as _;
 
@@ -828,7 +832,10 @@ pub mod parse_worker {
                     // `Cached`/`AlreadyBundled` are runtime-loader
                     // states that never reach the bundler's `getAST`, so unwrap.
                     match res {
-                        bun_js_parser::Result::Ast(ast) => Ok(JSAst::init(*ast)),
+                        bun_js_parser::Result::Ast(ast) => {
+                            *source_mapping_url = ast.source_mapping_url;
+                            Ok(JSAst::init(*ast))
+                        }
                         bun_js_parser::Result::Cached
                         | bun_js_parser::Result::AlreadyBundled(_) => {
                             unreachable!("bundler parse never yields Cached/AlreadyBundled")
@@ -2663,9 +2670,14 @@ pub mod parse_worker {
         // SAFETY: task.ctx backref valid for the bundle pass (outlives `'r`).
         let task_ctx = unsafe { task.ctx() };
         let module_type = opts.module_type;
+        // The dev server joins per-file maps itself (`SourceMapStore`) and
+        // assumes one `sources` entry per file, so it gets no input maps.
+        let use_input_source_maps =
+            topts.source_map != options::SourceMapOption::None && !topts.has_dev_server();
         // `topts` (a `&BundleOptions`) is dead past this point; the callees take
         // raw `*mut Transpiler` and reborrow `(*transpiler).options` mutably.
         let _ = topts;
+        let mut source_mapping_url: Option<bun_ast::Span> = None;
         let ast_result: core::result::Result<JSAst, AnyError> =
             if !is_empty || loader.handles_empty_file() {
                 get_ast(
@@ -2679,6 +2691,7 @@ pub mod parse_worker {
                     task_ctx.unique_key,
                     &mut unique_key_for_additional_file,
                     &task_ctx.linker.has_any_css_locals,
+                    &mut source_mapping_url,
                 )
             } else if loader.is_css() {
                 get_empty_css_ast(log, transpiler, opts, bump, source)
@@ -2724,6 +2737,13 @@ pub mod parse_worker {
 
         *step = Step::Resolve;
 
+        let input_source_map = match source_mapping_url {
+            Some(comment) if use_input_source_maps => {
+                crate::input_source_map::load(log, source, comment)
+            }
+            _ => None,
+        };
+
         Ok(Success {
             ast,
             source: source.clone(),
@@ -2736,6 +2756,8 @@ pub mod parse_worker {
 
             // Hash the files in here so that we do it in parallel.
             content_hash_for_additional_file: unique_key_for_additional_file.content_hash,
+
+            input_source_map,
         })
     }
 

--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -203,6 +203,7 @@ fn task_callback(
         unique_key_for_additional_file: bun_ast::StoreStr::EMPTY,
         content_hash_for_additional_file: 0,
         package_name: bun_ast::StoreStr::EMPTY,
+        input_source_map: None,
     })
 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5190,6 +5190,10 @@ pub mod bv2_impl {
             // macro takes only one side (`linker.graph.ast` is a bitwise SoA
             // `memcpy` of `graph.ast`), and `CssChunk::asts` `forget()`s its
             // aliases, so this is the unique drop.
+            // `InputFile.input_source_map` is likewise global-heap, not arena.
+            for input_source_map in self.graph.input_files.items_input_source_map_mut() {
+                drop(input_source_map.take());
+            }
             {
                 macro_rules! take_ast_cols {
                     ($ast:expr) => {{
@@ -7356,6 +7360,8 @@ pub mod bv2_impl {
 
                     // Record which loader we used for this file
                     this.graph.input_files.items_loader_mut()[result_source_index] = result.loader;
+                    this.graph.input_files.items_input_source_map_mut()[result_source_index] =
+                        result.input_source_map.take();
 
                     bun_core::scoped_log!(
                         Bundle,

--- a/src/bundler/input_source_map.rs
+++ b/src/bundler/input_source_map.rs
@@ -46,7 +46,10 @@ pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<
                 // `https://…` and the like: nothing a build can read, and not
                 // something the author of this build can fix, so stay quiet.
                 return None;
-            } else if let Some(source_dir) = source_dir {
+            } else {
+                // A virtual module (plugin namespace) has no directory to
+                // resolve a relative URL against.
+                let source_dir = source_dir?;
                 let url = strip_query_and_fragment(url);
                 let decoded;
                 let url: &[u8] = if bun_core::strings::contains_char(url, b'%') {
@@ -61,17 +64,9 @@ pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<
                     url
                 };
                 let mut buf = bun_paths::path_buffer_pool::get();
-                match bun_paths::resolve_path::join_abs_string_buf_checked::<
+                Box::from(bun_paths::resolve_path::join_abs_string_buf_checked::<
                     bun_paths::resolve_path::platform::Auto,
-                >(source_dir, &mut buf[..], &[url])
-                {
-                    Some(joined) => Box::from(joined),
-                    None => return None,
-                }
-            } else {
-                // A virtual module (plugin namespace) has no directory to
-                // resolve a relative URL against.
-                return None;
+                >(source_dir, &mut buf[..], &[url])?)
             };
 
             json = match bun_sys::File::read_from(bun_sys::Fd::cwd(), &map_path) {
@@ -118,7 +113,7 @@ pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<
                 format_args!(
                     "Ignoring the source map \"{}\" of this file: {}",
                     bstr::BStr::new(&map_name),
-                    err.0
+                    bstr::BStr::new(&err.0)
                 ),
             );
             None

--- a/src/bundler/input_source_map.rs
+++ b/src/bundler/input_source_map.rs
@@ -1,13 +1,10 @@
-//! Loads the source map an input file names in its `sourceMappingURL`
-//! comment, so the output map can point through it at the original sources.
+//! Loads the source map an input file's `sourceMappingURL` comment names.
 
 use bun_ast::{Log, Source, Span};
 use bun_sourcemap::InputSourceMap;
 use bun_sourcemap::input_source_map::{path_from_file_url, url_scheme};
 
-/// `comment` is the URL of the file's last `sourceMappingURL` comment. A map
-/// that cannot be loaded is reported as a warning on `log` and skipped: the
-/// file then maps to itself, as if it had no comment.
+/// A map that cannot be loaded is a warning on `log`; the file then maps to itself.
 pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<InputSourceMap>> {
     let url: &[u8] = comment.text.slice();
     if url.is_empty() {
@@ -43,12 +40,10 @@ pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<
             let map_path: Box<[u8]> = if let Some(path) = path_from_file_url(url) {
                 path
             } else if url_scheme(url).is_some() || url.starts_with(b"//") {
-                // `https://…` and the like: nothing a build can read, and not
-                // something the author of this build can fix, so stay quiet.
+                // `https://…` and the like: unreadable here and not the user's to fix, so no warning.
                 return None;
             } else {
-                // A virtual module (plugin namespace) has no directory to
-                // resolve a relative URL against.
+                // A virtual module (plugin namespace) has no directory to resolve against.
                 let source_dir = source_dir?;
                 let url = strip_query_and_fragment(url);
                 let decoded;

--- a/src/bundler/input_source_map.rs
+++ b/src/bundler/input_source_map.rs
@@ -4,6 +4,8 @@ use bun_ast::{Log, Source, Span};
 use bun_sourcemap::InputSourceMap;
 use bun_sourcemap::input_source_map::{path_from_file_url, url_scheme};
 
+bun_core::declare_scope!(InputSourceMap, hidden);
+
 /// A map that cannot be loaded is a warning on `log`; the file then maps to itself.
 pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<InputSourceMap>> {
     let url: &[u8] = comment.text.slice();
@@ -66,27 +68,25 @@ pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<
 
             json = match bun_sys::File::read_from(bun_sys::Fd::cwd(), &map_path) {
                 Ok(bytes) => bytes,
+                // Published packages routinely name a `.map` they do not ship; like esbuild, say nothing.
+                Err(err) if err.get_errno() == bun_sys::E::ENOENT => {
+                    bun_core::scoped_log!(
+                        InputSourceMap,
+                        "missing source map {}",
+                        bstr::BStr::new(&map_path)
+                    );
+                    return None;
+                }
                 Err(err) => {
-                    if err.get_errno() == bun_sys::E::ENOENT {
-                        log.add_range_warning_fmt(
-                            Some(source),
-                            comment.range,
-                            format_args!(
-                                "Cannot find source map file: {}",
-                                bstr::BStr::new(&map_path)
-                            ),
-                        );
-                    } else {
-                        log.add_range_warning_fmt(
-                            Some(source),
-                            comment.range,
-                            format_args!(
-                                "Cannot read source map file \"{}\": {}",
-                                bstr::BStr::new(&map_path),
-                                bstr::BStr::new(err.name())
-                            ),
-                        );
-                    }
+                    log.add_range_warning_fmt(
+                        Some(source),
+                        comment.range,
+                        format_args!(
+                            "Cannot read source map file \"{}\": {}",
+                            bstr::BStr::new(&map_path),
+                            bstr::BStr::new(err.name())
+                        ),
+                    );
                     return None;
                 }
             };

--- a/src/bundler/input_source_map.rs
+++ b/src/bundler/input_source_map.rs
@@ -1,0 +1,134 @@
+//! Loads the source map an input file names in its `sourceMappingURL`
+//! comment, so the output map can point through it at the original sources.
+
+use bun_ast::{Log, Source, Span};
+use bun_sourcemap::InputSourceMap;
+use bun_sourcemap::input_source_map::{path_from_file_url, url_scheme};
+
+/// `comment` is the URL of the file's last `sourceMappingURL` comment. A map
+/// that cannot be loaded is reported as a warning on `log` and skipped: the
+/// file then maps to itself, as if it had no comment.
+pub(crate) fn load(log: &mut Log, source: &Source, comment: Span) -> Option<Box<InputSourceMap>> {
+    let url: &[u8] = comment.text.slice();
+    if url.is_empty() {
+        return None;
+    }
+    let source_dir: Option<&[u8]> = source
+        .path
+        .is_file()
+        .then(|| source.path.name().dir_with_trailing_slash());
+
+    let json: Vec<u8>;
+    let map_dir: Option<Box<[u8]>>;
+    let map_name: Box<[u8]>;
+    match bun_resolver::DataURL::parse(url) {
+        Ok(Some(data_url)) => {
+            match data_url.decode_data() {
+                Ok(bytes) => json = bytes,
+                Err(_) => {
+                    log.add_range_warning_fmt(
+                        Some(source),
+                        comment.range,
+                        format_args!(
+                            "Unsupported source map comment: could not decode the \"data:\" URL"
+                        ),
+                    );
+                    return None;
+                }
+            }
+            map_dir = source_dir.map(Box::from);
+            map_name = Box::from(&b"data: URL"[..]);
+        }
+        Ok(None) | Err(_) => {
+            let map_path: Box<[u8]> = if let Some(path) = path_from_file_url(url) {
+                path
+            } else if url_scheme(url).is_some() || url.starts_with(b"//") {
+                // `https://…` and the like: nothing a build can read, and not
+                // something the author of this build can fix, so stay quiet.
+                return None;
+            } else if let Some(source_dir) = source_dir {
+                let url = strip_query_and_fragment(url);
+                let decoded;
+                let url: &[u8] = if bun_core::strings::contains_char(url, b'%') {
+                    match bun_url::PercentEncoding::decode_alloc(url) {
+                        Ok(d) => {
+                            decoded = d;
+                            &decoded
+                        }
+                        Err(_) => url,
+                    }
+                } else {
+                    url
+                };
+                let mut buf = bun_paths::path_buffer_pool::get();
+                match bun_paths::resolve_path::join_abs_string_buf_checked::<
+                    bun_paths::resolve_path::platform::Auto,
+                >(source_dir, &mut buf[..], &[url])
+                {
+                    Some(joined) => Box::from(joined),
+                    None => return None,
+                }
+            } else {
+                // A virtual module (plugin namespace) has no directory to
+                // resolve a relative URL against.
+                return None;
+            };
+
+            json = match bun_sys::File::read_from(bun_sys::Fd::cwd(), &map_path) {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    if err.get_errno() == bun_sys::E::ENOENT {
+                        log.add_range_warning_fmt(
+                            Some(source),
+                            comment.range,
+                            format_args!(
+                                "Cannot find source map file: {}",
+                                bstr::BStr::new(&map_path)
+                            ),
+                        );
+                    } else {
+                        log.add_range_warning_fmt(
+                            Some(source),
+                            comment.range,
+                            format_args!(
+                                "Cannot read source map file \"{}\": {}",
+                                bstr::BStr::new(&map_path),
+                                bstr::BStr::new(err.name())
+                            ),
+                        );
+                    }
+                    return None;
+                }
+            };
+            map_dir = Some(Box::from(bun_paths::resolve_path::dirname::<
+                bun_paths::resolve_path::platform::Auto,
+            >(&map_path)));
+            map_name = map_path;
+        }
+    }
+
+    let mut read_file = |path: &[u8]| bun_sys::File::read_from(bun_sys::Fd::cwd(), path).ok();
+    match InputSourceMap::parse(&json, map_dir.as_deref(), &mut read_file) {
+        Ok(Some(map)) => Some(Box::new(map)),
+        Ok(None) => None,
+        Err(err) => {
+            log.add_range_warning_fmt(
+                Some(source),
+                comment.range,
+                format_args!(
+                    "Ignoring the source map \"{}\" of this file: {}",
+                    bstr::BStr::new(&map_name),
+                    err.0
+                ),
+            );
+            None
+        }
+    }
+}
+
+fn strip_query_and_fragment(url: &[u8]) -> &[u8] {
+    match bun_core::strings::index_of_any(url, b"?#") {
+        Some(i) => &url[..i],
+        None => url,
+    }
+}

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -104,6 +104,7 @@ pub mod linker_graph;
 // const without a cross-crate hook. Re-export for existing callers.
 pub use bun_js_parser::defines_table;
 pub mod bundle_v2;
+pub(crate) mod input_source_map;
 #[path = "LinkerContext.rs"]
 pub mod linker_context_mod;
 #[path = "options.rs"]

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2129,8 +2129,7 @@ impl<'a> Lexer<'a> {
     }
 
     /// Scans the string for a pragma.
-    /// `chunk_start` is the offset of `chunk` in the file; the spans recorded
-    /// here carry it so a later diagnostic about the pragma points at it.
+    /// `chunk_start` is the file offset of `chunk`, for the spans recorded here.
     /// Returns the byte length to advance by if found, otherwise 0.
     fn scan_pragma(
         &mut self,

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -1961,7 +1961,7 @@ impl<'a> Lexer<'a> {
                 b'@' | b'#' => {
                     let chunk = rest;
                     let offset = self.scan_pragma(
-                        self.start + i + (text.len() - rest.len()),
+                        self.start + (end_comment_text - rest.len()),
                         chunk,
                         CommentKind::MultiLine,
                         PureAnnotation::Allow,
@@ -2103,7 +2103,7 @@ impl<'a> Lexer<'a> {
                         first_marker = false;
                         let chunk = js_ast::StoreStr::new(self.remaining());
                         self.current += self.scan_pragma(
-                            pragma_trigger_pos,
+                            self.current,
                             chunk.slice(),
                             CommentKind::SingleLine,
                             pure,
@@ -2129,11 +2129,12 @@ impl<'a> Lexer<'a> {
     }
 
     /// Scans the string for a pragma.
-    /// offset is used when there's an issue with the JSX pragma later on.
+    /// `chunk_start` is the offset of `chunk` in the file; the spans recorded
+    /// here carry it so a later diagnostic about the pragma points at it.
     /// Returns the byte length to advance by if found, otherwise 0.
     fn scan_pragma(
         &mut self,
-        offset_for_errors: usize,
+        chunk_start: usize,
         chunk: &[u8],
         comment: CommentKind,
         pure: PureAnnotation,
@@ -2148,9 +2149,7 @@ impl<'a> Lexer<'a> {
         }
 
         if strings::has_prefix_with_word_boundary(chunk, b"jsx") {
-            if let Some(span) =
-                PragmaArg::scan(self.start + offset_for_errors, b"jsx", chunk, allow_newline)
-            {
+            if let Some(span) = PragmaArg::scan(chunk_start, b"jsx", chunk, allow_newline) {
                 self.jsx_pragma._jsx = span;
                 return "jsx".len()
                     + if span.range.len > 0 {
@@ -2160,12 +2159,7 @@ impl<'a> Lexer<'a> {
                     };
             }
         } else if strings::has_prefix_with_word_boundary(chunk, b"jsxFrag") {
-            if let Some(span) = PragmaArg::scan(
-                self.start + offset_for_errors,
-                b"jsxFrag",
-                chunk,
-                allow_newline,
-            ) {
+            if let Some(span) = PragmaArg::scan(chunk_start, b"jsxFrag", chunk, allow_newline) {
                 self.jsx_pragma._jsx_frag = span;
                 return "jsxFrag".len()
                     + if span.range.len > 0 {
@@ -2175,12 +2169,7 @@ impl<'a> Lexer<'a> {
                     };
             }
         } else if strings::has_prefix_with_word_boundary(chunk, b"jsxRuntime") {
-            if let Some(span) = PragmaArg::scan(
-                self.start + offset_for_errors,
-                b"jsxRuntime",
-                chunk,
-                allow_newline,
-            ) {
+            if let Some(span) = PragmaArg::scan(chunk_start, b"jsxRuntime", chunk, allow_newline) {
                 self.jsx_pragma._jsx_runtime = span;
                 return "jsxRuntime".len()
                     + if span.range.len > 0 {
@@ -2190,12 +2179,9 @@ impl<'a> Lexer<'a> {
                     };
             }
         } else if strings::has_prefix_with_word_boundary(chunk, b"jsxImportSource") {
-            if let Some(span) = PragmaArg::scan(
-                self.start + offset_for_errors,
-                b"jsxImportSource",
-                chunk,
-                allow_newline,
-            ) {
+            if let Some(span) =
+                PragmaArg::scan(chunk_start, b"jsxImportSource", chunk, allow_newline)
+            {
                 self.jsx_pragma._jsx_import_source = span;
                 return "jsxImportSource".len()
                     + if span.range.len > 0 {
@@ -2209,8 +2195,7 @@ impl<'a> Lexer<'a> {
         {
             // Check includes space for prefix
             return PragmaArg::scan_source_mapping_url_value(
-                self.start,
-                offset_for_errors,
+                chunk_start,
                 chunk,
                 &mut self.source_mapping_url,
             );
@@ -3465,8 +3450,7 @@ impl PragmaArg {
     /// "//# sourceMappingURL=data:/adspaoksdpkz"
     ///                       ^^^^^^^^^^^^^^^^^^
     pub(crate) fn scan_source_mapping_url_value(
-        start: usize,
-        offset_for_errors: usize,
+        chunk_start: usize,
         chunk: &[u8],
         result: &mut Option<js_ast::Span>,
     ) -> usize {
@@ -3490,8 +3474,7 @@ impl PragmaArg {
         // Now we have the correct argument length (url_len) and the argument text.
         let url = &url_and_rest_of_code[0..url_len];
 
-        // Calculate absolute start location of the argument
-        let absolute_arg_start = start + offset_for_errors + PREFIX as usize;
+        let absolute_arg_start = chunk_start + PREFIX as usize;
 
         *result = Some(js_ast::Span {
             range: Range {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9414,6 +9414,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_import_meta: self.has_import_meta,
 
             hashbang: hashbang.into(),
+            source_mapping_url: self.lexer.source_mapping_url,
             export_default_alias_of_import: self.export_default_alias_of_import,
             // TODO: cross-module constant inlining
             // const_values: self.const_values,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1378,9 +1378,7 @@ pub struct Options<'a> {
     /// builder as `LineOffsetTables::Borrowed`.
     pub line_offset_tables: Option<&'a SourceMap::line_offset_table::List<bun_alloc::AstAlloc>>,
 
-    /// The source map the input file itself carried (its `sourceMappingURL`
-    /// comment). The builder maps every position through it, see
-    /// `SourceMap::chunk::Builder::input_source_map`.
+    /// See `SourceMap::chunk::Builder::input_source_map`.
     pub input_source_map: Option<&'a SourceMap::InputSourceMap>,
 
     pub mangled_props: Option<&'a crate::MangledProps>,
@@ -7762,10 +7760,7 @@ pub(crate) fn get_source_map_builder<'a, const IS_BUN_PLATFORM: bool>(
             // opts.source_map_allocator orelse opts.allocator — allocator dropped
             IS_BUN_PLATFORM && generate_source_map == GenerateSourceMap::Lazy,
         ),
-        // Repeating the previous mapping at the start of an unmapped line only
-        // helps when that mapping is ours. Through an input source map it would
-        // point wherever that map last pointed, so leave such lines unmapped
-        // (esbuild does the same).
+        // Through an input source map the repeated mapping would point anywhere (esbuild does the same).
         cover_lines_without_mappings: opts.input_source_map.is_none(),
         approximate_input_line_count: tree.approximate_newline_count,
         prepend_count: IS_BUN_PLATFORM && generate_source_map == GenerateSourceMap::Lazy,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1378,6 +1378,11 @@ pub struct Options<'a> {
     /// builder as `LineOffsetTables::Borrowed`.
     pub line_offset_tables: Option<&'a SourceMap::line_offset_table::List<bun_alloc::AstAlloc>>,
 
+    /// The source map the input file itself carried (its `sourceMappingURL`
+    /// comment). The builder maps every position through it, see
+    /// `SourceMap::chunk::Builder::input_source_map`.
+    pub input_source_map: Option<&'a SourceMap::InputSourceMap>,
+
     pub mangled_props: Option<&'a crate::MangledProps>,
 }
 
@@ -1433,6 +1438,7 @@ impl<'a> Default for Options<'a> {
             import_member_bindings: None,
             has_dynamic_import_items: false,
             line_offset_tables: None,
+            input_source_map: None,
             mangled_props: None,
         }
     }
@@ -7756,9 +7762,14 @@ pub(crate) fn get_source_map_builder<'a, const IS_BUN_PLATFORM: bool>(
             // opts.source_map_allocator orelse opts.allocator — allocator dropped
             IS_BUN_PLATFORM && generate_source_map == GenerateSourceMap::Lazy,
         ),
-        cover_lines_without_mappings: true,
+        // Repeating the previous mapping at the start of an unmapped line only
+        // helps when that mapping is ours. Through an input source map it would
+        // point wherever that map last pointed, so leave such lines unmapped
+        // (esbuild does the same).
+        cover_lines_without_mappings: opts.input_source_map.is_none(),
         approximate_input_line_count: tree.approximate_newline_count,
         prepend_count: IS_BUN_PLATFORM && generate_source_map == GenerateSourceMap::Lazy,
+        input_source_map: opts.input_source_map,
         line_offset_tables: match opts.line_offset_tables.take() {
             Some(table) => LineOffsetTables::Borrowed(table),
             None if generate_source_map == GenerateSourceMap::Lazy => LineOffsetTables::Deferred {

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -369,15 +369,10 @@ pub struct NewBuilder<'a, T: SourceMapFormatCtx> {
     /// `line_offset_table_byte_offset_list`.
     pub line_offset_table_first_non_ascii: RawSlice<u32>,
 
-    /// The input file's own source map (from its `sourceMappingURL` comment).
-    /// When set, every mapping is translated through it and a position it does
-    /// not cover gets no mapping, so `source_index` and `original_*` in the
-    /// chunk refer to `input_source_map.sources`, not to the input file.
+    /// When set, mappings are translated through it (uncovered positions get none) and index its `sources`.
     pub input_source_map: Option<&'a crate::InputSourceMap>,
 
-    /// Line in the input file of the previous `add_source_mapping` call, the
-    /// seed for `find_line_with_hint`. (`prev_state.original_line` is a line in
-    /// some other file once an input source map has rewritten it.)
+    /// Input-file line of the previous mapping (`prev_state.original_line` may be post-remap).
     pub prev_input_line: u32,
 
     // This is a workaround for a bug in the popular "source-map" library:
@@ -620,8 +615,7 @@ impl NewBuilder<'_, VLQSourceMap> {
         self.last_generated_update = output.len() as u32;
     }
 
-    /// Returns `false` when the input source map does not cover the position,
-    /// in which case nothing was appended.
+    /// `false`: the input source map does not cover the position; nothing was appended.
     #[inline(always)]
     pub(crate) fn append_mapping(&mut self, mut current_state: SourceMapState) -> bool {
         if let Some(input_source_map) = self.input_source_map {
@@ -695,9 +689,9 @@ impl NewBuilder<'_, VLQSourceMap> {
         let byte_offsets = self.line_offset_table_byte_offset_list.slice();
 
         // The printer emits mappings in (mostly) source order, so the previous
-        // call's line is the right answer or one/two lines before it >95% of
-        // the time. Seed `find_line_with_hint` with it; the fallback is the
-        // same binary search as before.
+        // call's `original_line` is the right answer or one/two lines before
+        // it >95% of the time. Seed `find_line_with_hint` with it; the
+        // fallback is the same binary search as before.
         let original_line =
             LineOffsetTable::find_line_with_hint(byte_offsets, loc, self.prev_input_line);
         let idx = original_line.max(0) as usize;

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -369,6 +369,17 @@ pub struct NewBuilder<'a, T: SourceMapFormatCtx> {
     /// `line_offset_table_byte_offset_list`.
     pub line_offset_table_first_non_ascii: RawSlice<u32>,
 
+    /// The input file's own source map (from its `sourceMappingURL` comment).
+    /// When set, every mapping is translated through it and a position it does
+    /// not cover gets no mapping, so `source_index` and `original_*` in the
+    /// chunk refer to `input_source_map.sources`, not to the input file.
+    pub input_source_map: Option<&'a crate::InputSourceMap>,
+
+    /// Line in the input file of the previous `add_source_mapping` call, the
+    /// seed for `find_line_with_hint`. (`prev_state.original_line` is a line in
+    /// some other file once an input source map has rewritten it.)
+    pub prev_input_line: u32,
+
     // This is a workaround for a bug in the popular "source-map" library:
     // https://github.com/mozilla/source-map/issues/261. The library will
     // sometimes return null when querying a source map unless every line
@@ -400,6 +411,8 @@ impl<T: SourceMapFormatCtx + Default> Default for NewBuilder<'_, T> {
             has_prev_state: false,
             line_offset_table_byte_offset_list: RawSlice::EMPTY,
             line_offset_table_first_non_ascii: RawSlice::EMPTY,
+            input_source_map: None,
+            prev_input_line: 0,
             line_starts_with_mapping: false,
             cover_lines_without_mappings: false,
             approximate_input_line_count: 0,
@@ -607,9 +620,22 @@ impl NewBuilder<'_, VLQSourceMap> {
         self.last_generated_update = output.len() as u32;
     }
 
+    /// Returns `false` when the input source map does not cover the position,
+    /// in which case nothing was appended.
     #[inline(always)]
-    pub(crate) fn append_mapping(&mut self, current_state: SourceMapState) {
+    pub(crate) fn append_mapping(&mut self, mut current_state: SourceMapState) -> bool {
+        if let Some(input_source_map) = self.input_source_map {
+            let Some(mapping) =
+                input_source_map.find(current_state.original_line, current_state.original_column)
+            else {
+                return false;
+            };
+            current_state.source_index = mapping.source_index;
+            current_state.original_line = mapping.original.lines.zero_based();
+            current_state.original_column = mapping.original.columns.zero_based();
+        }
         self.append_mapping_without_remapping(current_state);
+        true
     }
 
     #[inline(always)]
@@ -669,15 +695,13 @@ impl NewBuilder<'_, VLQSourceMap> {
         let byte_offsets = self.line_offset_table_byte_offset_list.slice();
 
         // The printer emits mappings in (mostly) source order, so the previous
-        // call's `original_line` is the right answer or one/two lines before
-        // it >95% of the time. Seed `find_line_with_hint` with it; the
-        // fallback is the same binary search as before.
-        let original_line = LineOffsetTable::find_line_with_hint(
-            byte_offsets,
-            loc,
-            self.prev_state.original_line as u32,
-        );
+        // call's line is the right answer or one/two lines before it >95% of
+        // the time. Seed `find_line_with_hint` with it; the fallback is the
+        // same binary search as before.
+        let original_line =
+            LineOffsetTable::find_line_with_hint(byte_offsets, loc, self.prev_input_line);
         let idx = original_line.max(0) as usize;
+        self.prev_input_line = idx as u32;
 
         // PERF: read the three columns directly instead of `list.get(idx)`.
         // `MultiArrayList::get` builds a 272-byte `Slice` (`[*mut u8; 32]` +
@@ -716,7 +740,7 @@ impl NewBuilder<'_, VLQSourceMap> {
             });
         }
 
-        self.append_mapping(SourceMapState {
+        let appended = self.append_mapping(SourceMapState {
             generated_line: self.prev_state.generated_line,
             generated_column: self.generated_column.max(0),
             source_index: self.prev_state.source_index,
@@ -725,7 +749,9 @@ impl NewBuilder<'_, VLQSourceMap> {
         });
 
         // This line now has a mapping on it, so don't insert another one
-        self.line_starts_with_mapping = true;
+        if appended {
+            self.line_starts_with_mapping = true;
+        }
     }
 }
 

--- a/src/sourcemap/InputSourceMap.rs
+++ b/src/sourcemap/InputSourceMap.rs
@@ -1,7 +1,4 @@
-//! A source map that an input file points at through its `sourceMappingURL`
-//! comment: the map a previous tool (tsc, esbuild, a Svelte compiler) emitted
-//! for that file. The printer translates every output position through it, so
-//! the emitted map names the files this map names instead of the input file.
+//! The source map an input file's `sourceMappingURL` names; output maps are composed through it.
 
 use std::borrow::Cow;
 
@@ -14,23 +11,19 @@ use crate::{LineColumnOffset, Ordinal};
 
 pub struct InputSourceMap {
     mappings: mapping::List,
-    /// The map's `sources`, with `sourceRoot` applied and relative entries
-    /// resolved against the map's directory.
+    /// `sources` with `sourceRoot` applied and relative entries resolved against the map's directory.
     pub sources: Box<[InputSource]>,
-    /// The `sourcesContent` entry for each of `sources`, as JSON (`"..."` or
-    /// `null`), joined with `",\n    "`: ready to splice into an output map.
+    /// `sourcesContent` per source as JSON (`"..."` or `null`), joined with `",\n    "`.
     pub quoted_sources_content: Box<[u8]>,
 }
 
 pub struct InputSource {
     pub path: Box<[u8]>,
-    /// `path` is an absolute file-system path. Otherwise it is a URL or an
-    /// opaque name and is emitted as written.
+    /// `path` is an absolute file-system path, as opposed to a URL or opaque name kept as written.
     pub is_file: bool,
 }
 
-/// Why an input source map was rejected (UTF-8 text). The input file is still
-/// bundled; its output map then points at the input file itself.
+/// Why an input source map was rejected, as UTF-8 text.
 pub struct ParseError(pub Cow<'static, [u8]>);
 
 impl ParseError {
@@ -40,14 +33,7 @@ impl ParseError {
 }
 
 impl InputSourceMap {
-    /// Parses source-map `json` (ECMA-426, including `sections` index maps).
-    ///
-    /// `map_dir` is the directory relative `sources` entries resolve against:
-    /// the `.map` file's directory, or the input file's directory for a `data:`
-    /// URL. `None` leaves them as written. `read_file` supplies the text of a
-    /// file source whose `sourcesContent` entry is missing or `null`.
-    ///
-    /// `Ok(None)`: the map is well-formed but maps nothing.
+    /// `map_dir`: base for relative `sources`; `read_file`: fills a missing `sourcesContent`; `Ok(None)`: maps nothing.
     pub fn parse(
         json: &[u8],
         map_dir: Option<&[u8]>,
@@ -136,8 +122,7 @@ impl InputSourceMap {
         for section in &sections {
             match section.map.get(b"version") {
                 Some(JsonValue::Number(n)) if n.value() == 3.0 => {}
-                // Silently skip a section with a missing or unknown version,
-                // like esbuild does.
+                // A missing or unknown version skips the section silently, as in esbuild.
                 _ => continue,
             }
             let vlq: &[u8] = match section.map.get(b"mappings") {
@@ -288,8 +273,7 @@ impl InputSourceMap {
         }))
     }
 
-    /// The mapping that covers `line`:`column` (zero-based, columns in UTF-16
-    /// code units) of the file this map was emitted for, if any.
+    /// The mapping covering zero-based `line`:`column` (UTF-16 columns) of the generated file.
     #[inline]
     pub fn find(&self, line: i32, column: i32) -> Option<Mapping> {
         self.mappings.find(
@@ -299,10 +283,7 @@ impl InputSourceMap {
     }
 }
 
-/// Applies `sourceRoot` to one `sources` entry and resolves the result the way
-/// ECMA-426 "Resolving Sources" does: a URL with a scheme other than `file:`
-/// stays as written, a `file:` URL becomes a path, and anything else is a path
-/// relative to `map_dir`.
+/// ECMA-426 "Resolving Sources": non-`file:` URLs stay as written, the rest become paths under `map_dir`.
 fn resolve_source(name: &[u8], source_root: &[u8], map_dir: Option<&[u8]>) -> InputSource {
     let name: Cow<'_, [u8]> = if source_root.is_empty() || url_scheme(name).is_some() {
         Cow::Borrowed(name)
@@ -345,17 +326,14 @@ fn resolve_source(name: &[u8], source_root: &[u8], map_dir: Option<&[u8]>) -> In
     }
 }
 
-/// `path` resolved against the absolute directory `base` and normalized (an
-/// absolute `path` is only normalized). `None` when the result does not fit a
-/// path buffer.
+/// `path` resolved against `base` and normalized; `None` if it does not fit a path buffer.
 fn join_path(base: &[u8], path: &[u8]) -> Option<Box<[u8]>> {
     use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
     let mut buf = bun_paths::path_buffer_pool::get();
     join_abs_string_buf_checked::<platform::Auto>(base, &mut buf[..], &[path]).map(Box::from)
 }
 
-/// The scheme of `url` (`file` for `file:///a.js`), if it has one. A single
-/// ASCII letter before `:\` or `:/` is a Windows drive letter, not a scheme.
+/// The scheme of `url`, if any. One ASCII letter before `:/` or `:\` is a drive letter, not a scheme.
 pub fn url_scheme(url: &[u8]) -> Option<&[u8]> {
     let (&first, rest) = url.split_first()?;
     if !first.is_ascii_alphabetic() {
@@ -377,8 +355,7 @@ pub fn url_scheme(url: &[u8]) -> Option<&[u8]> {
     None
 }
 
-/// The file-system path a `file:` URL names, percent-decoded. `None` when
-/// `url` is not a `file:` URL or names a remote host.
+/// The percent-decoded path of a `file:` URL; `None` for other URLs or a remote host.
 pub fn path_from_file_url(url: &[u8]) -> Option<Box<[u8]>> {
     let scheme = url_scheme(url)?;
     if !scheme.eq_ignore_ascii_case(b"file") {

--- a/src/sourcemap/InputSourceMap.rs
+++ b/src/sourcemap/InputSourceMap.rs
@@ -1,0 +1,428 @@
+//! A source map that an input file points at through its `sourceMappingURL`
+//! comment: the map a previous tool (tsc, esbuild, a Svelte compiler) emitted
+//! for that file. The printer translates every output position through it, so
+//! the emitted map names the files this map names instead of the input file.
+
+use std::borrow::Cow;
+
+use bun_ast::e::{JsonValue, ObjectJSON};
+use bun_ast::expr::Data as ExprData;
+use bun_core::MutableString;
+
+use crate::mapping::{self, Mapping};
+use crate::{LineColumnOffset, Ordinal};
+
+pub struct InputSourceMap {
+    mappings: mapping::List,
+    /// The map's `sources`, with `sourceRoot` applied and relative entries
+    /// resolved against the map's directory.
+    pub sources: Box<[InputSource]>,
+    /// The `sourcesContent` entry for each of `sources`, as JSON (`"..."` or
+    /// `null`), joined with `",\n    "`: ready to splice into an output map.
+    pub quoted_sources_content: Box<[u8]>,
+}
+
+pub struct InputSource {
+    pub path: Box<[u8]>,
+    /// `path` is an absolute file-system path. Otherwise it is a URL or an
+    /// opaque name and is emitted as written.
+    pub is_file: bool,
+}
+
+/// Why an input source map was rejected. The input file is still bundled; its
+/// output map then points at the input file itself.
+pub struct ParseError(pub Cow<'static, str>);
+
+impl InputSourceMap {
+    /// Parses source-map `json` (ECMA-426, including `sections` index maps).
+    ///
+    /// `map_dir` is the directory relative `sources` entries resolve against:
+    /// the `.map` file's directory, or the input file's directory for a `data:`
+    /// URL. `None` leaves them as written. `read_file` supplies the text of a
+    /// file source whose `sourcesContent` entry is missing or `null`.
+    ///
+    /// `Ok(None)`: the map is well-formed but maps nothing.
+    pub fn parse(
+        json: &[u8],
+        map_dir: Option<&[u8]>,
+        read_file: &mut dyn FnMut(&[u8]) -> Option<Vec<u8>>,
+    ) -> Result<Option<InputSourceMap>, ParseError> {
+        let json_source = bun_ast::Source::init_path_string("input.js.map", json);
+        let mut log = bun_ast::Log::init();
+        let parsed = match bun_parsers::json::ParsedJson::parse_json(&json_source, &mut log) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                let reason = log
+                    .msgs
+                    .iter()
+                    .find(|msg| msg.kind == bun_ast::Kind::Err)
+                    .map(|msg| String::from_utf8_lossy(&msg.data.text).into_owned());
+                return Err(ParseError(match reason {
+                    Some(text) => Cow::Owned(format!("invalid JSON: {text}")),
+                    None => Cow::Borrowed("invalid JSON"),
+                }));
+            }
+        };
+        let ExprData::EObjectJSON(root) = parsed.root.data else {
+            return Err(ParseError(Cow::Borrowed("expected a JSON object")));
+        };
+        let root: &ObjectJSON = root.get();
+
+        struct Section<'a> {
+            line_offset: i32,
+            column_offset: i32,
+            map: &'a ObjectJSON,
+        }
+        let mut sections: Vec<Section<'_>> = Vec::new();
+        match root.get(b"sections") {
+            None => sections.push(Section {
+                line_offset: 0,
+                column_offset: 0,
+                map: root,
+            }),
+            Some(JsonValue::Array(items)) => {
+                for item in items.get().items() {
+                    let Some(section) = item.as_object() else {
+                        continue;
+                    };
+                    let Some(map) = section.get(b"map") else {
+                        continue;
+                    };
+                    let Some(map) = map.as_object() else {
+                        return Err(ParseError(Cow::Borrowed(
+                            "expected \"map\" in \"sections\" to be an object",
+                        )));
+                    };
+                    let (mut line_offset, mut column_offset) = (0, 0);
+                    if let Some(offset) = section.get(b"offset") {
+                        let Some(offset) = offset.as_object() else {
+                            return Err(ParseError(Cow::Borrowed(
+                                "expected \"offset\" in \"sections\" to be an object",
+                            )));
+                        };
+                        if let Some(JsonValue::Number(line)) = offset.get(b"line") {
+                            line_offset = line.value() as i32;
+                        }
+                        if let Some(JsonValue::Number(column)) = offset.get(b"column") {
+                            column_offset = column.value() as i32;
+                        }
+                    }
+                    if line_offset < 0 || column_offset < 0 {
+                        return Err(ParseError(Cow::Borrowed(
+                            "negative \"offset\" in \"sections\"",
+                        )));
+                    }
+                    sections.push(Section {
+                        line_offset,
+                        column_offset,
+                        map,
+                    });
+                }
+            }
+            Some(_) => {
+                return Err(ParseError(Cow::Borrowed(
+                    "expected \"sections\" to be an array",
+                )));
+            }
+        }
+
+        let mut mappings = mapping::List::default();
+        let mut sources: Vec<InputSource> = Vec::new();
+        let mut sources_content: Vec<Option<&[u8]>> = Vec::new();
+        let mut needs_sort = false;
+        let mut prev_offset = (0i32, 0i32);
+
+        for section in &sections {
+            match section.map.get(b"version") {
+                Some(JsonValue::Number(n)) if n.value() == 3.0 => {}
+                // Silently skip a section with a missing or unknown version,
+                // like esbuild does.
+                _ => continue,
+            }
+            let vlq: &[u8] = match section.map.get(b"mappings") {
+                Some(JsonValue::String(s)) => s.slice(),
+                Some(_) => {
+                    return Err(ParseError(Cow::Borrowed(
+                        "expected \"mappings\" to be a string",
+                    )));
+                }
+                None => continue,
+            };
+            let section_sources: &[JsonValue] = match section.map.get(b"sources") {
+                Some(JsonValue::Array(items)) => items.get().items(),
+                Some(_) => {
+                    return Err(ParseError(Cow::Borrowed(
+                        "expected \"sources\" to be an array",
+                    )));
+                }
+                None => continue,
+            };
+            if vlq.is_empty() || section_sources.is_empty() {
+                continue;
+            }
+            let source_root: &[u8] = match section.map.get(b"sourceRoot") {
+                Some(JsonValue::String(s)) => s.slice(),
+                _ => b"",
+            };
+            let section_sources_content: &[JsonValue] = match section.map.get(b"sourcesContent") {
+                Some(JsonValue::Array(items)) => items.get().items(),
+                _ => &[],
+            };
+
+            let Ok(section_sources_len) = i32::try_from(section_sources.len()) else {
+                return Err(ParseError(Cow::Borrowed("too many \"sources\"")));
+            };
+            let Ok(source_offset) = i32::try_from(sources.len()) else {
+                return Err(ParseError(Cow::Borrowed("too many \"sources\"")));
+            };
+            let parsed = match mapping::parse(
+                vlq,
+                None,
+                section_sources_len,
+                i32::MAX as usize,
+                mapping::ParseOptions {
+                    allow_names: false,
+                    sort: true,
+                },
+            ) {
+                Ok(parsed) => parsed,
+                Err(fail) => {
+                    return Err(ParseError(Cow::Owned(format!(
+                        "bad \"mappings\" data at character {}: {}",
+                        fail.loc.start.max(0),
+                        fail.err.message()
+                    ))));
+                }
+            };
+
+            if (section.line_offset, section.column_offset) < prev_offset {
+                needs_sort = true;
+            }
+            prev_offset = (section.line_offset, section.column_offset);
+
+            if sections.len() == 1 && prev_offset == (0, 0) {
+                let mut parsed = parsed;
+                mappings = core::mem::take(&mut parsed.mappings);
+            } else {
+                let section_mappings = &parsed.mappings;
+                let generated = section_mappings.generated();
+                let original = section_mappings.original();
+                let source_index = section_mappings.source_index();
+                for i in 0..generated.len() {
+                    let on_first_line = generated[i].lines.zero_based() == 0;
+                    mappings
+                        .append(&Mapping {
+                            generated: LineColumnOffset {
+                                lines: Ordinal::from_zero_based(
+                                    generated[i]
+                                        .lines
+                                        .zero_based()
+                                        .saturating_add(section.line_offset),
+                                ),
+                                columns: Ordinal::from_zero_based(
+                                    generated[i].columns.zero_based().saturating_add(
+                                        if on_first_line {
+                                            section.column_offset
+                                        } else {
+                                            0
+                                        },
+                                    ),
+                                ),
+                            },
+                            original: original[i],
+                            source_index: source_index[i] + source_offset,
+                            name_index: -1,
+                        })
+                        .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?;
+                }
+            }
+
+            for name in section_sources {
+                sources.push(resolve_source(
+                    name.as_str().unwrap_or(b""),
+                    source_root,
+                    map_dir,
+                ));
+            }
+            for i in 0..section_sources.len() {
+                sources_content.push(section_sources_content.get(i).and_then(JsonValue::as_str));
+            }
+        }
+
+        if sources.is_empty() || mappings.generated().is_empty() {
+            return Ok(None);
+        }
+        if needs_sort {
+            mappings.sort();
+        }
+
+        let mut quoted = MutableString::init_empty();
+        for (i, (source, content)) in sources.iter().zip(&sources_content).enumerate() {
+            if i > 0 {
+                quoted
+                    .append(b",\n    ")
+                    .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?;
+            }
+            let from_disk;
+            let content: Option<&[u8]> = match content {
+                Some(content) => Some(content),
+                None if source.is_file => {
+                    from_disk = read_file(&source.path);
+                    from_disk.as_deref()
+                }
+                None => None,
+            };
+            match content {
+                Some(content) => bun_core::quote_for_json(content, &mut quoted, false)
+                    .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?,
+                None => quoted
+                    .append(b"null")
+                    .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?,
+            }
+        }
+
+        Ok(Some(InputSourceMap {
+            mappings,
+            sources: sources.into_boxed_slice(),
+            quoted_sources_content: quoted.list.into_boxed_slice(),
+        }))
+    }
+
+    /// The mapping that covers `line`:`column` (zero-based, columns in UTF-16
+    /// code units) of the file this map was emitted for, if any.
+    #[inline]
+    pub fn find(&self, line: i32, column: i32) -> Option<Mapping> {
+        self.mappings.find(
+            Ordinal::from_zero_based(line),
+            Ordinal::from_zero_based(column),
+        )
+    }
+}
+
+/// Applies `sourceRoot` to one `sources` entry and resolves the result the way
+/// ECMA-426 "Resolving Sources" does: a URL with a scheme other than `file:`
+/// stays as written, a `file:` URL becomes a path, and anything else is a path
+/// relative to `map_dir`.
+fn resolve_source(name: &[u8], source_root: &[u8], map_dir: Option<&[u8]>) -> InputSource {
+    let name: Cow<'_, [u8]> = if source_root.is_empty() || url_scheme(name).is_some() {
+        Cow::Borrowed(name)
+    } else {
+        let mut joined = Vec::with_capacity(source_root.len() + 1 + name.len());
+        joined.extend_from_slice(source_root);
+        if !joined.ends_with(b"/") {
+            joined.push(b'/');
+        }
+        joined.extend_from_slice(name);
+        Cow::Owned(joined)
+    };
+
+    let verbatim = |name: &[u8]| InputSource {
+        path: Box::from(name),
+        is_file: false,
+    };
+
+    if let Some(path) = path_from_file_url(&name) {
+        return InputSource {
+            path: match map_dir {
+                Some(map_dir) => join_path(map_dir, &path).unwrap_or(path),
+                None => path,
+            },
+            is_file: true,
+        };
+    }
+    if url_scheme(&name).is_some() || name.starts_with(b"//") {
+        return verbatim(&name);
+    }
+    let Some(map_dir) = map_dir else {
+        return verbatim(&name);
+    };
+    match join_path(map_dir, &percent_decode(&name)) {
+        Some(path) => InputSource {
+            path,
+            is_file: true,
+        },
+        None => verbatim(&name),
+    }
+}
+
+/// `path` resolved against the absolute directory `base` and normalized (an
+/// absolute `path` is only normalized). `None` when the result does not fit a
+/// path buffer.
+fn join_path(base: &[u8], path: &[u8]) -> Option<Box<[u8]>> {
+    use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
+    let mut buf = bun_paths::path_buffer_pool::get();
+    join_abs_string_buf_checked::<platform::Auto>(base, &mut buf[..], &[path]).map(Box::from)
+}
+
+/// The scheme of `url` (`file` for `file:///a.js`), if it has one. A single
+/// ASCII letter before `:\` or `:/` is a Windows drive letter, not a scheme.
+pub fn url_scheme(url: &[u8]) -> Option<&[u8]> {
+    let (&first, rest) = url.split_first()?;
+    if !first.is_ascii_alphabetic() {
+        return None;
+    }
+    for (i, &c) in rest.iter().enumerate() {
+        match c {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'+' | b'-' | b'.' => {}
+            b':' => {
+                let scheme = &url[..i + 1];
+                if scheme.len() == 1 && matches!(url.get(i + 2), Some(b'/' | b'\\')) {
+                    return None;
+                }
+                return Some(scheme);
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// The file-system path a `file:` URL names, percent-decoded. `None` when
+/// `url` is not a `file:` URL or names a remote host.
+pub fn path_from_file_url(url: &[u8]) -> Option<Box<[u8]>> {
+    let scheme = url_scheme(url)?;
+    if !scheme.eq_ignore_ascii_case(b"file") {
+        return None;
+    }
+    let mut rest = &url[scheme.len() + 1..];
+    if let Some(after_slashes) = rest.strip_prefix(b"//") {
+        let host_end = bun_core::strings::index_of_char_usize(after_slashes, b'/')
+            .unwrap_or(after_slashes.len());
+        let host = &after_slashes[..host_end];
+        if !host.is_empty() && !host.eq_ignore_ascii_case(b"localhost") {
+            return None;
+        }
+        rest = &after_slashes[host_end..];
+    }
+    let decoded = percent_decode(rest);
+    // `file:///C:/dir/file.js` names `C:/dir/file.js` on Windows.
+    if cfg!(windows)
+        && decoded.len() >= 3
+        && decoded[0] == b'/'
+        && decoded[1].is_ascii_alphabetic()
+        && decoded[2] == b':'
+    {
+        return Some(Box::from(&decoded[1..]));
+    }
+    Some(Box::from(&*decoded))
+}
+
+fn percent_decode(text: &[u8]) -> Cow<'_, [u8]> {
+    if !bun_core::strings::contains_char(text, b'%') {
+        return Cow::Borrowed(text);
+    }
+    let mut out = Vec::with_capacity(text.len());
+    let mut i = 0;
+    while i < text.len() {
+        if text[i] == b'%' && i + 2 < text.len() {
+            if let Some(byte) = bun_core::fmt::hex_pair_value(text[i + 1], text[i + 2]) {
+                out.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(text[i]);
+        i += 1;
+    }
+    Cow::Owned(out)
+}

--- a/src/sourcemap/InputSourceMap.rs
+++ b/src/sourcemap/InputSourceMap.rs
@@ -29,9 +29,15 @@ pub struct InputSource {
     pub is_file: bool,
 }
 
-/// Why an input source map was rejected. The input file is still bundled; its
-/// output map then points at the input file itself.
-pub struct ParseError(pub Cow<'static, str>);
+/// Why an input source map was rejected (UTF-8 text). The input file is still
+/// bundled; its output map then points at the input file itself.
+pub struct ParseError(pub Cow<'static, [u8]>);
+
+impl ParseError {
+    const fn msg(text: &'static str) -> ParseError {
+        ParseError(Cow::Borrowed(text.as_bytes()))
+    }
+}
 
 impl InputSourceMap {
     /// Parses source-map `json` (ECMA-426, including `sections` index maps).
@@ -52,19 +58,18 @@ impl InputSourceMap {
         let parsed = match bun_parsers::json::ParsedJson::parse_json(&json_source, &mut log) {
             Ok(parsed) => parsed,
             Err(_) => {
-                let reason = log
-                    .msgs
-                    .iter()
-                    .find(|msg| msg.kind == bun_ast::Kind::Err)
-                    .map(|msg| String::from_utf8_lossy(&msg.data.text).into_owned());
-                return Err(ParseError(match reason {
-                    Some(text) => Cow::Owned(format!("invalid JSON: {text}")),
-                    None => Cow::Borrowed("invalid JSON"),
-                }));
+                return Err(
+                    match log.msgs.iter().find(|msg| msg.kind == bun_ast::Kind::Err) {
+                        Some(msg) => {
+                            ParseError(Cow::Owned([b"invalid JSON: ", &*msg.data.text].concat()))
+                        }
+                        None => ParseError::msg("invalid JSON"),
+                    },
+                );
             }
         };
         let ExprData::EObjectJSON(root) = parsed.root.data else {
-            return Err(ParseError(Cow::Borrowed("expected a JSON object")));
+            return Err(ParseError::msg("expected a JSON object"));
         };
         let root: &ObjectJSON = root.get();
 
@@ -89,16 +94,16 @@ impl InputSourceMap {
                         continue;
                     };
                     let Some(map) = map.as_object() else {
-                        return Err(ParseError(Cow::Borrowed(
+                        return Err(ParseError::msg(
                             "expected \"map\" in \"sections\" to be an object",
-                        )));
+                        ));
                     };
                     let (mut line_offset, mut column_offset) = (0, 0);
                     if let Some(offset) = section.get(b"offset") {
                         let Some(offset) = offset.as_object() else {
-                            return Err(ParseError(Cow::Borrowed(
+                            return Err(ParseError::msg(
                                 "expected \"offset\" in \"sections\" to be an object",
-                            )));
+                            ));
                         };
                         if let Some(JsonValue::Number(line)) = offset.get(b"line") {
                             line_offset = line.value() as i32;
@@ -108,9 +113,7 @@ impl InputSourceMap {
                         }
                     }
                     if line_offset < 0 || column_offset < 0 {
-                        return Err(ParseError(Cow::Borrowed(
-                            "negative \"offset\" in \"sections\"",
-                        )));
+                        return Err(ParseError::msg("negative \"offset\" in \"sections\""));
                     }
                     sections.push(Section {
                         line_offset,
@@ -120,9 +123,7 @@ impl InputSourceMap {
                 }
             }
             Some(_) => {
-                return Err(ParseError(Cow::Borrowed(
-                    "expected \"sections\" to be an array",
-                )));
+                return Err(ParseError::msg("expected \"sections\" to be an array"));
             }
         }
 
@@ -142,18 +143,14 @@ impl InputSourceMap {
             let vlq: &[u8] = match section.map.get(b"mappings") {
                 Some(JsonValue::String(s)) => s.slice(),
                 Some(_) => {
-                    return Err(ParseError(Cow::Borrowed(
-                        "expected \"mappings\" to be a string",
-                    )));
+                    return Err(ParseError::msg("expected \"mappings\" to be a string"));
                 }
                 None => continue,
             };
             let section_sources: &[JsonValue] = match section.map.get(b"sources") {
                 Some(JsonValue::Array(items)) => items.get().items(),
                 Some(_) => {
-                    return Err(ParseError(Cow::Borrowed(
-                        "expected \"sources\" to be an array",
-                    )));
+                    return Err(ParseError::msg("expected \"sources\" to be an array"));
                 }
                 None => continue,
             };
@@ -170,10 +167,10 @@ impl InputSourceMap {
             };
 
             let Ok(section_sources_len) = i32::try_from(section_sources.len()) else {
-                return Err(ParseError(Cow::Borrowed("too many \"sources\"")));
+                return Err(ParseError::msg("too many \"sources\""));
             };
             let Ok(source_offset) = i32::try_from(sources.len()) else {
-                return Err(ParseError(Cow::Borrowed("too many \"sources\"")));
+                return Err(ParseError::msg("too many \"sources\""));
             };
             let parsed = match mapping::parse(
                 vlq,
@@ -187,11 +184,14 @@ impl InputSourceMap {
             ) {
                 Ok(parsed) => parsed,
                 Err(fail) => {
-                    return Err(ParseError(Cow::Owned(format!(
-                        "bad \"mappings\" data at character {}: {}",
-                        fail.loc.start.max(0),
-                        fail.err.message()
-                    ))));
+                    return Err(ParseError(Cow::Owned(
+                        format!(
+                            "bad \"mappings\" data at character {}: {}",
+                            fail.loc.start.max(0),
+                            fail.err.message()
+                        )
+                        .into_bytes(),
+                    )));
                 }
             };
 
@@ -233,7 +233,7 @@ impl InputSourceMap {
                             source_index: source_index[i] + source_offset,
                             name_index: -1,
                         })
-                        .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?;
+                        .map_err(|_| ParseError::msg("out of memory"))?;
                 }
             }
 
@@ -261,7 +261,7 @@ impl InputSourceMap {
             if i > 0 {
                 quoted
                     .append(b",\n    ")
-                    .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?;
+                    .map_err(|_| ParseError::msg("out of memory"))?;
             }
             let from_disk;
             let content: Option<&[u8]> = match content {
@@ -274,10 +274,10 @@ impl InputSourceMap {
             };
             match content {
                 Some(content) => bun_core::quote_for_json(content, &mut quoted, false)
-                    .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?,
+                    .map_err(|_| ParseError::msg("out of memory"))?,
                 None => quoted
                     .append(b"null")
-                    .map_err(|_| ParseError(Cow::Borrowed("out of memory")))?,
+                    .map_err(|_| ParseError::msg("out of memory"))?,
             }
         }
 

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -12,6 +12,8 @@ pub use error::{Error, Result};
 
 #[path = "Chunk.rs"]
 pub mod chunk;
+#[path = "InputSourceMap.rs"]
+pub mod input_source_map;
 #[path = "InternalSourceMap.rs"]
 pub mod internal_source_map;
 #[path = "LineOffsetTable.rs"]
@@ -46,6 +48,7 @@ unsafe impl Sync for ParsedSourceMap {}
 pub use bun_core::Ordinal;
 
 pub use chunk::Chunk;
+pub use input_source_map::InputSourceMap;
 pub use internal_source_map::InternalSourceMap;
 
 // ── leaf types that compile cleanly today ─────────────────────────────────

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -3127,7 +3127,8 @@ pub(crate) fn serialize_json_source_map_for_standalone(
     }
 
     for item in sources_content.items() {
-        let utf8 = item.as_str().ok_or(crate::Error::InvalidSourceMap)?;
+        // A `null` entry (content unavailable) is stored as empty, which the loader treats as "no contents".
+        let utf8 = item.as_str().unwrap_or(b"");
 
         let offset = string_payload.len();
 

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -903,6 +903,27 @@ describe("Bun.build", () => {
     expect(x.logs[0].position).toEqual(null);
   });
 
+  // The location of a pragma comment's argument had the comment's own offset
+  // added twice, so a warning about a pragma that was not in the file's first
+  // comment pointed somewhere past it.
+  test.concurrent("a pragma warning points at the pragma", async () => {
+    using dir = tempDir("build-api-pragma-location", {
+      "a.jsx": `// a first comment, so the pragma below is not at offset 0\n// @jsxRuntime bogus\nexport const x = <div />;\n`,
+      "b.jsx": `"some code";\n/* a block comment\n   @jsxRuntime fake */\nexport const x = <div />;\n`,
+    });
+    const logs = [];
+    for (const file of ["a.jsx", "b.jsx"]) {
+      const build = await Bun.build({ entrypoints: [join(String(dir), file)], external: ["*"] });
+      logs.push(
+        ...build.logs.map(log => [log.message, log.position?.line, log.position?.column, log.position?.length]),
+      );
+    }
+    expect(logs).toEqual([
+      [`Unsupported JSX runtime: "bogus"`, 2, 16, 5],
+      [`Unsupported JSX runtime: "fake"`, 3, 16, 4],
+    ]);
+  });
+
   test.concurrent("fails instead of truncating when a module is too deeply nested to print", async () => {
     // A TOML dotted header builds an object nested arbitrarily deep without
     // recursing in the parser, so the printer's recursion guard is the first

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1642,11 +1642,12 @@ describe("bundler", () => {
   });
   itBundled("edgecase/InputSourceMapMissingOrInvalid", {
     files: {
+      // A sidecar that does not exist (common in published packages) and a
+      // remote URL are skipped silently; a map that is there but unusable warns.
       "/lib/missing.js": inputSourceMapFixture.js.replaceAll("MARK", "MISS") + `//# sourceMappingURL=missing.js.map\n`,
       "/lib/invalid.js":
         inputSourceMapFixture.js.replaceAll("MARK", "OOPS") +
         `//# sourceMappingURL=data:application/json;base64,${Buffer.from("{oops").toString("base64")}\n`,
-      // Not something the build can read: skipped without a warning.
       "/lib/remote.js":
         inputSourceMapFixture.js.replaceAll("MARK", "HTTP") +
         `//# sourceMappingURL=https://example.com/remote.js.map\n`,
@@ -1656,7 +1657,6 @@ describe("bundler", () => {
     outdir: "/out",
     sourceMap: "external",
     bundleWarnings: {
-      "/lib/missing.js": ["Cannot find source map file: "],
       "/lib/invalid.js": [`Ignoring the source map "data: URL" of this file: invalid JSON`],
     },
     async onAfterBundle(api) {
@@ -1668,6 +1668,26 @@ describe("bundler", () => {
         '"OOPS"': "../lib/invalid.js:3:18",
         '"HTTP"': "../lib/remote.js:3:18",
       });
+    },
+  });
+  itBundled("edgecase/InputSourceMapCompile", {
+    files: {
+      // The original is not on disk and the sidecar has no `sourcesContent`,
+      // so the composed map carries a `null` entry the executable must accept.
+      "/lib/lib.js": inputSourceMapFixture.js + `//# sourceMappingURL=lib.js.map\n`,
+      "/lib/lib.js.map": inputSourceMapFixture.map({ sourcesContent: undefined }),
+      "/entry.ts": `import { f } from "./lib/lib.js";\nf({ x: 1 });\n`,
+    },
+    entryPoints: ["/entry.ts"],
+    target: "bun",
+    compile: true,
+    sourceMap: "external",
+    run: {
+      exitCode: 1,
+      validate({ stderr }) {
+        expect(stderr).toInclude("error: MARK");
+        expect(stderr).toMatch(/src[\\/]lib\.ts:6:9/);
+      },
     },
   });
   itBundled("edgecase/NoUselessConstructorTS", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2,12 +2,52 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
+import { SourceMapConsumer } from "source-map";
+import { type BundlerTestBundleAPI, decodeSourceMappingsLine, encodeSourceMappings, itBundled } from "./expectBundled";
 
 // A public path composes with the referenced file's path relative to the output
 // directory, never relative to the importing chunk (esbuild's semantics).
 const CDN_PUBLIC_PATH = "https://cdn.example/app/";
 const cdnUrls = (source: string) => [...source.matchAll(/"(https:\/\/cdn\.example\/[^"]+)"/g)].map(match => match[1]);
+
+// `js` + `map()` is what `esbuild lib.ts --sourcemap` emits for `ts`: a
+// pre-compiled input whose own source map points back at the TypeScript.
+const inputSourceMapFixture = {
+  ts: `interface P { x: number }\ntype T = P | null;\n\nexport function f(p: P): never {\n  const q: T = p;\n  throw new Error("MARK");\n}\n`,
+  js: `export function f(p) {\n  const q = p;\n  throw new Error("MARK");\n}\n`,
+  map(overrides: Record<string, unknown> = {}) {
+    return JSON.stringify({
+      version: 3,
+      sources: ["../src/lib.ts"],
+      sourcesContent: [inputSourceMapFixture.ts],
+      mappings: "AAGO,gBAAS,EAAE,GAAa;AAC7B,QAAM,IAAO;AACb,QAAM,IAAI,MAAM,MAAM;AACxB;",
+      names: [],
+      ...overrides,
+    });
+  },
+  dataUrl(encoding: "base64" | "percent", overrides: Record<string, unknown> = {}) {
+    const json = inputSourceMapFixture.map(overrides);
+    return encoding === "base64"
+      ? `data:application/json;base64,${Buffer.from(json).toString("base64")}`
+      : `data:application/json;charset=utf-8,${encodeURIComponent(json)}`;
+  },
+};
+
+/** Where the first occurrence of each token in `file` maps to, as `source:line:column` (1-based line, 0-based column). */
+async function originalPositionsFor(api: BundlerTestBundleAPI, file: string, tokens: string[]) {
+  const lines = api.readFile(file).split("\n");
+  const map = JSON.parse(api.readFile(file + ".map"));
+  return await SourceMapConsumer.with(map, null, consumer =>
+    Object.fromEntries(
+      tokens.map(token => {
+        const line = lines.findIndex(text => text.includes(token));
+        if (line === -1) throw new Error(`${JSON.stringify(token)} is not in ${file}`);
+        const pos = consumer.originalPositionFor({ line: line + 1, column: lines[line].indexOf(token) });
+        return [token, pos.source === null ? null : `${pos.source}:${pos.line}:${pos.column}`];
+      }),
+    ),
+  );
+}
 
 describe("bundler", () => {
   itBundled("edgecase/EmptyFile", {
@@ -1378,6 +1418,256 @@ describe("bundler", () => {
       const keepCol = js.split("\n")[0].indexOf("keep=[");
       expect(keepCol).toBeGreaterThan(0);
       expect(line1).toContainEqual({ gen: keepCol, src: 0, ol: 3, oc: 6 });
+    },
+  });
+  // An input file that carries its own `sourceMappingURL` (the output of a
+  // previous tsc/esbuild/svelte step) has the bundle's source map composed
+  // through that map, so it points at the original sources.
+  itBundled("edgecase/InputSourceMapInline", {
+    files: {
+      "/lib/lib.js": inputSourceMapFixture.js + `//# sourceMappingURL=${inputSourceMapFixture.dataUrl("base64")}\n`,
+      "/entry.ts": `import { f } from "./lib/lib.js";\nf({ x: 1 });\n`,
+    },
+    entryPoints: ["/entry.ts"],
+    outdir: "/out",
+    target: "node",
+    sourceMap: "external",
+    async onAfterBundle(api) {
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      // `src/lib.ts` is not on disk: its text comes from the input map.
+      expect(map.sources).toEqual(["../src/lib.ts", "../entry.ts"]);
+      expect(map.sourcesContent).toEqual([inputSourceMapFixture.ts, api.readFile("/entry.ts")]);
+      expect(
+        await originalPositionsFor(api, "/out/entry.js", ["f(p)", "q = p", "new Error", "Error(", `"MARK"`, "f({"]),
+      ).toEqual({
+        "f(p)": "../src/lib.ts:4:16",
+        "q = p": "../src/lib.ts:5:8",
+        "new Error": "../src/lib.ts:6:8",
+        "Error(": "../src/lib.ts:6:12",
+        '"MARK"': "../src/lib.ts:6:18",
+        "f({": "../entry.ts:2:0",
+      });
+    },
+  });
+  itBundled("edgecase/InputSourceMapInlineMinified", {
+    files: {
+      "/lib/lib.js": inputSourceMapFixture.js + `//# sourceMappingURL=${inputSourceMapFixture.dataUrl("base64")}\n`,
+      "/entry.ts": `import { f } from "./lib/lib.js";\nf({ x: 1 });\n`,
+    },
+    entryPoints: ["/entry.ts"],
+    outdir: "/out",
+    sourceMap: "external",
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    minifySyntax: true,
+    async onAfterBundle(api) {
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      expect(map.sources).toEqual(["../src/lib.ts", "../entry.ts"]);
+      expect(await originalPositionsFor(api, "/out/entry.js", ["Error(", `"MARK"`])).toEqual({
+        "Error(": "../src/lib.ts:6:12",
+        '"MARK"': "../src/lib.ts:6:18",
+      });
+    },
+  });
+  itBundled("edgecase/InputSourceMapCommentFormsAndSidecar", {
+    files: {
+      "/src/one.ts": inputSourceMapFixture.ts.replaceAll("MARK", "ONE1"),
+      "/src/two.ts": inputSourceMapFixture.ts.replaceAll("MARK", "TWO2"),
+      // Legacy `//@` form, percent-encoded `data:` URL, no `sourcesContent`:
+      // the content is read from `/src/one.ts`.
+      "/lib/one.js":
+        inputSourceMapFixture.js.replaceAll("MARK", "ONE1") +
+        `//@ sourceMappingURL=${inputSourceMapFixture.dataUrl("percent", { sources: ["../src/one.ts"], sourcesContent: undefined })}\n`,
+      // Block-comment form pointing at a sidecar `.map` that uses `sourceRoot`
+      // and a `null` `sourcesContent` entry.
+      "/lib/two.js": inputSourceMapFixture.js.replaceAll("MARK", "TWO2") + `/*# sourceMappingURL=two.js.map */\n`,
+      "/lib/two.js.map": inputSourceMapFixture.map({
+        sourceRoot: "../src",
+        sources: ["two.ts"],
+        sourcesContent: [null],
+      }),
+      "/entry.js": `import { f as one } from "./lib/one.js";\nimport { f as two } from "./lib/two.js";\n[one, two][Date.now() % 1]({ x: 1 });\n`,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    sourceMap: "external",
+    async onAfterBundle(api) {
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      expect(map.sources).toEqual(["../src/one.ts", "../src/two.ts", "../entry.js"]);
+      // Both read from disk, since neither map carried the content.
+      expect(map.sourcesContent).toEqual([
+        api.readFile("/src/one.ts"),
+        api.readFile("/src/two.ts"),
+        api.readFile("/entry.js"),
+      ]);
+      expect(await originalPositionsFor(api, "/out/entry.js", [`"ONE1"`, `"TWO2"`])).toEqual({
+        '"ONE1"': "../src/one.ts:6:18",
+        '"TWO2"': "../src/two.ts:6:18",
+      });
+    },
+  });
+  itBundled("edgecase/InputSourceMapNodeModulesSidecar", {
+    files: {
+      "/node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "dist/index.js" }),
+      "/node_modules/pkg/dist/index.js": inputSourceMapFixture.js + `//# sourceMappingURL=index.js.map\n`,
+      "/node_modules/pkg/dist/index.js.map": inputSourceMapFixture.map({ sources: ["../src/index.ts"] }),
+      "/entry.js": `import { f } from "pkg";\nf({ x: 1 });\n`,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    sourceMap: "linked",
+    async onAfterBundle(api) {
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      expect(map.sources).toEqual(["../node_modules/pkg/src/index.ts", "../entry.js"]);
+      expect(map.sourcesContent[0]).toBe(inputSourceMapFixture.ts);
+      expect(await originalPositionsFor(api, "/out/entry.js", [`"MARK"`])).toEqual({
+        '"MARK"': "../node_modules/pkg/src/index.ts:6:18",
+      });
+    },
+  });
+  itBundled("edgecase/InputSourceMapSections", {
+    files: {
+      "/a.js": `console.log("a1");\nconsole.log("a2");\n`,
+      "/b.js": `console.log("b1");\nconsole.log("b2");\n`,
+      // `ab.js` is `a.js` and `b.js` concatenated, described by an index map
+      // with one section per file. The second section has no `sourcesContent`.
+      "/ab.js":
+        `console.log("a1");\nconsole.log("a2");\nconsole.log("b1");\nconsole.log("b2");\n` +
+        `//# sourceMappingURL=data:application/json;base64,${Buffer.from(
+          JSON.stringify({
+            version: 3,
+            sections: [
+              {
+                offset: { line: 0, column: 0 },
+                map: {
+                  version: 3,
+                  sources: ["a.js"],
+                  sourcesContent: [`console.log("a1");\nconsole.log("a2");\n`],
+                  names: [],
+                  mappings: encodeSourceMappings([
+                    [
+                      [0, 0, 0, 0],
+                      [8, 0, 0, 8],
+                      [12, 0, 0, 12],
+                    ],
+                    [
+                      [0, 0, 1, 0],
+                      [8, 0, 1, 8],
+                      [12, 0, 1, 12],
+                    ],
+                  ]),
+                },
+              },
+              {
+                offset: { line: 2, column: 0 },
+                map: {
+                  version: 3,
+                  sources: ["b.js"],
+                  names: [],
+                  mappings: encodeSourceMappings([
+                    [
+                      [0, 0, 0, 0],
+                      [8, 0, 0, 8],
+                      [12, 0, 0, 12],
+                    ],
+                    [
+                      [0, 0, 1, 0],
+                      [8, 0, 1, 8],
+                      [12, 0, 1, 12],
+                    ],
+                  ]),
+                },
+              },
+            ],
+          }),
+        ).toString("base64")}\n`,
+      "/entry.js": `import "./ab.js";\nconsole.log("entry");\n`,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    sourceMap: "external",
+    async onAfterBundle(api) {
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      expect(map.sources).toEqual(["../a.js", "../b.js", "../entry.js"]);
+      expect(map.sourcesContent).toEqual([
+        `console.log("a1");\nconsole.log("a2");\n`,
+        api.readFile("/b.js"),
+        api.readFile("/entry.js"),
+      ]);
+      expect(
+        await originalPositionsFor(api, "/out/entry.js", [`"a1"`, `"a2"`, `log("b1")`, `"b2"`, `"entry"`]),
+      ).toEqual({
+        '"a1"': "../a.js:1:12",
+        '"a2"': "../a.js:2:12",
+        'log("b1")': "../b.js:1:8",
+        '"b2"': "../b.js:2:12",
+        '"entry"': "../entry.js:2:12",
+      });
+    },
+  });
+  itBundled("edgecase/InputSourceMapUncoveredCode", {
+    files: {
+      // The input map only covers the first line. Output that comes from the
+      // other lines gets no mapping rather than a wrong one.
+      "/lib.js":
+        inputSourceMapFixture.js +
+        `//# sourceMappingURL=data:application/json;base64,${Buffer.from(
+          JSON.stringify({
+            version: 3,
+            sources: ["lib.coffee"],
+            sourcesContent: ["original();\n"],
+            names: [],
+            mappings: encodeSourceMappings([
+              [
+                [0, 0, 0, 0],
+                [16, 0, 0, 9],
+              ],
+            ]),
+          }),
+        ).toString("base64")}\n`,
+      "/entry.js": `import { f } from "./lib.js";\nf({ x: 1 });\n`,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    sourceMap: "external",
+    async onAfterBundle(api) {
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      expect(map.sources).toEqual(["../lib.coffee", "../entry.js"]);
+      expect(await originalPositionsFor(api, "/out/entry.js", ["f(p)", "q = p", `"MARK"`])).toEqual({
+        "f(p)": "../lib.coffee:1:9",
+        "q = p": null,
+        '"MARK"': null,
+      });
+    },
+  });
+  itBundled("edgecase/InputSourceMapMissingOrInvalid", {
+    files: {
+      "/lib/missing.js": inputSourceMapFixture.js.replaceAll("MARK", "MISS") + `//# sourceMappingURL=missing.js.map\n`,
+      "/lib/invalid.js":
+        inputSourceMapFixture.js.replaceAll("MARK", "OOPS") +
+        `//# sourceMappingURL=data:application/json;base64,${Buffer.from("{oops").toString("base64")}\n`,
+      // Not something the build can read: skipped without a warning.
+      "/lib/remote.js":
+        inputSourceMapFixture.js.replaceAll("MARK", "HTTP") +
+        `//# sourceMappingURL=https://example.com/remote.js.map\n`,
+      "/entry.js": `import { f as a } from "./lib/missing.js";\nimport { f as b } from "./lib/invalid.js";\nimport { f as c } from "./lib/remote.js";\n[a, b, c][Date.now() % 1]({ x: 1 });\n`,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    sourceMap: "external",
+    bundleWarnings: {
+      "/lib/missing.js": ["Cannot find source map file: "],
+      "/lib/invalid.js": [`Ignoring the source map "data: URL" of this file: invalid JSON`],
+    },
+    async onAfterBundle(api) {
+      const map = JSON.parse(api.readFile("/out/entry.js.map"));
+      // Each file falls back to mapping to itself.
+      expect(map.sources).toEqual(["../lib/missing.js", "../lib/invalid.js", "../lib/remote.js", "../entry.js"]);
+      expect(await originalPositionsFor(api, "/out/entry.js", [`"MISS"`, `"OOPS"`, `"HTTP"`])).toEqual({
+        '"MISS"': "../lib/missing.js:3:18",
+        '"OOPS"': "../lib/invalid.js:3:18",
+        '"HTTP"': "../lib/remote.js:3:18",
+      });
     },
   });
   itBundled("edgecase/NoUselessConstructorTS", {

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -77,6 +77,41 @@ export function decodeSourceMappingsLine(line: string) {
   return segs;
 }
 
+/**
+ * Encodes a source map "mappings" string. `lines[i]` holds the segments of
+ * generated line `i` as `[generatedColumn, sourceIndex, originalLine, originalColumn]`,
+ * every value absolute and zero-based.
+ */
+export function encodeSourceMappings(lines: [number, number, number, number][][]): string {
+  const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const vlq = (value: number) => {
+    let v = value < 0 ? (-value << 1) | 1 : value << 1;
+    let out = "";
+    do {
+      let digit = v & 31;
+      v >>>= 5;
+      if (v > 0) digit |= 32;
+      out += B64[digit];
+    } while (v > 0);
+    return out;
+  };
+  let src = 0,
+    ol = 0,
+    oc = 0;
+  return lines
+    .map(segments => {
+      let gen = 0;
+      return segments
+        .map(([g, s, l, c]) => {
+          const text = vlq(g - gen) + vlq(s - src) + vlq(l - ol) + vlq(c - oc);
+          [gen, src, ol, oc] = [g, s, l, c];
+          return text;
+        })
+        .join(",");
+    })
+    .join(";");
+}
+
 let currentFile: string | undefined;
 
 function errorOrWarnParser(isError = true) {


### PR DESCRIPTION
### Problem
- `bun build --sourcemap` ignores an input file's own `//# sourceMappingURL=` map (the output of a tsc, esbuild or Svelte step, or a `node_modules` `dist/*.js` with a `.map`). The emitted map stops at the intermediate `.js`: `sources: ["../lib/lib.js"]` where esbuild gives `["../src/lib.ts"]`. Stack traces under `bun` and `node --enable-source-maps` stop there too.
- Cause: the lexer records the comment (`Lexer::source_mapping_url`) but nothing reads it. The linker builds `sources` from the input file alone (`LinkerContext::generate_source_map_for_chunk`).

### Fix
- `ParseTask` loads the map the comment names: a `data:` URL (base64 or percent-encoded) or a sidecar file, from `//#`, `//@` or `/* */` comments. `InputSourceMap::parse` applies `sourceRoot` and `sections`, resolves `sources` against the map's directory, and reads a missing `sourcesContent` entry from disk. A missing sidecar is skipped silently (as in esbuild); an unreadable or malformed map is a warning. Either way the file maps to itself as before.
- The printer's chunk builder translates each mapping through that map and drops positions it does not cover. The linker writes the map's `sources` and `sourcesContent` in place of the intermediate file. This is esbuild's design, so the output matches esbuild's. `--compile` stores a `null` `sourcesContent` entry as empty instead of failing with `InvalidSourceMap`.
- The lexer added a comment's start offset twice to pragma argument locations. Warnings about a pragma (these new ones, `@jsxRuntime`) now point at it.
- Verified: `test/bundler/bundler_edgecase.test.ts` (`edgecase/InputSourceMap*`, 8 cases including `--compile`, all fail on 1.4.3) and `bun-build-api.test.ts` (pragma location). Self-reviewed: the `--compile` rejection of `null` `sourcesContent` and the missing-sidecar warning noise were raised and fixed.

### Background
- A source map's `mappings` tie output positions to `(source index, line, column)`. Composing means looking each intermediate position up in the input map (`InputSourceMap::find`, a binary search per printed token) and emitting what it points at instead.
- The bundler prints each file into a map chunk in parallel, with source indices counted from 0, and `generate_source_map_for_chunk` rebases them when it joins the chunks. A file with an input map now takes one `sources` slot per source of that map, so the rebase adds the file's base slot instead of assigning it.
- The dev server joins per-file maps itself (`SourceMapStore`, one slot per file), so files get no input map when it is attached. That path is unchanged.

<details><summary>Notes</summary>

- Sequencing. This supersedes #30539 and the bundler half of #32473; both can close once it lands. It does not fix #26713: that report is the dev-server path, which #32473's `SourceMapStore` half would restack on top of this. #20865 (draft) hooks the same `js_printer`/chunk-builder seam for `onLoad` plugins; a plugin result with an inline `data:` map already composes here, a relative sidecar needs a file-namespace path. #41939 makes `--no-bundle` emit maps; whichever lands second can pass `InputSourceMap` through the transform-only printer too. #40834 (`names`, closing-brace mappings) is independent; if it lands first, input-map `names` can be carried through in a follow-up. #41127 deletes `Lexer::source_mapping_url` as dead code and has been asked to keep it.
- Prior shape: #30539/#32473 scan only a last-line `//#` comment, keep the intermediate file as `sources[0]` and map uncovered positions to it, and do not handle `sections` or percent-encoded `data:` URLs. This PR follows esbuild instead (`bundler.go` `extractSourceMapFromComment`, `js_parser/sourcemap_parser.go`, `sourcemap.go` `ChunkBuilder.appendMapping`), which is what the composition fuzz compares against.
- Like esbuild, `cover_lines_without_mappings` is off for a file with an input map: repeating the previous mapping at the start of an unmapped line would point wherever the input map last pointed.
- Deliberate differences from esbuild: a malformed map is a warning, never an error (esbuild fails the build on invalid JSON in a referenced map). `sourceRoot` is prepended with a `/` separator (mozilla `source-map` behavior) instead of being truncated at its last `/`. `names` are not carried through, since bun does not emit `names` yet.
- Runtime check from the report: with `--target=bun --sourcemap=linked`, `bun out/entry.js` now prints the frame `at f (src/lib.ts:6:9)` with the TypeScript source line, and `node --enable-source-maps` does the same for `--target=node`. A `--compile`d executable reports `src/lib.ts:6:9` as well.
- Suites run locally with the debug build: `bundler_edgecase` (190), `esbuild/default -t SourceMap`, `bun-build-api -t sourcemap`, `bundler_comments`, `bundler_jsx`, `test/js/bun/sourcemap/*`, `compile-sourcemap-internal`, `test/bake/dev/sourcemap`, `cli.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->