### PR TITLE
bake: dispose a self-accepting HMR boundary once per hot update

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -616,7 +616,8 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   const toReload = new Set<HMRModule>();
   const toAccept: ToAccept[] = [];
   let failures: Set<Id> | null = null;
-  const toDispose: HMRModule[] = [];
+  /** A boundary that several keys of `modules` reach is disposed once. */
+  const toDispose = new Set<HMRModule>();
 
   // Discover all HMR boundaries
   outer: for (const key of Object.keys(modules)) {
@@ -648,7 +649,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         visited.add(mod);
         hadSelfAccept = false;
         if (mod.onDispose) {
-          toDispose.push(mod);
+          toDispose.add(mod);
         }
       }
       // Modules that mutate data are implied to handle updates via reusing their `data` property
@@ -658,7 +659,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         visited.add(mod);
         hadSelfAccept = false;
         if (mod.onDispose) {
-          toDispose.push(mod);
+          toDispose.add(mod);
         }
       }
 
@@ -733,7 +734,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   }
 
   // Dispose all modules
-  if (toDispose.length > 0) {
+  if (toDispose.size > 0) {
     const disposePromises: Promise<void>[] = [];
     for (const mod of toDispose) {
       mod.state = State.Stale;

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -388,6 +388,44 @@ devTest("import.meta.hot.dispose cleanup", {
     await c.expectMessage("Cleaning up", "Third setup");
   },
 });
+devTest("import.meta.hot.dispose runs once when one update changes several imported files", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { a } from "./a";
+      import { b } from "./b";
+
+      const n = (import.meta.hot.data.n = (import.meta.hot.data.n ?? 0) + 1);
+      globalThis.state = { n, a, b };
+      console.log("eval " + n);
+
+      import.meta.hot.dispose(() => {
+        console.log("dispose " + n);
+      });
+      import.meta.hot.accept();
+    `,
+    "a.ts": `export const a = "a1";`,
+    "b.ts": `export const b = "b1";`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("eval 1");
+
+    // Both files land in one hot update, and both reach the same boundary.
+    {
+      await using batch = await dev.batchChanges();
+      await dev.write("a.ts", `export const a = "a2";`);
+      await dev.write("b.ts", `export const b = "b2";`);
+    }
+    await c.expectMessage("dispose 1", "eval 2");
+
+    await dev.write("a.ts", `export const a = "a3";`);
+    await c.expectMessage("dispose 2", "eval 3");
+    expect(await c.js`globalThis.state`).toEqual({ n: 3, a: "a3", b: "b2" });
+  },
+});
 devTest("import.meta.hot invalid usage", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
### Problem
- In the dev server, a self-accepting module that registered `import.meta.hot.dispose(cb)` breaks any hot update whose payload carries two or more modules that reach it. The HMR runtime throws `TypeError: mod.onDispose is not iterable` in `replaceModules`, logs it, and does a full page reload. Page state and `import.meta.hot.data` are lost. Triggers: two imports saved together, editing an imported JSON file (the payload carries the importer too), a plugin that emits several records per file (#29418, svelte).
- Cause: `replaceModules` (`src/runtime/bake/hmr-module.ts:622`) walks importers once per payload key with a per-key `visited` set, and `toDispose` was a plain array. A boundary reached from two keys was pushed twice. The first dispose pass ran the callbacks and set `mod.onDispose = null`, the second iterated `null`.

### Fix
- `toDispose` becomes a `Set<HMRModule>`, like `toReload` next to it. A boundary is disposed once per update no matter how many payload keys reach it. Which importers are walked and when a root triggers a reload is unchanged.
- Verified: `test/bake/dev/hot.test.ts` ("import.meta.hot.dispose runs once when one update changes several imported files") fails on bun 1.4.3-canary and without the `src/` change (`TypeError: mod.onDispose is not iterable`, client exits), passes with it. All of `hot.test.ts` and `esm.test.ts` pass on the debug build.

### Background
- `replaceModules` applies one hot update on the client. For each changed module it walks up the importer graph until it finds a boundary: a module that called `import.meta.hot.accept()` or used `import.meta.hot.data`. Boundaries are re-evaluated; their `dispose` callbacks run first.
- One update payload can carry several changed modules. The dev server batches file events, and some edits re-emit importers along with the changed file.

Fixes #29418

<details><summary>Notes</summary>

- The same change was part of #37773, closed in favor of the consolidation PR #39488, which rewrites this function and also disposes once. #39488 has not landed, so the bug is still on main and in 1.4.x. This PR is the standalone fix; it conflicts trivially with #39488 (which deletes `toDispose`).
- Separate and not changed here: when one payload carries a boundary's dependency after the boundary (or two dependencies of one boundary), the boundary re-evaluates before the later module reloads and reads its previous copy. #31944 fixes that ordering together with stale CommonJS/JSON exports. The new test asserts dependency values only after a later single-file update so it holds with or without #31944.
- `import.meta.hot.on()` registers its cleanup through `dispose()`, so modules using `on()` plus `accept()` hit the same reload.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->