### PR TITLE
docs(HTMLRewriter): warn that unwrapping or renaming a raw-text element exposes its text as markup

### DIFF
--- a/docs/runtime/html-rewriter.mdx
+++ b/docs/runtime/html-rewriter.mdx
@@ -262,6 +262,24 @@ rewriter.on("div", {
 });
 ```
 
+<Warning>
+`removeAndKeepContent()` and assigning `tagName` rewrite the element's own tags only. The contents stream through unchanged and are not re-parsed. This matters for elements whose contents are text to the HTML parser, not markup: `<script>`, `<style>`, `<textarea>`, `<title>`, `<noscript>`, `<iframe>`, `<xmp>`, `<noembed>`, `<noframes>` and `<plaintext>`. Once such an element is unwrapped, or renamed to an ordinary element like `<div>`, a browser parses its former text as markup.
+
+```ts
+new HTMLRewriter()
+  .on("textarea", {
+    element(el) {
+      el.removeAndKeepContent();
+    },
+  })
+  .transform('<textarea><img src=x onerror="alert(1)"></textarea>');
+// => '<img src=x onerror="alert(1)">', a live element rather than text
+```
+
+An allowlist-based sanitizer should `remove()` these elements instead of unwrapping them. To keep the text, add a `text` handler on the same selector and call `text.replace(text.text)`. A replacement without `{ html: true }` is escaped on output.
+
+</Warning>
+
 ### Text Operations
 
 Text chunks represent portions of text content and report their position in the text node:

--- a/packages/bun-types/html-rewriter.d.ts
+++ b/packages/bun-types/html-rewriter.d.ts
@@ -70,7 +70,16 @@ declare namespace HTMLRewriterTypes {
   }
 
   interface Element {
-    /** The tag name in lowercase (e.g. "div", "span") */
+    /**
+     * The tag name in lowercase (e.g. "div", "span").
+     *
+     * Assigning a new name rewrites the start and end tags only. The
+     * contents are not re-parsed, so the new name should have the same
+     * content model as the old one. Renaming a `<script>`, `<style>`,
+     * `<textarea>`, `<title>` or other raw-text element to an ordinary
+     * element such as `<div>` makes a browser parse its former text
+     * contents as markup. The reverse turns child markup into text.
+     */
     tagName: string;
     /** Iterator for the element's attributes */
     readonly attributes: IterableIterator<[string, string]>;
@@ -106,7 +115,19 @@ declare namespace HTMLRewriterTypes {
     replace(content: Content, options?: ContentOptions): Element;
     /** Remove this element and its contents */
     remove(): Element;
-    /** Remove this element but keep its contents */
+    /**
+     * Remove this element's start and end tags but keep its contents.
+     *
+     * The contents are written out unchanged. Some elements hold text that
+     * the HTML parser does not read as markup: `<script>`, `<style>`,
+     * `<textarea>`, `<title>`, `<noscript>`, `<iframe>`, `<xmp>`,
+     * `<noembed>`, `<noframes>` and `<plaintext>`. Once the tags are gone,
+     * a browser parses that text as markup. For example, unwrapping
+     * `<textarea><img src=x onerror="..."></textarea>` yields a live
+     * `<img>`. A sanitizer should {@link Element.remove | remove()} these
+     * elements, or escape their text in a `text` handler, rather than
+     * unwrap them.
+     */
     removeAndKeepContent(): Element;
     /** Set the inner content of this element */
     setInnerContent(content: Content, options?: ContentOptions): Element;

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2876,6 +2876,76 @@ describe("tagName, endTag.name, and comment.text setters", () => {
   });
 });
 
+// The documented contract (packages/bun-types/html-rewriter.d.ts,
+// docs/runtime/html-rewriter.mdx): unwrapping or renaming rewrites the
+// element's own tags only. The contents of a raw-text element are not
+// re-parsed or escaped, and the documented text-handler recipe is what
+// escapes them.
+describe("raw-text element contents pass through removeAndKeepContent and tagName unchanged", () => {
+  const unwrap = selector =>
+    new HTMLRewriter().on(selector, {
+      element(el) {
+        el.removeAndKeepContent();
+      },
+    });
+
+  it("removeAndKeepContent emits RCDATA, RAWTEXT and script contents verbatim", () => {
+    expect({
+      textarea: unwrap("textarea").transform("<textarea><script>alert(1)</script></textarea><p>n</p>"),
+      style: unwrap("style").transform(`<div><style>a{content:'</sty'}</style><i>x</i></div>`),
+      noscript: unwrap("noscript").transform('<noscript><img src="a.png"></noscript>'),
+      script: unwrap("script").transform('<script>if(a<b)document.write("<p id=9>")</script>'),
+    }).toEqual({
+      textarea: "<script>alert(1)</script><p>n</p>",
+      style: `<div>a{content:'</sty'}<i>x</i></div>`,
+      noscript: '<img src="a.png">',
+      script: 'if(a<b)document.write("<p id=9>")',
+    });
+  });
+
+  it("tagName assignment does not re-parse or escape the contents", () => {
+    const out = new HTMLRewriter()
+      .on("script", {
+        element(el) {
+          el.tagName = "div";
+        },
+      })
+      .transform('<script>if(a<b)document.write("<p id=9>")</script>');
+    expect(out).toBe('<div>if(a<b)document.write("<p id=9>")</div>');
+  });
+
+  it("a text handler on the same selector escapes the kept contents", () => {
+    // text.replace(text.text) re-emits each chunk as text, which escapes <, > and &.
+    const escaped = new HTMLRewriter()
+      .on("style, textarea", {
+        element(el) {
+          el.removeAndKeepContent();
+        },
+        text(t) {
+          if (!t.removed && t.text) t.replace(t.text);
+        },
+      })
+      .transform(
+        `<style>p{content:"</sty"} b &amp; c</style><textarea><img src=x onerror="alert(1)"></textarea><p>n</p>`,
+      );
+    expect(escaped).toBe(`p{content:"&lt;/sty"} b &amp;amp; c&lt;img src=x onerror="alert(1)"&gt;<p>n</p>`);
+
+    // For RCDATA (textarea, title) entities are already live, so escaping "<" alone
+    // with { html: true } matches what the DOM would serialize.
+    const rcdata = new HTMLRewriter()
+      .on("textarea, title", {
+        element(el) {
+          el.removeAndKeepContent();
+        },
+        text(t) {
+          if (!t.removed) t.replace(t.text.replaceAll("<", "&lt;"), { html: true });
+        },
+      })
+      .transform('<title>a &amp; b <i>x</i></title><textarea><img src=x onerror="alert(1)"></textarea>');
+    expect(rcdata).toBe('a &amp; b &lt;i>x&lt;/i>&lt;img src=x onerror="alert(1)">');
+  });
+});
+
 // `transform(await fetch(url)).text()` never stores the output Response, and
 // the upstream ByteStream dispatches in via a SinkHandle raw pointer between
 // event-loop turns, so the input source's `sinkOwner` slot is what keeps the


### PR DESCRIPTION
### Problem
- `element.removeAndKeepContent()` and `element.tagName = "..."` rewrite the element's own tags only. The contents stream through unchanged. For `<script>`, `<style>`, `<textarea>`, `<title>`, `<noscript>`, `<iframe>`, `<xmp>`, `<noembed>`, `<noframes>` and `<plaintext>` the contents are text to the parser, not markup. Once the tags are gone, a browser parses that text as markup: `rw("textarea").transform('<textarea><script>alert(1)</script></textarea>')` yields a live `<script>`.
- This is lol-html's contract (`remove_and_keep_content` is "remove start and end tags", and `set_tag_name` says the new name "must have the same content model"). Workers behaves the same. Bun's types and docs said nothing, and allowlist sanitizers that unwrap unknown tags hit it as a stored-XSS bypass unless they drop every raw-text element.

### Fix
- Document the hazard on `Element.tagName` and `Element.removeAndKeepContent()` in `packages/bun-types/html-rewriter.d.ts`, and in a warning block under Element Operations in `docs/runtime/html-rewriter.mdx`, with the two safe alternatives: `remove()` the element, or escape its text in a `text` handler (`text.replace(text.text)`).
- No behavior change. Escaping the pass-through text by default would diverge from Workers and break the `<noscript>` unwrap pattern (no-JS page variants), which relies on the contents becoming live markup.
- Verified: `test/js/workerd/html-rewriter.test.js` gains a block that pins this contract (contents pass through verbatim for textarea/style/noscript/script, `tagName` does not re-parse) and checks both documented text-handler recipes. `bun test test/integration/bun-types/bun-types.test.ts` still compiles the types.

### Background
- `HTMLRewriter` is a streaming token rewriter (lol-html), not a DOM. An element handler sees the start tag. The bytes between the tags are tokenized in whatever mode that start tag selected (RCDATA for textarea/title, RAWTEXT for style/noscript/xmp/..., script data for script) and are copied to the output as-is unless a `text` handler replaces them.
- The DOM equivalent of unwrap, `el.replaceWith(...el.childNodes)`, keeps that content a text node, so it serializes escaped. The streaming rewriter has no such step.

<details><summary>Notes</summary>

Repros on bun 1.4.3 (main @ 333863f5d1):

```js
const rw = s => new HTMLRewriter().on(s, { element(e) { e.removeAndKeepContent(); } });
rw("textarea").transform('<textarea><script>alert(1)</script></textarea><p>n</p>');
// -> <script>alert(1)</script><p>n</p>
rw("style").transform(`<div><style>a{content:'</sty'}</style><i>x</i></div>`);
// -> <div>a{content:'</sty'}<i>x</i></div>   (browser reads "</sty'}<i>" as one bogus end tag)
new HTMLRewriter().on("script",{element(e){e.tagName="div"}}).transform('<script>if(a<b)document.write("<p id=9>")</script>');
// -> <div>if(a<b)document.write("<p id=9>")</div>
```

Workarounds that work today:

```js
// RAWTEXT/script (style, xmp, noscript, ...): escape <, > and &
.on("style", { element(e){ e.removeAndKeepContent(); }, text(t){ if (!t.removed && t.text) t.replace(t.text); } })
// RCDATA (textarea, title): entities are already live, escape "<" only for an exact DOM match
.on("textarea, title", { element(e){ e.removeAndKeepContent(); }, text(t){ if (!t.removed) t.replace(t.text.replaceAll("<", "&lt;"), { html: true }); } })
```

If escape-by-default is wanted later, the change belongs in the oven-sh/lol-html fork: when `remove_and_keep_content` or a content-model-changing `set_tag_name` runs on a raw-text element, force `TokenCaptureFlags::TEXT` until its end tag and escape unmutated chunks on serialization (`<` for `TextType::RCData`, `<` and `&` for `RawText`/`ScriptData`/`PlainText`).

</details>
