### PR TITLE
docs: warn that Bun.secrets lacks inter-script isolation

### DIFF
--- a/docs/runtime/secrets.mdx
+++ b/docs/runtime/secrets.mdx
@@ -268,6 +268,12 @@ await Bun.secrets.set({
 4. **Memory Safety**: Bun zeros out password memory after use
 5. **Process Isolation**: Credentials are isolated per user account
 
+<Note>
+  Any `bun` script run as the same OS user can read or delete secrets stored by any other `bun` script with no
+  additional prompt — they share the `bun` binary identity. Compiled binaries (`bun build --compile`) get per-app
+  prompts and isolation. Use `--compile` when you need real isolation between apps.
+</Note>
+
 ## Limitations
 
 - Maximum password length varies by platform (typically 2048-4096 bytes)


### PR DESCRIPTION
docs: warn that Bun.secrets lacks inter-script isolation

Any bun script run as the same OS user can get()/delete() secrets stored by any other bun script with no Keychain prompt, since they share the bun binary identity. Compiled binaries (bun build --compile) get per-app isolation. Fixes #28071.
