### PR TITLE
bun test --parallel: forward runtime flags and --config to worker processes

### DIFF
--- a/docs/test/parallel.mdx
+++ b/docs/test/parallel.mdx
@@ -55,7 +55,7 @@ Each worker gets `BUN_TEST_WORKER_ID` and `JEST_WORKER_ID` set to its 1-based in
 const dbName = `app_test_${process.env.BUN_TEST_WORKER_ID ?? "1"}`;
 ```
 
-Flags that affect how tests execute (`--timeout`, `--preload`, `--define`, `--coverage`, `--update-snapshots`, `-t`, `--retry`, `--rerun-each`, `--concurrent`, `--randomize`/`--seed`, …) are forwarded to workers. The coordinator handles `--bail` at file granularity: once the failure threshold is reached it starts no new files, but files already running finish.
+Flags that affect how tests execute (`--timeout`, `--preload`, `--define`, `--coverage`, `--update-snapshots`, `-t`, `--retry`, `--rerun-each`, `--concurrent`, `--randomize`/`--seed`, …) are forwarded to workers, and so are runtime flags such as `--config`, `--conditions`, `--smol`, `--console-depth`, `--throw-deprecation` or `--max-http-header-size`. `--cpu-prof` and `--heap-prof` write one profile per worker process. `--inspect`, `--watch` and `--hot` apply to the coordinator only. The coordinator handles `--bail` at file granularity: once the failure threshold is reached it starts no new files, but files already running finish.
 
 The coordinator merges coverage, JUnit XML and snapshot writes, so `--parallel --coverage --reporter=junit --reporter-outfile=junit.xml` produces one report.
 

--- a/docs/test/parallel.mdx
+++ b/docs/test/parallel.mdx
@@ -55,7 +55,7 @@ Each worker gets `BUN_TEST_WORKER_ID` and `JEST_WORKER_ID` set to its 1-based in
 const dbName = `app_test_${process.env.BUN_TEST_WORKER_ID ?? "1"}`;
 ```
 
-Flags that affect how tests execute (`--timeout`, `--preload`, `--define`, `--coverage`, `--update-snapshots`, `-t`, `--retry`, `--rerun-each`, `--concurrent`, `--randomize`/`--seed`, …) are forwarded to workers, and so are runtime flags such as `--config`, `--conditions`, `--smol`, `--console-depth`, `--throw-deprecation` or `--max-http-header-size`. `--cpu-prof` and `--heap-prof` write one profile per worker process. `--inspect`, `--watch` and `--hot` apply to the coordinator only. The coordinator handles `--bail` at file granularity: once the failure threshold is reached it starts no new files, but files already running finish.
+Flags that affect how tests execute (`--timeout`, `--preload`, `--define`, `--coverage`, `--update-snapshots`, `-t`, `--retry`, `--rerun-each`, `--concurrent`, `--randomize`/`--seed`, …) are forwarded to workers, and so are runtime flags such as `--config`, `--conditions`, `--smol`, `--console-depth`, `--throw-deprecation` or `--max-http-header-size`. `--inspect`, `--watch` and `--hot` apply to the coordinator only. The coordinator handles `--bail` at file granularity: once the failure threshold is reached it starts no new files, but files already running finish.
 
 The coordinator merges coverage, JUnit XML and snapshot writes, so `--parallel --coverage --reporter=junit --reporter-outfile=junit.xml` produces one report.
 

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -440,8 +440,7 @@ pub struct TestOptions {
     /// `bun test --parallel-delay=MS`: how long the first worker must be
     /// busy before spawning the rest. None = use the built-in default.
     pub parallel_delay_ms: Option<u32>,
-    /// `bun test --parallel`: command-line flags re-serialized for the worker
-    /// argv (`TEST_WORKER_FORWARDED_FLAGS` in Arguments.rs).
+    /// `bun test --parallel`: CLI flags re-serialized for the worker argv.
     pub parallel_forwarded_argv: Vec<Box<[u8]>>,
     /// Internal: this process is a `--parallel` worker. Files arrive over
     /// fd 3, results are written back over fd 3; no discovery, no header.

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -445,6 +445,11 @@ pub struct TestOptions {
     /// appends to every worker's argv (`TEST_WORKER_FORWARDED_FLAGS` in
     /// Arguments.rs).
     pub parallel_forwarded_argv: Vec<Box<[u8]>>,
+    /// `bun test --parallel`: runtime flags from this command line,
+    /// re-serialized as one `--name[=value]` token each, that the coordinator
+    /// appends to every worker's argv (`TEST_WORKER_FORWARDED_FLAGS` in
+    /// Arguments.rs).
+    pub parallel_forwarded_argv: Vec<Box<[u8]>>,
     /// Internal: this process is a `--parallel` worker. Files arrive over
     /// fd 3, results are written back over fd 3; no discovery, no header.
     pub test_worker: bool,

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -445,11 +445,6 @@ pub struct TestOptions {
     /// appends to every worker's argv (`TEST_WORKER_FORWARDED_FLAGS` in
     /// Arguments.rs).
     pub parallel_forwarded_argv: Vec<Box<[u8]>>,
-    /// `bun test --parallel`: runtime flags from this command line,
-    /// re-serialized as one `--name[=value]` token each, that the coordinator
-    /// appends to every worker's argv (`TEST_WORKER_FORWARDED_FLAGS` in
-    /// Arguments.rs).
-    pub parallel_forwarded_argv: Vec<Box<[u8]>>,
     /// Internal: this process is a `--parallel` worker. Files arrive over
     /// fd 3, results are written back over fd 3; no discovery, no header.
     pub test_worker: bool,

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -440,10 +440,8 @@ pub struct TestOptions {
     /// `bun test --parallel-delay=MS`: how long the first worker must be
     /// busy before spawning the rest. None = use the built-in default.
     pub parallel_delay_ms: Option<u32>,
-    /// `bun test --parallel`: runtime flags from this command line,
-    /// re-serialized as one `--name[=value]` token each, that the coordinator
-    /// appends to every worker's argv (`TEST_WORKER_FORWARDED_FLAGS` in
-    /// Arguments.rs).
+    /// `bun test --parallel`: command-line flags re-serialized for the worker
+    /// argv (`TEST_WORKER_FORWARDED_FLAGS` in Arguments.rs).
     pub parallel_forwarded_argv: Vec<Box<[u8]>>,
     /// Internal: this process is a `--parallel` worker. Files arrive over
     /// fd 3, results are written back over fd 3; no discovery, no header.

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -440,6 +440,11 @@ pub struct TestOptions {
     /// `bun test --parallel-delay=MS`: how long the first worker must be
     /// busy before spawning the rest. None = use the built-in default.
     pub parallel_delay_ms: Option<u32>,
+    /// `bun test --parallel`: runtime flags from this command line,
+    /// re-serialized as one `--name[=value]` token each, that the coordinator
+    /// appends to every worker's argv (`TEST_WORKER_FORWARDED_FLAGS` in
+    /// Arguments.rs).
+    pub parallel_forwarded_argv: Vec<Box<[u8]>>,
     /// Internal: this process is a `--parallel` worker. Files arrive over
     /// fd 3, results are written back over fd 3; no discovery, no header.
     pub test_worker: bool,
@@ -518,6 +523,7 @@ impl Default for TestOptions {
             isolate: false,
             parallel: 0,
             parallel_delay_ms: None,
+            parallel_forwarded_argv: Vec::new(),
             test_worker: false,
             changed: None,
             shard: None,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -650,15 +650,9 @@ const TEST_PARAMS: &[ParamType] = concat_params!(
 );
 
 // ─── `bun test --parallel`: which flags reach the worker processes ──────────
-// Every named `TEST_PARAMS` flag is in exactly one of the two lists below
-// (a compile-time check follows them), so a new flag cannot silently go
-// missing from `--parallel` workers.
 
-/// Flags whose whole effect is inside the process that runs the test files.
-/// The coordinator re-serializes each one given on its command line as
-/// `--name[=value]` onto every worker's argv
-/// (`TestOptions::parallel_forwarded_argv`). A bunfig setting needs no entry:
-/// a worker loads the same bunfig, which is why `--config` is here.
+/// Re-serialized from the parsed command line as `--name[=value]` onto every
+/// worker's argv. bunfig settings need no entry: a worker loads bunfig itself.
 const TEST_WORKER_FORWARDED_FLAGS: &[&[u8]] = &[
     b"--no-orphans",
     // Module loading and transpilation.
@@ -715,10 +709,10 @@ const TEST_WORKER_FORWARDED_FLAGS: &[&[u8]] = &[
     b"--stack-trace-limit",
 ];
 
-/// Every other named flag `bun test` accepts.
+/// Every other `bun test` flag. Each `TEST_PARAMS` flag is in exactly one of the
+/// two lists; the compile-time check below names any that is not.
 const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
-    // `build_worker_argv` forwards these from merged bunfig + command-line
-    // state instead.
+    // Forwarded by `build_worker_argv` from merged bunfig + command-line state.
     b"--timeout",
     b"--update-snapshots",
     b"--rerun-each",
@@ -759,9 +753,7 @@ const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
     b"--jsx-import-source",
     b"--jsx-runtime",
     b"--jsx-side-effects",
-    // Coordinator concerns: file discovery, reporting, supervision. A worker
-    // starts in the coordinator's working directory with the coordinator's
-    // environment, so `--cwd` and the env-file flags are already applied.
+    // Coordinator-only. A worker inherits the cwd and the environment.
     b"--test-worker",
     b"--parallel",
     b"--parallel-delay",
@@ -782,16 +774,13 @@ const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
     b"--cwd",
     b"--env-file",
     b"--no-env-file",
-    // `DEBUG_PARAMS`: absent from release builds, where the forwarded list
-    // could not resolve it.
+    // `DEBUG_PARAMS`: not in release builds' `TEST_PARAMS`.
     b"--breakpoint-resolve",
     // One debugger endpoint cannot serve N workers.
     b"--inspect",
     b"--inspect-wait",
     b"--inspect-brk",
-    // `bun test` does not start the profilers (#40184). An explicit
-    // `--cpu-prof-name`/`--heap-prof-name` would also name one file for N
-    // workers, so per-worker profiling needs its own naming rule first.
+    // Not started by `bun test` (#40184); one output name would collide.
     b"--cpu-prof",
     b"--cpu-prof-name",
     b"--cpu-prof-dir",
@@ -880,8 +869,7 @@ const fn const_panic_concat(parts: &[&[u8]]) -> ! {
     }
 }
 
-/// `TEST_WORKER_FORWARDED_FLAGS` with each flag's value arity, resolved
-/// against `TEST_PARAMS` at compile time.
+/// `TEST_WORKER_FORWARDED_FLAGS` with each flag's value arity from `TEST_PARAMS`.
 static TEST_WORKER_FORWARDED: [(&[u8], clap::Values); TEST_WORKER_FORWARDED_FLAGS.len()] = {
     let mut out = [(b"" as &[u8], clap::Values::None); TEST_WORKER_FORWARDED_FLAGS.len()];
     let mut i = 0;
@@ -931,8 +919,7 @@ const _: () = {
     }
 };
 
-/// `bun test --parallel`: every `TEST_WORKER_FORWARDED_FLAGS` entry given on
-/// this command line, one `--name[=value]` token per occurrence.
+/// The `TEST_WORKER_FORWARDED_FLAGS` given on this command line, as argv tokens.
 #[cold]
 #[inline(never)]
 fn test_worker_forwarded_argv(args: &clap::Args<clap::Help>) -> Vec<Box<[u8]>> {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -651,8 +651,7 @@ const TEST_PARAMS: &[ParamType] = concat_params!(
 
 // ─── `bun test --parallel`: which flags reach the worker processes ──────────
 
-/// Re-serialized from the parsed command line as `--name[=value]` onto every
-/// worker's argv. bunfig settings need no entry: a worker loads bunfig itself.
+/// Re-serialized from the parsed command line onto every worker's argv.
 const TEST_WORKER_FORWARDED_FLAGS: &[&[u8]] = &[
     b"--no-orphans",
     // Module loading and transpilation.
@@ -709,8 +708,7 @@ const TEST_WORKER_FORWARDED_FLAGS: &[&[u8]] = &[
     b"--stack-trace-limit",
 ];
 
-/// Every other `bun test` flag. Each `TEST_PARAMS` flag is in exactly one of the
-/// two lists; the compile-time check below names any that is not.
+/// Every other `bun test` flag; the check below keeps the two lists exhaustive.
 const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
     // Forwarded by `build_worker_argv` from merged bunfig + command-line state.
     b"--timeout",

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -713,7 +713,7 @@ const TEST_WORKER_FORWARDED_FLAGS: &[&[u8]] = &[
     b"--trace-env-native-stack",
     b"--trace-exit",
     b"--stack-trace-limit",
-    // Profilers: one profile per worker process.
+    // Profilers are per process; default profile names carry the pid.
     b"--cpu-prof",
     b"--cpu-prof-name",
     b"--cpu-prof-dir",

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -793,6 +793,8 @@ const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
     b"--cwd",
     b"--env-file",
     b"--no-env-file",
+    // `DEBUG_PARAMS`: absent from release builds, where the forwarded list
+    // could not resolve it.
     b"--breakpoint-resolve",
     // One debugger endpoint cannot serve N workers.
     b"--inspect",

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -713,17 +713,6 @@ const TEST_WORKER_FORWARDED_FLAGS: &[&[u8]] = &[
     b"--trace-env-native-stack",
     b"--trace-exit",
     b"--stack-trace-limit",
-    // Profilers are per process; default profile names carry the pid.
-    b"--cpu-prof",
-    b"--cpu-prof-name",
-    b"--cpu-prof-dir",
-    b"--cpu-prof-md",
-    b"--cpu-prof-interval",
-    b"--heap-prof",
-    b"--heap-prof-name",
-    b"--heap-prof-dir",
-    b"--heap-prof-md",
-    b"--heap-prof-interval",
 ];
 
 /// Every other named flag `bun test` accepts.
@@ -800,6 +789,19 @@ const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
     b"--inspect",
     b"--inspect-wait",
     b"--inspect-brk",
+    // `bun test` does not start the profilers (#40184). An explicit
+    // `--cpu-prof-name`/`--heap-prof-name` would also name one file for N
+    // workers, so per-worker profiling needs its own naming rule first.
+    b"--cpu-prof",
+    b"--cpu-prof-name",
+    b"--cpu-prof-dir",
+    b"--cpu-prof-md",
+    b"--cpu-prof-interval",
+    b"--heap-prof",
+    b"--heap-prof-name",
+    b"--heap-prof-dir",
+    b"--heap-prof-md",
+    b"--heap-prof-interval",
     // No meaning for `bun test`.
     b"--help",
     b"--interactive",
@@ -810,32 +812,18 @@ const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
     b"--cron-period",
 ];
 
-const fn const_bytes_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut i = 0;
-    while i < a.len() {
-        if a[i] != b[i] {
-            return false;
-        }
-        i += 1;
-    }
-    true
-}
-
 /// Does `dashed` (`--long` or `-s`) name `param`?
 const fn param_has_name(param: &ParamType, dashed: &[u8]) -> bool {
     if dashed.len() > 2 && dashed[0] == b'-' && dashed[1] == b'-' {
         let (_, key) = dashed.split_at(2);
         if let Some(long) = param.names.long {
-            if const_bytes_eq(long, key) {
+            if strings::const_bytes_eq(long, key) {
                 return true;
             }
         }
         let mut i = 0;
         while i < param.names.long_aliases.len() {
-            if const_bytes_eq(param.names.long_aliases[i], key) {
+            if strings::const_bytes_eq(param.names.long_aliases[i], key) {
                 return true;
             }
             i += 1;

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -649,6 +649,338 @@ const TEST_PARAMS: &[ParamType] = concat_params!(
     BASE_PARAMS_
 );
 
+// ─── `bun test --parallel`: which flags reach the worker processes ──────────
+// Every named `TEST_PARAMS` flag is in exactly one of the two lists below
+// (a compile-time check follows them), so a new flag cannot silently go
+// missing from `--parallel` workers.
+
+/// Flags whose whole effect is inside the process that runs the test files.
+/// The coordinator re-serializes each one given on its command line as
+/// `--name[=value]` onto every worker's argv
+/// (`TestOptions::parallel_forwarded_argv`). A bunfig setting needs no entry:
+/// a worker loads the same bunfig, which is why `--config` is here.
+const TEST_WORKER_FORWARDED_FLAGS: &[&[u8]] = &[
+    b"--no-orphans",
+    // Module loading and transpilation.
+    b"--config",
+    b"--install",
+    b"--no-install",
+    b"-i",
+    b"--prefer-offline",
+    b"--prefer-latest",
+    b"--preserve-symlinks-main",
+    b"--ignore-dce-annotations",
+    b"--expose-internals",
+    b"--experimental-stream-iter",
+    // Network defaults.
+    b"--port",
+    b"--origin",
+    b"--fetch-preconnect",
+    b"--redis-preconnect",
+    b"--sql-preconnect",
+    b"--max-http-header-size",
+    b"--insecure-http-parser",
+    b"--user-agent",
+    b"--dns-result-order",
+    b"--use-system-ca",
+    b"--use-openssl-ca",
+    b"--use-bundled-ca",
+    b"--tls-min-v1.0",
+    b"--tls-min-v1.1",
+    b"--tls-min-v1.2",
+    b"--tls-min-v1.3",
+    b"--tls-max-v1.2",
+    b"--tls-max-v1.3",
+    // `process`, `console`, `Buffer` and warning behaviour.
+    b"--title",
+    b"--zero-fill-buffers",
+    b"--expose-gc",
+    b"--console-depth",
+    b"--unhandled-rejections",
+    b"--no-deprecation",
+    b"--throw-deprecation",
+    b"--no-warnings",
+    b"--trace-warnings",
+    b"--trace-deprecation",
+    b"--pending-deprecation",
+    b"--redirect-warnings",
+    b"--disable-warning",
+    b"--trace-events-enabled",
+    b"--trace-event-categories",
+    b"--trace-event-file-pattern",
+    b"--trace-env",
+    b"--trace-env-js-stack",
+    b"--trace-env-native-stack",
+    b"--trace-exit",
+    b"--stack-trace-limit",
+    // Profilers: one profile per worker process.
+    b"--cpu-prof",
+    b"--cpu-prof-name",
+    b"--cpu-prof-dir",
+    b"--cpu-prof-md",
+    b"--cpu-prof-interval",
+    b"--heap-prof",
+    b"--heap-prof-name",
+    b"--heap-prof-dir",
+    b"--heap-prof-md",
+    b"--heap-prof-interval",
+];
+
+/// Every other named flag `bun test` accepts.
+const TEST_WORKER_UNFORWARDED_FLAGS: &[&[u8]] = &[
+    // `build_worker_argv` forwards these from merged bunfig + command-line
+    // state instead.
+    b"--timeout",
+    b"--update-snapshots",
+    b"--rerun-each",
+    b"--retry",
+    b"--todo",
+    b"--only",
+    b"--concurrent",
+    b"--randomize",
+    b"--seed",
+    b"--coverage",
+    b"--test-name-pattern",
+    b"--reporter",
+    b"--dots",
+    b"--only-failures",
+    b"--max-concurrency",
+    b"--isolate",
+    b"--no-isolate",
+    b"--preload",
+    b"--require",
+    b"--import",
+    b"--smol",
+    b"--conditions",
+    b"--experimental-http2-fetch",
+    b"--experimental-http3-fetch",
+    b"--no-addons",
+    b"--no-ffi-cc",
+    b"--main-fields",
+    b"--preserve-symlinks",
+    b"--extension-order",
+    b"--tsconfig-override",
+    b"--define",
+    b"--drop",
+    b"--feature",
+    b"--loader",
+    b"--no-macros",
+    b"--jsx-factory",
+    b"--jsx-fragment",
+    b"--jsx-import-source",
+    b"--jsx-runtime",
+    b"--jsx-side-effects",
+    // Coordinator concerns: file discovery, reporting, supervision. A worker
+    // starts in the coordinator's working directory with the coordinator's
+    // environment, so `--cwd` and the env-file flags are already applied.
+    b"--test-worker",
+    b"--parallel",
+    b"--parallel-delay",
+    b"--pass-with-no-tests",
+    b"--bail",
+    b"--coverage-reporter",
+    b"--coverage-dir",
+    b"--reporter-outfile",
+    b"--path-ignore-patterns",
+    b"--changed",
+    b"--shard",
+    b"--timings",
+    b"--update-timings",
+    b"--watch",
+    b"--watch-kill-signal",
+    b"--hot",
+    b"--no-clear-screen",
+    b"--cwd",
+    b"--env-file",
+    b"--no-env-file",
+    b"--breakpoint-resolve",
+    // One debugger endpoint cannot serve N workers.
+    b"--inspect",
+    b"--inspect-wait",
+    b"--inspect-brk",
+    // No meaning for `bun test`.
+    b"--help",
+    b"--interactive",
+    b"--eval",
+    b"--print",
+    b"--if-present",
+    b"--cron-title",
+    b"--cron-period",
+];
+
+const fn const_bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Does `dashed` (`--long` or `-s`) name `param`?
+const fn param_has_name(param: &ParamType, dashed: &[u8]) -> bool {
+    if dashed.len() > 2 && dashed[0] == b'-' && dashed[1] == b'-' {
+        let (_, key) = dashed.split_at(2);
+        if let Some(long) = param.names.long {
+            if const_bytes_eq(long, key) {
+                return true;
+            }
+        }
+        let mut i = 0;
+        while i < param.names.long_aliases.len() {
+            if const_bytes_eq(param.names.long_aliases[i], key) {
+                return true;
+            }
+            i += 1;
+        }
+        false
+    } else if dashed.len() == 2 && dashed[0] == b'-' {
+        matches!(param.names.short, Some(s) if s == dashed[1])
+    } else {
+        false
+    }
+}
+
+const fn find_test_param(dashed: &[u8]) -> Option<&'static ParamType> {
+    let mut i = 0;
+    while i < TEST_PARAMS.len() {
+        if param_has_name(&TEST_PARAMS[i], dashed) {
+            return Some(&TEST_PARAMS[i]);
+        }
+        i += 1;
+    }
+    None
+}
+
+const fn flag_list_contains(list: &[&[u8]], param: &ParamType) -> bool {
+    let mut i = 0;
+    while i < list.len() {
+        if param_has_name(param, list[i]) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Compile-time panic whose message is the concatenation of `parts`.
+#[track_caller]
+const fn const_panic_concat(parts: &[&[u8]]) -> ! {
+    let mut buf = [0u8; 256];
+    let mut len = 0;
+    let mut p = 0;
+    while p < parts.len() {
+        let mut i = 0;
+        while i < parts[p].len() && len < buf.len() {
+            buf[len] = parts[p][i];
+            len += 1;
+            i += 1;
+        }
+        p += 1;
+    }
+    let (msg, _) = buf.as_slice().split_at(len);
+    match core::str::from_utf8(msg) {
+        Ok(msg) => panic!("{}", msg),
+        Err(_) => panic!("TEST_WORKER_*_FLAGS classification error (non-UTF-8 flag name)"),
+    }
+}
+
+/// `TEST_WORKER_FORWARDED_FLAGS` with each flag's value arity, resolved
+/// against `TEST_PARAMS` at compile time.
+static TEST_WORKER_FORWARDED: [(&[u8], clap::Values); TEST_WORKER_FORWARDED_FLAGS.len()] = {
+    let mut out = [(b"" as &[u8], clap::Values::None); TEST_WORKER_FORWARDED_FLAGS.len()];
+    let mut i = 0;
+    while i < out.len() {
+        let name = TEST_WORKER_FORWARDED_FLAGS[i];
+        out[i] = match find_test_param(name) {
+            Some(param) => (name, param.takes_value),
+            None => const_panic_concat(&[
+                b"TEST_WORKER_FORWARDED_FLAGS lists `",
+                name,
+                b"`, which is not a `bun test` flag",
+            ]),
+        };
+        i += 1;
+    }
+    out
+};
+
+const _: () = {
+    let mut i = 0;
+    while i < TEST_PARAMS.len() {
+        let param = &TEST_PARAMS[i];
+        i += 1;
+        if param.names.long.is_none() && param.names.short.is_none() {
+            continue; // positional
+        }
+        let forwarded = flag_list_contains(TEST_WORKER_FORWARDED_FLAGS, param);
+        let unforwarded = flag_list_contains(TEST_WORKER_UNFORWARDED_FLAGS, param);
+        if forwarded != unforwarded {
+            continue;
+        }
+        let short = match param.names.short {
+            Some(s) => [b'-', s],
+            None => [0, 0],
+        };
+        let (dashes, name): (&[u8], &[u8]) = match param.names.long {
+            Some(long) => (b"--", long),
+            None => (b"", &short),
+        };
+        const_panic_concat(&[
+            b"`bun test` flag `",
+            dashes,
+            name,
+            b"` must be listed in exactly one of TEST_WORKER_FORWARDED_FLAGS / ",
+            b"TEST_WORKER_UNFORWARDED_FLAGS (does a `--parallel` worker need it?)",
+        ]);
+    }
+};
+
+/// `bun test --parallel`: every `TEST_WORKER_FORWARDED_FLAGS` entry given on
+/// this command line, one `--name[=value]` token per occurrence.
+#[cold]
+#[inline(never)]
+fn test_worker_forwarded_argv(args: &clap::Args<clap::Help>) -> Vec<Box<[u8]>> {
+    fn with_value(name: &[u8], value: &[u8]) -> Box<[u8]> {
+        let mut token = Vec::with_capacity(name.len() + 1 + value.len());
+        token.extend_from_slice(name);
+        token.push(b'=');
+        token.extend_from_slice(value);
+        token.into_boxed_slice()
+    }
+    let mut argv: Vec<Box<[u8]>> = Vec::new();
+    for &(name, takes_value) in TEST_WORKER_FORWARDED.iter() {
+        match takes_value {
+            clap::Values::None => {
+                if args.flag(name) {
+                    argv.push(name.into());
+                }
+            }
+            clap::Values::OneOptional => match args.option(name) {
+                Some(b"") => argv.push(name.into()),
+                Some(value) => argv.push(with_value(name, value)),
+                None => {}
+            },
+            clap::Values::One => {
+                if let Some(value) = args.option(name) {
+                    argv.push(with_value(name, value));
+                }
+            }
+            clap::Values::Many => {
+                for value in args.options(name) {
+                    argv.push(with_value(name, value));
+                }
+            }
+        }
+    }
+    argv
+}
+
 /// Fallback table for `Command::tag_params`.
 const BASE_RUNTIME_TRANSPILER_PARAMS: &[ParamType] =
     concat_params!(BASE_PARAMS_, RUNTIME_PARAMS_, TRANSPILER_PARAMS_);
@@ -1990,6 +2322,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         }
         ctx.test_options.parallel = parsed;
         ctx.test_options.isolate = !no_isolate;
+        ctx.test_options.parallel_forwarded_argv = test_worker_forwarded_argv(args);
     }
 
     if let Some(delay_str) = args.option(b"--parallel-delay") {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -234,12 +234,9 @@ pub(crate) fn run_as_coordinator(
 /// `--only-failures` since the worker formats result lines and the coordinator
 /// prints them verbatim. `--reporter=junit` is forwarded (without the outfile)
 /// so workers attach the per-test detail the coordinator's JunitReporter
-/// needs. Test-runner and transpiler options are rebuilt here from merged
-/// bunfig + command-line state; plain runtime flags (`--console-depth`,
-/// `--throw-deprecation`, `--config`, ...) arrive pre-serialized in
-/// `test_options.parallel_forwarded_argv`. `TEST_WORKER_FORWARDED_FLAGS` /
-/// `TEST_WORKER_UNFORWARDED_FLAGS` in Arguments.rs classify every flag
-/// `bun test` accepts. Coordinator-only concerns — file discovery
+/// needs. Plain runtime flags arrive pre-serialized in
+/// `test_options.parallel_forwarded_argv` (`TEST_WORKER_FORWARDED_FLAGS` in
+/// Arguments.rs). Coordinator-only concerns — file discovery
 /// (`--path-ignore-patterns`, `--changed`), `--reporter-outfile`,
 /// `--pass-with-no-tests`, `--parallel` itself — are intentionally not
 /// forwarded.

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -234,8 +234,7 @@ pub(crate) fn run_as_coordinator(
 /// `--only-failures` since the worker formats result lines and the coordinator
 /// prints them verbatim. `--reporter=junit` is forwarded (without the outfile)
 /// so workers attach the per-test detail the coordinator's JunitReporter
-/// needs. Runtime flags arrive in `test_options.parallel_forwarded_argv`.
-/// Coordinator-only concerns — file discovery
+/// needs. Coordinator-only concerns — file discovery
 /// (`--path-ignore-patterns`, `--changed`), `--reporter-outfile`,
 /// `--pass-with-no-tests`, `--parallel` itself — are intentionally not
 /// forwarded.

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -234,7 +234,12 @@ pub(crate) fn run_as_coordinator(
 /// `--only-failures` since the worker formats result lines and the coordinator
 /// prints them verbatim. `--reporter=junit` is forwarded (without the outfile)
 /// so workers attach the per-test detail the coordinator's JunitReporter
-/// needs. Coordinator-only concerns — file discovery
+/// needs. Test-runner and transpiler options are rebuilt here from merged
+/// bunfig + command-line state; plain runtime flags (`--console-depth`,
+/// `--throw-deprecation`, `--config`, ...) arrive pre-serialized in
+/// `test_options.parallel_forwarded_argv`. `TEST_WORKER_FORWARDED_FLAGS` /
+/// `TEST_WORKER_UNFORWARDED_FLAGS` in Arguments.rs classify every flag
+/// `bun test` accepts. Coordinator-only concerns — file discovery
 /// (`--path-ignore-patterns`, `--changed`), `--reporter-outfile`,
 /// `--pass-with-no-tests`, `--parallel` itself — are intentionally not
 /// forwarded.
@@ -409,6 +414,9 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
         if jsx.side_effects {
             argv.push(lit(b"--jsx-side-effects\0"));
         }
+    }
+    for token in &opts.parallel_forwarded_argv {
+        argv.push(dupe_z(token));
     }
     if opts.coverage.enabled {
         argv.push(lit(b"--coverage\0"));

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -234,9 +234,8 @@ pub(crate) fn run_as_coordinator(
 /// `--only-failures` since the worker formats result lines and the coordinator
 /// prints them verbatim. `--reporter=junit` is forwarded (without the outfile)
 /// so workers attach the per-test detail the coordinator's JunitReporter
-/// needs. Plain runtime flags arrive pre-serialized in
-/// `test_options.parallel_forwarded_argv` (`TEST_WORKER_FORWARDED_FLAGS` in
-/// Arguments.rs). Coordinator-only concerns — file discovery
+/// needs. Runtime flags arrive in `test_options.parallel_forwarded_argv`.
+/// Coordinator-only concerns — file discovery
 /// (`--path-ignore-patterns`, `--changed`), `--reporter-outfile`,
 /// `--pass-with-no-tests`, `--parallel` itself — are intentionally not
 /// forwarded.

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1181,6 +1181,58 @@ test("--parallel forwards --conditions to workers", async () => {
   expect(exitCode).toBe(0);
 });
 
+test("--parallel forwards runtime flags and --config to workers", async () => {
+  // Serial `bun test` applies these to the one process that runs the tests; a
+  // worker must see the same values. `[console] depth` lives only in the
+  // bunfig named by --config, so the worker has to load that file itself.
+  const fixture = /* js */ `
+    import { test, expect } from "bun:test";
+    import { maxHeaderSize } from "node:http";
+    test("runtime flags", () => {
+      expect({
+        maxHeaderSize,
+        throwDeprecation: process.throwDeprecation,
+        noDeprecation: process.noDeprecation,
+        title: process.title,
+      }).toEqual({
+        maxHeaderSize: 7777,
+        throwDeprecation: true,
+        noDeprecation: true,
+        title: "parallel-title-probe",
+      });
+      // Printed in full at depth 8, "[Object ...]" at the default depth of 2.
+      console.log({ l1: { l2: { l3: { l4: { l5: "DEEP_MARKER" } } } } });
+    });
+  `;
+  using dir = tempDir("parallel-runtime-flags", {
+    "custom.bunfig.toml": `[console]\ndepth = 8\n`,
+    "a.test.js": fixture,
+    "b.test.js": fixture,
+  });
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "test",
+      "--parallel=2",
+      "--config=custom.bunfig.toml",
+      "--max-http-header-size=7777",
+      "--throw-deprecation",
+      "--no-deprecation",
+      "--title=parallel-title-probe",
+    ],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(stdout + stderr).toContain(`l5: "DEEP_MARKER"`);
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel: workers get the --env-file values and skip the default .env", async () => {
   const fixture = `import {test,expect} from "bun:test"; test("env", () => { expect(process.env.BUNTEST_CUSTOM).toBe("1"); expect(process.env.BUNTEST_DOTENV).toBeUndefined(); });`;
   using dir = tempDir("parallel-env-file", {


### PR DESCRIPTION
### Problem
- `bun test --parallel` silently drops runtime flags that serial `bun test` honours. With `--max-http-header-size=7777 --throw-deprecation --title=x`, workers see `http.maxHeaderSize` 16384, `process.throwDeprecation` false and the default title. `--console-depth`, `--no-deprecation`, `--zero-fill-buffers` and `--config=<file>` are lost the same way.
- The cause is `build_worker_argv` (`src/runtime/cli/test/parallel/runner.rs:246`). It rebuilds the worker command line from a hand-picked set of options. Flags that `Arguments::parse` writes straight into process globals (`Bun__Node__ProcessThrowDeprecation`, `bun_http::set_max_http_header_size`, ...) were never in that set.

### Fix
- `Arguments.rs` now classifies every flag `bun test` accepts. `TEST_WORKER_FORWARDED_FLAGS` are re-serialized from the parsed command line as `--name[=value]` into `TestOptions::parallel_forwarded_argv`, which `build_worker_argv` appends. `TEST_WORKER_UNFORWARDED_FLAGS` lists the rest, with a reason per group.
- A compile-time check fails the build, naming the flag, when a `bun test` flag is in neither list or in both. A new flag cannot go missing from workers unnoticed again.
- Verified: `test/cli/test/parallel.test.ts` ("forwards runtime flags and --config to workers") fails on stock bun and passes with this change. The rest of that file still passes. Self-reviewed; review feedback on profiler output names and a duplicated helper addressed.

### Background
- `bun test --parallel` runs a coordinator that spawns `bun test --test-worker` processes and hands them files over IPC. A worker parses its own argv like any `bun test` and loads bunfig itself.
- `Arguments::parse` scatters runtime flags across `ctx.runtime_options`, `ctx.args` and process-global atomics. The parsed `clap::Args` is the one place that has all of them.
- Workers already honoured `BUN_OPTIONS`, because every Bun process splices it into argv. A flag given both ways now reaches a worker twice with the same value. That is harmless.

<details><summary>Notes</summary>

- Newly forwarded: `--config`, `--max-http-header-size`, `--insecure-http-parser`, `--user-agent`, `--port`, `--origin`, `--dns-result-order`, `--use-*-ca`, `--tls-min-*`/`--tls-max-*`, `--fetch-preconnect`, `--redis-preconnect`, `--sql-preconnect`, `--install`, `--no-install`, `-i`, `--prefer-offline`, `--prefer-latest`, `--title`, `--zero-fill-buffers`, `--expose-gc`, `--console-depth`, `--unhandled-rejections`, `--no-deprecation`, `--throw-deprecation`, `--no-warnings`, `--trace-warnings`, `--trace-deprecation`, `--pending-deprecation`, `--redirect-warnings`, `--disable-warning`, the Node `--trace-*` flags, `--stack-trace-limit`, `--expose-internals`, `--experimental-stream-iter`, `--preserve-symlinks-main`, `--ignore-dce-annotations` and `--no-orphans`.
- Not forwarded: `--inspect*` (one debugger endpoint cannot serve N workers), `--watch`, `--hot`, `--cwd` and `--env-file` (a worker inherits the cwd and the environment), discovery and reporting flags, `--bail` (handled by the coordinator at file granularity, as before), and `--cpu-prof*`/`--heap-prof*`: `bun test` does not start the profilers today (#40184), and an explicit `--cpu-prof-name`/`--heap-prof-name` would name one output file for N workers, so per-worker profiling needs a naming rule first. `--redirect-warnings` is forwarded: warnings are appended per line, so N workers writing one file lose nothing.
- Already forwarded before this change, from merged bunfig + CLI state, and left as they were: `--timeout`, `--preload`, `--define`, `--loader`, `--conditions`, `--smol`, `--tsconfig-override`, `--jsx-*`, `--no-macros`, `--no-addons`, `--no-ffi-cc`, `--drop`, `--feature`, `--main-fields`, `--extension-order`, `--preserve-symlinks`, `--experimental-http2-fetch`, `--experimental-http3-fetch`, and the test-runner options.
- `--expose-gc`, `--dns-result-order` and `--no-macros` are reported inert in serial `bun test` as well. That is a separate issue. They are forwarded so that workers follow once serial honours them.
- Serialization uses the parsed values, so `--console-depth 8`, `--console-depth=8` and a value from `BUN_OPTIONS` all become `--console-depth=8`. A bare optional-value flag (`-c`) is forwarded bare (`--config`).
- Worker argv observed for `bun test --parallel=2 --console-depth 8 -c --disable-warning=DEP0001 --disable-warning ExperimentalWarning --user-agent "my agent/1.0" --port 0`: `test --test-worker --isolate --timeout=5000 --max-concurrency=5 --config --port=0 --user-agent=my agent/1.0 --console-depth=8 --disable-warning=DEP0001 --disable-warning=ExperimentalWarning`.
- The compile-time check was exercised by removing `--title` from both lists: `error[E0080]: evaluation panicked: \`bun test\` flag \`--title\` must be listed in exactly one of TEST_WORKER_FORWARDED_FLAGS / TEST_WORKER_UNFORWARDED_FLAGS (does a \`--parallel\` worker need it?)`.
- The "lazily scales workers based on file duration" case in `parallel.test.ts` is timing-sensitive under a debug build in a constrained container and fails there independent of this change. It passes no extra flags, so its worker argv is byte-identical to before.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts

<!-- robobun:evidence:end -->