### PR TITLE
bundler: keep exports.default as the default import of a bun: module in CommonJS output

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2977,7 +2977,14 @@ pub(crate) mod __gated_printer {
                 }
 
                 if wrap_with_to_esm {
-                    self.print_to_esm_suffix();
+                    // Only Bun loads a `bun:` module, and its loader makes an own
+                    // `default` of the exports the ES default for every importer.
+                    // `isNodeMode` would make it the whole exports object.
+                    if strings::has_prefix_comptime(record.path.text, b"bun:") {
+                        self.print(b")");
+                    } else {
+                        self.print_to_esm_suffix();
+                    }
                 }
                 if wrap {
                     self.print(b")");

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -836,6 +836,60 @@ describe("bundler", () => {
     },
   });
 
+  // A `bun:` module never gets `isNodeMode`, whatever the importer's type.
+  // Bun's loader makes an own `default` of a builtin's exports the ES default
+  // export (`import Database from "bun:sqlite"` is the class), and
+  // `require("bun:sqlite")` carries `__esModule` so that `__toESM` agrees.
+  const bunBuiltinDefaultImport = /* js */ `
+    import Database from "bun:sqlite";
+    import * as ns from "bun:sqlite";
+    import fs from "node:fs";
+    const db = new Database(":memory:");
+    console.log(typeof Database, ns.default === Database, db instanceof ns.Database, typeof fs.readFileSync);
+    db.close();
+  `;
+
+  itBundled("cjs/__toESM_bun_builtin_mjs_importer_format_cjs", {
+    files: {
+      "/entry.mjs": bunBuiltinDefaultImport,
+    },
+    target: "bun",
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('__toESM(require("bun:sqlite"))');
+    },
+    run: {
+      stdout: "function true true function",
+    },
+  });
+
+  itBundled("cjs/__toESM_bun_builtin_type_module_importer_format_iife", {
+    files: {
+      "/entry.ts": bunBuiltinDefaultImport,
+      "/package.json": `{ "name": "app", "type": "module" }`,
+    },
+    target: "bun",
+    format: "iife",
+    run: {
+      stdout: "function true true function",
+    },
+  });
+
+  itBundled("cjs/__toESM_bun_builtin_mts_importer_target_node", {
+    files: {
+      "/entry.mts": bunBuiltinDefaultImport,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('__toESM(require("bun:sqlite"))');
+      api.expectFile("/out.js").toContain('__toESM(require("node:fs"), 1)');
+    },
+    run: {
+      stdout: "function true true function",
+    },
+  });
+
   // ============================================================================
   // Files reached through a package.json "exports" map. The matched "import" or
   // "require" condition is not a module type. Only the extension and the


### PR DESCRIPTION
### Problem
- `bun build --target=bun --format=cjs` (or `--format=iife`) of `import Database from "bun:sqlite"` in a `.mjs`/`.mts` file, or a `.js`/`.ts` file under `"type": "module"`, prints `__toESM(require("bun:sqlite"), 1)`. The default import is then the whole `require("bun:sqlite")` object and `new Database()` throws `TypeError: Object is not a constructor (evaluating 'new import_bun_sqlite.default(":memory:")')`. 1.4.0 was correct. 1.4.1 regressed.
- Cause: #41150 made the printer add `, 1` (`isNodeMode`) to every external `__toESM(require(...))` when the importer is an ES module by type (`src/js_printer/lib.rs:2979`). `require("bun:sqlite")` is `{ __esModule: true, default: Database, Database, ... }` (`src/js/bun/sqlite.ts:671`), and `isNodeMode` ignores `__esModule`.

### Fix
- The external `require()` path prints no `, 1` when the specifier starts with `bun:`. `__toESM` then honors `__esModule` and the default import is `exports.default`, on every target and for every importer type.
- Correct because only Bun can load a `bun:` module, and Bun's loader makes an own `default` property of a builtin's exports the ES default export for every importer (`generateInternalModuleSourceCode`, `src/jsc/bindings/ModuleLoader.cpp:70-128`). The importer's module type plays no part at runtime, so it must not in the bundle.
- `node:` builtins keep the esbuild rule. Their `require()` values have no own `default`, so both modes give the same result for them. I checked every entry of `require("node:module").builtinModules` plus the `bun:*` modules: `bun:sqlite` is the only builtin where the two modes differ.
- Verified: `test/bundler/bundler_cjs.test.ts` (3 new tests, all fail on bun 1.4.3). Also the rest of `bundler_cjs`, `bundler_bun`, `bundler_edgecase`, `regression/issue/03844`.

### Background
- `__toESM(mod, isNodeMode)` is the runtime helper that builds the ESM view of a `require()` result. With `isNodeMode` unset it honors `__esModule`: `default` is `mod.default`. With `isNodeMode = 1` it copies Node: `default` is `mod` itself.
- Since #41150 the bundler picks `isNodeMode` from the importer's module type (extension or package.json `"type"`), as esbuild does. That models what Node does when a real ES module imports a CommonJS file.
- A `bun:` module is not a CommonJS file. Its `require()` value is the object the builtin exports, and `bun:sqlite` puts `__esModule` and `default` on it so that TypeScript's and Babel's `require` interop find the class.

<details><summary>Notes</summary>

Repro (1.4.1, 1.4.2, 1.4.3, main):

```
cat > a.mjs <<'JS'
import Database from "bun:sqlite";
console.log(typeof Database);
new Database(":memory:");
JS
bun a.mjs                                                    # function
bun build a.mjs --target=bun --format=cjs --outfile=o.cjs && bun o.cjs
# object
# TypeError: Object is not a constructor (evaluating 'new import_bun_sqlite.default(":memory:")')
```

The same file named `a.ts` without `"type": "module"` was fine: it printed `__toESM(require("bun:sqlite"))`. `--format=esm` keeps the `import` statement and was fine too.

Why the specifier prefix and not `ImportRecordTag::Builtin`: the tag is only set under `--target=bun`, where it also covers `node:*` and the packages Bun overrides (`ws`, `node-fetch`, `undici`, ...). Under `--target=node` a `bun:sqlite` import stays external with tag `None` and had the same bug, and the output can only run its `require("bun:sqlite")` on Bun. The prefix covers both targets and leaves `node:*` output byte-identical to esbuild's.

Matrix used to find affected modules, run on bun 1.4.3: for each builtin `m`, compare `(await import(m)).default` with `__toESM(require(m), 1).default` and `__toESM(require(m), 0).default`. Mismatches: `bun:sqlite` (node mode only) and `bun:wrap` (no default export at all, so `import d from "bun:wrap"` is a SyntaxError unbundled). The overridden packages (`ws`, `node-fetch`, `undici`, `isomorphic-fetch`, `@vercel/fetch`, `abort-controller`) agree in both modes.

Not changed here, for a maintainer to judge: for a user-land CommonJS file, `bun run` honors `__esModule` for every importer and keys only on the CommonJS file's own package.json `"type"` (`populateESMExports`, `src/jsc/bindings/JSCommonJSModule.cpp:1012`). The bundler keys on the importer, as esbuild and Node do. So `entry.mjs` importing a Babel-style `dep.cjs` prints `function` under `bun entry.mjs` and `object` after `bun build --target=bun`. #41150 chose the esbuild rule on purpose. This PR only takes `bun:` modules out of it.

`import Bun from "bun"` under `--format=cjs` is `globalThis.Bun.default`, which is `undefined`. That is older than 1.4.1 and a different code path (`ImportRecordTag::Bun`), so it is not touched here.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1074.32ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [536.28ms]
(pass) bundler > cjs/__toESM_import_syntax_function [491.71ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [589.95ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [438.88ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [450.25ms]
(pass) bundler > cjs/__toESM_target_node [651.59ms]
(pass) bundler > cjs/__toESM_target_browser [463.40ms]
(pass) bundler > cjs/__toESM_target_bun [514.26ms]
(pass) bundler > cjs/__toESM_format_esm [695.29ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [538.64ms]
(pass) bundler > cjs/__toESM_mjs_reexport [561.26ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [430.48ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [471.39ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [671.39ms]
(pass) bundler > cjs/__toESM_default_pro
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [20.73ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [9.66ms]
(pass) bundler > cjs/__toESM_import_syntax_function [13.40ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [13.85ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [13.31ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [12.10ms]
(pass) bundler > cjs/__toESM_target_node [10.25ms]
(pass) bundler > cjs/__toESM_target_browser [10.89ms]
(pass) bundler > cjs/__toESM_target_bun [11.33ms]
(pass) bundler > cjs/__toESM_format_esm [10.98ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [9.84ms]
(pass) bundler > cjs/__toESM_mjs_reexport [11.28ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [10.68ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [10.82ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [9.93ms]
(pass) bundler > cjs/__toESM_default_prop_no_esModule [10.50ms]
(pass) bundler > cjs/__toESM_mixed_import_styles [9.91ms]
(pass) bundler > cjs/__toESM_esModule_non_true [10.33ms]
(pass) bundler > cjs/__toESM_esModul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1086.82ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [427.98ms]
(pass) bundler > cjs/__toESM_import_syntax_function [543.56ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [647.02ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [439.75ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [441.75ms]
(pass) bundler > cjs/__toESM_target_node [454.73ms]
(pass) bundler > cjs/__toESM_target_browser [571.77ms]
(pass) bundler > cjs/__toESM_target_bun [534.17ms]
(pass) bundler > cjs/__toESM_format_esm [640.35ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [837.72ms]
(pass) bundler > cjs/__toESM_mjs_reexport [552.13ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [441.33ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [601.10ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [436.59ms]
(pass) bundler > cjs/__toESM_default_pro
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 764ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs            |  9 ++++++-
 test/bundler/bundler_cjs.test.ts | 54 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 62 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/js_printer/lib.rs                 2      1      9
test/bundler/bundler_cjs.test.ts      1      1      9
```

</details>

<!-- robobun:evidence:end -->