### PR TITLE
install: check peer ranges in the linkers, against the copy each dependent resolves

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2538,30 +2538,13 @@ fn get_or_put_resolved_package(
                             }));
                         }
 
-                        let res_tag = resolutions[existing_id as usize].tag;
-                        let ver_tag = version.tag;
-                        if (res_tag == ResolutionTag::Npm
-                            && ver_tag == dependency::version::Tag::Npm)
-                            || (res_tag == ResolutionTag::Git
-                                && ver_tag == dependency::version::Tag::Git)
-                            || (res_tag == ResolutionTag::Github
-                                && ver_tag == dependency::version::Tag::Github)
-                        {
-                            let existing_package = this.lockfile.packages.get(existing_id as usize);
-                            this.log_mut().add_warning_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!(
-                                    "incorrect peer dependency \"{}@{}\"",
-                                    existing_package
-                                        .name
-                                        .fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                                    existing_package.resolution.fmt(
-                                        this.lockfile.buffers.string_bytes.as_slice(),
-                                        bun_fmt::PathSep::Auto
-                                    ),
-                                ),
-                            );
+                        // Nothing satisfies the range: bind the copy that exists anyway. The
+                        // linker reports the mismatch against the copy it actually serves
+                        // (`Lockfile::warn_if_peer_out_of_range`), which may be a different one.
+                        if peer_binds_out_of_range(
+                            resolutions[existing_id as usize].tag,
+                            version.tag,
+                        ) {
                             success_fn(this, dependency_id, existing_id);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
@@ -2587,32 +2570,8 @@ fn get_or_put_resolved_package(
                     }
 
                     if (list[0] as usize) < resolutions.len() {
-                        let res_tag = resolutions[list[0] as usize].tag;
-                        let ver_tag = version.tag;
-                        if (res_tag == ResolutionTag::Npm
-                            && ver_tag == dependency::version::Tag::Npm)
-                            || (res_tag == ResolutionTag::Git
-                                && ver_tag == dependency::version::Tag::Git)
-                            || (res_tag == ResolutionTag::Github
-                                && ver_tag == dependency::version::Tag::Github)
-                        {
+                        if peer_binds_out_of_range(resolutions[list[0] as usize].tag, version.tag) {
                             let existing_package_id = list[0];
-                            let existing_package =
-                                this.lockfile.packages.get(existing_package_id as usize);
-                            this.log_mut().add_warning_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!(
-                                    "incorrect peer dependency \"{}@{}\"",
-                                    existing_package
-                                        .name
-                                        .fmt(this.lockfile.buffers.string_bytes.as_slice()),
-                                    existing_package.resolution.fmt(
-                                        this.lockfile.buffers.string_bytes.as_slice(),
-                                        bun_fmt::PathSep::Auto
-                                    ),
-                                ),
-                            );
                             success_fn(this, dependency_id, list[0]);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
@@ -3145,6 +3104,17 @@ fn resolution_satisfies_dependency(
 ) -> bool {
     let buf = this.lockfile.buffers.string_bytes.as_slice();
     resolution.satisfies_dependency_version(dependency, buf, buf)
+}
+
+/// A peer nothing in the lockfile satisfies still binds to an existing copy of the same kind
+/// instead of pulling in its own version.
+fn peer_binds_out_of_range(existing: ResolutionTag, range: dependency::version::Tag) -> bool {
+    matches!(
+        (existing, range),
+        (ResolutionTag::Npm, dependency::version::Tag::Npm)
+            | (ResolutionTag::Git, dependency::version::Tag::Git)
+            | (ResolutionTag::Github, dependency::version::Tag::Github)
+    )
 }
 
 fn patched_package_satisfying(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2538,9 +2538,7 @@ fn get_or_put_resolved_package(
                             }));
                         }
 
-                        // Nothing satisfies the range: bind the copy that exists anyway. The
-                        // linker reports the mismatch against the copy it actually serves
-                        // (`Lockfile::warn_if_peer_out_of_range`), which may be a different one.
+                        // The linker warns, against the copy it serves (`warn_if_peer_out_of_range`).
                         if peer_binds_out_of_range(
                             resolutions[existing_id as usize].tag,
                             version.tag,
@@ -3106,8 +3104,7 @@ fn resolution_satisfies_dependency(
     resolution.satisfies_dependency_version(dependency, buf, buf)
 }
 
-/// A peer nothing in the lockfile satisfies still binds to an existing copy of the same kind
-/// instead of pulling in its own version.
+/// A peer no lockfile package satisfies binds an existing copy of its kind rather than a new one.
 fn peer_binds_out_of_range(existing: ResolutionTag, range: dependency::version::Tag) -> bool {
     matches!(
         (existing, range),

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -220,8 +220,7 @@ pub(crate) fn build_store(
     workspace_filters: &[WorkspaceFilter],
     packages_to_install: Option<&[PackageID]>,
     timings: Timings,
-    // Where to report peers an entry resolves out of range; `None` for a store that is not
-    // about to be installed.
+    // `Some` only for a store about to be installed: where its out-of-range peers are reported.
     mut peer_warnings: Option<&mut bun_ast::Log>,
 ) -> Result<Store, AllocError> {
     let mut timer = std::time::Instant::now();
@@ -401,8 +400,7 @@ pub(crate) fn build_store(
 
     let mut visited_parent_node_ids: Vec<store::node::Id> = Vec::new();
 
-    // A package is visited once per peer context, so the same edge can resolve the same way many
-    // times; each distinct `(peer edge, resolved package)` is range-checked once.
+    // A package is visited once per peer context; each `(peer edge, resolution)` is checked once.
     let mut reported_peers: HashMap<(DependencyID, PackageID), ()> = HashMap::default();
 
     // First pass: create full dependency tree with resolved peers
@@ -752,8 +750,7 @@ pub(crate) fn build_store(
                             continue;
                         }
 
-                        // The nearest ancestor that provides the name wins whether or not its
-                        // version is in range; the range is checked once the peer is resolved.
+                        // The nearest provider wins even out of range; the range is checked below.
                         break 'resolved_pkg_id (ids.pkg_id, false);
                     }
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -398,6 +398,10 @@ pub(crate) fn build_store(
 
     let mut visited_parent_node_ids: Vec<store::node::Id> = Vec::new();
 
+    // A package is visited once per peer context, so the same edge can resolve the same way many
+    // times; each distinct `(peer edge, resolved package)` is range-checked once.
+    let mut reported_peers: HashMap<(DependencyID, PackageID), ()> = HashMap::default();
+
     // First pass: create full dependency tree with resolved peers
     'next_node: while let Some(entry) = node_queue.pop() {
         'check_cycle: {
@@ -745,24 +749,8 @@ pub(crate) fn build_store(
                             continue;
                         }
 
-                        let res = &pkg_resolutions[ids.pkg_id as usize];
-
-                        if peer_dep.version.tag != VersionTag::Npm || res.tag != ResolutionTag::Npm
-                        {
-                            // TODO: print warning for this? we don't have a version
-                            // to compare to say if this satisfies or not.
-                            break 'resolved_pkg_id (ids.pkg_id, false);
-                        }
-
-                        // SAFETY: tag was checked == .Npm directly above for both
-                        // `peer_dep.version` and `res`.
-                        let peer_dep_version = &peer_dep.version.npm().version;
-                        let res_version = &res.npm().version;
-
-                        if !peer_dep_version.satisfies(*res_version, string_buf, string_buf) {
-                            // TODO: add warning!
-                        }
-
+                        // The nearest ancestor that provides the name wins whether or not its
+                        // version is in range; the range is checked once the peer is resolved.
                         break 'resolved_pkg_id (ids.pkg_id, false);
                     }
 
@@ -780,8 +768,6 @@ pub(crate) fn build_store(
                         if !ids.auto_installed {
                             // The resolution was found here or above. Choose the same
                             // peer resolution. No need to mark this node or above.
-
-                            // TODO: add warning if not satisfies()!
                             break 'resolved_pkg_id (ids.pkg_id, false);
                         }
 
@@ -825,6 +811,22 @@ pub(crate) fn build_store(
                 // these are optional peers that failed to find any dependency with a matching
                 // name. they are completely excluded
                 continue;
+            }
+
+            if packages_to_install.is_none()
+                && !dependencies[peer_dep_id as usize]
+                    .behavior
+                    .is_optional_peer()
+                && reported_peers
+                    .insert((peer_dep_id, resolved_pkg_id), ())
+                    .is_none()
+            {
+                lockfile.warn_if_peer_out_of_range(
+                    manager.log_mut(),
+                    entry.pkg_id,
+                    peer_dep_id,
+                    resolved_pkg_id,
+                );
             }
 
             for &visited_parent_id in &visited_parent_node_ids {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -220,6 +220,9 @@ pub(crate) fn build_store(
     workspace_filters: &[WorkspaceFilter],
     packages_to_install: Option<&[PackageID]>,
     timings: Timings,
+    // Where to report peers an entry resolves out of range; `None` for a store that is not
+    // about to be installed.
+    mut peer_warnings: Option<&mut bun_ast::Log>,
 ) -> Result<Store, AllocError> {
     let mut timer = std::time::Instant::now();
     let pkgs = lockfile.packages.slice();
@@ -813,7 +816,7 @@ pub(crate) fn build_store(
                 continue;
             }
 
-            if packages_to_install.is_none()
+            if let Some(log) = peer_warnings.as_deref_mut()
                 && !dependencies[peer_dep_id as usize]
                     .behavior
                     .is_optional_peer()
@@ -821,12 +824,7 @@ pub(crate) fn build_store(
                     .insert((peer_dep_id, resolved_pkg_id), ())
                     .is_none()
             {
-                lockfile.warn_if_peer_out_of_range(
-                    manager.log_mut(),
-                    entry.pkg_id,
-                    peer_dep_id,
-                    resolved_pkg_id,
-                );
+                lockfile.warn_if_peer_out_of_range(log, entry.pkg_id, peer_dep_id, resolved_pkg_id);
             }
 
             for &visited_parent_id in &visited_parent_node_ids {
@@ -1156,6 +1154,8 @@ pub(crate) fn install_isolated_packages(
     } else {
         Timings::Quiet
     };
+    // The partial store that installs a security scanner ahead of the real install stays quiet.
+    let peer_warnings = packages_to_install.is_none().then(|| manager.log_mut());
     let store: Store = build_store(
         &*manager,
         &*lockfile,
@@ -1163,6 +1163,7 @@ pub(crate) fn install_isolated_packages(
         workspace_filters,
         packages_to_install,
         timings,
+        peer_warnings,
     )?;
 
     let global_store_path: Option<Vec<u8>> = if manager.options.enable.global_virtual_store() {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -756,9 +756,8 @@ impl Lockfile {
         Some(catalog_dep.version)
     }
 
-    /// The range the resolver resolves an edge against: an `overrides` rule replaces the declared
-    /// range, then a `catalog:` reference is looked up. Mirrors
-    /// `enqueue_dependency_with_main_and_success_fn`, minus its per-session npm alias redirects.
+    /// The range the resolver resolves an edge against: its `overrides` rule if any, else the
+    /// declared range, with `catalog:` references looked up either way.
     pub(crate) fn enforced_range(&self, dep_id: DependencyID) -> EnforcedRange<'_> {
         use dependency::DependencyExt as _;
 
@@ -800,10 +799,7 @@ impl Lockfile {
         }
     }
 
-    /// A linker calls this with the package it wires a peer edge of `dependent` to. Warns when
-    /// that package is outside the range the edge enforces. Only like kinds are compared (an npm
-    /// range against an npm version, a git range against a git resolution): a peer served by a
-    /// workspace, folder or tarball package has nothing to reject.
+    /// Called by a linker with the package it wires a required peer edge of `dependent` to.
     pub(crate) fn warn_if_peer_out_of_range(
         &self,
         log: &mut bun_ast::Log,
@@ -819,6 +815,7 @@ impl Lockfile {
         let pkg_resolutions = self.packages.items_resolution();
         let served_res = &pkg_resolutions[served as usize];
         let range = self.enforced_range(peer_dep_id);
+        // A workspace, folder or tarball copy has no version to reject.
         let comparable = matches!(
             (served_res.tag, range.version.tag),
             (ResolutionTag::Npm, dependency::Tag::Npm)
@@ -1451,8 +1448,7 @@ impl Lockfile {
         Ok(())
     }
 
-    /// The tree an install lays out on disk. Peers it serves out of range are reported to `log`,
-    /// except for the partial tree that installs a security scanner ahead of the real install.
+    /// The tree an install writes to disk. Reports the out-of-range peers of a full install.
     pub(crate) fn filter(
         &mut self,
         log: &mut bun_ast::Log,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1442,7 +1442,7 @@ impl Lockfile {
             true,
             &[],
             None,
-            false,
+            tree::PeerRanges::Ignore,
         )? {}
         Ok(())
     }
@@ -1462,7 +1462,11 @@ impl Lockfile {
             install_root_dependencies,
             workspace_filters,
             packages_to_install,
-            packages_to_install.is_none(),
+            if packages_to_install.is_none() {
+                tree::PeerRanges::Report
+            } else {
+                tree::PeerRanges::Ignore
+            },
         )?;
         Ok(())
     }
@@ -1477,7 +1481,7 @@ impl Lockfile {
         install_root_dependencies: bool,
         workspace_filters: &[WorkspaceFilter],
         packages_to_install: Option<&[PackageID]>,
-        report_peers: bool,
+        peer_ranges: tree::PeerRanges,
     ) -> Result<bool, tree::SubtreeError> {
         let slice = self.packages.slice();
 
@@ -1509,7 +1513,7 @@ impl Lockfile {
             packages_to_install,
             pending_optional_peers: Default::default(),
             late_bound_optional_peer: false,
-            report_peers,
+            peer_ranges,
             reported_peers: Default::default(),
             list: Default::default(),
             sort_buf: Default::default(),

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1440,10 +1440,19 @@ impl<'a> Cloner<'a> {
 impl Lockfile {
     /// Re-hoists while a pass bound an optional peer late; a reload has that binding up front.
     pub(crate) fn resolve(&mut self, log: &mut bun_ast::Log) -> Result<(), tree::SubtreeError> {
-        while self.hoist::<{ tree::BuilderMethod::Resolvable }>(log, None, true, &[], None)? {}
+        while self.hoist::<{ tree::BuilderMethod::Resolvable }>(
+            log,
+            None,
+            true,
+            &[],
+            None,
+            false,
+        )? {}
         Ok(())
     }
 
+    /// The tree an install lays out on disk. Peers it serves out of range are reported to `log`,
+    /// except for the partial tree that installs a security scanner ahead of the real install.
     pub(crate) fn filter(
         &mut self,
         log: &mut bun_ast::Log,
@@ -1458,6 +1467,7 @@ impl Lockfile {
             install_root_dependencies,
             workspace_filters,
             packages_to_install,
+            packages_to_install.is_none(),
         )?;
         Ok(())
     }
@@ -1472,6 +1482,7 @@ impl Lockfile {
         install_root_dependencies: bool,
         workspace_filters: &[WorkspaceFilter],
         packages_to_install: Option<&[PackageID]>,
+        report_peers: bool,
     ) -> Result<bool, tree::SubtreeError> {
         let slice = self.packages.slice();
 
@@ -1503,6 +1514,7 @@ impl Lockfile {
             packages_to_install,
             pending_optional_peers: Default::default(),
             late_bound_optional_peer: false,
+            report_peers,
             reported_peers: Default::default(),
             list: Default::default(),
             sort_buf: Default::default(),

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -756,8 +756,7 @@ impl Lockfile {
         Some(catalog_dep.version)
     }
 
-    /// The range the resolver resolves an edge against: its `overrides` rule if any, else the
-    /// declared range, with `catalog:` references looked up either way.
+    /// The range the resolver holds an edge to: its `overrides` rule, else the declared range.
     pub(crate) fn enforced_range(&self, dep_id: DependencyID) -> EnforcedRange<'_> {
         use dependency::DependencyExt as _;
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2,6 +2,7 @@
 
 use core::cmp::Ordering;
 use core::fmt;
+use std::borrow::Cow;
 use std::io::Write as _;
 
 use crate::Error as BunError;
@@ -96,6 +97,13 @@ type DependencyVersion = dependency::Version;
 type ResolutionTag = resolution::Tag;
 type SemverStringBuf<'a> = bun_semver::semver_string::Buf<'a>;
 type SemverStringBuilder = bun_semver::semver_string::Builder;
+
+/// See [`Lockfile::enforced_range`].
+pub(crate) struct EnforcedRange<'a> {
+    pub version: Cow<'a, DependencyVersion>,
+    /// The range came from an `overrides` rule rather than the dependent's manifest.
+    pub overridden: bool,
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // Type aliases / collection types
@@ -748,6 +756,107 @@ impl Lockfile {
         Some(catalog_dep.version)
     }
 
+    /// The range the resolver resolves an edge against: an `overrides` rule replaces the declared
+    /// range, then a `catalog:` reference is looked up. Mirrors
+    /// `enqueue_dependency_with_main_and_success_fn`, minus its per-session npm alias redirects.
+    pub(crate) fn enforced_range(&self, dep_id: DependencyID) -> EnforcedRange<'_> {
+        use dependency::DependencyExt as _;
+
+        let buf = self.buffers.string_bytes.as_slice();
+        let dep = &self.buffers.dependencies[dep_id as usize];
+
+        let overridable = !dep.behavior.is_workspace()
+            && (dep.version.tag != dependency::Tag::Npm || !dep.version.npm().is_alias);
+        if overridable && !self.overrides.is_empty() {
+            let name = dep.realname();
+            let name_hash = match dep.version.tag {
+                dependency::Tag::DistTag
+                | dependency::Tag::Git
+                | dependency::Tag::Github
+                | dependency::Tag::Npm
+                | dependency::Tag::Tarball
+                | dependency::Tag::Workspace => SemverStringBuilder::string_hash(name.slice(buf)),
+                _ => dep.name_hash,
+            };
+            if let Some(rule) = self.overrides.get(self, dep_id, name_hash) {
+                if rule.tag == dependency::Tag::Catalog {
+                    if let Some(entry) = self.catalogs.get_ref(buf, *rule.catalog(), name) {
+                        return EnforcedRange {
+                            version: Cow::Borrowed(&entry.version),
+                            overridden: true,
+                        };
+                    }
+                }
+                return EnforcedRange {
+                    version: Cow::Owned(rule),
+                    overridden: true,
+                };
+            }
+        }
+
+        EnforcedRange {
+            version: Cow::Borrowed(self.catalogs.resolve_range(buf, dep)),
+            overridden: false,
+        }
+    }
+
+    /// A linker calls this with the package it wires a peer edge of `dependent` to. Warns when
+    /// that package is outside the range the edge enforces. Only like kinds are compared (an npm
+    /// range against an npm version, a git range against a git resolution): a peer served by a
+    /// workspace, folder or tarball package has nothing to reject.
+    pub(crate) fn warn_if_peer_out_of_range(
+        &self,
+        log: &mut bun_ast::Log,
+        dependent: PackageID,
+        peer_dep_id: DependencyID,
+        served: PackageID,
+    ) {
+        let dep = &self.buffers.dependencies[peer_dep_id as usize];
+        debug_assert!(dep.behavior.is_peer());
+        if dep.behavior.is_optional_peer() {
+            return;
+        }
+        let pkg_resolutions = self.packages.items_resolution();
+        let served_res = &pkg_resolutions[served as usize];
+        let range = self.enforced_range(peer_dep_id);
+        let comparable = matches!(
+            (served_res.tag, range.version.tag),
+            (ResolutionTag::Npm, dependency::Tag::Npm)
+                | (ResolutionTag::Git, dependency::Tag::Git)
+                | (ResolutionTag::Github, dependency::Tag::Github)
+        );
+        let buf = self.buffers.string_bytes.as_slice();
+        if !comparable || served_res.satisfies_dependency_version(&range.version, buf, buf) {
+            return;
+        }
+
+        let pkg_names = self.packages.items_name();
+        let dependent_res = &pkg_resolutions[dependent as usize];
+        let dependent_name = pkg_names[dependent as usize].slice(buf);
+        log.add_warning_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "incorrect peer dependency \"{}@{}\" ({}{}{} requires \"{}\"{})",
+                bstr::BStr::new(pkg_names[served as usize].slice(buf)),
+                served_res.fmt(buf, PathSep::Auto),
+                bstr::BStr::new(if dependent_name.is_empty() && dependent == 0 {
+                    b"package.json".as_slice()
+                } else {
+                    dependent_name
+                }),
+                if dependent_res.tag == ResolutionTag::Root {
+                    ""
+                } else {
+                    "@"
+                },
+                dependent_res.fmt(buf, PathSep::Posix),
+                bstr::BStr::new(range.version.literal.slice(buf)),
+                if range.overridden { " by override" } else { "" },
+            ),
+        );
+    }
+
     /// Is this a direct dependency of the workspace root package.json?
     pub(crate) fn is_workspace_root_dependency(&self, id: DependencyID) -> bool {
         self.packages.items_dependencies()[0].contains(id)
@@ -1394,6 +1503,7 @@ impl Lockfile {
             packages_to_install,
             pending_optional_peers: Default::default(),
             late_bound_optional_peer: false,
+            reported_peers: Default::default(),
             list: Default::default(),
             sort_buf: Default::default(),
         };

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -127,8 +127,7 @@ enum HoistDependencyResult {
     Resolve(PackageID),
     ResolveReplace(ResolveReplace),
     ResolveLater,
-    /// `Hoisted`, for a peer: nothing is placed and the dependent resolves this other package,
-    /// already on its path, instead of the one the edge is bound to.
+    /// `Hoisted`, for a peer served by this different package already on its path.
     Dedupe(PackageID),
     Placement(Placement),
 }
@@ -437,11 +436,9 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
         ArrayHashMap<PackageNameHash, ArrayHashMap<DependencyID, ()>>,
     /// An optional peer got bound after its dependent was placed; see `Lockfile::resolve`.
     pub(crate) late_bound_optional_peer: bool,
-    /// Check the range of every peer this tree serves (`report_peer`). Only the tree an install
-    /// lays out on disk does; the saved (`Resolvable`) tree is also built on every load.
+    /// Range-check the peers this tree serves (`report_peer`); only the tree an install writes does.
     pub(crate) report_peers: bool,
-    /// `(peer edge, package it is served by)` pairs already checked by `report_peer`, so a
-    /// dependent placed at several paths is reported once per distinct outcome.
+    /// `(peer edge, package serving it)` pairs already checked, one per distinct outcome.
     pub(crate) reported_peers: HashMap<(DependencyID, PackageID), ()>,
     pub(crate) manager: Option<&'a PackageManager>,
     pub(crate) sort_buf: Vec<DependencyID>,
@@ -490,8 +487,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
         let _ = self.log.add_error_fmt(None, bun_ast::Loc::EMPTY, args);
     }
 
-    /// This tree decided which package `dependent` resolves for its peer edge `dep_id`; warn if
-    /// that package is outside the peer's range.
+    /// This tree serves `dependent`'s peer edge `dep_id` with `served`; warn if it is out of range.
     fn report_peer(&mut self, dependent: PackageID, dep_id: DependencyID, served: PackageID) {
         if !self.report_peers {
             return;
@@ -937,8 +933,7 @@ impl Tree {
                 HoistDependencyResult::Dedupe(res_id) => {
                     debug_assert!(dependency.behavior.is_peer());
                     if dependency.behavior.is_optional_peer() {
-                        // An optional peer's binding follows the dedupe, but only in the tree
-                        // being saved.
+                        // An optional peer's binding follows the dedupe, in the saved tree only.
                         if METHOD == BuilderMethod::Resolvable {
                             builder.resolutions[dep_id as usize] = res_id;
                         }
@@ -1092,8 +1087,7 @@ impl Tree {
                 }
 
                 // Root dependencies are manually chosen by the user. Allow them
-                // to hoist other peers even if they don't satisfy the version;
-                // the tree being installed reports the mismatch (`Builder::report_peer`).
+                // to hoist other peers even if they don't satisfy the version
                 if builder.lockfile().is_workspace_root_dependency(dep_id) {
                     return HoistDependencyResult::Dedupe(res_id); // 1
                 }

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -143,6 +143,13 @@ pub(crate) struct Placement {
     pub bundled: bool,
 }
 
+/// Whether a tree reports the peers it serves out of range; only the tree an install writes does.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PeerRanges {
+    Report,
+    Ignore,
+}
+
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum SubtreeError {
     #[error("OutOfMemory")]
@@ -436,8 +443,7 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
         ArrayHashMap<PackageNameHash, ArrayHashMap<DependencyID, ()>>,
     /// An optional peer got bound after its dependent was placed; see `Lockfile::resolve`.
     pub(crate) late_bound_optional_peer: bool,
-    /// Range-check the peers this tree serves (`report_peer`); only the tree an install writes does.
-    pub(crate) report_peers: bool,
+    pub(crate) peer_ranges: PeerRanges,
     /// `(peer edge, package serving it)` pairs already checked, one per distinct outcome.
     pub(crate) reported_peers: HashMap<(DependencyID, PackageID), ()>,
     pub(crate) manager: Option<&'a PackageManager>,
@@ -489,7 +495,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 
     /// This tree serves `dependent`'s peer edge `dep_id` with `served`; warn if it is out of range.
     fn report_peer(&mut self, dependent: PackageID, dep_id: DependencyID, served: PackageID) {
-        if !self.report_peers {
+        if self.peer_ranges == PeerRanges::Ignore {
             return;
         }
         if self.reported_peers.insert((dep_id, served), ()).is_some() {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -437,6 +437,9 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
         ArrayHashMap<PackageNameHash, ArrayHashMap<DependencyID, ()>>,
     /// An optional peer got bound after its dependent was placed; see `Lockfile::resolve`.
     pub(crate) late_bound_optional_peer: bool,
+    /// Check the range of every peer this tree serves (`report_peer`). Only the tree an install
+    /// lays out on disk does; the saved (`Resolvable`) tree is also built on every load.
+    pub(crate) report_peers: bool,
     /// `(peer edge, package it is served by)` pairs already checked by `report_peer`, so a
     /// dependent placed at several paths is reported once per distinct outcome.
     pub(crate) reported_peers: HashMap<(DependencyID, PackageID), ()>,
@@ -487,12 +490,10 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
         let _ = self.log.add_error_fmt(None, bun_ast::Loc::EMPTY, args);
     }
 
-    /// The tree being installed decided which package `dependent` resolves for its peer edge
-    /// `dep_id`; warn if that package is outside the peer's range. The saved (`Resolvable`) tree
-    /// is built on every load and is not what ends up on disk, so it stays quiet, as does the
-    /// partial tree built to install a security scanner ahead of the real install.
+    /// This tree decided which package `dependent` resolves for its peer edge `dep_id`; warn if
+    /// that package is outside the peer's range.
     fn report_peer(&mut self, dependent: PackageID, dep_id: DependencyID, served: PackageID) {
-        if METHOD != BuilderMethod::Filter || self.packages_to_install.is_some() {
+        if !self.report_peers {
             return;
         }
         if self.reported_peers.insert((dep_id, served), ()).is_some() {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -2,7 +2,7 @@ use core::marker::ConstParamTy;
 use core::mem::MaybeUninit;
 
 use bun_alloc::AllocError;
-use bun_collections::{ArrayHashMap, DynamicBitSet, MultiArrayList, index_sort};
+use bun_collections::{ArrayHashMap, DynamicBitSet, HashMap, MultiArrayList, index_sort};
 use bun_core::Output;
 use bun_core::ZStr;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
@@ -127,8 +127,9 @@ enum HoistDependencyResult {
     Resolve(PackageID),
     ResolveReplace(ResolveReplace),
     ResolveLater,
-    /// `Hoisted`, plus the optional peer's slot now points at the version it deduplicated onto.
-    Rebind(PackageID),
+    /// `Hoisted`, for a peer: nothing is placed and the dependent resolves this other package,
+    /// already on its path, instead of the one the edge is bound to.
+    Dedupe(PackageID),
     Placement(Placement),
 }
 
@@ -436,6 +437,9 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
         ArrayHashMap<PackageNameHash, ArrayHashMap<DependencyID, ()>>,
     /// An optional peer got bound after its dependent was placed; see `Lockfile::resolve`.
     pub(crate) late_bound_optional_peer: bool,
+    /// `(peer edge, package it is served by)` pairs already checked by `report_peer`, so a
+    /// dependent placed at several paths is reported once per distinct outcome.
+    pub(crate) reported_peers: HashMap<(DependencyID, PackageID), ()>,
     pub(crate) manager: Option<&'a PackageManager>,
     pub(crate) sort_buf: Vec<DependencyID>,
     pub(crate) workspace_filters: &'a [WorkspaceFilter],
@@ -481,6 +485,23 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 
     fn maybe_report_error(&mut self, args: core::fmt::Arguments<'_>) {
         let _ = self.log.add_error_fmt(None, bun_ast::Loc::EMPTY, args);
+    }
+
+    /// The tree being installed decided which package `dependent` resolves for its peer edge
+    /// `dep_id`; warn if that package is outside the peer's range. The saved (`Resolvable`) tree
+    /// is built on every load and is not what ends up on disk, so it stays quiet, as does the
+    /// partial tree built to install a security scanner ahead of the real install.
+    fn report_peer(&mut self, dependent: PackageID, dep_id: DependencyID, served: PackageID) {
+        if METHOD != BuilderMethod::Filter || self.packages_to_install.is_some() {
+            return;
+        }
+        if self.reported_peers.insert((dep_id, served), ()).is_some() {
+            return;
+        }
+        let lockfile = self.lockfile;
+        lockfile
+            .get()
+            .warn_if_peer_out_of_range(self.log, dependent, dep_id, served);
     }
 
     fn buf(&self) -> &[u8] {
@@ -792,20 +813,21 @@ impl Tree {
                 if pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder {
                     // A peer an ancestor edge already provides dedupes instead of nesting
                     // a second copy of the folder (#40561).
-                    if dependency.behavior.is_peer()
-                        && matches!(
-                            Tree::hoist_dependency::<true, METHOD>(
-                                next_id,
-                                hoist_root_id,
-                                pkg_id,
-                                dep_id,
-                                resolution_list,
-                                builder,
-                            ),
-                            HoistDependencyResult::Hoisted
-                        )
-                    {
-                        break 'hoisted HoistDependencyResult::Hoisted;
+                    if dependency.behavior.is_peer() {
+                        let probe = Tree::hoist_dependency::<true, METHOD>(
+                            next_id,
+                            hoist_root_id,
+                            pkg_id,
+                            dep_id,
+                            resolution_list,
+                            builder,
+                        );
+                        if matches!(
+                            probe,
+                            HoistDependencyResult::Hoisted | HoistDependencyResult::Dedupe(_)
+                        ) {
+                            break 'hoisted probe;
+                        }
                     }
 
                     // Folder packages never hoist, so a cycle between them would nest forever.
@@ -839,7 +861,12 @@ impl Tree {
             };
 
             match hoisted {
-                HoistDependencyResult::DependencyLoop | HoistDependencyResult::Hoisted => continue,
+                HoistDependencyResult::DependencyLoop => continue,
+                HoistDependencyResult::Hoisted => {
+                    if dependency.behavior.is_peer() && !dependency.behavior.is_optional_peer() {
+                        builder.report_peer(parent_pkg_id, dep_id, pkg_id);
+                    }
+                }
 
                 HoistDependencyResult::Resolve(res_id) => {
                     debug_assert!(pkg_id == invalid_package_id);
@@ -906,9 +933,17 @@ impl Tree {
                         })?;
                     }
                 }
-                HoistDependencyResult::Rebind(res_id) => {
-                    debug_assert!(dependency.behavior.is_optional_peer());
-                    builder.resolutions[dep_id as usize] = res_id;
+                HoistDependencyResult::Dedupe(res_id) => {
+                    debug_assert!(dependency.behavior.is_peer());
+                    if dependency.behavior.is_optional_peer() {
+                        // An optional peer's binding follows the dedupe, but only in the tree
+                        // being saved.
+                        if METHOD == BuilderMethod::Resolvable {
+                            builder.resolutions[dep_id as usize] = res_id;
+                        }
+                    } else {
+                        builder.report_peer(parent_pkg_id, dep_id, res_id);
+                    }
                 }
                 HoistDependencyResult::ResolveLater => {
                     // `dep_id` is an unresolved optional peer. while hoisting it deduplicated
@@ -931,6 +966,9 @@ impl Tree {
                         builder.list.items_tree_mut()[dest.id as usize]
                             .dependencies
                             .len += 1;
+                    }
+                    if dependency.behavior.is_peer() && !dependency.behavior.is_optional_peer() {
+                        builder.report_peer(parent_pkg_id, dep_id, pkg_id);
                     }
                     if pkg_id != invalid_package_id
                         && builder.resolution_lists[pkg_id as usize].len > 0
@@ -1027,6 +1065,9 @@ impl Tree {
 
             if input_dep_range.contains(dep_id) {
                 // same package lists this name in another dependency group
+                if dependency.behavior.is_peer() && !dependency.behavior.is_optional_peer() {
+                    return HoistDependencyResult::Dedupe(res_id); // 1
+                }
                 return HoistDependencyResult::Hoisted; // 1
             }
 
@@ -1034,16 +1075,6 @@ impl Tree {
             // or hoist if peer version allows it
 
             if dependency.behavior.is_peer() {
-                // An optional peer's binding follows the dedupe, but only in the tree being saved.
-                let dedupe = || {
-                    if METHOD == BuilderMethod::Resolvable && dependency.behavior.is_optional_peer()
-                    {
-                        HoistDependencyResult::Rebind(res_id)
-                    } else {
-                        HoistDependencyResult::Hoisted
-                    }
-                };
-
                 let peer_range: &crate::dependency::Version = builder
                     .lockfile()
                     .catalogs
@@ -1055,15 +1086,15 @@ impl Tree {
                     if resolution.tag == crate::resolution::Tag::Npm
                         && version.satisfies(resolution.npm().version, builder.buf(), builder.buf())
                     {
-                        return dedupe(); // 1
+                        return HoistDependencyResult::Dedupe(res_id); // 1
                     }
                 }
 
                 // Root dependencies are manually chosen by the user. Allow them
-                // to hoist other peers even if they don't satisfy the version
+                // to hoist other peers even if they don't satisfy the version;
+                // the tree being installed reports the mismatch (`Builder::report_peer`).
                 if builder.lockfile().is_workspace_root_dependency(dep_id) {
-                    // TODO: warning about peer dependency version mismatch
-                    return dedupe(); // 1
+                    return HoistDependencyResult::Dedupe(res_id); // 1
                 }
             }
 

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -780,7 +780,14 @@ fn hoist_install_tree(
         unsafe {
             let lf: *mut Lockfile = &raw mut *(*pm).lockfile;
             let log: *mut bun_ast::Log = (*pm).log;
-            (*lf).hoist::<{ tree::BuilderMethod::Filter }>(&mut *log, Some(&*pm), true, &[], None)
+            (*lf).hoist::<{ tree::BuilderMethod::Filter }>(
+                &mut *log,
+                Some(&*pm),
+                true,
+                &[],
+                None,
+                false,
+            )
         }
     });
     match result {
@@ -1714,6 +1721,7 @@ fn build_store_with(manager: &mut PackageManager, features: InstallFeatures) -> 
             &[],
             None,
             Timings::Quiet,
+            None,
         ))
     })
 }

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -786,7 +786,7 @@ fn hoist_install_tree(
                 true,
                 &[],
                 None,
-                false,
+                tree::PeerRanges::Ignore,
             )
         }
     });

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1,8 +1,9 @@
 import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
 import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { copyFileSync, mkdirSync } from "fs";
+import { copyFileSync, mkdirSync, realpathSync } from "fs";
 import { cp, exists, lstat, mkdir, readlink, rename, rm, writeFile } from "fs/promises";
+import { createRequire } from "module";
 import {
   assertManifestsPopulated,
   bunExe,
@@ -65,6 +66,14 @@ beforeEach(async () => {
 
 function registryUrl() {
   return registry.registryUrl();
+}
+
+/** The `incorrect peer dependency` lines of an install's stderr, sorted (their order follows the tree walk). */
+function peerWarnings(stderr: string): string[] {
+  return stderr
+    .split(/\r?\n/)
+    .filter(line => line.includes("incorrect peer dependency"))
+    .sort();
 }
 
 /**
@@ -4256,6 +4265,11 @@ describe("hoisting", async () => {
     expect(err).toContain("Saved lockfile");
     expect(err).not.toContain("not found");
     expect(err).not.toContain("error:");
+    // The resolver does not run again for peer-deps-fixed, but the tree now serves its peer from
+    // the root's 2.0.0, and the linker reports that.
+    expect(peerWarnings(err)).toEqual([
+      `warn: incorrect peer dependency "no-deps@2.0.0" (peer-deps-fixed@1.0.0 requires "^1.0.0")`,
+    ]);
 
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
@@ -4380,7 +4394,11 @@ describe("hoisting", async () => {
     expect(err).toContain("Saved lockfile");
     expect(err).not.toContain("not found");
     expect(err).not.toContain("error:");
-    expect(err).toContain("incorrect peer dependency");
+    // One line, naming the dependent and its range (the resolver alone used to print
+    // `incorrect peer dependency "no-deps@2.0.0"` with neither).
+    expect(peerWarnings(err)).toEqual([
+      `warn: incorrect peer dependency "no-deps@2.0.0" (peer-deps-fixed@1.0.0 requires "^1.0.0")`,
+    ]);
 
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
@@ -4432,6 +4450,7 @@ describe("hoisting", async () => {
     expect(err).toContain("Saved lockfile");
     expect(err).not.toContain("not found");
     expect(err).not.toContain("error:");
+    expect(peerWarnings(err)).toEqual([]);
 
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
@@ -4456,6 +4475,150 @@ describe("hoisting", async () => {
       },
     } as any);
     expect(await exists(join(packageDir, "node_modules", "peer-deps-fixed", "node_modules"))).toBeFalse();
+  });
+
+  // The linker that lays out node_modules decides which copy of a peer a package resolves, so it
+  // is the one that checks the peer's range: on every install, for both linkers, naming the
+  // dependent (#7403). The cases below get the same report from either linker.
+  describe.each(["hoisted", "isolated"] as const)("peer a dependent cannot resolve in range (%s linker)", linker => {
+    async function install(dir: string, ...args: string[]) {
+      await using proc = spawn({
+        cmd: [bunExe(), "install", "--linker", linker, ...args],
+        cwd: dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      return { out, err };
+    }
+
+    /** The version of `no-deps` that `dependent` loads at runtime, resolved from its real directory. */
+    async function noDepsSeenBy(dir: string, dependent: string): Promise<string> {
+      const from = realpathSync(join(dir, "node_modules", dependent, "package.json"));
+      return (await file(createRequire(from).resolve("no-deps/package.json")).json()).version;
+    }
+
+    test("a satisfying copy nested elsewhere does not hide that the dependent gets the root's copy", async () => {
+      // one-fixed-dep nests no-deps@1.0.0, which satisfies peer-deps-fixed's `^1.0.0`, but
+      // peer-deps-fixed sits next to the root's no-deps@2.0.0 and that is what it loads. The
+      // resolver bound the peer to the nested 1.0.0 and said nothing.
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: { "one-fixed-dep": "1.0.0", "no-deps": "2.0.0", "peer-deps-fixed": "1.0.0" },
+        }),
+      );
+
+      const expected = [`warn: incorrect peer dependency "no-deps@2.0.0" (peer-deps-fixed@1.0.0 requires "^1.0.0")`];
+      expect(peerWarnings((await install(packageDir)).err)).toEqual(expected);
+      expect(await noDepsSeenBy(packageDir, "peer-deps-fixed")).toBe("2.0.0");
+      expect(await noDepsSeenBy(packageDir, "one-fixed-dep")).toBe("1.0.0");
+
+      // Nothing is re-resolved on a warm install; the report comes from the layout, every time.
+      expect(peerWarnings((await install(packageDir)).err)).toEqual(expected);
+      expect(peerWarnings((await install(packageDir, "--frozen-lockfile")).err)).toEqual(expected);
+    });
+
+    test("no report when the copy the dependent resolves is in range", async () => {
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({ name: "foo", dependencies: { "one-fixed-dep": "1.0.0", "peer-deps-fixed": "1.0.0" } }),
+      );
+
+      expect(peerWarnings((await install(packageDir)).err)).toEqual([]);
+      expect(await noDepsSeenBy(packageDir, "peer-deps-fixed")).toBe("1.0.0");
+    });
+
+    test("one line per dependent, not one anonymous line per edge", async () => {
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: { "no-deps": "2.0.0", "1-peer-dep-a": "1.0.0", "1-peer-dep-b": "1.0.0" },
+        }),
+      );
+
+      expect(peerWarnings((await install(packageDir)).err)).toEqual([
+        `warn: incorrect peer dependency "no-deps@2.0.0" (1-peer-dep-a@1.0.0 requires "1.0.0")`,
+        `warn: incorrect peer dependency "no-deps@2.0.0" (1-peer-dep-b@1.0.0 requires "1.0.0")`,
+      ]);
+    });
+
+    test("the range an override sets is the one enforced", async () => {
+      // A flat override rewrites every `no-deps` edge, the peer included, so it is satisfied...
+      {
+        const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+        await write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            dependencies: { "no-deps": "2.0.0", "peer-deps-fixed": "1.0.0" },
+            overrides: { "no-deps": "2.0.0" },
+          }),
+        );
+        expect(peerWarnings((await install(packageDir)).err)).toEqual([]);
+        expect(await noDepsSeenBy(packageDir, "peer-deps-fixed")).toBe("2.0.0");
+      }
+      // ...and a scoped one that narrows the peer is reported against the narrowed range.
+      {
+        const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+        await write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            dependencies: { "no-deps": "1.1.0", "peer-deps-fixed": "1.0.0" },
+            overrides: { "peer-deps-fixed": { "no-deps": "1.0.0" } },
+          }),
+        );
+        expect(peerWarnings((await install(packageDir)).err)).toEqual([
+          `warn: incorrect peer dependency "no-deps@1.1.0" (peer-deps-fixed@1.0.0 requires "1.0.0" by override)`,
+        ]);
+        expect(await noDepsSeenBy(packageDir, "peer-deps-fixed")).toBe("1.1.0");
+      }
+    });
+
+    test("workspace and root dependents are named by what they are", async () => {
+      const { packageDir } = await registry.createTestDir({
+        bunfigOpts: { linker },
+        files: {
+          "package.json": JSON.stringify({
+            name: "mono",
+            workspaces: ["packages/*"],
+            dependencies: { "no-deps": "2.0.0" },
+            peerDependencies: { "no-deps": "^1.0.0" },
+          }),
+          "packages/pkg1/package.json": JSON.stringify({
+            name: "pkg1",
+            version: "1.0.0",
+            dependencies: { "peer-deps-fixed": "1.0.0" },
+            peerDependencies: { "no-deps": "1.0.0" },
+          }),
+        },
+      });
+
+      expect(peerWarnings((await install(packageDir)).err)).toEqual([
+        `warn: incorrect peer dependency "no-deps@2.0.0" (mono requires "^1.0.0")`,
+        `warn: incorrect peer dependency "no-deps@2.0.0" (peer-deps-fixed@1.0.0 requires "^1.0.0")`,
+        `warn: incorrect peer dependency "no-deps@2.0.0" (pkg1@workspace:packages/pkg1 requires "1.0.0")`,
+      ]);
+    });
+
+    test("--omit=peer leaves peer edges out of the install, so they are not checked", async () => {
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({ name: "foo", dependencies: { "no-deps": "2.0.0", "peer-deps-fixed": "1.0.0" } }),
+      );
+      expect(peerWarnings((await install(packageDir, "--omit=peer")).err)).toEqual([]);
+    });
   });
 
   describe("devDependencies", () => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4619,6 +4619,20 @@ describe("hoisting", async () => {
       );
       expect(peerWarnings((await install(packageDir, "--omit=peer")).err)).toEqual([]);
     });
+
+    test("--lockfile-only lays nothing out, so no peer is served and none is reported", async () => {
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({ name: "foo", dependencies: { "no-deps": "2.0.0", "peer-deps-fixed": "1.0.0" } }),
+      );
+      expect(peerWarnings((await install(packageDir, "--lockfile-only")).err)).toEqual([]);
+      expect(await exists(join(packageDir, "node_modules"))).toBeFalse();
+      // The install that follows does lay it out, and reports it.
+      expect(peerWarnings((await install(packageDir)).err)).toEqual([
+        `warn: incorrect peer dependency "no-deps@2.0.0" (peer-deps-fixed@1.0.0 requires "^1.0.0")`,
+      ]);
+    });
   });
 
   describe("devDependencies", () => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3,7 +3,6 @@ import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-fo
 import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync } from "fs";
 import { cp, exists, lstat, mkdir, readlink, rename, rm, writeFile } from "fs/promises";
-import { createRequire } from "module";
 import {
   assertManifestsPopulated,
   bunExe,
@@ -26,6 +25,7 @@ import {
   VerdaccioRegistry,
   writeShebangScript,
 } from "harness";
+import { createRequire } from "module";
 import { join, resolve } from "path";
 const { parseLockfile } = install_test_helpers;
 


### PR DESCRIPTION
### Problem
- A dependent can load a copy of its peer outside the peer's range with no warning, under both linkers. Root `no-deps@2.0.0` + `peer-deps-fixed` (peer `no-deps@^1.0.0`) + `one-fixed-dep` (depends on `no-deps@1.0.0`): `peer-deps-fixed` loads 2.0.0, silently. Without `one-fixed-dep`, `warn: incorrect peer dependency "no-deps@2.0.0"` prints once, with no dependent and no range (#7403).
- The resolver did the check (`get_or_put_resolved_package`, `PackageManagerEnqueue.rs`): it binds a peer to any lockfile package in range and warns only when none is. The served copy is chosen later: `Tree::hoist_dependency` dedupes a peer onto a root dependency regardless of range, and `build_store` (`isolated_install.rs`) takes the nearest ancestor's dependency of that name. Both carried a TODO for it.

### Fix
- Each linker checks the range where it picks the copy. `Lockfile::warn_if_peer_out_of_range` compares that copy with the range the resolver enforces (overrides, then catalogs) and prints `warn: incorrect peer dependency "no-deps@2.0.0" (peer-deps-fixed@1.0.0 requires "^1.0.0")`.
- The resolver still binds an out-of-range copy when nothing satisfies, but no longer warns: the linker covers that case. The warning now prints on every install that writes `node_modules`, as npm, pnpm and yarn do, and not on `--lockfile-only`. A flat override still silences it.
- Verified: `test/cli/install/bun-install-registry.test.ts`, both linkers. Supersedes #39053 (hoisted case only).

### Background
- A dependent resolves its peer to the copy visible from where it lands: the nearest enclosing `node_modules` (hoisted), or the nearest graph ancestor that depends on the name (isolated).
- The hoisted tree is built as `Resolvable` (saved, rebuilt on each load) and as `Filter` (what the install writes). Only `Filter` reports.

<details><summary>Notes</summary>

- Ledger context: this is the "peer satisfied by a copy the requester can never resolve, warning suppressed" finding (hoisted and isolated). The `bun why` half (phantom peer edge since #32182) is a separate change.
- What is checked: required peers whose enforced range and served copy are of the same kind (npm range vs npm version, git vs git, github vs github), the same pairs the resolver compared. Optional peers, `--omit=peer` installs, and peers served by a workspace, folder or tarball package are not checked, as before.
- Overrides: `enforced_range` mirrors `enqueue_dependency_with_main_and_success_fn` (scoped rules through `OverrideMap::get`, catalog-valued rules, then `catalog:` ranges). It does not see the resolver's per-session npm alias redirects. A narrowing scoped override is reported with `by override` after the range.
- Dedupe: the tree builder and the store builder each keep a `(peer edge, served package)` set, so a dependent placed at several paths, or visited in several peer contexts, is reported once per distinct outcome. Two dependents with the same unmet peer give two lines (previously two identical anonymous lines).
- Quiet callers: `bun pm prune` builds both a `Filter` tree and a store and passes `false`/`None`. The partial install of a security scanner ahead of the real install does too, so nothing is reported twice. `bun why` and `bun pm ls` only build the `Resolvable` tree and print nothing new.
- `Tree.rs`: the optional-peer `Rebind(PackageID)` result became `Dedupe(PackageID)`, returned for any peer deduped onto a different copy. `process_subtree` rebinds optional peers in the `Resolvable` build exactly as before and reports required ones in the `Filter` build (same-copy hoist, dedupe onto another copy, or nested placement). The folder-peer probe from #40564 now also accepts a dedupe onto a different copy (it only matched the same-copy case).
- Placement is unchanged: no tree or store layout differs, and `bun.lock` output is identical.
- Suites run on the debug build besides the new tests: isolated-install, bun-lock, bun-lockb, nested-overrides, overrides, catalogs, bun-workspaces, bun-workspaces-self-contained, hoist, bun-dedupe, bun-prune, bun-audit, bun-update, bun-update-transitive, frozen-lockfile-pruned, bun-add, bun-add-catalog, bun-add-filter, bun-remove, bun-pm, bun-pm-licenses, bun-pm-why, bun-install (only the external-host tests fail, as on main here), the security-scanner suites, the migration suites, and the peer-related regression tests. No expectation changed outside the two tightened tests.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->