### PR TITLE
why: show a peer dependency under the copy its owner resolves

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -206,11 +206,54 @@ impl<'a, 'b> Wait<'a, 'b> {
     }
 }
 
-/// Whether `build_store` reports how long each of its two passes took.
+/// Whether `build_store` prints an install's `--verbose` output: pass timings and skipped packages.
 #[derive(Clone, Copy)]
-pub(crate) enum Timings {
-    Print,
+pub(crate) enum StoreLog {
+    Verbose,
     Quiet,
+}
+
+/// Every `(peer edge, package)` pair the isolated store wires, one per peer context of the owner.
+pub fn served_peers(
+    manager: &PackageManager,
+    lockfile: &Lockfile,
+) -> Result<Vec<(DependencyID, PackageID)>, AllocError> {
+    let store = build_store(manager, lockfile, true, &[], None, StoreLog::Quiet)?;
+    let nodes = store.nodes.slice();
+    let node_pkg_ids = nodes.items_pkg_id();
+    let node_dependencies = nodes.items_dependencies();
+    let dependencies = lockfile.buffers.dependencies.as_slice();
+    let pkg_dependencies = lockfile.packages.items_dependencies();
+
+    let mut served: Vec<(DependencyID, PackageID)> = Vec::new();
+    let mut seen: HashMap<(DependencyID, PackageID), ()> = HashMap::default();
+    for node in 0..nodes.len() {
+        let wired = &node_dependencies[node];
+        let deps = pkg_dependencies[node_pkg_ids[node] as usize];
+        for dep_id in deps.begin()..deps.end() {
+            let dep = &dependencies[dep_id as usize];
+            if !dep.behavior.is_peer() {
+                continue;
+            }
+            // The edge itself when the store queued it, else the owner's own dependency of that name.
+            let target = wired
+                .iter()
+                .find(|ids| ids.dep_id == dep_id)
+                .or_else(|| {
+                    wired
+                        .iter()
+                        .find(|ids| dependencies[ids.dep_id as usize].name_hash == dep.name_hash)
+                })
+                .map(|ids| ids.pkg_id);
+            if let Some(target) = target
+                && target != invalid_package_id
+                && seen.insert((dep_id, target), ()).is_none()
+            {
+                served.push((dep_id, target));
+            }
+        }
+    }
+    Ok(served)
 }
 
 pub(crate) fn build_store(
@@ -219,9 +262,10 @@ pub(crate) fn build_store(
     install_root_dependencies: bool,
     workspace_filters: &[WorkspaceFilter],
     packages_to_install: Option<&[PackageID]>,
-    timings: Timings,
+    log: StoreLog,
 ) -> Result<Store, AllocError> {
     let mut timer = std::time::Instant::now();
+    let verbose = matches!(log, StoreLog::Verbose);
     let pkgs = lockfile.packages.slice();
     let pkg_dependency_slices = pkgs.items_dependencies();
     let pkg_resolutions = pkgs.items_resolution();
@@ -313,6 +357,7 @@ pub(crate) fn build_store(
                     manager,
                     lockfile,
                     resolutions,
+                    verbose,
                 ) {
                     provides.set(pkg_id as usize, bit);
                 }
@@ -383,6 +428,7 @@ pub(crate) fn build_store(
             manager,
             lockfile,
             resolutions,
+            verbose,
         ) {
             continue;
         }
@@ -694,6 +740,7 @@ pub(crate) fn build_store(
                     manager,
                     lockfile,
                     resolutions,
+                    verbose,
                 ) {
                     continue;
                 }
@@ -860,7 +907,7 @@ pub(crate) fn build_store(
         node_queue[queue_mark..].reverse();
     }
 
-    if matches!(timings, Timings::Print) {
+    if verbose {
         let full_tree_end = timer.elapsed();
         timer = std::time::Instant::now();
         bun_core::pretty_errorln!(
@@ -1117,7 +1164,7 @@ pub(crate) fn build_store(
         }
     }
 
-    if matches!(timings, Timings::Print) {
+    if verbose {
         let dedupe_end = timer.elapsed();
         bun_core::pretty_errorln!(
             "Created store [{}]",
@@ -1149,10 +1196,10 @@ pub(crate) fn install_isolated_packages(
     // while this reborrow is live (column slices below borrow through it).
     let lockfile: &mut Lockfile = unsafe { &mut *lockfile };
 
-    let timings = if manager.options.log_level.is_verbose() {
-        Timings::Print
+    let log = if manager.options.log_level.is_verbose() {
+        StoreLog::Verbose
     } else {
-        Timings::Quiet
+        StoreLog::Quiet
     };
     let store: Store = build_store(
         &*manager,
@@ -1160,7 +1207,7 @@ pub(crate) fn install_isolated_packages(
         install_root_dependencies,
         workspace_filters,
         packages_to_install,
-        timings,
+        log,
     )?;
 
     let global_store_path: Option<Vec<u8>> = if manager.options.enable.global_virtual_store() {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -42,7 +42,7 @@ use bun_wyhash::{Wyhash, Wyhash11};
 use crate::analytics;
 use crate::bun_bunfig::Arguments as Command;
 use crate::bun_progress::{Node as ProgressNode, Progress};
-use crate::lockfile::tree::is_filtered_dependency_or_workspace;
+use crate::lockfile::tree::{InstallLog, is_filtered_dependency_or_workspace};
 use crate::lockfile::{self, Lockfile};
 use crate::package_manager::{self, PackageManager, WorkspaceFilter, run_tasks};
 use crate::package_manager_real::ProgressStrings;
@@ -206,19 +206,12 @@ impl<'a, 'b> Wait<'a, 'b> {
     }
 }
 
-/// Whether `build_store` prints an install's `--verbose` output: pass timings and skipped packages.
-#[derive(Clone, Copy)]
-pub(crate) enum StoreLog {
-    Verbose,
-    Quiet,
-}
-
 /// Every `(peer edge, package)` pair the isolated store wires, one per peer context of the owner.
 pub fn served_peers(
     manager: &PackageManager,
     lockfile: &Lockfile,
 ) -> Result<Vec<(DependencyID, PackageID)>, AllocError> {
-    let store = build_store(manager, lockfile, true, &[], None, StoreLog::Quiet)?;
+    let store = build_store(manager, lockfile, true, &[], None, InstallLog::Quiet)?;
     let nodes = store.nodes.slice();
     let node_pkg_ids = nodes.items_pkg_id();
     let node_dependencies = nodes.items_dependencies();
@@ -262,10 +255,10 @@ pub(crate) fn build_store(
     install_root_dependencies: bool,
     workspace_filters: &[WorkspaceFilter],
     packages_to_install: Option<&[PackageID]>,
-    log: StoreLog,
+    log: InstallLog,
 ) -> Result<Store, AllocError> {
     let mut timer = std::time::Instant::now();
-    let verbose = matches!(log, StoreLog::Verbose);
+    let verbose = log == InstallLog::Verbose;
     let pkgs = lockfile.packages.slice();
     let pkg_dependency_slices = pkgs.items_dependencies();
     let pkg_resolutions = pkgs.items_resolution();
@@ -357,7 +350,7 @@ pub(crate) fn build_store(
                     manager,
                     lockfile,
                     resolutions,
-                    verbose,
+                    log,
                 ) {
                     provides.set(pkg_id as usize, bit);
                 }
@@ -428,7 +421,7 @@ pub(crate) fn build_store(
             manager,
             lockfile,
             resolutions,
-            verbose,
+            log,
         ) {
             continue;
         }
@@ -740,7 +733,7 @@ pub(crate) fn build_store(
                     manager,
                     lockfile,
                     resolutions,
-                    verbose,
+                    log,
                 ) {
                     continue;
                 }
@@ -1196,11 +1189,7 @@ pub(crate) fn install_isolated_packages(
     // while this reborrow is live (column slices below borrow through it).
     let lockfile: &mut Lockfile = unsafe { &mut *lockfile };
 
-    let log = if manager.options.log_level.is_verbose() {
-        StoreLog::Verbose
-    } else {
-        StoreLog::Quiet
-    };
+    let log = InstallLog::of(manager);
     let store: Store = build_store(
         &*manager,
         &*lockfile,

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1145,12 +1145,10 @@ pub fn served_peers(lockfile: &Lockfile) -> Vec<(DependencyID, PackageID)> {
     }
     let mut seen: HashMap<(DependencyID, PackageID), ()> = HashMap::default();
 
-    // The `node_modules` folder of a package placed in `parent`, if it has one.
-    let mut own_folder: HashMap<(Id, PackageID), Id> = HashMap::default();
+    // The `node_modules` folder of the package an edge placed in `parent`, if it has one.
+    let mut own_folder: HashMap<(Id, DependencyID), Id> = HashMap::default();
     for tree in &trees[1..] {
-        if let Some(&pkg_id) = resolutions.get(tree.dependency_id as usize) {
-            own_folder.insert((tree.parent, pkg_id), tree.id);
-        }
+        own_folder.insert((tree.parent, tree.dependency_id), tree.id);
     }
 
     let resolve_from = |mut tree_id: Id, name_hash: PackageNameHash| -> Option<PackageID> {
@@ -1189,7 +1187,7 @@ pub fn served_peers(lockfile: &Lockfile) -> Vec<(DependencyID, PackageID)> {
                 continue;
             }
             let from = own_folder
-                .get(&(tree.id, pkg_id))
+                .get(&(tree.id, dep_id))
                 .copied()
                 .unwrap_or(tree.id);
             visit(pkg_id, from);

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -537,6 +537,23 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 // is_filtered_dependency_or_workspace
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Whether an install's `--verbose` diagnostics are printed while its layout is computed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstallLog {
+    Verbose,
+    Quiet,
+}
+
+impl InstallLog {
+    pub(crate) fn of(manager: &PackageManager) -> InstallLog {
+        if manager.options.log_level.is_verbose() {
+            InstallLog::Verbose
+        } else {
+            InstallLog::Quiet
+        }
+    }
+}
+
 // `Builder` holds a live `&mut [PackageID]` over the resolutions buffer (see
 // `Builder.lockfile` safety contract), so callers must thread `resolutions`
 // explicitly to avoid an aliasing read through the shared `&Lockfile`.
@@ -548,7 +565,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     manager: &PackageManager,
     lockfile: &Lockfile,
     resolutions: &[PackageID],
-    log_skipped: bool,
+    log: InstallLog,
 ) -> bool {
     let pkg_id = resolutions[dep_id as usize];
     if (pkg_id as usize) >= lockfile.packages.len() {
@@ -568,7 +585,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     let parent_res = &pkg_resolutions[parent_pkg_id as usize];
 
     if pkg_metas[pkg_id as usize].is_disabled(manager.options.cpu, manager.options.os) {
-        if log_skipped {
+        if log == InstallLog::Verbose {
             let meta = &pkg_metas[pkg_id as usize];
             let name = lockfile.str(&pkg_names[pkg_id as usize]);
             if !meta.os.is_match(manager.options.os) && !meta.arch.is_match(manager.options.cpu) {
@@ -718,7 +735,7 @@ impl Tree {
                     manager,
                     lockfile,
                     &*builder.resolutions,
-                    manager.options.log_level.is_verbose(),
+                    InstallLog::of(manager),
                 ) {
                     continue;
                 }

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -2,7 +2,7 @@ use core::marker::ConstParamTy;
 use core::mem::MaybeUninit;
 
 use bun_alloc::AllocError;
-use bun_collections::{ArrayHashMap, DynamicBitSet, MultiArrayList, index_sort};
+use bun_collections::{ArrayHashMap, DynamicBitSet, HashMap, MultiArrayList, index_sort};
 use bun_core::Output;
 use bun_core::ZStr;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
@@ -548,6 +548,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     manager: &PackageManager,
     lockfile: &Lockfile,
     resolutions: &[PackageID],
+    log_skipped: bool,
 ) -> bool {
     let pkg_id = resolutions[dep_id as usize];
     if (pkg_id as usize) >= lockfile.packages.len() {
@@ -567,7 +568,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     let parent_res = &pkg_resolutions[parent_pkg_id as usize];
 
     if pkg_metas[pkg_id as usize].is_disabled(manager.options.cpu, manager.options.os) {
-        if manager.options.log_level.is_verbose() {
+        if log_skipped {
             let meta = &pkg_metas[pkg_id as usize];
             let name = lockfile.str(&pkg_names[pkg_id as usize]);
             if !meta.os.is_match(manager.options.os) && !meta.arch.is_match(manager.options.cpu) {
@@ -708,14 +709,16 @@ impl Tree {
 
             // filter out disabled dependencies
             if METHOD == BuilderMethod::Filter {
+                let manager = builder.manager.expect("manager set when METHOD == Filter");
                 if is_filtered_dependency_or_workspace(
                     dep_id,
                     parent_pkg_id,
                     builder.workspace_filters,
                     builder.install_root_dependencies,
-                    builder.manager.expect("manager set when METHOD == Filter"),
+                    manager,
                     lockfile,
                     &*builder.resolutions,
+                    manager.options.log_level.is_verbose(),
                 ) {
                     continue;
                 }
@@ -1110,3 +1113,71 @@ pub struct FillItem {
 // Dynamic, heap-backed ring buffer.
 pub(crate) type TreeFiller =
     bun_collections::LinearFifo<FillItem, bun_collections::linear_fifo::DynamicBuffer<FillItem>>;
+
+/// Each `(peer edge, package)` pair a placement of the owner resolves, nearest `node_modules` first.
+pub fn served_peers(lockfile: &Lockfile) -> Vec<(DependencyID, PackageID)> {
+    let trees = lockfile.buffers.trees.as_slice();
+    let hoisted = lockfile.buffers.hoisted_dependencies.as_slice();
+    let dependencies = lockfile.buffers.dependencies.as_slice();
+    let resolutions = lockfile.buffers.resolutions.as_slice();
+    let pkg_dependencies = lockfile.packages.items_dependencies();
+
+    let mut served: Vec<(DependencyID, PackageID)> = Vec::new();
+    if trees.is_empty() {
+        return served;
+    }
+    let mut seen: HashMap<(DependencyID, PackageID), ()> = HashMap::default();
+
+    // The `node_modules` folder of a package placed in `parent`, if it has one.
+    let mut own_folder: HashMap<(Id, PackageID), Id> = HashMap::default();
+    for tree in &trees[1..] {
+        if let Some(&pkg_id) = resolutions.get(tree.dependency_id as usize) {
+            own_folder.insert((tree.parent, pkg_id), tree.id);
+        }
+    }
+
+    let resolve_from = |mut tree_id: Id, name_hash: PackageNameHash| -> Option<PackageID> {
+        while let Some(tree) = trees.get(tree_id as usize) {
+            for &dep_id in tree.dependencies.get(hoisted) {
+                if dependencies[dep_id as usize].name_hash == name_hash {
+                    return Some(resolutions[dep_id as usize]);
+                }
+            }
+            tree_id = tree.parent;
+        }
+        None
+    };
+
+    let mut visit = |pkg_id: PackageID, from: Id| {
+        let deps = pkg_dependencies[pkg_id as usize];
+        for dep_id in deps.begin()..deps.end() {
+            let dep = &dependencies[dep_id as usize];
+            if !dep.behavior.is_peer() {
+                continue;
+            }
+            if let Some(target) = resolve_from(from, dep.name_hash)
+                && target != invalid_package_id
+                && seen.insert((dep_id, target), ()).is_none()
+            {
+                served.push((dep_id, target));
+            }
+        }
+    };
+
+    visit(0, 0);
+    for tree in trees {
+        for &dep_id in tree.dependencies.get(hoisted) {
+            let pkg_id = resolutions[dep_id as usize];
+            if pkg_id == invalid_package_id || pkg_dependencies[pkg_id as usize].len == 0 {
+                continue;
+            }
+            let from = own_folder
+                .get(&(tree.id, pkg_id))
+                .copied()
+                .unwrap_or(tree.id);
+            visit(pkg_id, from);
+        }
+    }
+
+    served
+}

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -11,9 +11,9 @@ use bun_paths::SEP;
 use bun_sys::{self as sys, Dir, E, EntryKind, O};
 
 use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _, entry as store_entry};
-use crate::isolated_install::{Store, StoreLog, build_store};
+use crate::isolated_install::{Store, build_store};
 use crate::lockfile::package::PackageColumns as _;
-use crate::lockfile::tree::is_filtered_dependency_or_workspace;
+use crate::lockfile::tree::{InstallLog, is_filtered_dependency_or_workspace};
 use crate::lockfile::{LoadResult, Lockfile, reachable, tree};
 use crate::lockfile_real::package::{Diff, DiffSummary, Package};
 use crate::package_manager::Options::{Enable, LogLevel};
@@ -1713,7 +1713,7 @@ fn build_store_with(manager: &mut PackageManager, features: InstallFeatures) -> 
             true,
             &[],
             None,
-            StoreLog::Quiet,
+            InstallLog::Quiet,
         ))
     })
 }
@@ -1780,7 +1780,7 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
             manager,
             lockfile,
             resolutions,
-            false,
+            InstallLog::of(manager),
         ) {
             continue;
         }

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1713,7 +1713,7 @@ fn build_store_with(manager: &mut PackageManager, features: InstallFeatures) -> 
             true,
             &[],
             None,
-            InstallLog::Quiet,
+            InstallLog::of(manager),
         ))
     })
 }

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -11,7 +11,7 @@ use bun_paths::SEP;
 use bun_sys::{self as sys, Dir, E, EntryKind, O};
 
 use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _, entry as store_entry};
-use crate::isolated_install::{Store, Timings, build_store};
+use crate::isolated_install::{Store, StoreLog, build_store};
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::tree::is_filtered_dependency_or_workspace;
 use crate::lockfile::{LoadResult, Lockfile, reachable, tree};
@@ -1713,7 +1713,7 @@ fn build_store_with(manager: &mut PackageManager, features: InstallFeatures) -> 
             true,
             &[],
             None,
-            Timings::Quiet,
+            StoreLog::Quiet,
         ))
     })
 }
@@ -1780,6 +1780,7 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
             manager,
             lockfile,
             resolutions,
+            false,
         ) {
             continue;
         }

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1713,7 +1713,7 @@ fn build_store_with(manager: &mut PackageManager, features: InstallFeatures) -> 
             true,
             &[],
             None,
-            InstallLog::of(manager),
+            InstallLog::Quiet,
         ))
     })
 }

--- a/src/runtime/cli/why_command.rs
+++ b/src/runtime/cli/why_command.rs
@@ -11,7 +11,10 @@ use bun_core::{Global, Output};
 use bun_install::dependency::Behavior;
 use bun_install::lockfile::Lockfile;
 use bun_install::lockfile::package::PackageColumns as _;
-use bun_install::{CommandLineArguments, PackageID, PackageManager, Subcommand, package_manager};
+use bun_install::{
+    CommandLineArguments, DependencyID, PackageID, PackageManager, Subcommand, package_manager,
+};
+use bun_install_types::NodeLinker::NodeLinker;
 use bun_semver as semver;
 
 use crate::command;
@@ -342,6 +345,7 @@ impl WhyCommand {
         // up front so we never need `pm` again once `lockfile` is borrowed.
         let depth_opt = pm.options.depth;
         let log_level = pm.options.log_level;
+        let configured_linker = pm.options.node_linker;
         // SAFETY: CLI dispatch is single-threaded and `log`'s last use is the
         // `load_from_cwd` call below, which receives it as the sole `&mut Log`;
         // no other path (`pm`, `ctx`) reborrows the process-static `Log` while
@@ -351,6 +355,7 @@ impl WhyCommand {
         let mut lockfile_box: Box<Lockfile> = core::mem::take(&mut pm.lockfile);
         let load_lockfile = lockfile_box.load_from_cwd::<true>(Some(pm), log);
         PackageManagerCommand::handle_load_lockfile_errors(&load_lockfile, log_level);
+        let linker = load_lockfile.node_linker(configured_linker);
 
         if top_only {
             MAX_DEPTH.store(1, AtomicOrdering::Relaxed);
@@ -375,6 +380,17 @@ impl WhyCommand {
 
         let mut all_dependents: HashMap<PackageID, Vec<DependentInfo>> = HashMap::default();
 
+        // A peer edge leads where each placement of its owner resolves the name, bound or not.
+        let mut peer_targets: HashMap<DependencyID, Vec<PackageID>> = HashMap::default();
+        let served_peers = if linker == NodeLinker::Isolated {
+            bun_install::isolated_install::served_peers(pm, lockfile)?
+        } else {
+            bun_install::lockfile::tree::served_peers(lockfile)
+        };
+        for (dep_id, pkg_id) in served_peers {
+            peer_targets.entry(dep_id).or_default().push(pkg_id);
+        }
+
         let glob = GlobPattern::init(package_pattern);
 
         // The column-backed `PackageList` exposes
@@ -396,12 +412,11 @@ impl WhyCommand {
             let resolutions = pkg_res_slices[pkg_idx].get(resolutions_items);
 
             for (dep_idx, dependency) in dependencies.iter().enumerate() {
-                let target_id = resolutions[dep_idx];
-                if target_id as usize >= packages.len() {
-                    continue;
-                }
-
-                let dependents_entry = all_dependents.entry(target_id).or_default();
+                let dep_id = pkg_dep_slices[pkg_idx].begin() + dep_idx as DependencyID;
+                let targets: &[PackageID] = match peer_targets.get(&dep_id) {
+                    Some(served) if dependency.behavior.is_peer() => served,
+                    _ => core::slice::from_ref(&resolutions[dep_idx]),
+                };
 
                 let mut dep_version_buf: Vec<u8> = Vec::new();
                 write!(
@@ -432,14 +447,28 @@ impl WhyCommand {
                 let workspace = strings::has_prefix(&dep_pkg_version, b"workspace:")
                     || dep_pkg_version.is_empty();
 
-                dependents_entry.push(DependentInfo {
+                let info = DependentInfo {
                     name: Box::<[u8]>::from(pkg_name),
                     version: dep_pkg_version,
                     spec,
                     dep_type,
                     pkg_id: PackageID::try_from(pkg_idx).expect("int cast"),
                     workspace,
-                });
+                };
+                let Some((&last_target, other_targets)) = targets.split_last() else {
+                    continue;
+                };
+                for &target_id in other_targets {
+                    if (target_id as usize) < packages.len() {
+                        all_dependents
+                            .entry(target_id)
+                            .or_default()
+                            .push(info.clone());
+                    }
+                }
+                if (last_target as usize) < packages.len() {
+                    all_dependents.entry(last_target).or_default().push(info);
+                }
             }
 
             if !glob.matches_name(pkg_name, package_pattern) {

--- a/test/cli/install/bun-pm-why.test.ts
+++ b/test/cli/install/bun-pm-why.test.ts
@@ -1,6 +1,6 @@
-import { spawn } from "bun";
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import { spawn, write } from "bun";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles, VerdaccioRegistry } from "harness";
 import { existsSync, mkdtempSync, realpathSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -578,5 +578,117 @@ describe.concurrent.each(["why", "pm why"])("bun %s", cmd => {
     expect(outputDepth2.split("\n").length).toBeLessThan(outputNoDepth.split("\n").length);
 
     expect(outputDepth2).toContain("mime-db@");
+  });
+});
+
+// A peer dependency points at the copy its owner actually resolves from where it is installed,
+// which need not be the package the resolver bound the edge to. `bun why` reads those edges from
+// the same layout the linker builds: the hoisted tree, or the isolated store's peer contexts.
+describe.concurrent("peer edges follow the installed layout", () => {
+  const registry = new VerdaccioRegistry();
+  beforeAll(async () => {
+    await registry.start();
+  });
+  afterAll(() => {
+    registry.stop();
+  });
+
+  async function run(cwd: string, ...cmd: string[]) {
+    await using proc = spawn({ cmd: [bunExe(), ...cmd], cwd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    return { out, exitCode };
+  }
+
+  async function install(cwd: string) {
+    expect((await run(cwd, "install")).exitCode).toBe(0);
+  }
+
+  async function why(cwd: string, pkg: string) {
+    return await run(cwd, "why", pkg);
+  }
+
+  // no-deps@1.0.0 nested under one-fixed-dep satisfies peer-deps-fixed's `^1.0.0`, and the
+  // resolver binds the peer there, but peer-deps-fixed is installed next to the root's 2.0.0 and
+  // that is what it loads, with either linker.
+  test.each(["hoisted", "isolated"] as const)("a peer shown under the copy its owner loads (%s)", async linker => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "app",
+        dependencies: { "no-deps": "2.0.0", "one-fixed-dep": "1.0.0", "peer-deps-fixed": "1.0.0" },
+      }),
+    );
+    await install(packageDir);
+
+    const { out, exitCode } = await why(packageDir, "no-deps");
+    expect(out).toMatchInlineSnapshot(`
+      "no-deps@2.0.0
+        ├─ app (requires 2.0.0)
+        └─ peer peer-deps-fixed@1.0.0 (requires ^1.0.0)
+           └─ app (requires 1.0.0)
+
+      no-deps@1.0.0
+        └─ one-fixed-dep@1.0.0 (requires 1.0.0)
+           └─ app (requires 1.0.0)
+
+      "
+    `);
+    expect(exitCode).toBe(0);
+  });
+
+  // peer-deps (peer `no-deps@*`) is reached from the root, next to no-deps@2.0.0, and from
+  // provides-peer-deps-1-0-0, which brings no-deps@1.0.0. The isolated linker gives it one store
+  // entry per context; the hoisted tree has a single copy at the root.
+  test("one edge per peer context with the isolated linker", async () => {
+    const manifest = JSON.stringify({
+      name: "app",
+      dependencies: { "no-deps": "2.0.0", "peer-deps": "1.0.0", "provides-peer-deps-1-0-0": "1.0.0" },
+    });
+
+    const isolated = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    await write(isolated.packageJson, manifest);
+    await install(isolated.packageDir);
+    let { out, exitCode } = await why(isolated.packageDir, "no-deps");
+    expect(out).toMatchInlineSnapshot(`
+      "no-deps@2.0.0
+        ├─ app (requires 2.0.0)
+        └─ peer peer-deps@1.0.0 (requires *)
+           ├─ app (requires 1.0.0)
+           └─ provides-peer-deps-1-0-0@1.0.0 (requires 1.0.0)
+              └─ app (requires 1.0.0)
+
+      no-deps@1.0.0
+        ├─ provides-peer-deps-1-0-0@1.0.0 (requires 1.0.0)
+        │  └─ app (requires 1.0.0)
+        └─ peer peer-deps@1.0.0 (requires *)
+           ├─ app (requires 1.0.0)
+           └─ provides-peer-deps-1-0-0@1.0.0 (requires 1.0.0)
+              └─ app (requires 1.0.0)
+
+      "
+    `);
+    expect(exitCode).toBe(0);
+
+    const hoisted = await registry.createTestDir({ bunfigOpts: { linker: "hoisted" } });
+    await write(hoisted.packageJson, manifest);
+    await install(hoisted.packageDir);
+    ({ out, exitCode } = await why(hoisted.packageDir, "no-deps"));
+    expect(out).toMatchInlineSnapshot(`
+      "no-deps@2.0.0
+        ├─ app (requires 2.0.0)
+        └─ peer peer-deps@1.0.0 (requires *)
+           ├─ app (requires 1.0.0)
+           └─ provides-peer-deps-1-0-0@1.0.0 (requires 1.0.0)
+              └─ app (requires 1.0.0)
+
+      no-deps@1.0.0
+        └─ provides-peer-deps-1-0-0@1.0.0 (requires 1.0.0)
+           └─ app (requires 1.0.0)
+
+      "
+    `);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/install/bun-pm-why.test.ts
+++ b/test/cli/install/bun-pm-why.test.ts
@@ -593,8 +593,11 @@ describe.concurrent("peer edges follow the installed layout", () => {
     registry.stop();
   });
 
+  // One cache per project dir: the CI runner points every test of a file at one shared cache, and
+  // these installs run concurrently.
   async function run(cwd: string, ...cmd: string[]) {
-    await using proc = spawn({ cmd: [bunExe(), ...cmd], cwd, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") };
+    await using proc = spawn({ cmd: [bunExe(), ...cmd], cwd, env, stdout: "pipe", stderr: "pipe" });
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(err).not.toContain("error:");
     return { out, exitCode };
@@ -611,31 +614,33 @@ describe.concurrent("peer edges follow the installed layout", () => {
   // no-deps@1.0.0 nested under one-fixed-dep satisfies peer-deps-fixed's `^1.0.0`, and the
   // resolver binds the peer there, but peer-deps-fixed is installed next to the root's 2.0.0 and
   // that is what it loads, with either linker.
-  test.each(["hoisted", "isolated"] as const)("a peer shown under the copy its owner loads (%s)", async linker => {
-    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
-    await write(
-      packageJson,
-      JSON.stringify({
-        name: "app",
-        dependencies: { "no-deps": "2.0.0", "one-fixed-dep": "1.0.0", "peer-deps-fixed": "1.0.0" },
-      }),
-    );
-    await install(packageDir);
+  describe.each(["hoisted", "isolated"] as const)("%s linker", linker => {
+    test("a peer is shown under the copy its owner loads", async () => {
+      const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "app",
+          dependencies: { "no-deps": "2.0.0", "one-fixed-dep": "1.0.0", "peer-deps-fixed": "1.0.0" },
+        }),
+      );
+      await install(packageDir);
 
-    const { out, exitCode } = await why(packageDir, "no-deps");
-    expect(out).toMatchInlineSnapshot(`
-      "no-deps@2.0.0
-        ├─ app (requires 2.0.0)
-        └─ peer peer-deps-fixed@1.0.0 (requires ^1.0.0)
-           └─ app (requires 1.0.0)
+      const { out, exitCode } = await why(packageDir, "no-deps");
+      expect(out).toMatchInlineSnapshot(`
+        "no-deps@2.0.0
+          ├─ app (requires 2.0.0)
+          └─ peer peer-deps-fixed@1.0.0 (requires ^1.0.0)
+             └─ app (requires 1.0.0)
 
-      no-deps@1.0.0
-        └─ one-fixed-dep@1.0.0 (requires 1.0.0)
-           └─ app (requires 1.0.0)
+        no-deps@1.0.0
+          └─ one-fixed-dep@1.0.0 (requires 1.0.0)
+             └─ app (requires 1.0.0)
 
-      "
-    `);
-    expect(exitCode).toBe(0);
+        "
+      `);
+      expect(exitCode).toBe(0);
+    });
   });
 
   // peer-deps (peer `no-deps@*`) is reached from the root, next to no-deps@2.0.0, and from


### PR DESCRIPTION
### Problem
- `bun why` lists a peer dependent under a version its owner never loads, and omits it under the one it does. Root `no-deps@2.0.0` + `peer-deps-fixed` (peer `no-deps@^1.0.0`) + `one-fixed-dep` (nests `no-deps@1.0.0`): `bun why no-deps` shows `peer peer-deps-fixed` under 1.0.0, while it loads the root's 2.0.0. 1.3.14 printed it under 2.0.0 from the same `bun.lock`.
- `why_command.rs` reads peer edges from `buffers.resolutions`, which holds the package the resolver bound: any lockfile copy in range, re-derived by version on load since #32182. Neither linker consults it when a copy of the name is visible from the owner's position.

### Fix
- `why` takes peer edges from the layout. `tree::served_peers` walks the hoisted tree up from each placement of the owner. `isolated_install::served_peers` reads the peer each store node was wired to by `build_store`. The linker is picked as `bun install` picks it.
- An owner placed at several paths, or wired in several isolated peer contexts, is listed under each copy it resolves. Other edges, and peers no placement reaches, still use `resolutions`.
- Display only: no lockfile, tree or store output changes.
- Verified: `test/cli/install/bun-pm-why.test.ts`, three new cases that fail on stock bun.

### Background
- A peer is not installed for its owner. The owner resolves the copy visible from where it lands: the nearest enclosing `node_modules` (hoisted), or the nearest graph ancestor that depends on the name (isolated, one store entry per distinct peer context).
- `buffers.trees` is the hoisted layout saved in `bun.lock`: one node per `node_modules` folder, listing the edges placed in it. `build_store`'s first pass is the isolated equivalent.

<details><summary>Notes</summary>

- Ledger context: "since 1.4 `bun why` prints that nonexistent edge and omits the real one" (1.3.14 to 1.4 regression for the hoisted case, same `bun.lock` bytes), and "isolated additionally shows one peer target per package while the store materialises 2-10 peer-context copies". The companion change that makes the linkers warn about the out-of-range copy is #41936. The two are independent, and whichever lands second needs a one-line update to the `build_store` call in `served_peers` (that PR adds a parameter).
- Why not rebind `resolutions` instead: one slot per edge cannot describe an owner placed at two paths or wired in two peer contexts, and the hoister also uses that slot as "what to place when nothing on the path provides the name", so rebinding it to a deduped copy would change placement elsewhere. Reading the layout keeps `why` exact without touching install behaviour.
- The hoisted walk uses the `Resolvable` tree (what `bun.lock` records), so it includes dev and optional edges the way the rest of `why` does. An install with `--production` or `--omit` can hoist differently.
- `why`'s tree is still per package, not per placement: under `no-deps@1.0.0 > peer peer-deps` it lists every dependent of `peer-deps`, including ones whose context resolves the other copy.
- Cost: one extra pass over the tree (hoisted) or one `build_store` (isolated, the same pass every isolated install runs) per `bun why`.

</details>
