### PR TITLE
fuzzilli: give the event loop one turn after each REPRL script

### DIFF
--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -17,8 +17,7 @@ globalThis.__filename = "/fuzzilli.js";
 // child, so fuzzed scripts must not be able to reach the real implementation.
 process.execve = () => {};
 
-// Everything the loop calls between scripts is captured here, because fuzzed
-// scripts overwrite globals and prototype methods.
+// Captured up front: fuzzed scripts overwrite globals and prototype methods.
 const { String, setTimeout, setInterval, setImmediate, clearTimeout, clearInterval, clearImmediate } = globalThis;
 const { apply } = Reflect;
 const { forEach: mapForEach, set: mapSet, clear: mapClear } = Map.prototype;
@@ -27,8 +26,7 @@ const addListener = process.on.bind(process);
 const removeListener = process.off.bind(process);
 const exit = process.exit.bind(process);
 
-// Print uncaught exception like workerd does. The thrown value comes from
-// fuzzed code, so converting it to a string can itself throw.
+// Print uncaught exception like workerd does. String(err) can throw.
 function reportUncaught(err) {
   try {
     print(`uncaught:${String(err)}`);
@@ -37,11 +35,8 @@ function reportUncaught(err) {
   }
 }
 
-// The loop gives the event loop a turn after every script, so promise
-// reactions and timer callbacks from fuzzed code do run. Without these
-// handlers the first unhandled rejection or async throw would exit the REPRL
-// child. Record it as a failed execution instead. A script can remove the
-// handlers, so they are installed again before every script.
+// An async throw or unhandled rejection fails the execution instead of
+// exiting the child. Installed before every script: scripts can remove them.
 let asyncFailure = false;
 const onAsyncFailure = err => {
   asyncFailure = true;
@@ -54,9 +49,8 @@ function installAsyncFailureHandlers() {
   addListener("unhandledRejection", onAsyncFailure);
 }
 
-// Timers that a script leaves behind would fire during later scripts. Track
-// the ones created through the globals and clear them once the script's
-// status is known.
+// Timers a script leaves behind are cleared so they do not fire during later
+// scripts.
 const pendingTimers = new Map();
 function tracked(set, clear) {
   return function () {
@@ -98,11 +92,8 @@ if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
 }
 
-// Main REPRL loop. Each iteration ends by scheduling the next one with
-// setImmediate, which gives the event loop one non-blocking turn per script:
-// it drains the microtasks the script queued (otherwise they, and everything
-// they capture, stay in the queue for the lifetime of this process), fires due
-// timers, and reaps subprocesses that have exited.
+// Main REPRL loop. setImmediate between scripts gives the event loop one
+// non-blocking turn: microtasks drain, due timers fire, exited children reap.
 function runNextScript() {
   // Read command
   const cmd = Buffer.alloc(4);

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -17,19 +17,61 @@ globalThis.__filename = "/fuzzilli.js";
 // child, so fuzzed scripts must not be able to reach the real implementation.
 process.execve = () => {};
 
-// The loop below yields to the event loop after every script, so promise
+// Everything the loop calls between scripts is captured here, because fuzzed
+// scripts overwrite globals and prototype methods.
+const { String, setTimeout, setInterval, setImmediate, clearTimeout, clearInterval, clearImmediate } = globalThis;
+const { apply } = Reflect;
+const { forEach: mapForEach, set: mapSet, clear: mapClear } = Map.prototype;
+const print = console.log.bind(console);
+const addListener = process.on.bind(process);
+const removeListener = process.off.bind(process);
+const exit = process.exit.bind(process);
+
+// Print uncaught exception like workerd does. The thrown value comes from
+// fuzzed code, so converting it to a string can itself throw.
+function reportUncaught(err) {
+  try {
+    print(`uncaught:${String(err)}`);
+  } catch {
+    print("uncaught:<unprintable>");
+  }
+}
+
+// The loop gives the event loop a turn after every script, so promise
 // reactions and timer callbacks from fuzzed code do run. Without these
 // handlers the first unhandled rejection or async throw would exit the REPRL
-// child. Record it as a failed execution instead.
+// child. Record it as a failed execution instead. A script can remove the
+// handlers, so they are installed again before every script.
 let asyncFailure = false;
 const onAsyncFailure = err => {
-  console.log(`uncaught:${err}`);
   asyncFailure = true;
+  reportUncaught(err);
 };
-process.on("uncaughtException", onAsyncFailure);
-process.on("unhandledRejection", onAsyncFailure);
+function installAsyncFailureHandlers() {
+  removeListener("uncaughtException", onAsyncFailure);
+  removeListener("unhandledRejection", onAsyncFailure);
+  addListener("uncaughtException", onAsyncFailure);
+  addListener("unhandledRejection", onAsyncFailure);
+}
 
-const { setImmediate } = globalThis;
+// Timers that a script leaves behind would fire during later scripts. Track
+// the ones created through the globals and clear them once the script's
+// status is known.
+const pendingTimers = new Map();
+function tracked(set, clear) {
+  return function () {
+    const timer = apply(set, this, arguments);
+    apply(mapSet, pendingTimers, [timer, clear]);
+    return timer;
+  };
+}
+globalThis.setTimeout = tracked(setTimeout, clearTimeout);
+globalThis.setInterval = tracked(setInterval, clearInterval);
+globalThis.setImmediate = tracked(setImmediate, clearImmediate);
+function clearPendingTimers() {
+  apply(mapForEach, pendingTimers, [(clear, timer) => clear(timer)]);
+  apply(mapClear, pendingTimers, []);
+}
 
 // ============================================================================
 // REPRL Protocol Loop
@@ -56,19 +98,24 @@ if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
 }
 
-// Main REPRL loop
-while (true) {
+// Main REPRL loop. Each iteration ends by scheduling the next one with
+// setImmediate, which gives the event loop one non-blocking turn per script:
+// it drains the microtasks the script queued (otherwise they, and everything
+// they capture, stay in the queue for the lifetime of this process), fires due
+// timers, and reaps subprocesses that have exited.
+function runNextScript() {
   // Read command
   const cmd = Buffer.alloc(4);
   const cmd_n = fs.readSync(REPRL_CRFD, cmd, 0, 4, null);
 
   if (cmd_n === 0) {
     // EOF
-    break;
+    return exit(0);
   }
 
   if (cmd_n !== 4 || cmd.toString() !== "exec") {
-    throw new Error(`Invalid REPRL command: expected 'exec', got ${cmd.toString()}`);
+    console.error(`Invalid REPRL command: expected 'exec', got ${cmd.toString()}`);
+    return exit(1);
   }
 
   // Read script size (8 bytes, little-endian)
@@ -89,20 +136,20 @@ while (true) {
 
   // Execute script
   let exit_code = 0;
+  installAsyncFailureHandlers();
   try {
     // Use indirect eval to execute in global scope
     (0, eval)(script);
   } catch (_e) {
-    // Print uncaught exception like workerd does
-    console.log(`uncaught:${_e}`);
+    reportUncaught(_e);
     exit_code = 1;
   }
 
-  // One non-blocking turn of the event loop before reporting: drains the
-  // microtasks the script queued (otherwise they, and everything they
-  // capture, stay in the queue for the lifetime of this process) and reaps
-  // subprocesses that have exited.
-  await new Promise(resolve => setImmediate(resolve));
+  setImmediate(finishScript, exit_code);
+}
+
+function finishScript(exit_code) {
+  clearPendingTimers();
   if (asyncFailure) {
     asyncFailure = false;
     exit_code = 1;
@@ -116,4 +163,7 @@ while (true) {
   fs.writeSync(REPRL_CWFD, status_bytes);
 
   resetCoverage();
+  runNextScript();
 }
+
+setImmediate(runNextScript);

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -17,6 +17,20 @@ globalThis.__filename = "/fuzzilli.js";
 // child, so fuzzed scripts must not be able to reach the real implementation.
 process.execve = () => {};
 
+// The loop below yields to the event loop after every script, so promise
+// reactions and timer callbacks from fuzzed code do run. Without these
+// handlers the first unhandled rejection or async throw would exit the REPRL
+// child. Record it as a failed execution instead.
+let asyncFailure = false;
+const onAsyncFailure = err => {
+  console.log(`uncaught:${err}`);
+  asyncFailure = true;
+};
+process.on("uncaughtException", onAsyncFailure);
+process.on("unhandledRejection", onAsyncFailure);
+
+const { setImmediate } = globalThis;
+
 // ============================================================================
 // REPRL Protocol Loop
 // ============================================================================
@@ -81,6 +95,16 @@ while (true) {
   } catch (_e) {
     // Print uncaught exception like workerd does
     console.log(`uncaught:${_e}`);
+    exit_code = 1;
+  }
+
+  // One non-blocking turn of the event loop before reporting: drains the
+  // microtasks the script queued (otherwise they, and everything they
+  // capture, stay in the queue for the lifetime of this process) and reaps
+  // subprocesses that have exited.
+  await new Promise(resolve => setImmediate(resolve));
+  if (asyncFailure) {
+    asyncFailure = false;
     exit_code = 1;
   }
 

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -35,8 +35,7 @@ function reportUncaught(err) {
   }
 }
 
-// An async throw or unhandled rejection fails the execution instead of
-// exiting the child. Installed before every script: scripts can remove them.
+// Async failures fail the execution instead of exiting the child.
 let asyncFailure = false;
 const onAsyncFailure = err => {
   asyncFailure = true;
@@ -49,8 +48,7 @@ function installAsyncFailureHandlers() {
   addListener("unhandledRejection", onAsyncFailure);
 }
 
-// Timers a script leaves behind are cleared so they do not fire during later
-// scripts.
+// Timers a script leaves behind must not fire during later scripts.
 const pendingTimers = new Map();
 function tracked(set, clear) {
   return function () {
@@ -92,8 +90,7 @@ if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
 }
 
-// Main REPRL loop. setImmediate between scripts gives the event loop one
-// non-blocking turn: microtasks drain, due timers fire, exited children reap.
+// Main REPRL loop. setImmediate gives the event loop one turn per script.
 function runNextScript() {
   // Read command
   const cmd = Buffer.alloc(4);

--- a/test/js/bun/util/fuzzilli-reprl.fixture.ts
+++ b/test/js/bun/util/fuzzilli-reprl.fixture.ts
@@ -3,10 +3,10 @@
 // normal (non-fuzzilli) build.
 //
 // argv[2] is a JSON array of payload scripts. Each one is fed to the loop as
-// one exec cycle, then the control pipe reports EOF. When the loop finishes,
-// the fixture prints one `REPRL_FIXTURE_RESULT=` line with the status the
-// loop wrote for each payload and the value of `globalThis.probe` at the time
-// of each status write.
+// one exec cycle, then the control pipe reports EOF, on which the loop exits
+// the process. On exit the fixture prints one `REPRL_FIXTURE_RESULT=` line
+// with the status the loop wrote for each payload and the value of
+// `globalThis.probe` at the time of each status write.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -63,7 +63,7 @@ const realWriteSync = fs.writeSync;
   if (fd === REPRL_CWFD) {
     if (Buffer.isBuffer(buffer) && buffer.length === 4 && buffer.toString() !== "HELO") {
       statuses.push(buffer.readUInt32LE(0));
-      probes.push((globalThis as any).probe ?? null);
+      probes.push(structuredClone((globalThis as any).probe ?? null));
     }
     return Buffer.isBuffer(buffer) ? buffer.length : String(buffer).length;
   }
@@ -73,9 +73,8 @@ const realWriteSync = fs.writeSync;
 (globalThis as any).resetCoverage = () => {};
 (globalThis as any).require = require;
 
-// The loop runs until the control pipe reports EOF. The source uses top-level
-// await, so importing it waits for the loop to finish.
-await import(path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts"));
+process.on("exit", () => {
+  realWriteSync.call(fs, 1, `REPRL_FIXTURE_RESULT=${JSON.stringify({ statuses, probes })}\n`);
+});
 
-realWriteSync.call(fs, 1, `REPRL_FIXTURE_RESULT=${JSON.stringify({ statuses, probes })}\n`);
-process.exit(0);
+await import(path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts"));

--- a/test/js/bun/util/fuzzilli-reprl.fixture.ts
+++ b/test/js/bun/util/fuzzilli-reprl.fixture.ts
@@ -1,9 +1,12 @@
 // Drives the fuzzilli REPRL loop with in-process mocks for the control/data
 // FDs so the real src/js/eval/fuzzilli-reprl.ts source can be exercised in a
-// normal (non-fuzzilli) build. Feeds a payload that calls process.execve with
-// a nonexistent path: the real implementation prints an error and aborts the
-// process (SIGABRT) when exec fails, so the REPRL wrapper must stub it out
-// before running fuzzed scripts.
+// normal (non-fuzzilli) build.
+//
+// argv[2] is a JSON array of payload scripts. Each one is fed to the loop as
+// one exec cycle, then the control pipe reports EOF. When the loop finishes,
+// the fixture prints one `REPRL_FIXTURE_RESULT=` line with the status the
+// loop wrote for each payload and the value of `globalThis.probe` at the time
+// of each status write.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -12,10 +15,7 @@ const REPRL_CRFD = 100;
 const REPRL_CWFD = 101;
 const REPRL_DRFD = 102;
 
-const payloads = [
-  Buffer.from(`process.execve("fuzzilli-reprl-execve-does-not-exist", []);`, "utf8"),
-  Buffer.from(`globalThis.stillAlive = true;`, "utf8"),
-];
+const payloads = (JSON.parse(process.argv[2]) as string[]).map(source => Buffer.from(source, "utf8"));
 
 // Script the control-read pipe (fd 100): HELO handshake, then one exec cycle
 // per payload (each followed by the 8-byte length), then EOF.
@@ -31,7 +31,8 @@ let controlStream = Buffer.concat(controlChunks);
 // Data-read pipe (fd 102): the payload for each exec cycle.
 let dataStream = Buffer.concat(payloads);
 
-let statusWrites = 0;
+const statuses: number[] = [];
+const probes: unknown[] = [];
 
 const realFstatSync = fs.fstatSync;
 const realReadSync = fs.readSync;
@@ -61,7 +62,8 @@ const realWriteSync = fs.writeSync;
 (fs as any).writeSync = function (fd: any, buffer: any, ...rest: any[]) {
   if (fd === REPRL_CWFD) {
     if (Buffer.isBuffer(buffer) && buffer.length === 4 && buffer.toString() !== "HELO") {
-      statusWrites++;
+      statuses.push(buffer.readUInt32LE(0));
+      probes.push((globalThis as any).probe ?? null);
     }
     return Buffer.isBuffer(buffer) ? buffer.length : String(buffer).length;
   }
@@ -71,12 +73,9 @@ const realWriteSync = fs.writeSync;
 (globalThis as any).resetCoverage = () => {};
 (globalThis as any).require = require;
 
-const reprlSource = fs.readFileSync(
-  path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts"),
-  "utf8",
-);
-(0, eval)(reprlSource);
+// The loop runs until the control pipe reports EOF. The source uses top-level
+// await, so importing it waits for the loop to finish.
+await import(path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts"));
 
-const liveAfterExecve = (globalThis as any).stillAlive === true;
-realWriteSync.call(fs, 1, `STATUS_WRITES=${statusWrites} LIVE=${liveAfterExecve}\n`);
-process.exit(statusWrites === 2 && liveAfterExecve ? 0 : 1);
+realWriteSync.call(fs, 1, `REPRL_FIXTURE_RESULT=${JSON.stringify({ statuses, probes })}\n`);
+process.exit(0);

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -13,10 +13,13 @@ async function runReprl(payloads: string[]) {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const resultLine = stdout.split("\n").find(line => line.startsWith("REPRL_FIXTURE_RESULT="));
+  const lines = stdout.trim().split("\n");
+  const resultLine = lines.find(line => line.startsWith("REPRL_FIXTURE_RESULT="));
   const result = resultLine ? JSON.parse(resultLine.slice("REPRL_FIXTURE_RESULT=".length)) : undefined;
-  return { stdout, stderr, exitCode, result };
+  return { stdout, lines, stderr, exitCode, result };
 }
+
+const FAILED = 1 << 8;
 
 // APIs that intentionally kill the process outside of normal exception
 // handling must be stubbed out before the loop starts, otherwise every fuzz
@@ -51,21 +54,61 @@ test.concurrent("REPRL loop drains microtasks queued by a payload before reporti
 });
 
 // Now that async code runs, an unhandled rejection or a throw from a microtask
-// must not take down the REPRL child. It is reported as a failed execution
-// (exit code 1 in the upper status byte) for the payload that caused it, and
-// the loop keeps going.
+// must not take down the REPRL child, whatever the thrown value is. It is
+// reported as a failed execution (exit code 1 in the upper status byte) for
+// the payload that caused it, and the loop keeps going. That includes the
+// case where an earlier payload removed the loop's process listeners.
 test.concurrent("REPRL loop reports async failures as a failed execution and keeps running", async () => {
-  const { stdout, stderr, exitCode, result } = await runReprl([
+  const { lines, stderr, exitCode, result } = await runReprl([
     `Promise.reject(new Error("unhandled"));`,
     `queueMicrotask(() => { throw new Error("thrown"); });`,
+    `queueMicrotask(() => { throw Symbol("not implicitly convertible"); });`,
+    `Promise.reject({ toString() { throw new Error("toString throws"); } });`,
+    `throw Symbol("sync");`,
+    `process.removeAllListeners("uncaughtException"); process.removeAllListeners("unhandledRejection");`,
+    `Promise.reject(new Error("still handled"));`,
     `globalThis.probe = "alive";`,
   ]);
   expect(stderr).toBe("");
-  expect(stdout.trim().split("\n")).toEqual([
+  const expected = {
+    statuses: [FAILED, FAILED, FAILED, FAILED, FAILED, 0, FAILED, 0],
+    probes: [null, null, null, null, null, null, null, "alive"],
+  };
+  expect(lines).toEqual([
     "uncaught:Error: unhandled",
     "uncaught:Error: thrown",
-    `REPRL_FIXTURE_RESULT=${JSON.stringify({ statuses: [256, 256, 0], probes: [null, null, "alive"] })}`,
+    "uncaught:Symbol(not implicitly convertible)",
+    "uncaught:<unprintable>",
+    "uncaught:Symbol(sync)",
+    "uncaught:Error: still handled",
+    `REPRL_FIXTURE_RESULT=${JSON.stringify(expected)}`,
   ]);
-  expect(result).toEqual({ statuses: [256, 256, 0], probes: [null, null, "alive"] });
+  expect(result).toEqual(expected);
+  expect(exitCode).toBe(0);
+});
+
+// Timers, intervals and immediates that a payload leaves behind must not fire
+// while later payloads run. A timer that is already due fires within its own
+// payload's turn; everything still pending when the status is written is
+// cleared.
+test.concurrent("REPRL loop clears timers a payload leaves behind", async () => {
+  const { lines, stderr, exitCode, result } = await runReprl([
+    `globalThis.probe = { interval: 0, immediates: 0, late: false };
+     setInterval(() => { globalThis.probe.interval++; throw new Error("interval"); }, 0);
+     setTimeout(() => { globalThis.probe.late = true; }, 20);
+     setImmediate(function again() { globalThis.probe.immediates++; setImmediate(again); });
+     const start = performance.now();
+     while (performance.now() - start < 5) {}`,
+    `const start = performance.now();
+     while (performance.now() - start < 40) {}`,
+    `globalThis.probe = "done";`,
+  ]);
+  expect(stderr).toBe("");
+  const expected = {
+    statuses: [FAILED, 0, 0],
+    probes: [{ interval: 1, immediates: 1, late: false }, { interval: 1, immediates: 1, late: false }, "done"],
+  };
+  expect(lines).toEqual(["uncaught:Error: interval", `REPRL_FIXTURE_RESULT=${JSON.stringify(expected)}`]);
+  expect(result).toEqual(expected);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -2,22 +2,70 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "node:path";
 
-// The fuzzilli REPRL wrapper (src/js/eval/fuzzilli-reprl.ts) executes
-// fuzzer-generated scripts in-process. APIs that intentionally kill the
-// process outside of normal exception handling must be stubbed out before the
-// loop starts, otherwise every fuzz case reaching them is reported as a
-// crash. process.execve is one of those: on success it replaces the process
-// image, which would silently end the REPRL loop.
-test("REPRL loop survives a payload that calls process.execve", async () => {
+// These tests drive the real fuzzilli REPRL wrapper (src/js/eval/fuzzilli-reprl.ts)
+// through fuzzilli-reprl.fixture.ts, which mocks the REPRL control/data FDs
+// in-process so the loop can run in a normal (non-fuzzilli) build.
+async function runReprl(payloads: string[]) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fuzzilli-reprl-execve.fixture.ts")],
+    cmd: [bunExe(), path.join(import.meta.dir, "fuzzilli-reprl.fixture.ts"), JSON.stringify(payloads)],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const resultLine = stdout.split("\n").find(line => line.startsWith("REPRL_FIXTURE_RESULT="));
+  const result = resultLine ? JSON.parse(resultLine.slice("REPRL_FIXTURE_RESULT=".length)) : undefined;
+  return { stdout, stderr, exitCode, result };
+}
 
-  expect(stdout).toContain("STATUS_WRITES=2 LIVE=true");
+// APIs that intentionally kill the process outside of normal exception
+// handling must be stubbed out before the loop starts, otherwise every fuzz
+// case reaching them is reported as a crash. process.execve is one of those:
+// on success it replaces the process image, which would silently end the
+// REPRL loop.
+test.concurrent("REPRL loop survives a payload that calls process.execve", async () => {
+  const { stderr, exitCode, result } = await runReprl([
+    `process.execve("fuzzilli-reprl-execve-does-not-exist", []);`,
+    `globalThis.probe = "alive";`,
+  ]);
+  expect(stderr).toBe("");
+  expect(result).toEqual({ statuses: [0, 0], probes: [null, "alive"] });
+  expect(exitCode).toBe(0);
+});
+
+// The loop must give the event loop a turn after each script. Otherwise
+// promise reactions queued by fuzzed code never run, and everything they
+// capture stays alive in the microtask queue for the lifetime of the REPRL
+// child, which grows without bound across executions.
+test.concurrent("REPRL loop drains microtasks queued by a payload before reporting its status", async () => {
+  const { stderr, exitCode, result } = await runReprl([
+    `globalThis.probe = 0;
+     Promise.resolve().then(() => { globalThis.probe++; });
+     queueMicrotask(() => { globalThis.probe++; });
+     (async () => { await 0; globalThis.probe++; })();`,
+    `globalThis.probe = "next";`,
+  ]);
+  expect(stderr).toBe("");
+  expect(result).toEqual({ statuses: [0, 0], probes: [3, "next"] });
+  expect(exitCode).toBe(0);
+});
+
+// Now that async code runs, an unhandled rejection or a throw from a microtask
+// must not take down the REPRL child. It is reported as a failed execution
+// (exit code 1 in the upper status byte) for the payload that caused it, and
+// the loop keeps going.
+test.concurrent("REPRL loop reports async failures as a failed execution and keeps running", async () => {
+  const { stdout, stderr, exitCode, result } = await runReprl([
+    `Promise.reject(new Error("unhandled"));`,
+    `queueMicrotask(() => { throw new Error("thrown"); });`,
+    `globalThis.probe = "alive";`,
+  ]);
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual([
+    "uncaught:Error: unhandled",
+    "uncaught:Error: thrown",
+    `REPRL_FIXTURE_RESULT=${JSON.stringify({ statuses: [256, 256, 0], probes: [null, null, "alive"] })}`,
+  ]);
+  expect(result).toEqual({ statuses: [256, 256, 0], probes: [null, null, "alive"] });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -88,27 +88,39 @@ test.concurrent("REPRL loop reports async failures as a failed execution and kee
 });
 
 // Timers, intervals and immediates that a payload leaves behind must not fire
-// while later payloads run. A timer that is already due fires within its own
-// payload's turn; everything still pending when the status is written is
-// cleared.
+// while later payloads run. One that is already due runs within its own
+// payload's turn (the interval below is made due by the 5ms spin, and a throw
+// from it fails that payload); everything still pending when the status is
+// written is cleared, which the next payload observes through `_destroyed`.
 test.concurrent("REPRL loop clears timers a payload leaves behind", async () => {
   const { lines, stderr, exitCode, result } = await runReprl([
-    `globalThis.probe = { interval: 0, immediates: 0, late: false };
-     setInterval(() => { globalThis.probe.interval++; throw new Error("interval"); }, 0);
-     setTimeout(() => { globalThis.probe.late = true; }, 20);
-     setImmediate(function again() { globalThis.probe.immediates++; setImmediate(again); });
+    `globalThis.probe = { interval: 0, immediates: 0 };
+     const handles = globalThis.handles = {};
+     handles.interval = setInterval(() => { globalThis.probe.interval++; throw new Error("interval"); }, 0);
+     handles.timeout = setTimeout(() => { throw new Error("timeout"); }, 1000000);
+     handles.immediate = setImmediate(function again() {
+       globalThis.probe.immediates++;
+       handles.immediate = setImmediate(again);
+     });
      const start = performance.now();
      while (performance.now() - start < 5) {}`,
-    `const start = performance.now();
-     while (performance.now() - start < 40) {}`,
-    `globalThis.probe = "done";`,
+    `const { interval, timeout, immediate } = globalThis.handles;
+     globalThis.probe = {
+       ...globalThis.probe,
+       destroyed: { interval: interval._destroyed, timeout: timeout._destroyed, immediate: immediate._destroyed },
+     };`,
   ]);
   expect(stderr).toBe("");
-  const expected = {
-    statuses: [FAILED, 0, 0],
-    probes: [{ interval: 1, immediates: 1, late: false }, { interval: 1, immediates: 1, late: false }, "done"],
-  };
-  expect(lines).toEqual(["uncaught:Error: interval", `REPRL_FIXTURE_RESULT=${JSON.stringify(expected)}`]);
-  expect(result).toEqual(expected);
+  expect(result.statuses).toEqual([FAILED, 0]);
+  const [afterTimers, afterNext] = result.probes;
+  // The interval is due, so it fires before the status is written. How many
+  // timer phases fit in that turn is platform-specific: assert the lower bound.
+  expect(afterTimers.interval).toBeGreaterThanOrEqual(1);
+  expect(afterTimers.immediates).toBe(1);
+  expect(afterNext).toEqual({ ...afterTimers, destroyed: { interval: true, timeout: true, immediate: true } });
+  expect(lines).toEqual([
+    ...Array(afterTimers.interval).fill("uncaught:Error: interval"),
+    `REPRL_FIXTURE_RESULT=${JSON.stringify(result)}`,
+  ]);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fuzzilli reported a flaky crash (fingerprint `22c69e27974effe4`): `TERMSIG: 9`, empty stderr, execution time 3277 ms against a 2500 ms timeout. The program itself is harmless (four `Bun.spawn(["true"])`, a `URLSearchParams`, `Bun.gc(true)`) and runs clean in isolation, in about 50 ms. A SIGKILL with no output is the kernel killing the REPRL child, not a fault in the script that happened to be running.

The REPRL wrapper (`src/js/eval/fuzzilli-reprl.ts`) is what makes the child killable. It ran scripts back to back from a synchronous `while (true)` loop, so the VM never returned to the event loop for the whole life of the child (up to 1000 executions):

- Microtasks queued by a fuzzed script never ran. Every promise reaction, `await` continuation and `queueMicrotask` callback stayed in the queue, with everything it captured, until the child was recycled. `Bun.gc(true)` in the code suffix cannot collect them. Driving the real wrapper over REPRL fds with a script that does `Promise.resolve().then(() => x[0])` on a 16 MB `Uint8Array` grows RSS by 16 MB per execution (375 MB to 1032 MB in 40 executions). It also means no code after an `await` was ever fuzzed.
- Spawned subprocesses were never reaped. The fuzzer's own script leaves 4 zombie `true` processes, 4 pidfds and their stdio sockets behind per execution. After 51 executions the child had 204 zombies and 380 leaked fds. In this container (`pids.max` 512) execution 120 dies with `ASSERTION FAILED: success` in `WTF::Thread::create` because `pthread_create` gets `EAGAIN`.

Whichever limit the box hits first (memory, pids, fds), the child dies at a random later script and Fuzzilli files it as a flaky crash of that script.

The loop now schedules each iteration from the previous one with `setImmediate`. That gives the event loop one non-blocking turn per script, before the status is written: the microtasks drain, I/O is polled once without blocking (so leftover servers or timers from fuzzed code cannot stall it), due timers fire, and exited children are reaped. Around that turn the wrapper now also:

- installs `uncaughtException` and `unhandledRejection` listeners before every script (a script can remove them), which record an async failure as a failed execution (exit code 1, printed as `uncaught:` like the sync path) instead of letting it exit the child. The thrown value is formatted with `String()` under `try`, so a `Symbol` or an object whose `toString` throws does not escape the handler. The sync `catch` had the same problem.
- tracks timers, intervals and immediates created through the globals and clears them once the script's status is written, so they do not fire while later scripts run.
- captures every global and prototype method it uses between scripts at startup, and drives the loop with the captured `setImmediate` instead of `await`, so a script that replaces `Promise`, `setTimeout`, `Map.prototype.set`, `Array.prototype[Symbol.iterator]`, `console.log`, `process.on` and so on cannot stall the loop.
- exits on EOF from the control pipe instead of falling off the end of the module with whatever the scripts left running.

With the change, the two scripts above run with flat RSS, 12 open fds and zero zombies after 130 executions. Per-execution overhead is about 1 ms on a trivial script in the ASAN debug build. `fuzzilli('FUZZILLI_CRASH', n)` is still detected, including from a promise reaction.

### How did you verify your code works?

- Drove the modified wrapper with the `debug-fuzz` binary over real REPRL fds (control pipes on 100/101, memfd data channels on 102/103) for: the original program, a microtask-retention script, scripts with unhandled rejections and async throws (including `Symbol` and throwing `toString`), scripts that leave a `Bun.serve()`, `setInterval`, pending `fetch`, a self-rescheduling `setImmediate` and a `sleep 10` child behind, a script that calls `process.removeAllListeners()`, a script that clobbers `Promise`, `setImmediate`, `setTimeout`, `Map.prototype`, `Array.prototype[Symbol.iterator]`, `Reflect.apply`, `Function.prototype.call/apply`, `console.log`, `String`, `process.on/off`, and the `FUZZILLI_CRASH` startup checks. The loop keeps reporting through all of them.
- `test/js/bun/util/fuzzilli-reprl.test.ts` now feeds payloads through a generic fixture and checks the status written for each one. New tests: microtasks queued by a payload have run by the time its status is written; async failures (rejection, microtask throw, `Symbol`, throwing `toString`, after `removeAllListeners`) are reported as status `1 << 8` while the loop keeps going; timers, intervals and immediates left behind by a payload do not fire during later payloads. All fail against the old wrapper. The existing `process.execve` test is kept.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/fuzzilli-reprl.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/util/fuzzilli-reprl.test.ts:
67 |     `throw Symbol("sync");`,
68 |     `process.removeAllListeners("uncaughtException"); process.removeAllListeners("unhandledRejection");`,
69 |     `Promise.reject(new Error("still handled"));`,
70 |     `globalThis.probe = "alive";`,
71 |   ]);
72 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "1 | queueMicrotask(() => { throw new Error("thrown"); });
+                                                     ^
+ error: thrown
+       at <anonymous> (file:///workspace/bun/src/js/eval/fuzzilli-reprl.ts:1:49)
+ 1 | queueMicrotask(() => { throw Symbol("not implicitly convertible"); });
+                                                                      ^
+ error: not implicitly convertible
+       at <anonymous> (file:///workspace/bun/src/js/eval/fuzzilli-reprl.ts:1:66)
+ 1 | Promise.reject(new Error("unhandled"));
+                    ^
+ error: unhandled
+       at eval (f
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (aff99fd5b)

test/js/bun/util/fuzzilli-reprl.test.ts:
47 |      queueMicrotask(() => { globalThis.probe++; });
48 |      (async () => { await 0; globalThis.probe++; })();`,
49 |     `globalThis.probe = "next";`,
50 |   ]);
51 |   expect(stderr).toBe("");
52 |   expect(result).toEqual({ statuses: [0, 0], probes: [3, "next"] });
                      ^
error: expect(received).toEqual(expected)

  {
    "probes": [
-     3,
+     0,
      "next",
    ],
    "statuses": [
      0,
      0,
    ],
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/util/fuzzilli-reprl.test.ts:52:18)
(pass) REPRL loop survives a payload that calls process.execve [21.89ms]
(fail) REPRL loop drains microtasks queued by a payload before reporting its status [20.64ms]
67 |     `throw Symbol("sync");`,
68 |     `process.removeAllListeners("uncaughtException"); process.removeAllListeners("unhandledRejection");`,
69 |     `Promise.reject(new Error("still handled"));`,
70 |     `globalThis.probe = "alive";`,
71 |   ]);
72 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "1 | queueMicrota
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/fuzzilli-reprl.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/util/fuzzilli-reprl.test.ts:
(pass) REPRL loop survives a payload that calls process.execve [752.61ms]
(pass) REPRL loop reports async failures as a failed execution and keeps running [750.15ms]
(pass) REPRL loop drains microtasks queued by a payload before reporting its status [835.44ms]
(pass) REPRL loop clears timers a payload leaves behind [1021.97ms]

 4 pass
 0 fail
 17 expect() calls
Ran 4 tests across 1 file. [4.47s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 733ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (10007ms)
Bundle modules (70ms)
Postprocesss modules (156ms)
Bundle Functions (513ms)
Generate Code (44ms)

[10.80s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/eval/fuzzilli-reprl.ts                      |  74 ++++++++++++-
 ...execve.fixture.ts => fuzzilli-reprl.fixture.ts} |  34 +++---
 test/js/bun/util/fuzzilli-reprl.test.ts            | 123 +++++++++++++++++++--
 3 files changed, 197 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/eval/fuzzilli-reprl.ts                   6     10     19
test/js/bun/util/fuzzilli-reprl.fixture.ts      3      5     18
test/js/bun/util/fuzzilli-reprl.test.ts         2      4     17
```

</details>

<!-- robobun:evidence:end -->