### PR TITLE
docs: document require(ESM) in module resolution interop

### DIFF
--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -336,6 +336,8 @@ Once the CommonJS module is successfully evaluated, Bun creates a Synthetic Modu
 
 Bun's bundler works differently: it wraps the CommonJS module in a `require_${moduleName}` function which returns the `module.exports` object.
 
+Synchronous `require()` of an ES module is also supported: Bun evaluates the ESM graph and returns the module namespace object. If the graph contains top-level await, `require()` throws `ERR_REQUIRE_ASYNC_MODULE` — use `import()` for async modules instead.
+
 </Accordion>
 
 ---


### PR DESCRIPTION
docs: document require(ESM) in module resolution interop

The low-level CommonJS interop section only explained the import(CJS) path. Documents that sync require() of an ESM module evaluates the graph and returns the namespace, throwing ERR_REQUIRE_ASYNC_MODULE for top-level await. Fixes #4601.
