### PR TITLE
bun build --no-bundle: honor --sourcemap

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1154,7 +1154,7 @@ impl<'a> LinkerContext<'a> {
     /// The relative path from the chunk directory to a file source, as written
     /// into the source map's `sources` array. `sources` entries are URLs, so the
     /// host separator is normalized to `/` (the invariant `Path::pretty` holds).
-    fn source_map_relative_path(
+    pub(crate) fn source_map_relative_path(
         chunk_abs_dir: &[u8],
         source_abs_path: &[u8],
     ) -> Result<Box<[u8]>, AllocError> {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2786,13 +2786,13 @@ impl<'a> Transpiler<'a> {
             bun_ast::store_ast_alloc_heap::reset();
 
             let errors_before = self.log().errors;
-            let output_file = match self.build_with_resolve_result_eager(
+            let (output_file, source_map_file) = match self.build_with_resolve_result_eager(
                 &item,
                 import_path_format,
                 outstream,
                 None,
             ) {
-                Ok(Some(f)) => f,
+                Ok(Some(files)) => files,
                 Ok(None) => continue,
                 Err(err) => {
                     // Print errors (unlike parse errors) add nothing to the
@@ -2815,6 +2815,7 @@ impl<'a> Transpiler<'a> {
                 }
             };
             self.output_files.push(output_file);
+            self.output_files.extend(source_map_file);
         }
         Ok(())
     }
@@ -2826,7 +2827,8 @@ impl<'a> Transpiler<'a> {
         let mut by_dest_path: bun_collections::StringArrayHashMap<Vec<usize>> = Default::default();
         let mut has_duplicates = false;
         for (index, file) in self.output_files.iter().enumerate() {
-            if file.dest_path.is_empty() {
+            // A `.map` collides exactly when the output it belongs to does.
+            if file.dest_path.is_empty() || file.output_kind == options::OutputKind::Sourcemap {
                 continue;
             }
             let entry = by_dest_path.get_or_put(&file.dest_path)?;
@@ -2871,13 +2873,15 @@ impl<'a> Transpiler<'a> {
         Ok(())
     }
 
+    /// Returns the output for `resolve_result` and, for `--sourcemap=linked` /
+    /// `external`, the `.map` that goes next to it.
     fn build_with_resolve_result_eager(
         &mut self,
         resolve_result: &resolver::Result,
         import_path_format: options::ImportPathFormat,
         _outstream: TransformOutstream,
         client_entry_point_: Option<&mut EntryPoints::ClientEntryPoint>,
-    ) -> crate::Result<Option<options::OutputFile>> {
+    ) -> crate::Result<Option<(options::OutputFile, Option<options::OutputFile>)>> {
         if resolve_result.flags.is_external() {
             return Ok(None);
         }
@@ -2922,6 +2926,8 @@ impl<'a> Transpiler<'a> {
         output_file.output_kind = options::OutputKind::Chunk;
         output_file.side = None;
         output_file.entry_point_index = None;
+
+        let mut pending_source_map: Option<PendingSourceMap> = None;
 
         match loader {
             options::Loader::Jsx
@@ -3016,21 +3022,34 @@ impl<'a> Transpiler<'a> {
                 // `result.ast` above. (`bun build` is one-shot — `self.arena`
                 // here is `cli_arena()` and lives for the process.)
                 let print_arena: &Arena = self.arena;
-                output_file.size = match self.options.target {
-                    options::Target::Browser | options::Target::Node => {
-                        self.print(print_arena, result, &mut writer, js_printer::Format::Esm)?
-                    }
+                let format = match self.options.target {
+                    options::Target::Browser | options::Target::Node => js_printer::Format::Esm,
                     options::Target::Bun
                     | options::Target::BunMacro
-                    | options::Target::ServerComponentsSsr => self.print(
-                        print_arena,
-                        result,
-                        &mut writer,
-                        js_printer::Format::EsmAscii,
-                    )?,
+                    | options::Target::ServerComponentsSsr => js_printer::Format::EsmAscii,
                 };
+                if self.options.source_map == options::SourceMapOption::None {
+                    self.print(print_arena, result, &mut writer, format)?;
+                } else {
+                    // Not `print_with_source_map`: its kill switch is for the
+                    // runtime's stack-trace maps, and bundling ignores it too.
+                    let mut source_map = PendingSourceMap::default();
+                    self.print_with_source_map_maybe::<true>(
+                        print_arena,
+                        result.ast,
+                        &result.source,
+                        &mut writer,
+                        format,
+                        Some(js_printer::SourceMapHandler::for_(&mut source_map)),
+                        None,
+                        None,
+                    )?;
+                    pending_source_map = Some(source_map);
+                }
+                let code = writer.ctx.written();
+                output_file.size = code.len();
                 output_file.value = crate::output_file::Value::Buffer {
-                    bytes: writer.ctx.written().to_vec().into_boxed_slice(),
+                    bytes: Box::from(code),
                 };
             }
             options::Loader::Dataurl | options::Loader::Base64 => {
@@ -3066,7 +3085,103 @@ impl<'a> Transpiler<'a> {
             output_file.dest_path = self.transform_only_dest_path(file_path_text, loader, bytes);
         }
 
-        Ok(Some(output_file))
+        let source_map_file = match pending_source_map {
+            Some(pending) => self.attach_source_map(&mut output_file, file_path_text, pending)?,
+            None => None,
+        };
+
+        Ok(Some((output_file, source_map_file)))
+    }
+
+    /// Appends the `//# sourceMappingURL` comment `--sourcemap` asks for to
+    /// `output_file` (named by now, so a linked comment can point at the
+    /// `.map`) and returns the `.map` itself for `linked` / `external`.
+    fn attach_source_map(
+        &self,
+        output_file: &mut options::OutputFile,
+        file_path_text: &[u8],
+        pending: PendingSourceMap,
+    ) -> crate::Result<Option<options::OutputFile>> {
+        use std::io::Write as _;
+
+        let crate::output_file::Value::Buffer { bytes } = &mut output_file.value else {
+            unreachable!("the transpiled arm always produces a buffer");
+        };
+        let mut code: Vec<u8> = core::mem::take(bytes).into_vec();
+
+        let map_dest_path: Box<[u8]> = strings::concat(&[&output_file.dest_path, b".map"]);
+        let debug_id = bun_sourcemap::DebugIDFormatter {
+            id: crate::ContentHasher::run(&code),
+        };
+        let json = pending.into_json(
+            &self.source_map_sources_entry(&output_file.dest_path, file_path_text)?,
+            debug_id,
+        )?;
+
+        if !code.ends_with(b"\n") {
+            code.push(b'\n');
+        }
+        if bun_core::FeatureFlags::SOURCE_MAP_DEBUG_ID {
+            writeln!(&mut code, "\n//# debugId={}", debug_id)?;
+        }
+        match self.options.source_map {
+            options::SourceMapOption::Inline => {
+                code.extend_from_slice(b"//# sourceMappingURL=data:application/json;base64,");
+                code.extend_from_slice(&bun_base64::encode_alloc(&json));
+                code.push(b'\n');
+            }
+            options::SourceMapOption::Linked => {
+                let [prefix, path]: [&[u8]; 2] = if self.options.public_path.is_empty() {
+                    [b"", bun_paths::basename(&map_dest_path)]
+                } else {
+                    bun_core::cheap_prefix_normalizer(&self.options.public_path, &map_dest_path)
+                };
+                code.extend_from_slice(b"//# sourceMappingURL=");
+                code.extend_from_slice(prefix);
+                code.extend_from_slice(path);
+                code.push(b'\n');
+            }
+            options::SourceMapOption::External => {}
+            options::SourceMapOption::None => unreachable!("no source map was generated"),
+        }
+
+        output_file.size = code.len();
+        *bytes = code.into_boxed_slice();
+
+        if !self.options.source_map.has_external_files() {
+            return Ok(None);
+        }
+        Ok(Some(options::OutputFile::init(options::OutputFileInit {
+            data: options::OutputFileData::Buffer { data: json },
+            loader: options::Loader::Json,
+            input_loader: options::Loader::File,
+            output_path: map_dest_path,
+            output_kind: options::OutputKind::Sourcemap,
+            input_path: strings::concat(&[file_path_text, b".map"]),
+            ..Default::default()
+        })))
+    }
+
+    /// The `sources` entry for `file_path_text`: relative to the directory the
+    /// `.map` is written to, which is `--outdir` plus whatever directory
+    /// `dest_path` adds. Relative to the cwd when nothing is written to disk.
+    fn source_map_sources_entry(
+        &self,
+        dest_path: &[u8],
+        file_path_text: &[u8],
+    ) -> Result<Box<[u8]>, bun_alloc::AllocError> {
+        let output_dir: &[u8] = &self.options.output_dir;
+        if output_dir.is_empty() {
+            return crate::LinkerContext::source_map_relative_path(output_dir, file_path_text);
+        }
+        let dest_dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Posix>(dest_path);
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let map_dir = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+            self.fs().top_level_dir,
+            &mut **buf,
+            &[output_dir, dest_dir],
+        );
+        crate::LinkerContext::source_map_relative_path(map_dir, file_path_text)
     }
 
     fn entry_naming_template(&self) -> options::PathTemplate {
@@ -3262,4 +3377,52 @@ impl<'a> Transpiler<'a> {
 enum TransformOutstream {
     Stdout,
     Dir(#[expect(dead_code)] bun_sys::Fd),
+}
+
+/// `--sourcemap` sink for a transform-only print. The source text is quoted
+/// while the printer still holds it (`ParseResult::source_contents_backing`
+/// frees it right after); the `.map` itself is serialized once the output has
+/// a name, see `Transpiler::attach_source_map`.
+#[derive(Default)]
+struct PendingSourceMap {
+    chunk: bun_sourcemap::Chunk,
+    quoted_source_contents: bun_core::MutableString,
+}
+
+impl js_printer::OnSourceMapChunk for PendingSourceMap {
+    fn on_source_map_chunk(
+        &mut self,
+        chunk: bun_sourcemap::Chunk,
+        source: &bun_ast::Source,
+    ) -> js_printer::Result<()> {
+        js_printer::quote_for_json(source.contents(), &mut self.quoted_source_contents, false)?;
+        self.chunk = chunk;
+        Ok(())
+    }
+}
+
+impl PendingSourceMap {
+    /// Same layout as `LinkerContext::generate_source_map_for_chunk`, for one source.
+    fn into_json(
+        self,
+        sources_entry: &[u8],
+        debug_id: bun_sourcemap::DebugIDFormatter,
+    ) -> crate::Result<Box<[u8]>> {
+        use std::io::Write as _;
+
+        let mut j = bun_core::MutableString::init_empty();
+        j.list
+            .extend_from_slice(b"{\n  \"version\": 3,\n  \"sources\": [");
+        js_printer::quote_for_json(sources_entry, &mut j, false)?;
+        j.list
+            .extend_from_slice(b"],\n  \"sourcesContent\": [\n    ");
+        j.list.extend_from_slice(&self.quoted_source_contents.list);
+        j.list.extend_from_slice(b"\n  ],\n  \"mappings\": \"");
+        j.list.extend_from_slice(&self.chunk.vlq_mappings());
+        if bun_core::FeatureFlags::SOURCE_MAP_DEBUG_ID {
+            write!(&mut j.list, "\",\n  \"debugId\": \"{}", debug_id)?;
+        }
+        j.list.extend_from_slice(b"\",\n  \"names\": []\n}");
+        Ok(j.list.into_boxed_slice())
+    }
 }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2873,8 +2873,7 @@ impl<'a> Transpiler<'a> {
         Ok(())
     }
 
-    /// Returns the output for `resolve_result` and, for `--sourcemap=linked` /
-    /// `external`, the `.map` that goes next to it.
+    /// The output for `resolve_result` plus, for `--sourcemap=linked|external`, its `.map`.
     fn build_with_resolve_result_eager(
         &mut self,
         resolve_result: &resolver::Result,
@@ -3031,8 +3030,7 @@ impl<'a> Transpiler<'a> {
                 if self.options.source_map == options::SourceMapOption::None {
                     self.print(print_arena, result, &mut writer, format)?;
                 } else {
-                    // Not `print_with_source_map`: its kill switch is for the
-                    // runtime's stack-trace maps, and bundling ignores it too.
+                    // Not `print_with_source_map`: its kill switch is for the runtime's stack-trace maps.
                     let mut source_map = PendingSourceMap::default();
                     self.print_with_source_map_maybe::<true>(
                         print_arena,
@@ -3093,9 +3091,7 @@ impl<'a> Transpiler<'a> {
         Ok(Some((output_file, source_map_file)))
     }
 
-    /// Appends the `//# sourceMappingURL` comment `--sourcemap` asks for to
-    /// `output_file` (named by now, so a linked comment can point at the
-    /// `.map`) and returns the `.map` itself for `linked` / `external`.
+    /// Appends the `--sourcemap` comment to the (already named) output; returns the `.map` for `linked`/`external`.
     fn attach_source_map(
         &self,
         output_file: &mut options::OutputFile,
@@ -3162,9 +3158,7 @@ impl<'a> Transpiler<'a> {
         })))
     }
 
-    /// The `sources` entry for `file_path_text`: relative to the directory the
-    /// `.map` is written to, which is `--outdir` plus whatever directory
-    /// `dest_path` adds. Relative to the cwd when nothing is written to disk.
+    /// `sources` entry: relative to the `.map`'s directory (`--outdir` + `dest_path`'s dir), or to cwd for stdout.
     fn source_map_sources_entry(
         &self,
         dest_path: &[u8],
@@ -3379,14 +3373,19 @@ enum TransformOutstream {
     Dir(#[expect(dead_code)] bun_sys::Fd),
 }
 
-/// `--sourcemap` sink for a transform-only print. The source text is quoted
-/// while the printer still holds it (`ParseResult::source_contents_backing`
-/// frees it right after); the `.map` itself is serialized once the output has
-/// a name, see `Transpiler::attach_source_map`.
-#[derive(Default)]
+/// Transform-only `--sourcemap` sink; quotes the source while the printer still holds it (see `attach_source_map`).
 struct PendingSourceMap {
     chunk: bun_sourcemap::Chunk,
     quoted_source_contents: bun_core::MutableString,
+}
+
+impl Default for PendingSourceMap {
+    fn default() -> Self {
+        PendingSourceMap {
+            chunk: bun_sourcemap::Chunk::init_empty(),
+            quoted_source_contents: bun_core::MutableString::init_empty(),
+        }
+    }
 }
 
 impl js_printer::OnSourceMapChunk for PendingSourceMap {

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -375,9 +375,7 @@ impl BuildCommand {
                 }
             }
 
-            // The transpiled output keeps the entry point's name, so the
-            // "next to the entry point" fallback the writer uses for a
-            // multi-file build without --outdir would overwrite a .js entry.
+            // Output keeps the entry's name, so the next-to-the-entry fallback would overwrite a .js entry.
             if output_to_stdout
                 && this_transpiler.options.source_map == options::SourceMapOption::Linked
             {
@@ -387,9 +385,7 @@ impl BuildCommand {
                 Global::exit(1);
             }
 
-            // Like the bundler below: name the output after --outfile and write
-            // into its directory, so a `.map` lands next to it under the name
-            // its sourceMappingURL comment points at.
+            // As when bundling: name the output after --outfile so its `.map` lands next to it.
             if ctx.bundler_options.outdir.is_empty() && !outfile.is_empty() {
                 this_transpiler.options.entry_naming =
                     strings::concat(&[b"./", bun_paths::basename(outfile)]);

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -374,6 +374,28 @@ impl BuildCommand {
                     Global::exit(1);
                 }
             }
+
+            // The transpiled output keeps the entry point's name, so the
+            // "next to the entry point" fallback the writer uses for a
+            // multi-file build without --outdir would overwrite a .js entry.
+            if output_to_stdout
+                && this_transpiler.options.source_map == options::SourceMapOption::Linked
+            {
+                bun_core::pretty_errorln!(
+                    "<r><red>error<r><d>:<r> cannot use a linked source map without --outdir or --outfile"
+                );
+                Global::exit(1);
+            }
+
+            // Like the bundler below: name the output after --outfile and write
+            // into its directory, so a `.map` lands next to it under the name
+            // its sourceMappingURL comment points at.
+            if ctx.bundler_options.outdir.is_empty() && !outfile.is_empty() {
+                this_transpiler.options.entry_naming =
+                    strings::concat(&[b"./", bun_paths::basename(outfile)]);
+                this_transpiler.options.output_dir =
+                    bun_core::dirname(outfile).unwrap_or(b".").into();
+            }
         }
 
         if ctx.bundler_options.outdir.is_empty()

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use bun_ast::{Loc, Source};
 use bun_core::{MutableString, strings};
 use bun_paths::fs::FileSystem;
@@ -11,6 +13,10 @@ use crate::{
 #[derive(Clone)]
 pub struct Chunk {
     pub buffer: MutableString,
+
+    /// `buffer` holds an `InternalSourceMap` blob (the runtime print path,
+    /// `Builder::prepend_count`) instead of VLQ text.
+    pub is_internal_format: bool,
 
     /// This end state will be used to rewrite the start of the following source
     /// map chunk so that the delta-encoded VLQ numbers are preserved.
@@ -29,6 +35,7 @@ impl Chunk {
     pub fn init_empty() -> Chunk {
         Chunk {
             buffer: MutableString::init_empty(),
+            is_internal_format: false,
             end_state: SourceMapState::default(),
             final_generated_column: 0,
             should_ignore: true,
@@ -47,6 +54,20 @@ impl Chunk {
         unsafe { core::ptr::read(self) }
     }
 
+    /// The mappings as a standard VLQ `"mappings"` string, re-encoding an
+    /// internal-format buffer.
+    pub fn vlq_mappings(&self) -> Cow<'_, [u8]> {
+        if !self.is_internal_format {
+            return Cow::Borrowed(&self.buffer.list);
+        }
+        let ism = InternalSourceMap {
+            data: self.buffer.list.as_ptr(),
+        };
+        let mut vlq = MutableString::init_empty();
+        ism.append_vlq_to(&mut vlq);
+        Cow::Owned(vlq.list)
+    }
+
     /// `chunk.buffer` holds an InternalSourceMap blob (the runtime path). Re-encode
     /// to a standard VLQ "mappings" string before emitting JSON.
     pub fn print_source_map_contents_from_internal<const ASCII_ONLY: bool>(
@@ -55,16 +76,12 @@ impl Chunk {
         mutable: &mut MutableString,
         include_sources_contents: bool,
     ) -> Result<(), crate::Error> {
-        let ism = InternalSourceMap {
-            data: self.buffer.list.as_ptr(),
-        };
-        let mut vlq = MutableString::init_empty();
-        ism.append_vlq_to(&mut vlq);
+        debug_assert!(self.is_internal_format);
         print_source_map_contents_json::<ASCII_ONLY>(
             source,
             mutable,
             include_sources_contents,
-            vlq.list.as_slice(),
+            &self.vlq_mappings(),
         )
     }
 }
@@ -476,6 +493,7 @@ impl NewBuilder<'_, VLQSourceMap> {
         }
         Chunk {
             buffer: self.source_map.take_buffer(),
+            is_internal_format: self.prepend_count,
             end_state: self.prev_state,
             final_generated_column: self.generated_column,
             should_ignore: self.source_map.should_ignore(),

--- a/src/sourcemap/Chunk.rs
+++ b/src/sourcemap/Chunk.rs
@@ -14,8 +14,7 @@ use crate::{
 pub struct Chunk {
     pub buffer: MutableString,
 
-    /// `buffer` holds an `InternalSourceMap` blob (the runtime print path,
-    /// `Builder::prepend_count`) instead of VLQ text.
+    /// `buffer` is an `InternalSourceMap` blob (`Builder::prepend_count`), not VLQ text.
     pub is_internal_format: bool,
 
     /// This end state will be used to rewrite the start of the following source
@@ -54,8 +53,7 @@ impl Chunk {
         unsafe { core::ptr::read(self) }
     }
 
-    /// The mappings as a standard VLQ `"mappings"` string, re-encoding an
-    /// internal-format buffer.
+    /// The mappings as a VLQ `"mappings"` string, re-encoded if `is_internal_format`.
     pub fn vlq_mappings(&self) -> Cow<'_, [u8]> {
         if !self.is_internal_format {
             return Cow::Borrowed(&self.buffer.list);

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import fs, { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path, { join } from "node:path";
+import { SourceMapConsumer } from "source-map";
 
 describe.concurrent(
   "bun build",
@@ -1015,5 +1016,366 @@ describe.concurrent("diagnostic markup", () => {
     expect(stderr).toContain("The value of color in the class foo is undefined.");
     expect(stderr).not.toContain("<b>");
     expect(stderr).not.toContain("\x1b[");
+  });
+});
+
+describe.concurrent("--no-bundle with --sourcemap", () => {
+  // The interface moves `greet` down three lines and the annotations move
+  // `1` right, so a mapping that merely copies positions fails below.
+  const source = [
+    "export const x: number = 1;",
+    "interface Unused {",
+    "  a: string;",
+    "}",
+    "export function greet(name: string): string {",
+    '  return "hi " + name;',
+    "}",
+    "",
+  ].join("\n");
+  const mappedTokens = ["1;", '"hi "'];
+
+  async function build(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", ...args],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function lineColumn(text: string, token: string) {
+    const index = text.indexOf(token);
+    expect(index).not.toBe(-1);
+    const before = text.slice(0, index);
+    return { line: before.split("\n").length, column: index - (before.lastIndexOf("\n") + 1) };
+  }
+
+  /** The `//# ...` comments at the end of a transpiled file, in order. */
+  function trailingComments(code: string) {
+    return code.split("\n").filter(line => line.startsWith("//# "));
+  }
+
+  function inlineMap(code: string) {
+    const comments = trailingComments(code).filter(line => line.startsWith("//# sourceMappingURL="));
+    expect(comments).toHaveLength(1);
+    const url = comments[0].slice("//# sourceMappingURL=".length);
+    expect(url).toStartWith("data:application/json;base64,");
+    return JSON.parse(Buffer.from(url.slice("data:application/json;base64,".length), "base64").toString());
+  }
+
+  /** Checks the map's shape and that `code`'s tokens map back to where they are in `original`. */
+  async function expectSourceMap(code: string, map: any, original: string, sources: string[]) {
+    expect(map).toEqual({
+      version: 3,
+      sources,
+      sourcesContent: [original],
+      mappings: expect.any(String),
+      debugId: expect.stringMatching(/^[0-9A-F]{32}$/),
+      names: [],
+    });
+    expect(trailingComments(code)[0]).toBe(`//# debugId=${map.debugId}`);
+    await SourceMapConsumer.with(map, null, consumer => {
+      for (const token of mappedTokens) {
+        const { line, column } = consumer.originalPositionFor(lineColumn(code, token));
+        expect({ token, line, column }).toEqual({ token, ...lineColumn(original, token) });
+      }
+    });
+  }
+
+  /** `name  N bytes  (kind)` rows of the build summary. */
+  function summaryRows(stdout: string) {
+    return [...stdout.matchAll(/^ {2}(\S+) +(\d+) bytes +\((.+?)\)$/gm)].map(([, name, size, kind]) => ({
+      name,
+      size: Number(size),
+      kind,
+    }));
+  }
+
+  test.each([
+    ["browser", []],
+    ["bun", ["--target=bun"]],
+    ["node", ["--target=node"]],
+  ])("--sourcemap=inline to stdout with --target=%s", async (_, targetArgs) => {
+    using dir = tempDir("no-bundle-sourcemap-inline", { "src/a.ts": source });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), ...targetArgs, "src/a.ts", "--sourcemap=inline");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(stdout).toContain("export function greet(name) {");
+    // Nothing is written to disk, so `sources` is relative to the cwd.
+    await expectSourceMap(stdout, inlineMap(stdout), source, ["src/a.ts"]);
+    expect(fs.readdirSync(path.join(String(dir), "src"))).toEqual(["a.ts"]);
+  });
+
+  test("--sourcemap=inline with --minify-whitespace puts the comments on their own lines", async () => {
+    using dir = tempDir("no-bundle-sourcemap-minify", { "src/a.ts": source });
+
+    const { stdout, stderr, exitCode } = await build(
+      String(dir),
+      "src/a.ts",
+      "--sourcemap=inline",
+      "--minify-whitespace",
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const map = inlineMap(stdout);
+    await expectSourceMap(stdout, map, source, ["src/a.ts"]);
+    // Minified output has no newline of its own, but the comment block still
+    // starts after a blank line, exactly as in bundle mode.
+    expect(stdout.split("\n")).toEqual([
+      'export const x=1;export function greet(name){return"hi "+name}',
+      "",
+      `//# debugId=${map.debugId}`,
+      expect.stringMatching(/^\/\/# sourceMappingURL=data:application\/json;base64,[A-Za-z0-9+/=]+$/),
+      "",
+    ]);
+  });
+
+  test.each([
+    ["no --sourcemap", []],
+    ["--sourcemap=none", ["--sourcemap=none"]],
+  ])("emits no source map comments with %s", async (_, sourcemapArgs) => {
+    using dir = tempDir("no-bundle-sourcemap-off", { "src/a.ts": source });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), "src/a.ts", ...sourcemapArgs);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(trailingComments(stdout)).toEqual([]);
+  });
+
+  test("--sourcemap=linked with --outdir writes a .map next to the output", async () => {
+    using dir = tempDir("no-bundle-sourcemap-linked", { "src/a.ts": source });
+    const out = path.join(String(dir), "out");
+
+    const { stdout, stderr, exitCode } = await build(String(dir), "src/a.ts", "--outdir=out", "--sourcemap=linked");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(out).sort()).toEqual(["a.js", "a.js.map"]);
+    const code = fs.readFileSync(path.join(out, "a.js"), "utf8");
+    const map = JSON.parse(fs.readFileSync(path.join(out, "a.js.map"), "utf8"));
+    expect(code).toEndWith(`}\n\n//# debugId=${map.debugId}\n//# sourceMappingURL=a.js.map\n`);
+    await expectSourceMap(code, map, source, ["../src/a.ts"]);
+    expect(fs.realpathSync(path.resolve(out, map.sources[0]))).toBe(
+      fs.realpathSync(path.join(String(dir), "src/a.ts")),
+    );
+
+    // The summary lists the .map and reports the sizes actually written.
+    expect(summaryRows(stdout)).toEqual([
+      { name: "a.js", size: fs.statSync(path.join(out, "a.js")).size, kind: "chunk" },
+      { name: "a.js.map", size: fs.statSync(path.join(out, "a.js.map")).size, kind: "source map" },
+    ]);
+  });
+
+  test("bare --sourcemap means linked", async () => {
+    using dir = tempDir("no-bundle-sourcemap-bare", { "src/a.ts": source });
+    const out = path.join(String(dir), "out");
+
+    const { stderr, exitCode } = await build(String(dir), "src/a.ts", "--outdir=out", "--sourcemap");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(out).sort()).toEqual(["a.js", "a.js.map"]);
+    expect(trailingComments(fs.readFileSync(path.join(out, "a.js"), "utf8"))[1]).toBe("//# sourceMappingURL=a.js.map");
+  });
+
+  test("--sourcemap=external writes the .map without a sourceMappingURL comment", async () => {
+    using dir = tempDir("no-bundle-sourcemap-external", { "src/a.ts": source });
+    const out = path.join(String(dir), "out");
+
+    const { stderr, exitCode } = await build(String(dir), "src/a.ts", "--outdir=out", "--sourcemap=external");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(out).sort()).toEqual(["a.js", "a.js.map"]);
+    const code = fs.readFileSync(path.join(out, "a.js"), "utf8");
+    const map = JSON.parse(fs.readFileSync(path.join(out, "a.js.map"), "utf8"));
+    expect(trailingComments(code)).toEqual([`//# debugId=${map.debugId}`]);
+    await expectSourceMap(code, map, source, ["../src/a.ts"]);
+  });
+
+  test("--sourcemap=inline with --outdir makes sources relative to the output", async () => {
+    using dir = tempDir("no-bundle-sourcemap-inline-outdir", { "src/nested/a.ts": source });
+    const out = path.join(String(dir), "out");
+
+    const { stderr, exitCode } = await build(
+      String(dir),
+      "--root=src",
+      "src/nested/a.ts",
+      "--outdir=out",
+      "--sourcemap=inline",
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(out, { recursive: true }).sort()).toEqual(["nested", path.join("nested", "a.js")]);
+    const code = fs.readFileSync(path.join(out, "nested", "a.js"), "utf8");
+    await expectSourceMap(code, inlineMap(code), source, ["../../src/nested/a.ts"]);
+  });
+
+  test("several entry points: nested outputs, css and data loaders", async () => {
+    using dir = tempDir("no-bundle-sourcemap-multi", {
+      "src/a.ts": source,
+      "src/nested/deep.ts": "export const deep: number = 2;\n",
+      "src/style.css": ".a {\n  color: red;\n}\n",
+      "src/data.json": '{ "key": 1 }\n',
+    });
+    const out = path.join(String(dir), "out");
+
+    const { stderr, exitCode } = await build(
+      String(dir),
+      "--root=src",
+      "src/a.ts",
+      "src/nested/deep.ts",
+      "src/style.css",
+      "src/data.json",
+      "--outdir=out",
+      "--sourcemap=linked",
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    // CSS gets no source map, as in bundle mode.
+    expect(fs.readdirSync(out, { recursive: true }).sort()).toEqual(
+      [
+        "a.js",
+        "a.js.map",
+        "data.js",
+        "data.js.map",
+        "nested",
+        path.join("nested", "deep.js"),
+        path.join("nested", "deep.js.map"),
+        "style.css",
+      ].sort(),
+    );
+    expect(fs.readFileSync(path.join(out, "style.css"), "utf8")).not.toContain("sourceMappingURL");
+
+    const deep = fs.readFileSync(path.join(out, "nested", "deep.js"), "utf8");
+    const deepMap = JSON.parse(fs.readFileSync(path.join(out, "nested", "deep.js.map"), "utf8"));
+    expect(trailingComments(deep)).toEqual([`//# debugId=${deepMap.debugId}`, "//# sourceMappingURL=deep.js.map"]);
+    // Relative to the directory the .map is in, not to --outdir.
+    expect(deepMap.sources).toEqual(["../../src/nested/deep.ts"]);
+    expect(deepMap.sourcesContent).toEqual(["export const deep: number = 2;\n"]);
+
+    const dataMap = JSON.parse(fs.readFileSync(path.join(out, "data.js.map"), "utf8"));
+    expect(dataMap.sources).toEqual(["../src/data.json"]);
+    expect(dataMap.sourcesContent).toEqual(['{ "key": 1 }\n']);
+    await SourceMapConsumer.with(dataMap, null, consumer => {
+      expect(consumer.originalPositionFor({ line: 1, column: 0 }).line).toBe(1);
+    });
+  });
+
+  test("--public-path is prefixed to the sourceMappingURL like bundle mode", async () => {
+    using dir = tempDir("no-bundle-sourcemap-public-path", {
+      "src/nested/deep.ts": "export const deep: number = 2;\n",
+    });
+
+    const { stderr, exitCode } = await build(
+      String(dir),
+      "--root=src",
+      "src/nested/deep.ts",
+      "--outdir=out",
+      "--sourcemap=linked",
+      "--public-path=https://cdn.example.com/assets/",
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const code = fs.readFileSync(path.join(String(dir), "out", "nested", "deep.js"), "utf8");
+    expect(trailingComments(code)[1]).toBe("//# sourceMappingURL=https://cdn.example.com/assets/nested/deep.js.map");
+  });
+
+  test("--sourcemap=linked with --outfile names the .map after the outfile", async () => {
+    using dir = tempDir("no-bundle-sourcemap-outfile", { "src/a.ts": source });
+    const dist = path.join(String(dir), "dist");
+
+    const { stdout, stderr, exitCode } = await build(
+      String(dir),
+      "src/a.ts",
+      "--outfile=dist/renamed.js",
+      "--sourcemap=linked",
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(dist).sort()).toEqual(["renamed.js", "renamed.js.map"]);
+    expect(fs.readdirSync(path.join(String(dir), "src"))).toEqual(["a.ts"]);
+    const code = fs.readFileSync(path.join(dist, "renamed.js"), "utf8");
+    const map = JSON.parse(fs.readFileSync(path.join(dist, "renamed.js.map"), "utf8"));
+    expect(trailingComments(code)).toEqual([`//# debugId=${map.debugId}`, "//# sourceMappingURL=renamed.js.map"]);
+    await expectSourceMap(code, map, source, ["../src/a.ts"]);
+    expect(summaryRows(stdout).map(row => row.name)).toEqual(["renamed.js", "renamed.js.map"]);
+  });
+
+  test("--outfile without a directory writes into the cwd", async () => {
+    using dir = tempDir("no-bundle-sourcemap-outfile-cwd", { "src/a.ts": source });
+
+    const { stderr, exitCode } = await build(String(dir), "src/a.ts", "--outfile=a.out.js", "--sourcemap=linked");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(String(dir)).sort()).toEqual(["a.out.js", "a.out.js.map", "src"]);
+    const map = JSON.parse(fs.readFileSync(path.join(String(dir), "a.out.js.map"), "utf8"));
+    expect(map.sources).toEqual(["src/a.ts"]);
+  });
+
+  test("--outfile without --sourcemap still writes exactly one file", async () => {
+    using dir = tempDir("no-bundle-sourcemap-outfile-plain", { "src/a.ts": source });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), "src/a.ts", "--outfile=dist/renamed.js");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(path.join(String(dir), "dist"))).toEqual(["renamed.js"]);
+    const code = fs.readFileSync(path.join(String(dir), "dist", "renamed.js"), "utf8");
+    expect(trailingComments(code)).toEqual([]);
+    expect(summaryRows(stdout)).toEqual([{ name: "renamed.js", size: Buffer.byteLength(code), kind: "chunk" }]);
+  });
+
+  test("--sourcemap=linked without --outdir or --outfile is an error", async () => {
+    using dir = tempDir("no-bundle-sourcemap-linked-stdout", { "a.js": "export const a = 1;\n" });
+
+    const { stdout, stderr, exitCode } = await build(String(dir), "a.js", "--sourcemap");
+    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(
+      `"error: cannot use a linked source map without --outdir or --outfile"`,
+    );
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+
+    // In particular the output was not written over the entry point.
+    expect(fs.readdirSync(String(dir))).toEqual(["a.js"]);
+    expect(fs.readFileSync(path.join(String(dir), "a.js"), "utf8")).toBe("export const a = 1;\n");
+  });
+
+  test("colliding output paths are reported once, not again for their .map files", async () => {
+    using dir = tempDir("no-bundle-sourcemap-collision", {
+      "src/app.ts": "export const a = 1;\n",
+      "src/app.js": "export const b = 2;\n",
+    });
+
+    const { stdout, stderr, exitCode } = await build(
+      String(dir),
+      "src/app.ts",
+      "src/app.js",
+      "--outdir=dist",
+      "--sourcemap=linked",
+    );
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "error: Multiple files share the same output path
+        ./app.js:
+          from input src/app.ts
+          from input src/app.js
+
+
+      note: entry naming is '[dir]/[name].[ext]', consider adding '[hash]' to make filenames unique"
+    `);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+    expect(fs.existsSync(path.join(String(dir), "dist"))).toBe(false);
   });
 });


### PR DESCRIPTION
### Problem
- `bun build --no-bundle a.ts --sourcemap=inline|linked|external` exits 0 and writes `a.js`, but emits no source map at all: no `.map` file, no inline `data:` URL, no `//# sourceMappingURL` comment, no warning. Bundle mode honors the flag.
- Cause: the transform-only path (`Transpiler::build_with_resolve_result_eager`, `src/bundler/transpiler.rs`) prints through `Transpiler::print`, the printer instantiation that collects no mappings, and nothing on that path reads `options.source_map`.

### Fix
- With `--sourcemap`, print through the mapping-collecting printer into a `PendingSourceMap`, then finish the output the way bundle mode finishes a chunk: `inline` appends the `data:` URL comment, `linked` writes `<name>.js.map` and a `//# sourceMappingURL=` comment (under `--public-path` when given), `external` writes only the `.map`. All three carry the `debugId` bundle mode emits. `sources` is relative to the directory the `.map` lands in.
- `--target=bun` prints its chunk in the runtime's `InternalSourceMap` layout, not VLQ. `Chunk` now records which layout it holds (`is_internal_format`) and `vlq_mappings()` re-encodes on demand.
- `--no-bundle --outfile x/y.js` names the output `y.js` in `x/` (as bundle mode does) so the `.map` lands next to it. `--sourcemap=linked` with neither `--outdir` nor `--outfile` is rejected, like `external` already is, instead of overwriting a `.js` entry. The summary also reported transpiled sizes one byte short; it now reports the bytes written.
- Verified: `test/bundler/cli.test.ts`, `--no-bundle with --sourcemap` (17 cases, 14 fail on 1.4.3; the three negative cases pass by design). The rest of `cli.test.ts` passes.

### Background
- `--no-bundle` transpiles each entry point on its own through `Transpiler::transform` instead of `BundleV2`, so the linker code that names, maps and writes chunks never runs; this path fills in each `OutputFile` itself.
- The printer hands its mappings to a `SourceMapHandler` callback as a `bun_sourcemap::Chunk` at the end of a print. The bun-target printer writes that chunk in `InternalSourceMap` form (the compact layout the runtime uses to remap stack traces); `append_vlq_to` turns it into a standard `mappings` string.
- A map's `sources` are resolved by consumers relative to the `.map` file, so they are computed from where the map is written, not from the input's location.

<details><summary>Notes</summary>

- This is #38651 rebased onto main. That branch was stacked on #35644 (`--no-bundle --outdir`), which has since merged, and it no longer merges cleanly. The only changes on top of the original commit: `Chunk` lost its `Default` derive on main, so `PendingSourceMap` implements `Default` by hand, and the added comments are one line each.
- Input files that carry their own `sourceMappingURL` are not yet composed through on this path; #41934 adds that for bundle mode, and once both land the transform-only path can pass the same `InputSourceMap` to the printer.
- Left as is, deliberately (same as #38651): CSS entries get no map (bundle mode emits none for CSS); data loaders (json, toml, ...) get a map of the generated module; `--compile` already rejects `--no-bundle`; `Bun.build()` has no transform-only mode, so the CLI is the only caller of this path.

</details>
