### PR TITLE
node:http2: setLocalWindowSize() grows the connection window only

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -193,6 +193,9 @@ pub trait Sink {
     fn on_headers_complete(&self, _stream_id: u32, _end_stream: bool, _flags: u8) {}
     /// A DATA payload (padding already stripped).
     fn on_data(&self, _stream_id: u32, _data: &[u8]) {}
+    /// The connection receive window changed: `size` is what the peer was given, `received`
+    /// the DATA counted against it since the last WINDOW_UPDATE.
+    fn on_recv_window(&self, _size: i64, _received: i64) {}
     /// The stream half/fully closed; `state` is the `stream::State` integer.
     fn on_stream_end(&self, _stream_id: u32, _state: u8) {}
     /// The stream was reset (inbound RST_STREAM or a local stream error). `code` is the raw
@@ -569,6 +572,7 @@ impl Connection {
     fn replenish_windows(&mut self, sink: &impl Sink) {
         if self.recv_window.needs_update() {
             let inc = self.recv_window.take_update();
+            sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
             if inc > 0 {
                 self.send_window_update(sink, 0, inc);
             }
@@ -1368,6 +1372,7 @@ impl Connection {
 
         // §6.9: the whole declared frame counts against the connection recv window on receipt.
         self.recv_window.on_data(hdr.length as i64);
+        sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,
@@ -1486,6 +1491,7 @@ impl Connection {
 
         // §6.9: the whole frame counts against the connection recv window.
         self.recv_window.on_data(consumed);
+        sink.on_recv_window(self.recv_window.size, self.recv_window.consumed);
         if self.recv_window.is_overflowed() {
             self.send_go_away(
                 sink,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1080,6 +1080,10 @@ pub struct H2FrameParser {
     /// Receive-window growth requested by setLocalWindowSize() while a dispatch held the engine
     /// borrow; applied by rewrite_read() on its next pass.
     pending_recv_window_growth: Cell<i64>,
+    /// The engine's connection receive window (size, DATA received since the last
+    /// WINDOW_UPDATE), mirrored through `Sink::on_recv_window` so `session.state` can read it
+    /// while a dispatch borrows the engine.
+    recv_window_snapshot: Cell<(i64, i64)>,
     /// Bridge: outbound DATA bytes the legacy encoder wrote since the engine last ran, applied to
     /// the engine's connection-level send window in rewrite_read (the engine cell may be borrowed
     /// when the DATA goes out). Without this the engine's window only ever grows and a compliant
@@ -1316,8 +1320,6 @@ pub struct Stream {
     weight: u16,
     // current window size for the stream
     window_size: u64,
-    // used window size for the stream
-    used_window_size: u64,
     // remote window size for the stream
     remote_window_size: u64,
     // remote used window size for the stream
@@ -1832,7 +1834,6 @@ impl Stream {
             // which is what stream.state.weight reports when no priority was signaled.
             weight: 16,
             window_size: initial_window_size as u64,
-            used_window_size: 0,
             remote_window_size: remote_window_size as u64,
             remote_used_window_size: 0,
             signal: None,
@@ -3566,6 +3567,8 @@ impl H2FrameParser {
             let pending = self.pending_recv_window_growth.replace(0);
             if pending > 0 {
                 engine.recv_window.grow(pending);
+                self.recv_window_snapshot
+                    .set((engine.recv_window.size, engine.recv_window.consumed));
             }
             // Apply outbound DATA the legacy encoder wrote since the last batch, so the engine's
             // send windows reflect what is actually in flight (§6.9.1 overflow stays peer-error
@@ -4070,6 +4073,10 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         }
     }
 
+    fn on_recv_window(&self, size: i64, received: i64) {
+        self.recv_window_snapshot.set((size, received));
+    }
+
     fn on_data(&self, stream_id: u32, data: &[u8]) {
         let g = self.global();
         let stream_ctx = self.rewrite_stream_ctx(stream_id);
@@ -4532,13 +4539,10 @@ impl H2FrameParser {
                 "Expected windowSize to be greater than usedWindowSize"
             )));
         }
+        // Only the connection window changes (nghttp2_session_set_local_window_size on stream
+        // 0). Stream windows keep SETTINGS_INITIAL_WINDOW_SIZE, the size the peer works from.
         let old_window_size = this.window_size.get();
         this.window_size.set(window_size_value as u64);
-        if this.local_settings.get().initial_window_size < window_size_value {
-            let mut s = this.local_settings.get();
-            s.initial_window_size = window_size_value;
-            this.local_settings.set(s);
-        }
         if window_size_value as u64 > old_window_size {
             let increment: u32 = (window_size_value as u64 - old_window_size) as u32;
             this.send_window_update(0, UInt31WithReserved::init(increment, false));
@@ -4549,7 +4553,11 @@ impl H2FrameParser {
             // delta keeps that path panic-free.
             match this.engine.try_borrow_mut() {
                 Ok(mut guard) => match guard.as_mut() {
-                    Some(engine) => engine.recv_window.grow(increment as i64),
+                    Some(engine) => {
+                        engine.recv_window.grow(increment as i64);
+                        this.recv_window_snapshot
+                            .set((engine.recv_window.size, engine.recv_window.consumed));
+                    }
                     None => {
                         // The engine is created lazily on the first inbound read; carry the
                         // growth forward so it applies when that happens.
@@ -4564,14 +4572,6 @@ impl H2FrameParser {
                         .set(this.pending_recv_window_growth.get() + increment as i64);
                 }
             }
-        }
-        for (_, item) in this.streams.get().iter() {
-            // SAFETY: item is &*mut Stream from streams.iter(); the boxed Stream outlives the iteration
-            let stream = unsafe { &mut **item };
-            if stream.used_window_size > window_size_value as u64 {
-                continue;
-            }
-            stream.window_size = window_size_value as u64;
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -4606,6 +4606,10 @@ impl H2FrameParser {
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let result = JSValue::create_empty_object(global_object, 9);
+        // node: localWindowSize is the window the peer was given (it never shrinks) minus the
+        // DATA received since the last WINDOW_UPDATE, effectiveRecvDataLength is that amount.
+        let (snapshot_size, received_since_update) = this.recv_window_snapshot.get();
+        let advertised_window = snapshot_size + this.pending_recv_window_growth.get();
         result.put(
             global_object,
             b"effectiveLocalWindowSize",
@@ -4614,7 +4618,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"effectiveRecvDataLength",
-            JSValue::js_number((this.window_size.get() - this.used_window_size.get()) as f64),
+            JSValue::js_number(received_since_update as f64),
         );
         result.put(
             global_object,
@@ -4629,7 +4633,6 @@ impl H2FrameParser {
 
         let settings = this.remote_settings.get().unwrap_or_default();
         let remote_iws = settings.initial_window_size;
-        let local_iws = this.local_settings.get().initial_window_size;
         let local_hts = this.local_settings.get().header_table_size;
         result.put(
             global_object,
@@ -4639,7 +4642,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"localWindowSize",
-            JSValue::js_number(local_iws as f64),
+            JSValue::js_number((advertised_window - received_since_update) as f64),
         );
         result.put(
             global_object,
@@ -7580,6 +7583,7 @@ impl H2FrameParser {
             max_header_list_pairs: Cell::new(128),
             max_settings: Cell::new(32),
             pending_recv_window_growth: Cell::new(0),
+            recv_window_snapshot: Cell::new((DEFAULT_WINDOW_SIZE as i64, 0)),
             pending_send_window_consumed: Cell::new(0),
             pending_stream_send_consumed: JsCell::new(Vec::new()),
             pending_engine_stream_closes: JsCell::new(Vec::new()),

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6009,3 +6009,111 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+// session.setLocalWindowSize() grows the connection window only (nghttp2_session_set_local_window_size
+// on stream 0). Stream windows keep SETTINGS_INITIAL_WINDOW_SIZE, so a transfer larger than that
+// still gets its stream-level WINDOW_UPDATEs and finishes.
+describe("session.setLocalWindowSize()", () => {
+  async function download(windowSize, bodySize) {
+    const server = http2.createServer((req, res) => res.end(Buffer.alloc(bodySize, 97)));
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      try {
+        await new Promise(resolve => client.once("connect", resolve));
+        if (windowSize !== undefined) client.setLocalWindowSize(windowSize);
+        const stateAfterCall = client.state;
+        const req = client.request({ ":path": "/" });
+        let received = 0;
+        let streamState;
+        let stateAtEnd;
+        const { promise, resolve, reject } = Promise.withResolvers();
+        req.on("response", () => (streamState = req.state));
+        req.on("data", chunk => (received += chunk.length));
+        req.on("error", reject);
+        req.on("end", () => {
+          stateAtEnd = client.state;
+          resolve();
+        });
+        await promise;
+        return { received, stateAfterCall, streamState, stateAtEnd };
+      } finally {
+        client.destroy();
+      }
+    } finally {
+      server.close();
+    }
+  }
+
+  it("client: a download larger than the initial stream window completes", async () => {
+    const { received, stateAfterCall, streamState } = await download(1 << 20, 2 * 1048576);
+    expect(received).toBe(2 * 1048576);
+    expect(stateAfterCall).toMatchObject({
+      effectiveLocalWindowSize: 1 << 20,
+      localWindowSize: 1 << 20,
+      effectiveRecvDataLength: 0,
+      remoteWindowSize: 65535,
+    });
+    // The stream window is still the SETTINGS value, like node.
+    expect(streamState.localWindowSize).toBe(65535);
+  });
+
+  it("server: an upload larger than the initial stream window completes", async () => {
+    const server = http2.createServer();
+    server.on("session", session => session.setLocalWindowSize(1 << 20));
+    server.on("stream", stream => {
+      let received = 0;
+      stream.on("data", chunk => (received += chunk.length));
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end(String(received));
+      });
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      try {
+        const req = client.request({ ":method": "POST", ":path": "/" });
+        const { promise, resolve, reject } = Promise.withResolvers();
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", chunk => (body += chunk));
+        req.on("error", reject);
+        req.on("end", resolve);
+        const chunk = Buffer.alloc(65536, 1);
+        for (let sent = 0; sent < 2 * 1048576; sent += chunk.length) {
+          if (!req.write(chunk)) await new Promise(drained => req.once("drain", drained));
+        }
+        req.end();
+        await promise;
+        expect(body).toBe(String(2 * 1048576));
+      } finally {
+        client.destroy();
+      }
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a smaller size keeps the window the peer already has", async () => {
+    const { received, stateAfterCall } = await download(20, 100000);
+    expect(received).toBe(100000);
+    expect(stateAfterCall).toMatchObject({ effectiveLocalWindowSize: 20, localWindowSize: 65535 });
+  });
+
+  it("state counts received DATA against the connection window", async () => {
+    const { stateAfterCall, stateAtEnd } = await download(undefined, 1000);
+    expect(stateAfterCall).toMatchObject({
+      effectiveLocalWindowSize: 65535,
+      localWindowSize: 65535,
+      effectiveRecvDataLength: 0,
+    });
+    // Read from inside the 'end' handler: 1000 bytes received and no WINDOW_UPDATE sent yet (below
+    // half the window), so the peer's remaining connection window is 65535 - 1000.
+    expect(stateAtEnd).toMatchObject({
+      effectiveLocalWindowSize: 65535,
+      localWindowSize: 64535,
+      effectiveRecvDataLength: 1000,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `session.setLocalWindowSize(n)` stalls every transfer at 65,535 bytes, on a client (download) and on a server (upload). The peer never receives a stream-level WINDOW_UPDATE, so it blocks on the stream flow-control window. node v26 completes the same 2 MB transfer in about 10 ms.
- The cause is `set_local_window_size` (`src/runtime/api/bun/h2_frame_parser.rs:4535` on main). Besides the connection window it raised `local_settings.initial_window_size` to `n`. The engine sizes each new stream's receive window from that value and sends a stream WINDOW_UPDATE only once half of it is consumed (512 KB). The peer still works from the SETTINGS value (65,535) and stops there.
- `session.state` was also wrong: `effectiveRecvDataLength` reported `window - used` (1,048,576 right after the call, node: 0) and `localWindowSize` reported the SETTINGS value.

### Fix
- `setLocalWindowSize()` changes the connection window only, like `nghttp2_session_set_local_window_size` on stream 0. Stream windows keep `SETTINGS_INITIAL_WINDOW_SIZE`. The dead per-stream `used_window_size` field goes away.
- `session.state` reads the engine's connection receive window through a new `Sink::on_recv_window` hook that mirrors `(size, received)` into the parser, so the getter also works while a dispatch borrows the engine. `localWindowSize` is the window the peer was given minus the DATA since the last WINDOW_UPDATE, and `effectiveRecvDataLength` is that DATA, as in node.
- Verified: `test/js/node/http2/node-http2.test.js` (4 new tests, 3 fail on bun 1.4.3: the client download, the server upload, and the state counters). Also the rest of `test/js/node/http2/` and node's 256 `test-http2-*.js` files.

### Background
- HTTP/2 has two receive windows per direction: one for the connection and one per stream (RFC 9113 §6.9). A sender stops when either reaches zero. The receiver reopens them with WINDOW_UPDATE frames, connection-level on stream 0 and stream-level on the stream id.
- The stream window starts at `SETTINGS_INITIAL_WINDOW_SIZE` (65,535 unless a SETTINGS frame says otherwise). `setLocalWindowSize()` in node maps to `nghttp2_session_set_local_window_size(session, NGHTTP2_FLAG_NONE, 0, size)`, which sends one WINDOW_UPDATE on stream 0 and leaves the setting alone.
- The inbound side of bun's http2 runs through the engine in `src/runtime/api/bun/h2/connection.rs`. Its `RecvWindow` sends a WINDOW_UPDATE once half the window is consumed. The parser talks to it through the `Sink` trait.

<details><summary>Notes</summary>

Repro (client side, from the report):

```js
import http2 from "node:http2";
const srv = http2.createServer((req, res) => res.end(Buffer.alloc(2 * 1048576, 97)));
srv.listen(0, () => {
  const s = http2.connect("http://127.0.0.1:" + srv.address().port);
  s.on("connect", () => {
    s.setLocalWindowSize(1 << 20);
    const r = s.request({ ":path": "/" }); let n = 0;
    r.on("data", d => n += d.length); r.on("end", () => { console.log("end bytes=", n); s.close(); srv.close(); });
    setTimeout(() => { console.log("STALLED bytes=", n, JSON.stringify(r.state)); process.exit(3); }, 5000);
  });
});
```

bun 1.4.3: `STALLED bytes= 65535 {"localWindowSize":65535,"state":5,...}`. This branch: `end bytes= 2097152`.

The server-side shape (`server.on("session", s => s.setLocalWindowSize(1 << 20))` with a 2 MB upload) stalls the same way on 1.4.3 and completes here. Calling it inside the `'stream'` handler always worked, because the stream already existed with the 65,535 window.

`session.state` after `settings({ initialWindowSize: 1 << 20 })` then `setLocalWindowSize(1 << 21)` and a 200,000 byte download, node v26 vs this branch:

```
node: {"effectiveLocalWindowSize":2097152,"effectiveRecvDataLength":200000,"localWindowSize":1897152,...}
bun:  {"effectiveLocalWindowSize":2097152,"effectiveRecvDataLength":200000,"localWindowSize":1897152,...}
```

`remoteWindowSize`, `deflateDynamicTableSize` and `inflateDynamicTableSize` keep their current approximations. They are not part of this fix.

Suites run with the debug build: `test/js/node/http2/` (503 pass, 6 skip), node's `test-http2-*.js` (256 pass), including `test-http2-client-setLocalWindowSize.js`, `test-http2-server-setLocalWindowSize.js`, `test-http2-window-size.js` and the misbehaving-flow-control tests.
</details>
