### PR TITLE
bundler(html): rewrite every local URL attribute, keep ?query#fragment, parse srcset

### DIFF
--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -455,10 +455,16 @@ await Bun.build({
 Bun automatically handles all common web assets:
 
 - **Scripts** (`<script src>`) are run through Bun's JavaScript/TypeScript/JSX bundler
-- **Stylesheets** (`<link rel="stylesheet">`) are run through Bun's CSS parser & bundler
-- **Images** (`<img>`, `<picture>`) are copied and hashed
-- **Media** (`<video>`, `<audio>`, `<source>`) are copied and hashed
-- Any `<link>` tag with an `href` attribute pointing to a local file is rewritten to the new path, and hashed
+- **Stylesheets** (`<link rel="stylesheet">`, `<link rel="preload" as="style">`) are run through Bun's CSS parser & bundler
+- **Images** (`<img src>`, `<img srcset>`, `<picture><source srcset>`, `<input type="image" src>`, `<video poster>`, SVG `<image href>` and `<use href>`) are copied and hashed. Each candidate in a `srcset` is rewritten on its own and keeps its descriptor.
+- **Media** (`<video src>`, `<audio src>`, `<source src>`, `<track src>`) are copied and hashed
+- **Embedded documents** (`<object data>`, `<embed src>`) are copied and hashed
+- **`<link href>`** for `rel="icon"` (including `shortcut icon`, `apple-touch-icon`, `apple-touch-startup-image`, `mask-icon`), `rel="manifest"`, and `rel="preload"` with `as="font|image|audio|video"` (plus `imagesrcset`) are copied and hashed
+- **Social images** in `<meta property="og:image|og:audio|og:video" content>` and `<meta name="twitter:image|msapplication-TileImage" content>` are copied and hashed
+
+A `?query` or `#fragment` on the URL is kept on the rewritten path, so `<use href="./icons.svg#menu">` becomes `<use href="./icons-a1b2c3.svg#menu">`. URLs with a scheme (`https://...`, `data:...`) and protocol-relative URLs (`//cdn.example.com/...`) are left as-is.
+
+Not processed: `<iframe src>`, `<a href>`, inline `style="..."` attributes and `<style>` blocks, `import` specifiers inside inline `<script>` blocks, and anything inside `<noscript>`.
 
 Bun resolves all paths relative to your HTML file, so you can organize your project however you want.
 

--- a/docs/bundler/html-static.mdx
+++ b/docs/bundler/html-static.mdx
@@ -464,7 +464,7 @@ Bun automatically handles all common web assets:
 
 A `?query` or `#fragment` on the URL is kept on the rewritten path, so `<use href="./icons.svg#menu">` becomes `<use href="./icons-a1b2c3.svg#menu">`. URLs with a scheme (`https://...`, `data:...`) and protocol-relative URLs (`//cdn.example.com/...`) are left as-is.
 
-Not processed: `<iframe src>`, `<a href>`, inline `style="..."` attributes and `<style>` blocks, `import` specifiers inside inline `<script>` blocks, and anything inside `<noscript>`.
+Not processed: `<iframe src>`, `<a href>` and other references from one HTML page to another, inline `style="..."` attributes and `<style>` blocks, `import` specifiers inside inline `<script>` blocks, and anything inside `<noscript>`.
 
 Bun resolves all paths relative to your HTML file, so you can organize your project however you want.
 

--- a/docs/bundler/loaders.mdx
+++ b/docs/bundler/loaders.mdx
@@ -407,21 +407,30 @@ The loader uses [`lol-html`](https://github.com/cloudflare/lol-html) to extract 
 The selectors are:
 
 - `audio[src]`
+- `embed[src]`
+- `image[href], image[xlink:href]` (SVG)
 - `img[src]`
-- `img[srcset]`
+- `img[srcset]` (each candidate)
+- `input[src]`
 - `link[as='font'][href], link[type^='font/'][href]`
-- `link[as='image'][href]`
+- `link[as='image'][href]`, `link[imagesrcset]` (each candidate)
 - `link[as='style'][href]`
 - `link[as='video'][href], link[as='audio'][href]`
 - `link[as='worker'][href]`
-- `link[rel='icon'][href], link[rel='apple-touch-icon'][href]`
+- `link[rel~='icon'][href], link[rel^='apple-touch-'][href], link[rel='mask-icon'][href]`
 - `link[rel='manifest'][href]`
 - `link[rel='stylesheet'][href]`
+- `meta[content]` for `property="og:image|og:image:url|og:image:secure_url|og:audio|og:audio:secure_url|og:video|og:video:secure_url"` and `name="twitter:image|msapplication-tileimage|msapplication-config|msapplication-*logo"`
+- `object[data]`
 - `script[src]`
 - `source[src]`
-- `source[srcset]`
+- `source[srcset]` (each candidate)
+- `track[src]`
+- `use[href], use[xlink:href]` (SVG)
 - `video[poster]`
 - `video[src]`
+
+A `?query` or `#fragment` is kept on the rewritten URL. URLs with a scheme, `//host` URLs, same-document `#references`, and references from one HTML page to another are left as written.
 
 </Accordion>
 

--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -110,7 +110,7 @@ Bun leaves external URLs (like CDN links or absolute URLs) untouched.
 
 These references are left exactly as written. If they point at a local file, that file will not be next to the output:
 
-- `<iframe src>` and `<a href>`
+- `<iframe src>`, `<a href>`, and any other reference from one HTML page to another (`<object data="./page.html">`)
 - `url()` inside a `style="..."` attribute or an inline `<style>` block (put the CSS in a `.css` file and `<link>` it instead)
 - `import` specifiers inside an inline `<script type="module">` block (use `<script src>` instead)
 - Anything inside `<noscript>`

--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -81,26 +81,40 @@ Bun inlines every local asset it finds in your HTML: anything with a relative pa
 
 ### What gets inlined
 
-| In your source                                   | In the output                                                            |
-| ------------------------------------------------ | ------------------------------------------------------------------------ |
-| `<script src="./app.tsx">`                       | `<script type="module">...bundled code...</script>`                      |
-| `<link rel="stylesheet" href="./styles.css">`    | `<style>...bundled CSS...</style>`                                       |
-| `<img src="./logo.png">`                         | `<img src="data:image/png;base64,...">`                                  |
-| `<img src="./icon.svg">`                         | `<img src="data:image/svg+xml;base64,...">`                              |
-| `<video src="./demo.mp4">`                       | `<video src="data:video/mp4;base64,...">`                                |
-| `<audio src="./click.wav">`                      | `<audio src="data:audio/x-wav;base64,...">`                              |
-| `<source src="./clip.webm">`                     | `<source src="data:video/webm;base64,...">`                              |
-| `<video poster="./thumb.jpg">`                   | `<video poster="data:image/jpeg;base64,...">`                            |
-| `<link rel="icon" href="./favicon.ico">`         | `<link rel="icon" href="data:image/x-icon;base64,...">`                  |
-| `<link rel="manifest" href="./app.webmanifest">` | `<link rel="manifest" href="data:application/manifest+json;base64,...">` |
-| CSS `url("./bg.png")`                            | CSS `url(data:image/png;base64,...)`                                     |
-| CSS `@import "./reset.css"`                      | Flattened into the `<style>` tag                                         |
-| CSS `url("./font.woff2")`                        | CSS `url(data:font/woff2;base64,...)`                                    |
-| JS `import "./styles.css"`                       | Merged into the `<style>` tag                                            |
+| In your source                                               | In the output                                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `<script src="./app.tsx">`                                   | `<script type="module">...bundled code...</script>`                                   |
+| `<link rel="stylesheet" href="./styles.css">`                | `<style>...bundled CSS...</style>`                                                    |
+| `<img src="./logo.png">`                                     | `<img src="data:image/png;base64,...">`                                               |
+| `<img src="./icons.svg#menu">`, `<use href="...">`           | `<img src="data:image/svg+xml;base64,...#menu">`                                      |
+| `<img srcset="./a.png 1x, ./b.png 2x">`                      | `<img srcset="data:image/png;base64,... 1x, data:image/png;base64,... 2x">`           |
+| `<video src="./demo.mp4#t=5">`                               | `<video src="data:video/mp4;base64,...#t=5">`                                         |
+| `<audio src="./click.wav">`                                  | `<audio src="data:audio/x-wav;base64,...">`                                           |
+| `<source src="./clip.webm">`, `<track src="./en.vtt">`       | `<source src="data:video/webm;base64,...">`, `<track src="data:text/vtt;base64,...">` |
+| `<video poster="./thumb.jpg">`                               | `<video poster="data:image/jpeg;base64,...">`                                         |
+| `<object data="./doc.pdf">`, `<embed src="./doc.pdf">`       | `<object data="data:application/pdf;base64,...">`                                     |
+| `<link rel="icon" href="./favicon.ico">`                     | `<link rel="icon" href="data:image/x-icon;base64,...">`                               |
+| `<link rel="manifest" href="./app.webmanifest">`             | `<link rel="manifest" href="data:application/manifest+json;base64,...">`              |
+| `<meta property="og:image" content="./og.png">`              | `<meta property="og:image" content="data:image/png;base64,...">`                      |
+| `<link rel="preload\|modulepreload\|prefetch" href="./...">` | Removed: the file it points at is already inline                                      |
+| CSS `url("./bg.png")`                                        | CSS `url(data:image/png;base64,...)`                                                  |
+| CSS `@import "./reset.css"`                                  | Flattened into the `<style>` tag                                                      |
+| CSS `url("./font.woff2")`                                    | CSS `url(data:font/woff2;base64,...)`                                                 |
+| JS `import "./styles.css"`                                   | Merged into the `<style>` tag                                                         |
 
-Images, fonts, WASM binaries, videos, audio files, SVGs: Bun base64-encodes any file referenced by a relative path into a `data:` URI and embeds it directly in the HTML. Bun detects the MIME type from the file extension.
+Images, fonts, WASM binaries, videos, audio files, SVGs: Bun base64-encodes any file referenced by a relative path into a `data:` URI and embeds it directly in the HTML. Bun detects the MIME type from the file extension. A `#fragment` on the URL is kept after the `data:` URI, so SVG sprite references and media fragments still work. The full list of elements and attributes is the same as for [HTML entrypoints in `bun build`](/bundler/html-static#what-gets-processed).
 
 Bun leaves external URLs (like CDN links or absolute URLs) untouched.
+
+### What is not inlined
+
+These references are left exactly as written. If they point at a local file, that file will not be next to the output:
+
+- `<iframe src>` and `<a href>`
+- `url()` inside a `style="..."` attribute or an inline `<style>` block (put the CSS in a `.css` file and `<link>` it instead)
+- `import` specifiers inside an inline `<script type="module">` block (use `<script src>` instead)
+- Anything inside `<noscript>`
+- URLs built at runtime in JavaScript, such as `fetch("./data.json")` or `new Worker(new URL("./worker.js", import.meta.url))`. Import the file instead (`import data from "./data.json"`) so the bundler can see it.
 
 ## Using with React
 

--- a/docs/runtime/file-types.mdx
+++ b/docs/runtime/file-types.mdx
@@ -445,21 +445,30 @@ The loader uses [`lol-html`](https://github.com/cloudflare/lol-html) to extract 
 The list of selectors is:
 
 - `audio[src]`
+- `embed[src]`
+- `image[href], image[xlink:href]` (SVG)
 - `img[src]`
-- `img[srcset]`
+- `img[srcset]` (each candidate)
+- `input[src]`
 - `link[as='font'][href], link[type^='font/'][href]`
-- `link[as='image'][href]`
+- `link[as='image'][href]`, `link[imagesrcset]` (each candidate)
 - `link[as='style'][href]`
 - `link[as='video'][href], link[as='audio'][href]`
 - `link[as='worker'][href]`
-- `link[rel='icon'][href], link[rel='apple-touch-icon'][href]`
+- `link[rel~='icon'][href], link[rel^='apple-touch-'][href], link[rel='mask-icon'][href]`
 - `link[rel='manifest'][href]`
 - `link[rel='stylesheet'][href]`
+- `meta[content]` for `property="og:image|og:image:url|og:image:secure_url|og:audio|og:audio:secure_url|og:video|og:video:secure_url"` and `name="twitter:image|msapplication-tileimage|msapplication-config|msapplication-*logo"`
+- `object[data]`
 - `script[src]`
 - `source[src]`
-- `source[srcset]`
+- `source[srcset]` (each candidate)
+- `track[src]`
+- `use[href], use[xlink:href]` (SVG)
 - `video[poster]`
 - `video[src]`
+
+A `?query` or `#fragment` is kept on the rewritten URL. URLs with a scheme, `//host` URLs, same-document `#references`, and references from one HTML page to another are left as written.
 
 <Note>
 

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -79,9 +79,14 @@ pub(crate) fn is_external_url(url: &[u8]) -> bool {
             .is_some_and(|len| len >= 2 && url[len] == b':' && url[0].is_ascii_alphabetic())
 }
 
-/// Splits `./sprite.svg?v=2#icon` into `./sprite.svg` and `?v=2#icon`.
+/// Splits `./sprite.svg?v=2#icon` into `./sprite.svg` and `?v=2#icon`. A URL
+/// that does not name a local file (`https://...`, `data:...`, a bare `#icon`)
+/// comes back whole with an empty suffix, so nothing is appended to it later.
 pub(crate) fn split_url_suffix(url: &[u8]) -> (&[u8], &[u8]) {
-    url.split_at(strings::index_of_any(url, b"?#").unwrap_or(url.len()))
+    match strings::index_of_any(url, b"?#") {
+        Some(i) if i > 0 && !is_external_url(url) => url.split_at(i),
+        _ => (url, b""),
+    }
 }
 
 const HTML_WHITESPACE: &[u8] = b" \t\n\r\x0c";
@@ -120,17 +125,13 @@ impl<'a> Iterator for SrcsetCandidates<'a> {
 
 impl<'a> HTMLScanner<'a> {
     fn create_import_record(&mut self, url: &[u8], kind: ImportKind) -> Result<(), Error> {
-        let external = is_external_url(url);
         // The browser requests the file without `?query#fragment`; the
         // rewrite pass appends it back from the attribute text.
-        let input_path = if external {
-            url
-        } else {
-            split_url_suffix(url).0
-        };
+        let (input_path, _suffix) = split_url_suffix(url);
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
-        let path_to_use: &[u8] = if external {
+        let path_to_use: &[u8] = if is_external_url(url) {
+            // `//cdn.example.com/x.png` is a host, not a project-root path.
             url
         } else if input_path.len() > 1 && input_path[0] == b'/' {
             resolve_path::join_abs_string::<platform::Auto>(
@@ -275,8 +276,9 @@ impl TagHandler {
     }
 }
 
-/// Keep `docs/bundler/html-static.mdx` and `docs/bundler/standalone-html.mdx`
-/// in sync with this list.
+/// Keep the selector lists in `docs/bundler/loaders.mdx`,
+/// `docs/runtime/file-types.mdx`, `docs/bundler/html-static.mdx` and
+/// `docs/bundler/standalone-html.mdx` in sync with this list.
 const TAG_HANDLERS: &[TagHandler] = &[
     // Module scripts with src
     TagHandler::new("script[src]", "src", ImportKind::Stmt),

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -111,9 +111,19 @@ impl<'a> Iterator for SrcsetCandidates<'a> {
         let desc_end = if url.len() < url_end {
             url_end
         } else {
-            url_end
-                + strings::index_of_char_usize(&rest[url_end..], b',')
-                    .unwrap_or(rest.len() - url_end)
+            // A comma inside `( )` is descriptor text (the tokenizer's "in parens" state).
+            let desc = &rest[url_end..];
+            let mut i = 0;
+            loop {
+                match strings::index_of_any(&desc[i..], b",(") {
+                    None => break rest.len(),
+                    Some(j) if desc[i + j] == b',' => break url_end + i + j,
+                    Some(j) => match strings::index_of_char_usize(&desc[i + j..], b')') {
+                        Some(k) => i += j + k + 1,
+                        None => break rest.len(),
+                    },
+                }
+            }
         };
         self.0 = &rest[desc_end..];
         Some((

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -6,6 +6,7 @@ use crate::bun_fs as fs;
 use bun_alloc::AstAlloc;
 use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag, Index as AstIndex};
 use bun_ast::{Loc, Log, Range, Source};
+use bun_core::strings;
 use bun_paths::fs::Path as FsPath;
 use bun_paths::{platform, resolve_path};
 use bun_sys as sys;
@@ -67,11 +68,71 @@ impl<'a> HTMLScanner<'a> {
     }
 }
 
+/// True for `//host/...` and `scheme:...` (two or more scheme characters, so
+/// not a Windows drive letter). Neither names a local file; the resolver marks
+/// them external (or inlines a `data:` module) from the text as written.
+pub(crate) fn is_external_url(url: &[u8]) -> bool {
+    url.starts_with(b"//")
+        || url
+            .iter()
+            .position(|&c| !(c.is_ascii_alphanumeric() || matches!(c, b'+' | b'-' | b'.')))
+            .is_some_and(|len| len >= 2 && url[len] == b':' && url[0].is_ascii_alphabetic())
+}
+
+/// Splits `./sprite.svg?v=2#icon` into `./sprite.svg` and `?v=2#icon`.
+pub(crate) fn split_url_suffix(url: &[u8]) -> (&[u8], &[u8]) {
+    url.split_at(strings::index_of_any(url, b"?#").unwrap_or(url.len()))
+}
+
+const HTML_WHITESPACE: &[u8] = b" \t\n\r\x0c";
+
+/// Yields each `srcset` image candidate as `(url, descriptor)`:
+/// `"./a.png, ./b.png 2x"` gives `("./a.png", "")`, `("./b.png", "2x")`.
+/// <https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute>
+struct SrcsetCandidates<'a>(&'a [u8]);
+
+impl<'a> Iterator for SrcsetCandidates<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let rest = strings::trim_left(self.0, b" \t\n\r\x0c,");
+        if rest.is_empty() {
+            return None;
+        }
+        // The URL runs to the first whitespace; a comma right before that
+        // whitespace (or the end) ends the candidate with no descriptor.
+        let url_end = strings::index_of_any(rest, HTML_WHITESPACE).unwrap_or(rest.len());
+        let url = strings::trim_right(&rest[..url_end], b",");
+        let desc_end = if url.len() < url_end {
+            url_end
+        } else {
+            url_end
+                + strings::index_of_char_usize(&rest[url_end..], b',')
+                    .unwrap_or(rest.len() - url_end)
+        };
+        self.0 = &rest[desc_end..];
+        Some((
+            url,
+            strings::trim(&rest[url_end..desc_end], HTML_WHITESPACE),
+        ))
+    }
+}
+
 impl<'a> HTMLScanner<'a> {
-    fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
+    fn create_import_record(&mut self, url: &[u8], kind: ImportKind) -> Result<(), Error> {
+        let external = is_external_url(url);
+        // The browser requests the file without `?query#fragment`; the
+        // rewrite pass appends it back from the attribute text.
+        let input_path = if external {
+            url
+        } else {
+            split_url_suffix(url).0
+        };
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
-        let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
+        let path_to_use: &[u8] = if external {
+            url
+        } else if input_path.len() > 1 && input_path[0] == b'/' {
             resolve_path::join_abs_string::<platform::Auto>(
                 fs::FileSystem::instance().top_level_dir,
                 &[&input_path[1..]],
@@ -80,8 +141,7 @@ impl<'a> HTMLScanner<'a> {
         // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
         else if input_path.len() > 2 && input_path[0] != b'.' && input_path[1] != b'/' {
             'blk: {
-                let Some(index_of_dot) = bun_core::strings::last_index_of_char(input_path, b'.')
-                else {
+                let Some(index_of_dot) = strings::last_index_of_char(input_path, b'.') else {
                     break 'blk input_path;
                 };
                 let ext = &input_path[index_of_dot..];
@@ -134,17 +194,6 @@ impl<'a> HTMLScanner<'a> {
             .add_error(Some(self.source), Loc::EMPTY, message.to_vec());
     }
 
-    fn on_tag(
-        &mut self,
-        _element: &mut Element<'_, '_>,
-        path: &[u8],
-        url_attribute: &[u8],
-        kind: ImportKind,
-    ) {
-        let _ = url_attribute;
-        let _ = self.create_import_record(path, kind);
-    }
-
     pub(crate) fn scan(&mut self, input: &[u8]) -> Result<(), Error> {
         Processor::run(self, input)
     }
@@ -156,17 +205,26 @@ type Processor<'a> = HTMLProcessor<HTMLScanner<'a>, false>;
 // HTMLProcessor — generic over visitor `T` and `VISIT_DOCUMENT_TAGS`
 // ───────────────────────────────────────────────────────────────────────────
 
+/// What `HTMLProcessor` does with a URL after `on_url` returns.
+pub(crate) enum UrlAction {
+    Keep,
+    Replace(Vec<u8>),
+    RemoveElement,
+}
+
 /// Trait capturing the methods `HTMLProcessor` calls on `T`.
 pub(crate) trait HTMLProcessorHandler {
-    fn on_tag(
-        &mut self,
-        element: &mut Element<'_, '_>,
-        path: &[u8],
-        url_attribute: &[u8],
-        kind: ImportKind,
-    );
+    /// Called once per URL in a matched attribute, in document order: once
+    /// for `src`/`href`, once per image candidate for `srcset`. The scan pass
+    /// creates one import record per call and the rewrite pass consumes one,
+    /// so both passes must see the same calls.
+    fn on_url(&mut self, url: &[u8], kind: ImportKind) -> UrlAction;
     fn on_write_html(&mut self, bytes: &[u8]);
     fn on_html_parse_error(&mut self, message: &[u8]);
+
+    /// `<link rel="preload|modulepreload|prefetch" href>`, before `on_url`
+    /// sees its `href`.
+    fn on_resource_hint(&mut self, _element: &mut Element<'_, '_>) {}
 
     // Only required when VISIT_DOCUMENT_TAGS == true; `run` only calls
     // these when visiting document tags, so the defaults are never
@@ -183,14 +241,9 @@ pub(crate) trait HTMLProcessorHandler {
 }
 
 impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
-    fn on_tag(
-        &mut self,
-        element: &mut Element<'_, '_>,
-        path: &[u8],
-        url_attribute: &[u8],
-        kind: ImportKind,
-    ) {
-        HTMLScanner::on_tag(self, element, path, url_attribute, kind)
+    fn on_url(&mut self, url: &[u8], kind: ImportKind) -> UrlAction {
+        let _ = self.create_import_record(url, kind);
+        UrlAction::Keep
     }
     fn on_write_html(&mut self, bytes: &[u8]) {
         HTMLScanner::on_write_html(self, bytes)
@@ -222,7 +275,9 @@ impl TagHandler {
     }
 }
 
-const TAG_HANDLERS: [TagHandler; 16] = [
+/// Keep `docs/bundler/html-static.mdx` and `docs/bundler/standalone-html.mdx`
+/// in sync with this list.
+const TAG_HANDLERS: &[TagHandler] = &[
     // Module scripts with src
     TagHandler::new("script[src]", "src", ImportKind::Stmt),
     // CSS Stylesheets
@@ -237,6 +292,7 @@ const TAG_HANDLERS: [TagHandler; 16] = [
     ),
     // Image assets
     TagHandler::new("link[as='image'][href]", "href", ImportKind::Url),
+    TagHandler::new("link[imagesrcset]", "imagesrcset", ImportKind::Url),
     // Audio/Video assets
     TagHandler::new(
         "link[as='video'][href], link[as='audio'][href]",
@@ -247,9 +303,9 @@ const TAG_HANDLERS: [TagHandler; 16] = [
     TagHandler::new("link[as='worker'][href]", "href", ImportKind::Stmt),
     // Manifest files
     TagHandler::new("link[rel='manifest'][href]", "href", ImportKind::Url),
-    // Icons
+    // Icons and splash screens: "icon", "shortcut icon", "apple-touch-icon(-precomposed)", ...
     TagHandler::new(
-        "link[rel='icon'][href], link[rel='apple-touch-icon'][href]",
+        "link[rel~='icon'][href], link[rel^='apple-touch-'][href], link[rel='mask-icon'][href]",
         "href",
         ImportKind::Url,
     ),
@@ -267,11 +323,36 @@ const TAG_HANDLERS: [TagHandler; 16] = [
     TagHandler::new("source[src]", "src", ImportKind::Url),
     // Source elements with srcset
     TagHandler::new("source[srcset]", "srcset", ImportKind::Url),
+    // Text tracks, plugins, image buttons
+    TagHandler::new("track[src], embed[src], input[src]", "src", ImportKind::Url),
+    TagHandler::new("object[data]", "data", ImportKind::Url),
+    // SVG
+    TagHandler::new("image[href], use[href]", "href", ImportKind::Url),
+    TagHandler::new(
+        "image[xlink\\:href], use[xlink\\:href]",
+        "xlink:href",
+        ImportKind::Url,
+    ),
+    // Social and tile images (the Open Graph and <meta name> values Vite also rewrites)
+    TagHandler::new(
+        "meta[property='og:image' i][content], meta[property='og:image:url' i][content], \
+         meta[property='og:image:secure_url' i][content], meta[property='og:audio' i][content], \
+         meta[property='og:audio:secure_url' i][content], meta[property='og:video' i][content], \
+         meta[property='og:video:secure_url' i][content], meta[name='twitter:image' i][content], \
+         meta[name^='msapplication-' i][name$='logo' i][content], \
+         meta[name='msapplication-tileimage' i][content], meta[name='msapplication-config' i][content]",
+        "content",
+        ImportKind::Url,
+    ),
     //     // Iframes
     //     TagHandler::new("iframe[src]", "src", ImportKind::Url),
 ];
 
-const SELECTOR_CAP: usize = TAG_HANDLERS.len() + 3;
+/// `<link>` hints whose local target is inlined or absent in the output.
+const RESOURCE_HINT_SELECTOR: &str =
+    "link[rel~='preload'][href], link[rel~='modulepreload'][href], link[rel~='prefetch'][href]";
+
+const SELECTOR_CAP: usize = TAG_HANDLERS.len() + 4;
 
 #[inline]
 fn lol_err<E>(_: E) -> Error {
@@ -301,6 +382,54 @@ fn element_entry<'h>(
     ))
 }
 
+/// lol-html escapes only `"` when it serializes the value, so entities in
+/// `value` pass through as written.
+fn set_attribute(element: &mut Element<'_, '_>, name: &str, value: &[u8]) {
+    let ok = match core::str::from_utf8(value) {
+        Ok(value) => element.set_attribute(name, value).is_ok(),
+        Err(_) => false,
+    };
+    if !ok {
+        panic!("unexpected error from Element.setAttribute");
+    }
+}
+
+/// Runs `on_url` for each image candidate in a `srcset` and rebuilds the list.
+fn rewrite_srcset<T: HTMLProcessorHandler>(
+    this: &mut T,
+    value: &[u8],
+    kind: ImportKind,
+) -> UrlAction {
+    let mut out = Vec::with_capacity(value.len());
+    let (mut changed, mut remove) = (false, false);
+    // Every candidate goes through `on_url`, even after one asks for removal,
+    // so the rewrite pass consumes as many import records as the scan made.
+    for (url, descriptor) in SrcsetCandidates(value) {
+        if !out.is_empty() {
+            out.extend_from_slice(b", ");
+        }
+        match this.on_url(url, kind) {
+            UrlAction::Keep => out.extend_from_slice(url),
+            UrlAction::Replace(new_url) => {
+                changed = true;
+                out.extend_from_slice(&new_url);
+            }
+            UrlAction::RemoveElement => remove = true,
+        }
+        if !descriptor.is_empty() {
+            out.push(b' ');
+            out.extend_from_slice(descriptor);
+        }
+    }
+    if remove {
+        UrlAction::RemoveElement
+    } else if changed {
+        UrlAction::Replace(out)
+    } else {
+        UrlAction::Keep
+    }
+}
+
 impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
     HTMLProcessor<T, VISIT_DOCUMENT_TAGS>
 {
@@ -312,29 +441,44 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
 
         let mut element_content_handlers = Vec::with_capacity(SELECTOR_CAP);
 
-        for tag_info in TAG_HANDLERS {
+        // Registered first: lol-html runs handlers in registration order, and
+        // this one must read `href` before a `TAG_HANDLERS` entry rewrites it.
+        element_content_handlers.push(element_entry(
+            RESOURCE_HINT_SELECTOR,
+            Box::new(
+                move |element: &mut Element<'_, '_>| -> lol_html::HandlerResult {
+                    // SAFETY: `this_ptr` was derived from `run`'s `&mut T`,
+                    // which is not reborrowed while the rewriter — the only
+                    // holder of these closures — is alive.
+                    unsafe { (*this_ptr).on_resource_hint(element) };
+                    Ok(())
+                },
+            ),
+        )?);
+
+        for &tag_info in TAG_HANDLERS {
             let on_element: lol_html::ElementHandler<'_> = Box::new(
                 move |element: &mut Element<'_, '_>| -> lol_html::HandlerResult {
-                    if !tag_info.url_attribute.is_empty()
-                        && element.has_attribute(tag_info.url_attribute)
-                    {
-                        let value = element
-                            .get_attribute(tag_info.url_attribute)
-                            .unwrap_or_default();
-                        if !value.is_empty() {
-                            bun_core::scoped_log!(HTMLScanner, "{} {}", tag_info.selector, value);
-                            // SAFETY: `this_ptr` was derived from `run`'s `&mut T`,
-                            // which is not reborrowed while the rewriter — the only
-                            // holder of these closures — is alive.
-                            unsafe {
-                                (*this_ptr).on_tag(
-                                    element,
-                                    value.as_bytes(),
-                                    tag_info.url_attribute.as_bytes(),
-                                    tag_info.kind,
-                                );
-                            }
+                    let value = element
+                        .get_attribute(tag_info.url_attribute)
+                        .unwrap_or_default();
+                    bun_core::scoped_log!(HTMLScanner, "{} {}", tag_info.selector, value);
+                    let action = if tag_info.url_attribute.ends_with("srcset") {
+                        // SAFETY: see `on_resource_hint` above.
+                        rewrite_srcset(unsafe { &mut *this_ptr }, value.as_bytes(), tag_info.kind)
+                    } else {
+                        match strings::trim(value.as_bytes(), HTML_WHITESPACE) {
+                            b"" => UrlAction::Keep,
+                            // SAFETY: see `on_resource_hint` above.
+                            url => unsafe { (*this_ptr).on_url(url, tag_info.kind) },
                         }
+                    };
+                    match action {
+                        UrlAction::Keep => {}
+                        UrlAction::Replace(new_value) => {
+                            set_attribute(element, tag_info.url_attribute, &new_value)
+                        }
+                        UrlAction::RemoveElement => element.remove(),
                     }
                     Ok(())
                 },
@@ -346,7 +490,7 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
             for (which, tag) in ["body", "head", "html"].into_iter().enumerate() {
                 let on_element: lol_html::ElementHandler<'_> = Box::new(
                     move |element: &mut Element<'_, '_>| -> lol_html::HandlerResult {
-                        // SAFETY: see `on_tag` above.
+                        // SAFETY: see `on_resource_hint` above.
                         let stop = unsafe {
                             match which {
                                 0 => (*this_ptr).on_body_tag(element),
@@ -382,7 +526,7 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
         // C-API sink routed that to a no-op `done()`, never to `on_write_html`.
         let output_sink = OutputSink::Callback(Box::new(move |chunk: &[u8]| {
             if !chunk.is_empty() {
-                // SAFETY: see `on_tag` above.
+                // SAFETY: see `on_resource_hint` above.
                 unsafe { (*this_ptr).on_write_html(chunk) }
             }
         }));

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -68,9 +68,7 @@ impl<'a> HTMLScanner<'a> {
     }
 }
 
-/// True for `//host/...` and `scheme:...` (two or more scheme characters, so
-/// not a Windows drive letter). Neither names a local file; the resolver marks
-/// them external (or inlines a `data:` module) from the text as written.
+/// `//host/...` or `scheme:...` (two or more scheme chars, so not a drive letter): not a local file.
 pub(crate) fn is_external_url(url: &[u8]) -> bool {
     url.starts_with(b"//")
         || url
@@ -79,9 +77,7 @@ pub(crate) fn is_external_url(url: &[u8]) -> bool {
             .is_some_and(|len| len >= 2 && url[len] == b':' && url[0].is_ascii_alphabetic())
 }
 
-/// Splits `./sprite.svg?v=2#icon` into `./sprite.svg` and `?v=2#icon`. A URL
-/// that does not name a local file (`https://...`, `data:...`, a bare `#icon`)
-/// comes back whole with an empty suffix, so nothing is appended to it later.
+/// `./sprite.svg?v=2#icon` -> (`./sprite.svg`, `?v=2#icon`). Non-file URLs (`https:`, bare `#icon`) are not split.
 pub(crate) fn split_url_suffix(url: &[u8]) -> (&[u8], &[u8]) {
     match strings::index_of_any(url, b"?#") {
         Some(i) if i > 0 && !is_external_url(url) => url.split_at(i),
@@ -91,9 +87,7 @@ pub(crate) fn split_url_suffix(url: &[u8]) -> (&[u8], &[u8]) {
 
 const HTML_WHITESPACE: &[u8] = b" \t\n\r\x0c";
 
-/// Yields each `srcset` image candidate as `(url, descriptor)`:
-/// `"./a.png, ./b.png 2x"` gives `("./a.png", "")`, `("./b.png", "2x")`.
-/// <https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute>
+/// `srcset` candidates as `(url, descriptor)` per <https://html.spec.whatwg.org/multipage/images.html#parsing-a-srcset-attribute>.
 struct SrcsetCandidates<'a>(&'a [u8]);
 
 impl<'a> Iterator for SrcsetCandidates<'a> {
@@ -104,8 +98,7 @@ impl<'a> Iterator for SrcsetCandidates<'a> {
         if rest.is_empty() {
             return None;
         }
-        // The URL runs to the first whitespace; a comma right before that
-        // whitespace (or the end) ends the candidate with no descriptor.
+        // The URL runs to whitespace; a comma right before that ends the candidate with no descriptor.
         let url_end = strings::index_of_any(rest, HTML_WHITESPACE).unwrap_or(rest.len());
         let url = strings::trim_right(&rest[..url_end], b",");
         let desc_end = if url.len() < url_end {
@@ -135,8 +128,7 @@ impl<'a> Iterator for SrcsetCandidates<'a> {
 
 impl<'a> HTMLScanner<'a> {
     fn create_import_record(&mut self, url: &[u8], kind: ImportKind) -> Result<(), Error> {
-        // The browser requests the file without `?query#fragment`; the
-        // rewrite pass appends it back from the attribute text.
+        // Resolve without `?query#fragment`; the rewrite pass re-appends it from the attribute text.
         let (input_path, _suffix) = split_url_suffix(url);
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
@@ -225,16 +217,12 @@ pub(crate) enum UrlAction {
 
 /// Trait capturing the methods `HTMLProcessor` calls on `T`.
 pub(crate) trait HTMLProcessorHandler {
-    /// Called once per URL in a matched attribute, in document order: once
-    /// for `src`/`href`, once per image candidate for `srcset`. The scan pass
-    /// creates one import record per call and the rewrite pass consumes one,
-    /// so both passes must see the same calls.
+    /// Once per URL (per `srcset` candidate), in document order: one import record made or consumed per call.
     fn on_url(&mut self, url: &[u8], kind: ImportKind) -> UrlAction;
     fn on_write_html(&mut self, bytes: &[u8]);
     fn on_html_parse_error(&mut self, message: &[u8]);
 
-    /// `<link rel="preload|modulepreload|prefetch" href>`, before `on_url`
-    /// sees its `href`.
+    /// `<link rel="preload|modulepreload|prefetch" href>`, before `on_url` sees its `href`.
     fn on_resource_hint(&mut self, _element: &mut Element<'_, '_>) {}
 
     // Only required when VISIT_DOCUMENT_TAGS == true; `run` only calls
@@ -286,9 +274,7 @@ impl TagHandler {
     }
 }
 
-/// Keep the selector lists in `docs/bundler/loaders.mdx`,
-/// `docs/runtime/file-types.mdx`, `docs/bundler/html-static.mdx` and
-/// `docs/bundler/standalone-html.mdx` in sync with this list.
+/// Listed in docs/bundler/{loaders,html-static,standalone-html}.mdx and docs/runtime/file-types.mdx.
 const TAG_HANDLERS: &[TagHandler] = &[
     // Module scripts with src
     TagHandler::new("script[src]", "src", ImportKind::Stmt),
@@ -394,8 +380,7 @@ fn element_entry<'h>(
     ))
 }
 
-/// lol-html escapes only `"` when it serializes the value, so entities in
-/// `value` pass through as written.
+/// lol-html escapes only `"` on output, so entities in `value` pass through as written.
 fn set_attribute(element: &mut Element<'_, '_>, name: &str, value: &[u8]) {
     let ok = match core::str::from_utf8(value) {
         Ok(value) => element.set_attribute(name, value).is_ok(),
@@ -414,8 +399,7 @@ fn rewrite_srcset<T: HTMLProcessorHandler>(
 ) -> UrlAction {
     let mut out = Vec::with_capacity(value.len());
     let (mut changed, mut remove) = (false, false);
-    // Every candidate goes through `on_url`, even after one asks for removal,
-    // so the rewrite pass consumes as many import records as the scan made.
+    // No early exit: every candidate reaches `on_url` so both passes stay in step.
     for (url, descriptor) in SrcsetCandidates(value) {
         if !out.is_empty() {
             out.extend_from_slice(b", ");
@@ -453,8 +437,7 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
 
         let mut element_content_handlers = Vec::with_capacity(SELECTOR_CAP);
 
-        // Registered first: lol-html runs handlers in registration order, and
-        // this one must read `href` before a `TAG_HANDLERS` entry rewrites it.
+        // First, so it reads `href` before a `TAG_HANDLERS` handler rewrites it (they run in order).
         element_content_handlers.push(element_entry(
             RESOURCE_HINT_SELECTOR,
             Box::new(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6687,6 +6687,22 @@ pub mod bv2_impl {
                     continue;
                 }
 
+                // `<object data="./page.html">` links to another page. That page is
+                // not an asset of this one (its scripts must not join this bundle),
+                // so leave the URL as written.
+                if loader == Loader::Html
+                    && import_record.kind == ImportKind::Url
+                    && import_record
+                        .loader
+                        .or_else(|| path.loader(&transpiler.options.loaders))
+                        == Some(Loader::Html)
+                {
+                    import_record
+                        .flags
+                        .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                    continue;
+                }
+
                 if let Some(dev_server) = self.dev_server_handle() {
                     'brk: {
                         if path.loader(&self.transpiler.options.loaders) == Some(Loader::Html)

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6687,9 +6687,7 @@ pub mod bv2_impl {
                     continue;
                 }
 
-                // `<object data="./page.html">` links to another page. That page is
-                // not an asset of this one (its scripts must not join this bundle),
-                // so leave the URL as written.
+                // `<object data="./page.html">` links to a page; bundling it would run its scripts here.
                 if loader == Loader::Html
                     && import_record.kind == ImportKind::Url
                     && import_record

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -9,7 +9,9 @@ use bun_threading::thread_pool::Task as ThreadPoolLibTask;
 use lol_html::HandlerResult;
 use lol_html::html_content::{ContentType, Element, EndTag};
 
-use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler};
+use crate::HTMLScanner::{
+    HTMLProcessor, HTMLProcessorHandler, UrlAction, is_external_url, split_url_suffix,
+};
 use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext, debug};
 use crate::options::Loader;
 use crate::{Chunk, CompileResult};
@@ -89,18 +91,6 @@ struct HTMLLoader<'a> {
     added_body_script: bool,
 }
 
-/// `Element::set_attribute` takes `&str`, so non-UTF-8 `name`/`value` bytes
-/// fail the same way an invalid attribute name does.
-fn set_attribute(element: &mut Element<'_, '_>, name: &[u8], value: &[u8]) {
-    let ok = match (core::str::from_utf8(name), core::str::from_utf8(value)) {
-        (Ok(name), Ok(value)) => element.set_attribute(name, value).is_ok(),
-        _ => false,
-    };
-    if !ok {
-        panic!("unexpected error from Element.setAttribute");
-    }
-}
-
 impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_write_html(&mut self, bytes: &[u8]) {
         self.output.extend_from_slice(bytes);
@@ -113,13 +103,19 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         ));
     }
 
-    fn on_tag(
-        &mut self,
-        element: &mut Element<'_, '_>,
-        _path: &[u8],
-        url_attribute: &[u8],
-        _kind: ImportKind,
-    ) {
+    fn on_resource_hint(&mut self, element: &mut Element<'_, '_>) {
+        // Everything local is inline in a standalone file, so a preload of it
+        // points at nothing (or repeats the bytes as a second data: URL).
+        if self.compile_to_standalone_html
+            && element
+                .get_attribute("href")
+                .is_some_and(|href| !is_external_url(href.trim_ascii().as_bytes()))
+        {
+            element.remove();
+        }
+    }
+
+    fn on_url(&mut self, url: &[u8], _kind: ImportKind) -> UrlAction {
         if self.current_import_record_index as usize >= self.import_records.len() {
             bun_core::Output::panic(format_args!(
                 "Assertion failure in HTMLLoader.onTag: current_import_record_index ({}) >= import_records.len ({})",
@@ -145,6 +141,10 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         } else {
             Loader::File
         };
+        // `./sprite.svg#icon` was resolved as `./sprite.svg`; put `#icon` back
+        // on whatever URL replaces it.
+        let suffix = split_url_suffix(url).1;
+        let replace = |new_url: &[u8], suffix| UrlAction::Replace([new_url, suffix].concat());
 
         if import_record
             .flags
@@ -154,21 +154,20 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
                 "Leaving external import: {}",
                 BStr::new(import_record.path.text)
             );
-            return;
+            return UrlAction::Keep;
         }
 
         if self.linker.dev_server.is_some() {
-            if !unique_key_for_additional_files.is_empty() {
-                set_attribute(element, url_attribute, unique_key_for_additional_files);
+            return if !unique_key_for_additional_files.is_empty() {
+                replace(unique_key_for_additional_files, suffix)
             } else if import_record.path.is_disabled
                 || loader.is_javascript_like()
                 || loader.is_css()
             {
-                element.remove();
+                UrlAction::RemoveElement
             } else {
-                set_attribute(element, url_attribute, import_record.path.pretty);
-            }
-            return;
+                replace(import_record.path.pretty, suffix)
+            };
         }
 
         if import_record.source_index.is_invalid() {
@@ -176,30 +175,34 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
                 "Leaving import with invalid source index: {}",
                 BStr::new(import_record.path.text)
             );
-            return;
+            return UrlAction::Keep;
         }
 
         if loader.is_javascript_like() || loader.is_css() {
             // Remove the original non-external tags
-            element.remove();
-            return;
+            return UrlAction::RemoveElement;
         }
 
-        if self.compile_to_standalone_html && import_record.source_index.is_valid() {
+        if self.compile_to_standalone_html {
             // In standalone HTML mode, inline assets as data: URIs
             let url_for_css =
                 parse_graph.ast.items_url_for_css()[import_record.source_index.get() as usize];
             if !url_for_css.is_empty() {
-                set_attribute(element, url_attribute, url_for_css);
-                return;
+                // A `?query` would land inside the base64 body; keep only the fragment.
+                let fragment = match strings::index_of_char_usize(suffix, b'#') {
+                    Some(i) => &suffix[i..],
+                    None => b"".as_slice(),
+                };
+                return replace(url_for_css, fragment);
             }
         }
 
         if !unique_key_for_additional_files.is_empty() {
             // Replace the external href/src with the unique key so that we later will rewrite it to the final URL or pathname
-            set_attribute(element, url_attribute, unique_key_for_additional_files);
-            return;
+            return replace(unique_key_for_additional_files, suffix);
         }
+
+        UrlAction::Keep
     }
 
     fn on_head_tag(&mut self, element: &mut Element<'_, '_>) -> bool {

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -104,8 +104,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     }
 
     fn on_resource_hint(&mut self, element: &mut Element<'_, '_>) {
-        // Everything local is inline in a standalone file, so a preload of it
-        // points at nothing (or repeats the bytes as a second data: URL).
+        // In a standalone file every local target is already inline, so a hint for it is dead weight.
         if self.compile_to_standalone_html
             && element
                 .get_attribute("href")
@@ -141,8 +140,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         } else {
             Loader::File
         };
-        // `./sprite.svg#icon` was resolved as `./sprite.svg`; put `#icon` back
-        // on whatever URL replaces it.
+        // Resolved as `./sprite.svg`; put `#icon` back on whatever URL replaces it.
         let suffix = split_url_suffix(url).1;
         let replace = |new_url: &[u8], suffix| UrlAction::Replace([new_url, suffix].concat());
 

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -99,8 +99,10 @@ devTest("image tag", {
 devTest("srcset candidates and #fragments on asset URLs", {
   files: {
     "index.html": `
-      <!DOCTYPE html><html><head></head><body>
-      <img srcset="./a.png 1x, ./b.png 2x">
+      <!DOCTYPE html><html><head>
+      <link rel="preload" as="image" href="a.png" imagesrcset="a.png 1x, b.png 2x" imagesizes="100vw">
+      </head><body>
+      <img srcset="./a.png 1x, ./b.png 2x, https://example.com/c.png 3x" sizes="50vw">
       <svg><use href="./sprite.svg#icon"></use><use href="#local"></use></svg>
       <object data="./other.html"></object>
       </body></html>
@@ -115,9 +117,13 @@ devTest("srcset candidates and #fragments on asset URLs", {
   htmlFiles: ["index.html"],
   async test(dev) {
     const html = await dev.fetch("/").text();
-    const [, a, b] = html.match(/srcset="(\/_bun\/asset\/[0-9a-f]+\.png) 1x, (\/_bun\/asset\/[0-9a-f]+\.png) 2x"/)!;
+    const [, a, b] = html.match(
+      / srcset="(\/_bun\/asset\/[0-9a-f]+\.png) 1x, (\/_bun\/asset\/[0-9a-f]+\.png) 2x, https:\/\/example\.com\/c\.png 3x" sizes="50vw"/,
+    )!;
     await dev.fetch(a).expect.toBe("A");
     await dev.fetch(b).expect.toBe("B");
+    // `imagesrcset` candidates resolve like `srcset` ones, next to the legacy `href`.
+    expect(html).toInclude(`href="${a}" imagesrcset="${a} 1x, ${b} 2x" imagesizes="100vw"`);
     const [, sprite] = html.match(/<use href="(\/_bun\/asset\/[0-9a-f]+\.svg)#icon">/)!;
     await dev.fetch(sprite).expect.toInclude(`<symbol id="icon"/>`);
     expect(html).toInclude(`<use href="#local">`);

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -96,6 +96,35 @@ devTest("image tag", {
     await dev.fetch(url).expect404(); // TODO
   },
 });
+devTest("srcset candidates and #fragments on asset URLs", {
+  files: {
+    "index.html": `
+      <!DOCTYPE html><html><head></head><body>
+      <img srcset="./a.png 1x, ./b.png 2x">
+      <svg><use href="./sprite.svg#icon"></use><use href="#local"></use></svg>
+      <object data="./other.html"></object>
+      </body></html>
+    `,
+    "a.png": "A",
+    "b.png": "B",
+    "sprite.svg": `<svg xmlns="http://www.w3.org/2000/svg"><symbol id="icon"/></svg>`,
+    // Only linked to from index.html, never a route: it must not be bundled,
+    // so its missing script is not an error.
+    "other.html": `<!DOCTYPE html><script src="./does-not-exist.js"></script>`,
+  },
+  htmlFiles: ["index.html"],
+  async test(dev) {
+    const html = await dev.fetch("/").text();
+    const [, a, b] = html.match(/srcset="(\/_bun\/asset\/[0-9a-f]+\.png) 1x, (\/_bun\/asset\/[0-9a-f]+\.png) 2x"/)!;
+    await dev.fetch(a).expect.toBe("A");
+    await dev.fetch(b).expect.toBe("B");
+    const [, sprite] = html.match(/<use href="(\/_bun\/asset\/[0-9a-f]+\.svg)#icon">/)!;
+    await dev.fetch(sprite).expect.toInclude(`<symbol id="icon"/>`);
+    expect(html).toInclude(`<use href="#local">`);
+    // A page that another page points at is a link: it is neither bundled nor rewritten.
+    expect(html).toInclude(`<object data="./other.html">`);
+  },
+});
 devTest("image import in JS", {
   files: {
     "index.html": `

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -185,6 +185,9 @@ describe("bundler", () => {
     <video src="./clip.mp4#t=1,2"></video>
     <img src="//cdn.example.com/x.png">
     <script src="//cdn.example.com/lib.js"></script>
+    <img src="https://cdn.example.com/y.png?v=1#f">
+    <svg><symbol id="local"></symbol><use href="#local"></use><use xlink:href="#local"></use></svg>
+    <img src="#">
   </body>
 </html>`,
       "/app.js": "console.log('app')",
@@ -208,6 +211,11 @@ describe("bundler", () => {
         `./${clip}#t=1,2`,
         `//cdn.example.com/x.png`,
         `//cdn.example.com/lib.js`,
+        `https://cdn.example.com/y.png?v=1#f`,
+        // Same-document references are not files.
+        `#local`,
+        `#local`,
+        `#`,
       ]);
       api.expectFile(`out/${html.match(/index-[a-z0-9]+\.js/)![0]}`).toContain("app");
     },

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -122,6 +122,172 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/19529
+  // srcset/imagesrcset hold a comma-separated list of "<url> <descriptor>"
+  // candidates; each URL is resolved and hashed on its own.
+  itBundled("html/srcset", {
+    outdir: "out/",
+    files: {
+      "/index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="preload" as="image" href="./small.png" imagesrcset="./small.png 480w, ./big.png 800w">
+  </head>
+  <body>
+    <img srcset="./small.png 1x, ./big.png 2x" src="./small.png">
+    <picture><source srcset="
+      ./small.png 480w,
+      ./big.png   800w
+    "></picture>
+    <img srcset="./small.png, ./big.png">
+    <img srcset="https://example.com/ext.png 1x, ./big.png 2x">
+    <img srcset="./small.png">
+    <img srcset="">
+  </body>
+</html>`,
+      "/small.png": "smallsmall",
+      "/big.png": "bigbigbigbig",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const small = html.match(/src="\.\/(small-[a-z0-9]+\.png)"/)![1];
+      const big = html.match(/(big-[a-z0-9]+\.png)/)![1];
+      api.assertFileExists(`out/${small}`);
+      api.assertFileExists(`out/${big}`);
+      expect([...html.matchAll(/srcset="([^"]*)"/g)].map(m => m[1])).toEqual([
+        `./${small} 480w, ./${big} 800w`,
+        `./${small} 1x, ./${big} 2x`,
+        `./${small} 480w, ./${big} 800w`,
+        `./${small}, ./${big}`,
+        `https://example.com/ext.png 1x, ./${big} 2x`,
+        `./${small}`,
+        ``,
+      ]);
+    },
+  });
+
+  // A ?query/#fragment is not part of the file name: resolve without it and
+  // put it back on the rewritten URL. Protocol-relative URLs are external.
+  itBundled("html/url-suffix", {
+    outdir: "out/",
+    files: {
+      "/index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <script src="./app.js?v=3"></script>
+    <link rel="stylesheet" href="./style.css?v=3">
+  </head>
+  <body>
+    <img src="./sprite.svg#icon">
+    <img src="./sprite.svg?v=2#icon">
+    <svg><use href="./sprite.svg#icon"></use></svg>
+    <video src="./clip.mp4#t=1,2"></video>
+    <img src="//cdn.example.com/x.png">
+    <script src="//cdn.example.com/lib.js"></script>
+  </body>
+</html>`,
+      "/app.js": "console.log('app')",
+      "/style.css": "body { color: red }",
+      "/sprite.svg": `<svg xmlns="http://www.w3.org/2000/svg"><symbol id="icon"/></svg>`,
+      "/clip.mp4": "not really a video",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const sprite = html.match(/(sprite-[a-z0-9]+\.svg)/)![1];
+      const clip = html.match(/(clip-[a-z0-9]+\.mp4)/)![1];
+      api.assertFileExists(`out/${sprite}`);
+      api.assertFileExists(`out/${clip}`);
+      expect([...html.matchAll(/(?:src|href)="([^"]*)"/g)].map(m => m[1])).toEqual([
+        expect.stringMatching(/^\.\/index-[a-z0-9]+\.css$/),
+        expect.stringMatching(/^\.\/index-[a-z0-9]+\.js$/),
+        `./${sprite}#icon`,
+        `./${sprite}?v=2#icon`,
+        `./${sprite}#icon`,
+        `./${clip}#t=1,2`,
+        `//cdn.example.com/x.png`,
+        `//cdn.example.com/lib.js`,
+      ]);
+      api.expectFile(`out/${html.match(/index-[a-z0-9]+\.js/)![0]}`).toContain("app");
+    },
+  });
+
+  // Every element/attribute pair the scanner treats as an asset URL emits a
+  // hashed copy; see TAG_HANDLERS in src/bundler/HTMLScanner.rs.
+  itBundled("html/asset-attributes", {
+    outdir: "out/",
+    files: {
+      "/index.html": `<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="shortcut icon" href="./a.png">
+    <link rel="apple-touch-icon-precomposed" href="./a.png">
+    <link rel="apple-touch-startup-image" href="./a.png">
+    <link rel="mask-icon" href="./a.svg">
+    <link rel="modulepreload" href="./keep-me.js">
+    <meta property="og:image" content="./a.png">
+    <meta property="og:image:alt" content="./not-a-file.png">
+    <meta name="twitter:image" content="./a.png">
+    <meta name="msapplication-TileImage" content="./a.png">
+    <meta name="description" content="./not-a-file.png">
+  </head>
+  <body>
+    <video><track src="./a.vtt"></video>
+    <object data="./a.pdf"><embed src="./a.pdf"></object>
+    <input type="image" src="./a.png">
+    <svg><image href="./a.png"/><image xlink:href="./a.png"/><use xlink:href="./a.svg#x"/></svg>
+    <iframe src="./page.html"></iframe>
+    <object data="./page.html"></object>
+    <a href="./a.pdf">download</a>
+  </body>
+</html>`,
+      "/a.png": "png",
+      "/a.svg": `<svg xmlns="http://www.w3.org/2000/svg"/>`,
+      "/a.vtt": "WEBVTT",
+      "/a.pdf": "%PDF-1.4",
+      // A page that another page points at is a link, not an asset: it is not
+      // parsed, so its script must not end up in index.html's bundle.
+      "/page.html": `<!DOCTYPE html><script src="./page.js"></script>`,
+      "/page.js": `console.log("only on page.html")`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const js = api.readFile(`out/${html.match(/index-\w+\.js/)![0]}`);
+      expect(js).not.toContain("only on page.html");
+      const hashed = (ext: string) => {
+        const name = html.match(new RegExp(`"\\./(a-[a-z0-9]+\\.${ext})[?#"]`))![1];
+        api.assertFileExists(`out/${name}`);
+        return `./${name}`;
+      };
+      const [png, svg, vtt, pdf] = ["png", "svg", "vtt", "pdf"].map(hashed);
+      const urls = [...html.matchAll(/(?:src|href|content|data)="([^"]*)"/g)].map(m => m[1]);
+      expect(urls.filter(url => !/^\.\/index-\w+\.js$/.test(url))).toEqual([
+        png, // shortcut icon
+        png, // apple-touch-icon-precomposed
+        png, // apple-touch-startup-image
+        svg, // mask-icon
+        "./keep-me.js", // modulepreload is only dropped in standalone mode
+        png, // og:image
+        "./not-a-file.png", // og:image:alt is text
+        png, // twitter:image
+        png, // msapplication-TileImage
+        "./not-a-file.png", // description is text
+        vtt,
+        pdf, // object
+        pdf, // embed
+        png, // input
+        png, // image href
+        png, // image xlink:href
+        `${svg}#x`, // use xlink:href
+        "./page.html", // iframes are left alone
+        "./page.html", // so are other pages
+        "./a.pdf", // and anchors
+      ]);
+    },
+  });
+
   // Test external assets preservation
   itBundled("html/external-assets", {
     outdir: "out/",

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -123,47 +123,141 @@ describe("bundler", () => {
   });
 
   // https://github.com/oven-sh/bun/issues/19529
-  // srcset/imagesrcset hold a comma-separated list of "<url> <descriptor>"
-  // candidates; each URL is resolved and hashed on its own.
+  // `srcset` / `imagesrcset` hold a comma-separated list of image candidates
+  // ("<url> <descriptor>"), not one URL. Each candidate URL is resolved, hashed
+  // and emitted on its own, descriptors survive, and external candidates are
+  // left alone.
   itBundled("html/srcset", {
     outdir: "out/",
     files: {
-      "/index.html": `<!DOCTYPE html>
+      "/index.html": `
+<!DOCTYPE html>
 <html>
   <head>
-    <link rel="preload" as="image" href="./small.png" imagesrcset="./small.png 480w, ./big.png 800w">
+    <link rel="preload" as="image" href="./fallback.png" imagesrcset="./small.png 1x, ./big.png 2x" imagesizes="100vw">
+    <link rel="preload" as="image" imagesrcset="./big.png 480w" imagesizes="(max-width: 600px) 480px, 800px">
   </head>
   <body>
-    <img srcset="./small.png 1x, ./big.png 2x" src="./small.png">
-    <picture><source srcset="
+    <img srcset="./small.png 1x, ./big.png 2x">
+    <picture>
+      <source srcset="./small.png 480w, ./big.png 800w" media="(min-width: 800px)" type="image/png">
+      <img src="./small.png" alt="image">
+    </picture>
+    <img srcset="./small.png 2x">
+    <img srcset="
       ./small.png 480w,
       ./big.png   800w
-    "></picture>
+    " sizes="50vw">
     <img srcset="./small.png, ./big.png">
     <img srcset="https://example.com/ext.png 1x, ./big.png 2x">
     <img srcset="./small.png">
+    <img srcset="https://example.com/a.png  1x ,  http://example.com/b.png 2x">
     <img srcset="">
+    <img srcset=" , ">
+    <img srcset="data:image/gif;base64,R0lGODlhAQABAAAAACw= 1x, ./big.png 2x">
+    <img srcset="data:image/gif;base64,R0lGODlhAQABAAAAACw=">
+    <img srcset="https://example.com/upload/c_scale,w_300/x.jpg 300w, ./big.png 800w">
+    <img srcset="./small.png foo(1x, 2), ./big.png 2x">
+    <img srcset="./small.png,, ./big.png">
+    <img srcset="./small.png\t1x,\t./big.png\t2x">
   </body>
 </html>`,
+      "/fallback.png": "fallback",
       "/small.png": "smallsmall",
       "/big.png": "bigbigbigbig",
     },
     entryPoints: ["/index.html"],
     onAfterBundle(api) {
       const html = api.readFile("out/index.html");
-      const small = html.match(/src="\.\/(small-[a-z0-9]+\.png)"/)![1];
-      const big = html.match(/(big-[a-z0-9]+\.png)/)![1];
-      api.assertFileExists(`out/${small}`);
-      api.assertFileExists(`out/${big}`);
-      expect([...html.matchAll(/srcset="([^"]*)"/g)].map(m => m[1])).toEqual([
-        `./${small} 480w, ./${big} 800w`,
-        `./${small} 1x, ./${big} 2x`,
-        `./${small} 480w, ./${big} 800w`,
-        `./${small}, ./${big}`,
-        `https://example.com/ext.png 1x, ./${big} 2x`,
-        `./${small}`,
-        ``,
+      const small = String.raw`\./small-[a-z0-9]+\.png`;
+      const big = String.raw`\./big-[a-z0-9]+\.png`;
+
+      expect([...html.matchAll(/imagesrcset="([^"]*)"/g)].map(m => m[1])).toEqual([
+        expect.stringMatching(new RegExp(`^${small} 1x, ${big} 2x$`)),
+        expect.stringMatching(new RegExp(`^${big} 480w$`)),
       ]);
+      // The legacy `href` fallback next to `imagesrcset` is still rewritten,
+      // and the non-URL attributes are untouched.
+      expect(html).toMatch(/href="\.\/fallback-[a-z0-9]+\.png" imagesrcset="[^"]+" imagesizes="100vw">/);
+      expect(html).toContain(`imagesizes="(max-width: 600px) 480px, 800px">`);
+
+      expect([...html.matchAll(/ srcset="([^"]*)"/g)].map(m => m[1])).toEqual([
+        // Density descriptors.
+        expect.stringMatching(new RegExp(`^${small} 1x, ${big} 2x$`)),
+        // <source> with width descriptors.
+        expect.stringMatching(new RegExp(`^${small} 480w, ${big} 800w$`)),
+        // Single candidate with a descriptor.
+        expect.stringMatching(new RegExp(`^${small} 2x$`)),
+        // Newlines and runs of whitespace between candidates are normalized.
+        expect.stringMatching(new RegExp(`^${small} 480w, ${big} 800w$`)),
+        // No descriptors: the comma directly follows each URL.
+        expect.stringMatching(new RegExp(`^${small}, ${big}$`)),
+        // External candidate is left alone, local one is hashed.
+        expect.stringMatching(new RegExp(`^https://example\\.com/ext\\.png 1x, ${big} 2x$`)),
+        // Bare single URL.
+        expect.stringMatching(new RegExp(`^${small}$`)),
+        // Nothing to rewrite: the attribute is left byte-for-byte as written.
+        "https://example.com/a.png  1x ,  http://example.com/b.png 2x",
+        "",
+        " , ",
+        // The rest tell the HTML srcset grammar apart from a plain comma split.
+        // A URL runs to the next whitespace, so a comma inside it (data: URI,
+        // CDN transform path) does not start a new candidate...
+        expect.stringMatching(new RegExp(`^data:image/gif;base64,R0lGODlhAQABAAAAACw= 1x, ${big} 2x$`)),
+        "data:image/gif;base64,R0lGODlhAQABAAAAACw=",
+        expect.stringMatching(new RegExp(`^https://example\\.com/upload/c_scale,w_300/x\\.jpg 300w, ${big} 800w$`)),
+        // ...nor does a comma inside a parenthesized descriptor.
+        expect.stringMatching(new RegExp(`^${small} foo\\(1x, 2\\), ${big} 2x$`)),
+        // A run of commas after a URL ends that candidate with no descriptor.
+        expect.stringMatching(new RegExp(`^${small}, ${big}$`)),
+        // Any ASCII whitespace separates a URL from its descriptor.
+        expect.stringMatching(new RegExp(`^${small} 1x, ${big} 2x$`)),
+      ]);
+      api.expectFile("out/index.html").toContain(`media="(min-width: 800px)" type="image/png">`);
+      api.expectFile("out/index.html").toContain(`" sizes="50vw">`);
+      api.expectFile("out/index.html").toMatch(new RegExp(`<img src="${small}" alt="image">`));
+
+      // Every candidate file was emitted exactly once, under the name the HTML references.
+      const [, smallFile, bigFile] = html.match(
+        new RegExp(`srcset="\\./(small-[a-z0-9]+\\.png) 1x, \\./(big-[a-z0-9]+\\.png) 2x"`),
+      )!;
+      expect(api.readFile(`out/${smallFile}`)).toBe("smallsmall");
+      expect(api.readFile(`out/${bigFile}`)).toBe("bigbigbigbig");
+      expect(new Set(html.match(/small-[a-z0-9]+\.png/g))).toEqual(new Set([smallFile]));
+      expect(new Set(html.match(/big-[a-z0-9]+\.png/g))).toEqual(new Set([bigFile]));
+    },
+  });
+
+  itBundled("html/srcset-public-path", {
+    outdir: "out/",
+    publicPath: "https://cdn.example.com/",
+    files: {
+      "/index.html": `<!DOCTYPE html><html><head><link rel="preload" as="image" imagesrcset="./a.png 1x,./b.png 2x"></head><body><img src="./a.png" srcset="./a.png 1x, ./b.png 2x"></body></html>`,
+      "/a.png": "aaaa",
+      "/b.png": "bbbbbbbb",
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const html = api.readFile("out/index.html");
+      const list =
+        /^https:\/\/cdn\.example\.com\/a-[a-z0-9]+\.png 1x, https:\/\/cdn\.example\.com\/b-[a-z0-9]+\.png 2x$/;
+      expect(html.match(/imagesrcset="([^"]*)"/)![1]).toMatch(list);
+      expect(html.match(/ srcset="([^"]*)"/)![1]).toMatch(list);
+      expect(html).toMatch(/src="https:\/\/cdn\.example\.com\/a-[a-z0-9]+\.png"/);
+    },
+  });
+
+  // A candidate that does not exist is a resolve error naming that candidate,
+  // not the whole attribute value.
+  itBundled("html/srcset-unresolved-candidate", {
+    outdir: "out/",
+    files: {
+      "/index.html": `<!DOCTYPE html><html><body><img srcset="./here.png 1x, ./missing.png 2x"></body></html>`,
+      "/here.png": "here",
+    },
+    entryPoints: ["/index.html"],
+    bundleErrors: {
+      "/index.html": [`Could not resolve: "./missing.png"`],
     },
   });
 

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -367,6 +367,7 @@ body { color: blue; }`,
 <meta name="twitter:image" content="./og.png">
 <script type="module" src="./app.js"></script></head><body>
 <img src="./i.png"> <img src="./sprite.svg#icon"> <img srcset="./h1.png 1x, ./h2.png 2x">
+<picture><source srcset="./h1.png, ./h2.png 600w"></picture>
 <video src="./clip.mp4#t=1,2"></video>
 <video poster="./i.png"><track src="./subs.vtt" kind="subtitles" srclang="en" default></video>
 <object data="./doc.pdf" type="application/pdf"><embed src="./doc.pdf"></object>
@@ -409,6 +410,9 @@ body { color: blue; }`,
     expect(attr(/<use xlink:href="([^"]*)">/)).toMatch(svgData);
     expect(attr(/<video src="([^"]*)">/)).toMatch(/^data:video\/mp4;base64,[A-Za-z0-9+/=]+#t=1,2$/);
     expect(attr(/<img srcset="([^"]*)">/)).toBe(`${pngData} 1x, ${pngData} 2x`);
+    // A descriptor-less candidate ends at "<data: URI>,", which the srcset
+    // grammar still reads back as one URL followed by a separator.
+    expect(attr(/<source srcset="([^"]*)">/)).toBe(`${pngData}, ${pngData} 600w`);
     expect(attr(/<track src="([^"]*)"/)).toStartWith("data:text/vtt");
     expect(attr(/<object data="([^"]*)"/)).toStartWith("data:application/pdf;base64,");
     expect(attr(/<embed src="([^"]*)"/)).toStartWith("data:application/pdf;base64,");

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -372,6 +372,7 @@ body { color: blue; }`,
 <object data="./doc.pdf" type="application/pdf"><embed src="./doc.pdf"></object>
 <input type="image" src="./i.png">
 <svg><use href="./sprite.svg#icon"></use><use xlink:href="./sprite.svg#icon"></use><image href="./i.png"/></svg>
+<svg><symbol id="local"></symbol><use href="#local"></use></svg>
 <img src="//cdn.example.com/x.png"> <img src="https://cdn.example.com/y.png"> <a href="./doc.pdf">pdf</a>
 </body></html>`,
       "app.js": `console.log("app");`,
@@ -426,8 +427,9 @@ body { color: blue; }`,
     expect(html).not.toContain("prefetch");
     expect(html).toContain('<link rel="preload" as="font" href="https://cdn.example.com/font.woff2" crossorigin>');
 
-    // External URLs are untouched.
+    // External URLs and same-document references are untouched.
     expect(html).toContain('<img src="//cdn.example.com/x.png"> <img src="https://cdn.example.com/y.png">');
+    expect(html).toContain('<use href="#local"></use>');
     expect(html).toContain('<script type="module">');
     expect(html).toContain('console.log("app")');
   });

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -352,6 +352,86 @@ body { color: blue; }`,
     expect(html).toContain('console.log("with image")');
   });
 
+  test("inlines every local URL attribute and keeps #fragments", async () => {
+    const png = Buffer.from("89504e470d0a1a0a78", "hex");
+    using dir = tempDir("compile-browser-url-attrs", {
+      "index.html": `<!DOCTYPE html><html><head>
+<link rel="preload" as="image" href="./i.png" imagesrcset="./h1.png 1x, ./h2.png 2x" imagesizes="100vw">
+<link rel="modulepreload" href="./app.js" integrity="sha384-AAAA">
+<link rel="prefetch" href="./doc.pdf">
+<link rel="preload" as="font" href="https://cdn.example.com/font.woff2" crossorigin>
+<link rel="shortcut icon" href="./i.png">
+<link rel="apple-touch-startup-image" href="./st.png">
+<meta property="og:image" content="./og.png">
+<meta property="og:image:width" content="1200">
+<meta name="twitter:image" content="./og.png">
+<script type="module" src="./app.js"></script></head><body>
+<img src="./i.png"> <img src="./sprite.svg#icon"> <img srcset="./h1.png 1x, ./h2.png 2x">
+<video src="./clip.mp4#t=1,2"></video>
+<video poster="./i.png"><track src="./subs.vtt" kind="subtitles" srclang="en" default></video>
+<object data="./doc.pdf" type="application/pdf"><embed src="./doc.pdf"></object>
+<input type="image" src="./i.png">
+<svg><use href="./sprite.svg#icon"></use><use xlink:href="./sprite.svg#icon"></use><image href="./i.png"/></svg>
+<img src="//cdn.example.com/x.png"> <img src="https://cdn.example.com/y.png"> <a href="./doc.pdf">pdf</a>
+</body></html>`,
+      "app.js": `console.log("app");`,
+      "i.png": png,
+      "h1.png": png,
+      "h2.png": png,
+      "st.png": png,
+      "og.png": png,
+      "sprite.svg": `<svg xmlns="http://www.w3.org/2000/svg"><symbol id="icon" viewBox="0 0 1 1"><path d="M0 0h1v1z"/></symbol></svg>`,
+      "clip.mp4": Buffer.from("00000018667479706d703432", "hex"),
+      "subs.vtt": "WEBVTT\n\n",
+      "doc.pdf": "%PDF-1.4\n",
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/index.html`],
+      compile: true,
+      target: "browser",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+    const html = await result.outputs[0].text();
+
+    // The only relative path left is the <a href>, which is navigation, not an asset.
+    expect([...html.matchAll(/"(\.\/[^"]*)"/g)].map(m => m[1])).toEqual(["./doc.pdf"]);
+    expect(html).toContain('<a href="./doc.pdf">pdf</a>');
+
+    const pngData = "data:image/png;base64," + png.toString("base64");
+    const svgData = /^data:image\/svg\+xml;base64,[A-Za-z0-9+/=]+#icon$/;
+    const attr = (re: RegExp) => html.match(re)?.[1];
+    expect(attr(/<img src="(data:image\/svg\+xml[^"]*)">/)).toMatch(svgData);
+    expect(attr(/<use href="([^"]*)">/)).toMatch(svgData);
+    expect(attr(/<use xlink:href="([^"]*)">/)).toMatch(svgData);
+    expect(attr(/<video src="([^"]*)">/)).toMatch(/^data:video\/mp4;base64,[A-Za-z0-9+/=]+#t=1,2$/);
+    expect(attr(/<img srcset="([^"]*)">/)).toBe(`${pngData} 1x, ${pngData} 2x`);
+    expect(attr(/<track src="([^"]*)"/)).toStartWith("data:text/vtt");
+    expect(attr(/<object data="([^"]*)"/)).toStartWith("data:application/pdf;base64,");
+    expect(attr(/<embed src="([^"]*)"/)).toStartWith("data:application/pdf;base64,");
+    expect(attr(/<input type="image" src="([^"]*)"/)).toBe(pngData);
+    expect(attr(/<image href="([^"]*)"/)).toBe(pngData);
+    expect(attr(/<link rel="shortcut icon" href="([^"]*)"/)).toBe(pngData);
+    expect(attr(/<link rel="apple-touch-startup-image" href="([^"]*)"/)).toBe(pngData);
+    expect(attr(/<meta property="og:image" content="([^"]*)"/)).toBe(pngData);
+    expect(attr(/<meta name="twitter:image" content="([^"]*)"/)).toBe(pngData);
+    expect(html).toContain('<meta property="og:image:width" content="1200">');
+
+    // Local preload hints point at files that are now inline, so they are dropped;
+    // the external one stays.
+    expect(html).not.toContain("modulepreload");
+    expect(html).not.toContain("imagesrcset");
+    expect(html).not.toContain("prefetch");
+    expect(html).toContain('<link rel="preload" as="font" href="https://cdn.example.com/font.woff2" crossorigin>');
+
+    // External URLs are untouched.
+    expect(html).toContain('<img src="//cdn.example.com/x.png"> <img src="https://cdn.example.com/y.png">');
+    expect(html).toContain('<script type="module">');
+    expect(html).toContain('console.log("app")');
+  });
+
   test("handles CSS url() references", async () => {
     const pixel = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4DwAAAQEABRjYTgAAAABJRU5ErkJggg==",


### PR DESCRIPTION
### Problem
- `bun build --compile --target=browser ./index.html` promises one file with no relative paths, but the HTML scanner only matched 16 element/attribute pairs. `<track src>`, `<object data>`, `<embed src>`, `<input type=image src>`, SVG `<use href>`/`<image href>` (and `xlink:href`), `<link imagesrcset>`, `rel="shortcut icon"`/`apple-touch-startup-image`/`mask-icon`, and `<meta property="og:image" content>` stayed as `./file` with nothing beside the output. A local `<link rel="modulepreload">` stayed too.
- Every rewritten URL lost its `?query#fragment`: `<img src="./sprite.svg#icon">` became a `data:` URL (or `./sprite-[hash].svg`) with no `#icon`. The CSS printer keeps it (`src/css/printer.rs` `get_import_record_url`).
- Three inputs failed the build: `srcset="./a.png 1x, ./b.png 2x"` (`Could not resolve: "./a.png 1x, ./b.png 2x"`, fixes #19529), `src="//cdn.example.com/x.png"` (`Could not resolve: "/cdn.example.com/x.png"`), and `<script src="./app.js?v=3">`.

### Fix
- `TAG_HANDLERS` (`src/bundler/HTMLScanner.rs`) now covers the element/attribute set Vite treats as HTML asset sources. `srcset`/`imagesrcset` values are split into candidates (WHATWG srcset grammar) and each URL gets its own import record. `on_tag` becomes `on_url(url, kind) -> UrlAction`, so the processor applies `Keep`/`Replace`/`RemoveElement` and can rebuild a `srcset`.
- `split_url_suffix` takes `?query#fragment` off before the scanner resolves, and `HTMLLoader::on_url` appends it to the hashed path, or the `#fragment` alone to a `data:` URL. URLs with a scheme, `//host` URLs and bare `#refs` are not split and go to the resolver as written, which marks them external.
- A page that another page points at (`<object data="./page.html">`) is marked external in `resolve_import_records` instead of parsed. Before, its scripts joined the referencing page's bundle. In standalone mode a local `<link rel="preload|modulepreload|prefetch">` is removed: its target is already inline.
- Verified: `test/bundler/standalone.test.ts` ("inlines every local URL attribute and keeps #fragments"), `test/bundler/bundler_html.test.ts` (`html/srcset`, `html/srcset-public-path`, `html/srcset-unresolved-candidate`, `html/url-suffix`, `html/asset-attributes`), `test/bake/dev/html.test.ts` ("srcset candidates and #fragments"), all red on 1.4.3. Also ran `bundler_html_server`, `html-import-manifest`, `bun-serve-html*`, and the source lints. Self-reviewed: 2 concerns raised, 2 addressed (a bare `#icon` was split into an empty path and failed to resolve; overlap with other open PRs, see Notes).

### Background
- The HTML loader runs lol-html over the page twice with the same selectors. The scan pass (`HTMLScanner`) creates one `ImportRecord` per URL. The rewrite pass (`HTMLLoader` in `generateCompileResultForHtmlChunk.rs`) walks the same URLs in the same order and consumes one record each, so both passes must make the same calls.
- A copied asset is written as a fixed-width unique key that `break_output_into_pieces` later swaps for the output path. Bytes after the key pass through, which is how the appended `#icon` survives. In standalone mode the rewrite pass writes the `data:` URL (`url_for_css`) directly.
- The HTML file's synthetic JS part depends on every import record, so any record that resolves to a script or page is bundled and executed. That is why a page-to-page reference must not become a parsed module, and why `iframe[src]` stays off the list.

<details><summary>Notes</summary>

- Still left as written, now documented in `standalone-html.mdx`, `html-static.mdx`, `loaders.mdx` and `file-types.mdx`: `<iframe src>`, `<a href>`, `url()` in `style=""` and inline `<style>`, `import` inside inline `<script>`, anything in `<noscript>` (lol-html lexes it as raw text), and URLs built at runtime (`fetch("./d.json")`, `new Worker(new URL("./w.js", import.meta.url))`).
- New selectors mean new resolve errors for projects that reference a missing local file from one of them, for example `<meta property="og:image" content="/og.png">` with no `og.png` in the project. The error names the file. An absolute URL (`https://...`) is what og:image consumers need anyway.
- `rel="modulepreload"` is only dropped in standalone mode. In an outdir build it is left as written (#36013 covers that case differently).
- Overlapping PRs: #42025 (the same `srcset`/`imagesrcset` change with the same `on_url -> UrlAction` shape) is closed in favor of this one. Its extra test vectors and its rule that a comma inside a parenthesized descriptor does not end the descriptor were carried over in d623d3c3dc. #36012 (srcset only) is closed too. #41616 also re-appends `?query#fragment` and passes `//host` through (plus `&amp;` and percent decoding, which this PR does not do), and #36015 carries the `//host` and srcset parts as well. Both shrink to a rebase once this lands.
- The `<meta>` list is Vite's: `og:image`, `og:image:url`, `og:image:secure_url`, `og:audio`, `og:audio:secure_url`, `og:video`, `og:video:secure_url`, `twitter:image`, `msapplication-tileimage`, `msapplication-square*logo`/`wide*logo`, `msapplication-config`.
- In the dev server an unresolved external (`https://...`) was already rewritten to its own text; the suffix is empty for those, so `?family=Roboto` is not doubled (covered in `html/url-suffix`).

</details>

