### PR TITLE
bundler: rewrite a Content-Security-Policy meta for what standalone HTML inlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "bun_ptr",
  "bun_resolve_builtins",
  "bun_resolver",
+ "bun_sha_hmac",
  "bun_sourcemap",
  "bun_sys",
  "bun_threading",

--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -334,5 +334,4 @@ Bun replaces references to `process.env.API_URL` in your JavaScript with the lit
 
 - **Code splitting** is not supported — `--splitting` cannot be used with `--compile --target=browser`
 - **Large assets** increase file size since they're base64-encoded (33% overhead vs the raw binary)
-- **Repeated references** to one asset each embed their own copy. A `data:` URI cannot be shared, so an image used by two `<img>` tags, a CSS `url()` and a JS import is stored four times. When size matters, reference a large asset from one place (one CSS class, or one JS import that the rest of the code reuses)
 - **External URLs** (CDN links, absolute URLs) stay as-is: Bun inlines only relative paths

--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -102,6 +102,28 @@ Images, fonts, WASM binaries, videos, audio files, SVGs: Bun base64-encodes any 
 
 Bun leaves external URLs (like CDN links or absolute URLs) untouched.
 
+### Content Security Policy
+
+A `<meta http-equiv="Content-Security-Policy">` written for the multi-file site usually allows `'self'`, which does not cover inline `<script>` and `<style>` elements or `data:` URLs. So that the single file still loads under its own policy, Bun rewrites the `content` of that tag at build time:
+
+- The directive that governs scripts (`script-src`, or `default-src` as its fallback) gets a `'sha256-...'` hash of the inlined `<script>`, and the one that governs styles gets a hash of the inlined `<style>`.
+- `img-src`, `font-src`, `media-src` and `manifest-src` get `data:` when an image, font, media file or manifest was inlined.
+- When only `default-src` is present, Bun adds a dedicated directive (for example `script-src 'self' 'sha256-...'`) and leaves `default-src` as written.
+- The build prints a note that lists what it added.
+
+```html
+<!-- source -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'" />
+
+<!-- output -->
+<meta
+  http-equiv="Content-Security-Policy"
+  content="default-src 'self'; script-src 'self' 'sha256-L+kgRXS/...'; style-src 'self' 'sha256-zNeGjz5m...'; img-src 'self' data:"
+/>
+```
+
+A directive that already allows the content (`'unsafe-inline'`, `data:`) is left alone, and so is `'none'`: content the policy blocked on the multi-file site stays blocked. Other directives, such as `connect-src`, are not touched, so a `fetch()` of an inlined `data:` URL still needs `data:` there. Pages without a policy are not changed.
+
 ## Using with React
 
 React apps need no extra configuration: Bun transpiles JSX and resolves npm packages.
@@ -231,7 +253,8 @@ When you pass `--compile --target=browser` with an HTML entrypoint, Bun:
 4. Converts every relative asset reference into a base64 `data:` URI
 5. Inlines the bundled JS as `<script type="module">` before `</body>`
 6. Inlines the bundled CSS as `<style>` in `<head>`
-7. Outputs a single `.html` file with no external dependencies
+7. Adds hashes of the inlined blocks, and `data:`, to a `<meta http-equiv="Content-Security-Policy">` if the page has one
+8. Outputs a single `.html` file with no external dependencies
 
 ## Minification
 
@@ -311,4 +334,5 @@ Bun replaces references to `process.env.API_URL` in your JavaScript with the lit
 
 - **Code splitting** is not supported — `--splitting` cannot be used with `--compile --target=browser`
 - **Large assets** increase file size since they're base64-encoded (33% overhead vs the raw binary)
+- **Repeated references** to one asset each embed their own copy. A `data:` URI cannot be shared, so an image used by two `<img>` tags, a CSS `url()` and a JS import is stored four times. When size matters, reference a large asset from one place (one CSS class, or one JS import that the rest of the code reuses)
 - **External URLs** (CDN links, absolute URLs) stay as-is: Bun inlines only relative paths

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -51,6 +51,9 @@ bun_md.workspace = true
 bun_options_types.workspace = true
 bun_paths.workspace = true
 bun_perf.workspace = true
+# SHA-256 for the CSP hashes of inline blocks in standalone HTML. Already in
+# this graph through `bun_exe_format`.
+bun_sha_hmac.workspace = true
 bun_sourcemap.workspace = true
 bun_sys.workspace = true
 bun_threading.workspace = true

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -554,10 +554,7 @@ impl IntermediateOutput {
         &()
     }
 
-    /// Calls `emit` with consecutive pieces of `content` as it must appear
-    /// inside an inline `<script>`/`<style>` element: each `</` that starts
-    /// `close_tag` (e.g. `</script`, `</style`) becomes `<\/` so it cannot
-    /// end the element early.
+    /// Streams `content` as it must appear inside an inline `<script>`/`<style>`: each `</` that starts `close_tag` becomes `<\/`.
     fn for_each_escaping_closing_tags(
         content: &[u8],
         close_tag: &[u8],
@@ -603,8 +600,7 @@ impl IntermediateOutput {
         dst
     }
 
-    /// SHA-256 of `content` as [`memcpy_escaping_closing_tags`] writes it,
-    /// which is what a browser hashes for the inline element's CSP check.
+    /// SHA-256 of `content` as [`memcpy_escaping_closing_tags`] writes it (what a browser hashes for CSP).
     pub(crate) fn sha256_escaping_closing_tags(content: &[u8], close_tag: &[u8]) -> [u8; 32] {
         let mut hasher = bun_sha_hmac::sha::SHA256::init();
         Self::for_each_escaping_closing_tags(content, close_tag, |bytes| hasher.update(bytes));
@@ -782,8 +778,7 @@ impl IntermediateOutput {
                     &[]
                 };
 
-                // Standalone HTML: the `content` of each
-                // `<meta http-equiv="Content-Security-Policy">`, by placeholder index.
+                // Standalone HTML: each CSP `<meta>`'s `content`, by placeholder index.
                 let content_security_policies: &[Box<[u8]>] =
                     match chunk.compile_results_for_chunk.iter().next() {
                         Some(CompileResult::Html {
@@ -1288,9 +1283,7 @@ pub enum QueryKind {
     HtmlImport = 4,
     /// Given a chunk index, print the chunk's content hash as `[hash]` prints it
     ChunkId = 5,
-    /// Given the ordinal of a `<meta http-equiv="Content-Security-Policy">`
-    /// in a standalone HTML document, print its policy rewritten to allow
-    /// the blocks and data: URLs inlined into that document
+    /// Given its ordinal in a standalone HTML document, print a CSP `<meta>`'s rewritten `content`
     ContentSecurityPolicy = 6,
 }
 

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -554,56 +554,72 @@ impl IntermediateOutput {
         &()
     }
 
-    /// Streams `content` as it must appear inside an inline `<script>`/`<style>`: each `</` that starts `close_tag` becomes `<\/`.
-    fn for_each_escaping_closing_tags(
-        content: &[u8],
-        close_tag: &[u8],
-        mut emit: impl FnMut(&[u8]),
-    ) {
+    /// Streams `content` as the text of an inline `<script>`/`<style>`: `close_tag`'s `</` becomes `<\/`, and CRLF or CR becomes LF as the HTML tokenizer would make it.
+    fn for_each_inline_text_piece(content: &[u8], close_tag: &[u8], mut emit: impl FnMut(&[u8])) {
         let tag_suffix = &close_tag[2..];
-        let mut remaining = content;
-        while let Some(idx) = strings::index_of(remaining, b"</") {
-            emit(&remaining[..idx]);
-            remaining = &remaining[idx + 2..];
-            if remaining.len() >= tag_suffix.len()
-                && strings::eql_case_insensitive_ascii_ignore_length(
-                    &remaining[..tag_suffix.len()],
-                    tag_suffix,
-                )
-            {
-                emit(b"<\\/");
+        let find_lt = |from: usize| strings::index_of(&content[from..], b"</").map(|i| from + i);
+        let find_cr =
+            |from: usize| strings::index_of_char_usize(&content[from..], b'\r').map(|i| from + i);
+        let mut start: usize = 0;
+        let mut next_lt = find_lt(0);
+        let mut next_cr = find_cr(0);
+        loop {
+            let at_cr = match (next_lt, next_cr) {
+                (Some(lt), Some(cr)) => cr < lt,
+                (Some(_), None) => false,
+                (None, Some(_)) => true,
+                (None, None) => break,
+            };
+            if at_cr {
+                let at = next_cr.unwrap();
+                emit(&content[start..at]);
+                emit(b"\n");
+                start = at + 1;
+                if content.get(start) == Some(&b'\n') {
+                    start += 1;
+                }
+                next_cr = find_cr(start);
             } else {
-                emit(b"</");
+                let at = next_lt.unwrap();
+                emit(&content[start..at]);
+                start = at + 2;
+                if content.len() - start >= tag_suffix.len()
+                    && strings::eql_case_insensitive_ascii_ignore_length(
+                        &content[start..start + tag_suffix.len()],
+                        tag_suffix,
+                    )
+                {
+                    emit(b"<\\/");
+                } else {
+                    emit(b"</");
+                }
+                next_lt = find_lt(start);
             }
         }
-        emit(remaining);
+        emit(&content[start..]);
     }
 
-    /// The extra bytes [`memcpy_escaping_closing_tags`] needs over `content.len()`.
-    fn count_closing_tags(content: &[u8], close_tag: &[u8]) -> usize {
-        let mut escaped_len: usize = 0;
-        Self::for_each_escaping_closing_tags(content, close_tag, |bytes| {
-            escaped_len += bytes.len()
-        });
-        escaped_len - content.len()
+    /// The number of bytes [`memcpy_inline_text`] writes for `content`.
+    fn inline_text_len(content: &[u8], close_tag: &[u8]) -> usize {
+        let mut len: usize = 0;
+        Self::for_each_inline_text_piece(content, close_tag, |bytes| len += bytes.len());
+        len
     }
 
-    /// Copy `content` into `dest`, escaping occurrences of `close_tag` by
-    /// replacing `</` with `<\/`. Returns the number of bytes written.
-    /// Caller must ensure `dest` has room for `content.len + countClosingTags(...)` bytes.
-    fn memcpy_escaping_closing_tags(dest: &mut [u8], content: &[u8], close_tag: &[u8]) -> usize {
+    /// Writes `content` as inline `<script>`/`<style>` text into `dest`, which must hold [`inline_text_len`] bytes. Returns the number written.
+    fn memcpy_inline_text(dest: &mut [u8], content: &[u8], close_tag: &[u8]) -> usize {
         let mut dst: usize = 0;
-        Self::for_each_escaping_closing_tags(content, close_tag, |bytes| {
+        Self::for_each_inline_text_piece(content, close_tag, |bytes| {
             dest[dst..][..bytes.len()].copy_from_slice(bytes);
             dst += bytes.len();
         });
         dst
     }
 
-    /// SHA-256 of `content` as [`memcpy_escaping_closing_tags`] writes it (what a browser hashes for CSP).
-    pub(crate) fn sha256_escaping_closing_tags(content: &[u8], close_tag: &[u8]) -> [u8; 32] {
+    /// SHA-256 of `content` as [`memcpy_inline_text`] writes it, which is the text a browser hashes for CSP.
+    pub(crate) fn sha256_inline_text(content: &[u8], close_tag: &[u8]) -> [u8; 32] {
         let mut hasher = bun_sha_hmac::sha::SHA256::init();
-        Self::for_each_escaping_closing_tags(content, close_tag, |bytes| hasher.update(bytes));
+        Self::for_each_inline_text_piece(content, close_tag, |bytes| hasher.update(bytes));
         let mut digest = [0u8; 32];
         hasher.r#final(&mut digest);
         digest
@@ -811,13 +827,10 @@ impl IntermediateOutput {
                                 match piece.query.kind() {
                                     QueryKind::Chunk => {
                                         if let Some(content) = scc[index].as_deref() {
-                                            // Account for escaping </script or </style inside inline content.
-                                            // Each occurrence of the closing tag adds 1 byte (`</` → `<\/`).
-                                            count += content.len()
-                                                + Self::count_closing_tags(
-                                                    content,
-                                                    chunks[index].closing_tag_for_content(),
-                                                );
+                                            count += Self::inline_text_len(
+                                                content,
+                                                chunks[index].closing_tag_for_content(),
+                                            );
                                             continue;
                                         }
                                     }
@@ -989,7 +1002,7 @@ impl IntermediateOutput {
                                     // For chunk content, escape closing tags (</script, </style)
                                     // that would prematurely terminate the inline tag.
                                     if piece.query.kind() == QueryKind::Chunk {
-                                        let written = Self::memcpy_escaping_closing_tags(
+                                        let written = Self::memcpy_inline_text(
                                             remain,
                                             content,
                                             chunks[index].closing_tag_for_content(),

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1258,7 +1258,7 @@ impl Query {
 
     #[inline]
     pub(crate) fn kind(self) -> QueryKind {
-        // Tags 5..=7 are never assigned; match exhaustively
+        // Tag 7 is never assigned; match exhaustively
         // (an out-of-range tag would be a bug, not UB).
         match (self.0 >> 29) as u8 {
             0 => QueryKind::None,

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -345,6 +345,11 @@ impl Chunk {
     }
 
     pub(crate) fn get_css_chunk_for_html<'a>(&self, chunks: &'a [Chunk]) -> Option<&'a Chunk> {
+        self.get_css_chunk_index_for_html(chunks)
+            .map(|i| &chunks[i])
+    }
+
+    pub(crate) fn get_css_chunk_index_for_html(&self, chunks: &[Chunk]) -> Option<usize> {
         // Look up the CSS chunk via the JS chunk's css_chunks indices.
         // This correctly handles deduplicated CSS chunks that are shared
         // across multiple HTML entry points (see issue #23668).
@@ -355,22 +360,18 @@ impl Chunk {
                     && other.entry_point.entry_point_id() == entry_point_id
                 {
                     if let Some(&css_idx) = js.css_chunks.first() {
-                        return Some(&chunks[css_idx as usize]);
+                        return Some(css_idx as usize);
                     }
                     break;
                 }
             }
         }
         // Fallback: match by entry_point_id for cases without a JS chunk.
-        for other in chunks.iter() {
-            if matches!(other.content, Content::Css(_))
+        chunks.iter().position(|other| {
+            matches!(other.content, Content::Css(_))
                 && other.entry_point.is_entry_point()
                 && other.entry_point.entry_point_id() == entry_point_id
-            {
-                return Some(other);
-            }
-        }
-        None
+        })
     }
 
     #[inline]
@@ -553,13 +554,19 @@ impl IntermediateOutput {
         &()
     }
 
-    /// Count occurrences of a closing HTML tag (e.g. `</script`, `</style`) in content.
-    /// Used to calculate the extra bytes needed when escaping `</` → `<\/`.
-    fn count_closing_tags(content: &[u8], close_tag: &[u8]) -> usize {
+    /// Calls `emit` with consecutive pieces of `content` as it must appear
+    /// inside an inline `<script>`/`<style>` element: each `</` that starts
+    /// `close_tag` (e.g. `</script`, `</style`) becomes `<\/` so it cannot
+    /// end the element early.
+    fn for_each_escaping_closing_tags(
+        content: &[u8],
+        close_tag: &[u8],
+        mut emit: impl FnMut(&[u8]),
+    ) {
         let tag_suffix = &close_tag[2..];
-        let mut count: usize = 0;
         let mut remaining = content;
         while let Some(idx) = strings::index_of(remaining, b"</") {
+            emit(&remaining[..idx]);
             remaining = &remaining[idx + 2..];
             if remaining.len() >= tag_suffix.len()
                 && strings::eql_case_insensitive_ascii_ignore_length(
@@ -567,44 +574,43 @@ impl IntermediateOutput {
                     tag_suffix,
                 )
             {
-                count += 1;
-                remaining = &remaining[tag_suffix.len()..];
+                emit(b"<\\/");
+            } else {
+                emit(b"</");
             }
         }
-        count
+        emit(remaining);
+    }
+
+    /// The extra bytes [`memcpy_escaping_closing_tags`] needs over `content.len()`.
+    fn count_closing_tags(content: &[u8], close_tag: &[u8]) -> usize {
+        let mut escaped_len: usize = 0;
+        Self::for_each_escaping_closing_tags(content, close_tag, |bytes| {
+            escaped_len += bytes.len()
+        });
+        escaped_len - content.len()
     }
 
     /// Copy `content` into `dest`, escaping occurrences of `close_tag` by
     /// replacing `</` with `<\/`. Returns the number of bytes written.
     /// Caller must ensure `dest` has room for `content.len + countClosingTags(...)` bytes.
     fn memcpy_escaping_closing_tags(dest: &mut [u8], content: &[u8], close_tag: &[u8]) -> usize {
-        let tag_suffix = &close_tag[2..];
-        let mut remaining = content;
         let mut dst: usize = 0;
-        while let Some(idx) = strings::index_of(remaining, b"</") {
-            dest[dst..][..idx].copy_from_slice(&remaining[..idx]);
-            dst += idx;
-            remaining = &remaining[idx + 2..];
-
-            if remaining.len() >= tag_suffix.len()
-                && strings::eql_case_insensitive_ascii_ignore_length(
-                    &remaining[..tag_suffix.len()],
-                    tag_suffix,
-                )
-            {
-                dest[dst] = b'<';
-                dest[dst + 1] = b'\\';
-                dest[dst + 2] = b'/';
-                dst += 3;
-            } else {
-                dest[dst] = b'<';
-                dest[dst + 1] = b'/';
-                dst += 2;
-            }
-        }
-        dest[dst..][..remaining.len()].copy_from_slice(remaining);
-        dst += remaining.len();
+        Self::for_each_escaping_closing_tags(content, close_tag, |bytes| {
+            dest[dst..][..bytes.len()].copy_from_slice(bytes);
+            dst += bytes.len();
+        });
         dst
+    }
+
+    /// SHA-256 of `content` as [`memcpy_escaping_closing_tags`] writes it,
+    /// which is what a browser hashes for the inline element's CSP check.
+    pub(crate) fn sha256_escaping_closing_tags(content: &[u8], close_tag: &[u8]) -> [u8; 32] {
+        let mut hasher = bun_sha_hmac::sha::SHA256::init();
+        Self::for_each_escaping_closing_tags(content, close_tag, |bytes| hasher.update(bytes));
+        let mut digest = [0u8; 32];
+        hasher.r#final(&mut digest);
+        digest
     }
 
     pub(crate) fn get_size(&self) -> usize {
@@ -776,12 +782,28 @@ impl IntermediateOutput {
                     &[]
                 };
 
+                // Standalone HTML: the `content` of each
+                // `<meta http-equiv="Content-Security-Policy">`, by placeholder index.
+                let content_security_policies: &[Box<[u8]>] =
+                    match chunk.compile_results_for_chunk.iter().next() {
+                        Some(CompileResult::Html {
+                            content_security_policies,
+                            ..
+                        }) => content_security_policies,
+                        _ => &[],
+                    };
+
                 for piece in pieces.slice() {
                     count += piece.data.len();
 
                     match piece.query.kind() {
                         QueryKind::ChunkId => {
                             count += chunks[piece.query.index() as usize].id().len()
+                        }
+                        QueryKind::ContentSecurityPolicy => {
+                            count += content_security_policies
+                                .get(piece.query.index() as usize)
+                                .map_or(0, |policy| policy.len());
                         }
                         QueryKind::Chunk
                         | QueryKind::Asset
@@ -849,7 +871,9 @@ impl IntermediateOutput {
                                     ));
                                     continue;
                                 }
-                                QueryKind::None | QueryKind::ChunkId => unreachable!(),
+                                QueryKind::None
+                                | QueryKind::ChunkId
+                                | QueryKind::ContentSecurityPolicy => unreachable!(),
                             };
 
                             let cheap_normalizer = cheap_prefix_normalizer(
@@ -921,6 +945,16 @@ impl IntermediateOutput {
                                 shifts.push(shift);
                             }
                             remain = &mut remain[len..];
+                        }
+                        QueryKind::ContentSecurityPolicy => {
+                            // Only HTML documents carry these, and they have no source map.
+                            debug_assert!(!ENABLE_SOURCE_MAP_SHIFTS);
+                            if let Some(policy) =
+                                content_security_policies.get(piece.query.index() as usize)
+                            {
+                                remain[..policy.len()].copy_from_slice(policy);
+                                remain = &mut remain[policy.len()..];
+                            }
                         }
                         QueryKind::Asset
                         | QueryKind::Chunk
@@ -1233,6 +1267,7 @@ impl Query {
             3 => QueryKind::Scb,
             4 => QueryKind::HtmlImport,
             5 => QueryKind::ChunkId,
+            6 => QueryKind::ContentSecurityPolicy,
             _ => unreachable!("Query: invalid kind tag"),
         }
     }
@@ -1253,6 +1288,10 @@ pub enum QueryKind {
     HtmlImport = 4,
     /// Given a chunk index, print the chunk's content hash as `[hash]` prints it
     ChunkId = 5,
+    /// Given the ordinal of a `<meta http-equiv="Content-Security-Policy">`
+    /// in a standalone HTML document, print its policy rewritten to allow
+    /// the blocks and data: URLs inlined into that document
+    ContentSecurityPolicy = 6,
 }
 
 impl QueryKind {
@@ -1266,6 +1305,7 @@ impl QueryKind {
             QueryKind::Scb => b'S',
             QueryKind::HtmlImport => b'H',
             QueryKind::ChunkId => b'I',
+            QueryKind::ContentSecurityPolicy => b'P',
             QueryKind::None => unreachable!(),
         }
     }
@@ -1279,6 +1319,7 @@ impl QueryKind {
             b'S' => Some(QueryKind::Scb),
             b'H' => Some(QueryKind::HtmlImport),
             b'I' => Some(QueryKind::ChunkId),
+            b'P' => Some(QueryKind::ContentSecurityPolicy),
             _ => None,
         }
     }

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -180,6 +180,10 @@ pub(crate) trait HTMLProcessorHandler {
     fn on_html_tag(&mut self, _element: &mut Element<'_, '_>) -> bool {
         unreachable!()
     }
+    /// `<meta http-equiv="…" content="…">`, with `http_equiv` as written.
+    fn on_meta_http_equiv_tag(&mut self, _element: &mut Element<'_, '_>, _http_equiv: &[u8]) {
+        unreachable!()
+    }
 }
 
 impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
@@ -271,7 +275,7 @@ const TAG_HANDLERS: [TagHandler; 16] = [
     //     TagHandler::new("iframe[src]", "src", ImportKind::Url),
 ];
 
-const SELECTOR_CAP: usize = TAG_HANDLERS.len() + 3;
+const SELECTOR_CAP: usize = TAG_HANDLERS.len() + 4;
 
 #[inline]
 fn lol_err<E>(_: E) -> Error {
@@ -365,6 +369,19 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
                 );
                 element_content_handlers.push(element_entry(tag, on_element)?);
             }
+
+            let on_meta: lol_html::ElementHandler<'_> = Box::new(
+                move |element: &mut Element<'_, '_>| -> lol_html::HandlerResult {
+                    if let Some(http_equiv) = element.get_attribute("http-equiv") {
+                        // SAFETY: see `on_tag` above.
+                        unsafe {
+                            (*this_ptr).on_meta_http_equiv_tag(element, http_equiv.as_bytes())
+                        };
+                    }
+                    Ok(())
+                },
+            );
+            element_content_handlers.push(element_entry("meta[http-equiv][content]", on_meta)?);
         }
 
         let settings = lol_html::Settings {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -5110,8 +5110,7 @@ impl<'a> LinkerContext<'a> {
                         break;
                     }
                 }
-                // Bounded by the number of CSP `<meta>` tags in the HTML
-                // document, which only its `CompileResult::Html` knows.
+                // Bounded by the document's CSP `<meta>` count, which only its `CompileResult::Html` knows.
                 crate::chunk::QueryKind::ContentSecurityPolicy => {}
                 crate::chunk::QueryKind::None => unreachable!(),
             }

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2650,7 +2650,9 @@ impl<'a> LinkerContext<'a> {
                                 out.push(chunk_index);
                             }
                         }
-                        crate::chunk::QueryKind::None | crate::chunk::QueryKind::HtmlImport => {}
+                        crate::chunk::QueryKind::None
+                        | crate::chunk::QueryKind::HtmlImport
+                        | crate::chunk::QueryKind::ContentSecurityPolicy => {}
                     }
                 }
             }
@@ -5108,7 +5110,10 @@ impl<'a> LinkerContext<'a> {
                         break;
                     }
                 }
-                _ => unreachable!(),
+                // Bounded by the number of CSP `<meta>` tags in the HTML
+                // document, which only its `CompileResult::Html` knows.
+                crate::chunk::QueryKind::ContentSecurityPolicy => {}
+                crate::chunk::QueryKind::None => unreachable!(),
             }
 
             // Note: `Query` is a packed `u32` (`index: u29`, `kind: u3`);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7713,13 +7713,7 @@ pub mod bv2_impl {
             source_index: IndexInt,
             code: Box<[u8]>,
             script_injection_offset: u32,
-            /// Standalone mode: the `content` attribute value of each
-            /// `<meta http-equiv="Content-Security-Policy">`, in document
-            /// order, ready to splice where `code` holds its
-            /// `QueryKind::ContentSecurityPolicy` placeholder. The HTML pass
-            /// stores the policy as written; `generate_chunks_in_parallel`
-            /// rewrites it for the inlined content once the sibling chunks
-            /// are final.
+            /// Standalone mode: attribute-ready `content` of each CSP `<meta>`, indexed by its `QueryKind::ContentSecurityPolicy` placeholder in `code`; as written until `generate_chunks_in_parallel` rewrites it.
             content_security_policies: Box<[Box<[u8]>]>,
         },
     }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7713,6 +7713,14 @@ pub mod bv2_impl {
             source_index: IndexInt,
             code: Box<[u8]>,
             script_injection_offset: u32,
+            /// Standalone mode: the `content` attribute value of each
+            /// `<meta http-equiv="Content-Security-Policy">`, in document
+            /// order, ready to splice where `code` holds its
+            /// `QueryKind::ContentSecurityPolicy` placeholder. The HTML pass
+            /// stores the policy as written; `generate_chunks_in_parallel`
+            /// rewrites it for the inlined content once the sibling chunks
+            /// are final.
+            content_security_policies: Box<[Box<[u8]>]>,
         },
     }
 

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -180,6 +180,9 @@ pub mod linker_context {
     #[path = "renameSymbolsInChunk.rs"]
     pub(crate) mod rename_symbols_in_chunk;
 
+    #[path = "standaloneHtmlCsp.rs"]
+    pub(crate) mod standalone_html_csp;
+
     #[path = "writeOutputFilesToDisk.rs"]
     pub mod write_output_files_to_disk;
 

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -820,9 +820,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             scc[ci] = Some(buffer);
         }
 
-        // A `<meta http-equiv="Content-Security-Policy">` written for the
-        // multi-file site blocks what this mode inlines. Now that the inlined
-        // chunks are final, rewrite each HTML document's policies for them.
+        // The inlined chunks are final: rewrite each HTML document's CSP `<meta>` to allow them.
         for ci in 0..chunks.len() {
             if !matches!(chunks[ci].content, crate::chunk::Content::Html) {
                 continue;

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -29,6 +29,7 @@ use crate::linker_context::output_file_list_builder::OutputFileList as OutputFil
 use crate::linker_context::prepare_css_asts_for_chunk::{
     PrepareCssAstTask, prepare_css_asts_for_chunk,
 };
+use crate::linker_context::standalone_html_csp;
 use crate::linker_context::static_route_visitor::StaticRouteVisitor;
 use crate::linker_context::write_output_files_to_disk::write_output_files_to_disk;
 use crate::linker_context_mod::{GenerateChunkCtx, PendingPartRange};
@@ -817,6 +818,25 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             }
 
             scc[ci] = Some(buffer);
+        }
+
+        // A `<meta http-equiv="Content-Security-Policy">` written for the
+        // multi-file site blocks what this mode inlines. Now that the inlined
+        // chunks are final, rewrite each HTML document's policies for them.
+        for ci in 0..chunks.len() {
+            if !matches!(chunks[ci].content, crate::chunk::Content::Html) {
+                continue;
+            }
+            if let Some(resolved) = standalone_html_csp::resolve_for_html_chunk(c, ci, chunks, &scc)
+            {
+                if let crate::CompileResult::Html {
+                    content_security_policies,
+                    ..
+                } = chunks[ci].compile_results_for_chunk.get_mut(0)
+                {
+                    *content_security_policies = resolved;
+                }
+            }
         }
 
         standalone_chunk_contents = Some(scc);

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -88,8 +88,7 @@ struct HTMLLoader<'a> {
     end_tag_indices: EndTagIndices,
     added_head_tags: bool,
     added_body_script: bool,
-    /// Standalone mode: the `content` of each
-    /// `<meta http-equiv="Content-Security-Policy">`, in document order.
+    /// Standalone mode: the `content` of each CSP `<meta>`, in document order.
     content_security_policies: Vec<Box<[u8]>>,
 }
 
@@ -231,12 +230,7 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
         let Some(policy) = element.get_attribute("content") else {
             return;
         };
-        // A policy written for the multi-file site blocks the inline blocks
-        // and data: URLs this mode emits. The sources that allow them (a hash
-        // per block) depend on the final bytes of sibling chunks, so leave a
-        // placeholder that `generate_chunks_in_parallel` resolves. The value
-        // is kept ready to splice into the double-quoted attribute lol-html
-        // writes: character references as written, `"` escaped.
+        // The hashes that allow the inlined blocks need the sibling chunks' final bytes: leave a placeholder for `generate_chunks_in_parallel`.
         let index = u32::try_from(self.content_security_policies.len()).expect("int cast");
         let mut value = Vec::with_capacity(policy.len());
         for byte in policy.into_bytes() {

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -10,6 +10,7 @@ use lol_html::HandlerResult;
 use lol_html::html_content::{ContentType, Element, EndTag};
 
 use crate::HTMLScanner::{HTMLProcessor, HTMLProcessorHandler};
+use crate::chunk::QueryKind;
 use crate::linker_context_mod::{GenerateChunkCtx, LinkerContext, debug};
 use crate::options::Loader;
 use crate::{Chunk, CompileResult};
@@ -87,6 +88,9 @@ struct HTMLLoader<'a> {
     end_tag_indices: EndTagIndices,
     added_head_tags: bool,
     added_body_script: bool,
+    /// Standalone mode: the `content` of each
+    /// `<meta http-equiv="Content-Security-Policy">`, in document order.
+    content_security_policies: Vec<Box<[u8]>>,
 }
 
 /// `Element::set_attribute` takes `&str`, so non-UTF-8 `name`/`value` bytes
@@ -212,6 +216,45 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
 
     fn on_body_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
         self.register_end_tag_handler(element, Self::end_body_tag_handler)
+    }
+
+    fn on_meta_http_equiv_tag(&mut self, element: &mut Element<'_, '_>, http_equiv: &[u8]) {
+        if !self.compile_to_standalone_html
+            || self.linker.dev_server.is_some()
+            || !strings::eql_case_insensitive_ascii_check_length(
+                strings::trim(http_equiv, b" \t\n\x0c\r"),
+                b"content-security-policy",
+            )
+        {
+            return;
+        }
+        let Some(policy) = element.get_attribute("content") else {
+            return;
+        };
+        // A policy written for the multi-file site blocks the inline blocks
+        // and data: URLs this mode emits. The sources that allow them (a hash
+        // per block) depend on the final bytes of sibling chunks, so leave a
+        // placeholder that `generate_chunks_in_parallel` resolves. The value
+        // is kept ready to splice into the double-quoted attribute lol-html
+        // writes: character references as written, `"` escaped.
+        let index = u32::try_from(self.content_security_policies.len()).expect("int cast");
+        let mut value = Vec::with_capacity(policy.len());
+        for byte in policy.into_bytes() {
+            if byte == b'"' {
+                value.extend_from_slice(b"&quot;");
+            } else {
+                value.push(byte);
+            }
+        }
+        self.content_security_policies
+            .push(value.into_boxed_slice());
+        let placeholder = format!(
+            "{}{}{:08}",
+            BStr::new(&self.linker.unique_key_prefix),
+            QueryKind::ContentSecurityPolicy.letter() as char,
+            index
+        );
+        set_attribute(element, b"content", placeholder.as_bytes());
     }
 }
 
@@ -404,6 +447,7 @@ fn generate_compile_result_for_html_chunk_impl<'a>(
         },
         added_head_tags: false,
         added_body_script: false,
+        content_security_policies: Vec::new(),
     };
 
     HTMLProcessor::<HTMLLoader, true>::run(&mut html_loader, contents)
@@ -460,5 +504,6 @@ fn generate_compile_result_for_html_chunk_impl<'a>(
         code: html_loader.output.into_boxed_slice(),
         source_index,
         script_injection_offset,
+        content_security_policies: html_loader.content_security_policies.into_boxed_slice(),
     }
 }

--- a/src/bundler/linker_context/standaloneHtmlCsp.rs
+++ b/src/bundler/linker_context/standaloneHtmlCsp.rs
@@ -137,7 +137,7 @@ pub(crate) fn resolve_for_html_chunk(
                 BStr::new(pretty_path),
                 BStr::new(&rewrite.summary),
             )
-            .ok();
+            .expect("infallible: in-memory write");
             c.log_disjoint().add_msg(bun_ast::Msg {
                 kind: bun_ast::Kind::Note,
                 data: bun_ast::Data {
@@ -172,18 +172,16 @@ fn decode_character_references(raw: &[u8]) -> Cow<'_, [u8]> {
     let mut utf8 = [0u8; 8];
     while !rest.is_empty() {
         // `rest` starts with `&`.
-        let reference_len = rest[1..]
-            .iter()
-            .take(48)
-            .position(|&b| !(b.is_ascii_alphanumeric() || b == b'#'))
-            .map(|name_len| name_len + 2)
-            .filter(|&len| len > 2 && rest[len - 1] == b';');
-        match reference_len
-            .and_then(|len| bun_md::helpers::decode_entity_to_utf8(&rest[..len], &mut utf8))
-        {
-            Some(decoded) => {
-                out.extend_from_slice(decoded);
-                rest = &rest[reference_len.unwrap()..];
+        let decoded = bun_md::helpers::find_entity(rest, 0).and_then(|len| {
+            Some((
+                len,
+                bun_md::helpers::decode_entity_to_utf8(&rest[..len], &mut utf8)?,
+            ))
+        });
+        match decoded {
+            Some((len, bytes)) => {
+                out.extend_from_slice(bytes);
+                rest = &rest[len..];
             }
             None => {
                 out.push(b'&');
@@ -244,7 +242,7 @@ impl DataUrlKinds {
         }
     }
 
-    fn any(&self) -> bool {
+    fn any(self) -> bool {
         self.image || self.font || self.media || self.manifest
     }
 }
@@ -289,10 +287,16 @@ impl<'a> Directive<'a> {
             .any(|s| strings::eql_case_insensitive_ascii_check_length(s, source))
     }
 
+    /// `'none'`, or an empty source list, which matches nothing either.
     fn is_none(&self) -> bool {
         let mut sources = self.sources();
-        matches!(sources.next(), Some(s) if strings::eql_case_insensitive_ascii_check_length(s, b"'none'"))
-            && sources.next().is_none()
+        match sources.next() {
+            None => true,
+            Some(s) => {
+                strings::eql_case_insensitive_ascii_check_length(s, b"'none'")
+                    && sources.next().is_none()
+            }
+        }
     }
 
     /// A nonce or hash in the list makes browsers ignore `'unsafe-inline'`.
@@ -386,7 +390,7 @@ fn rewrite(policy: &[u8], inlined: &InlinedContent<'_>) -> Option<Rewrite> {
         };
         let effective = &directives[index];
         if effective.is_none() {
-            // `'none'` blocked this content on the multi-file site too.
+            // `'none'` (or an empty list) blocked this on the multi-file site too.
             continue;
         }
 

--- a/src/bundler/linker_context/standaloneHtmlCsp.rs
+++ b/src/bundler/linker_context/standaloneHtmlCsp.rs
@@ -42,12 +42,10 @@ pub(crate) fn resolve_for_html_chunk(
         if content.is_empty() {
             return None;
         }
-        Some(hash_source(
-            &IntermediateOutput::sha256_escaping_closing_tags(
-                content,
-                chunks[index].closing_tag_for_content(),
-            ),
-        ))
+        Some(hash_source(&IntermediateOutput::sha256_inline_text(
+            content,
+            chunks[index].closing_tag_for_content(),
+        )))
     };
     let scripts: Vec<HashSource> = inline_block_hash(js_chunk).into_iter().collect();
     let styles: Vec<HashSource> = inline_block_hash(css_chunk).into_iter().collect();

--- a/src/bundler/linker_context/standaloneHtmlCsp.rs
+++ b/src/bundler/linker_context/standaloneHtmlCsp.rs
@@ -1,11 +1,4 @@
-//! `<meta http-equiv="Content-Security-Policy">` in standalone HTML.
-//!
-//! A policy written for the multi-file site (`default-src 'self'`) blocks the
-//! single-file output: the bundle becomes an inline `<script>`, the
-//! stylesheet an inline `<style>`, and every asset a `data:` URL, and none of
-//! those match `'self'`. The policy is rewritten with the narrowest
-//! additions that let the inlined content load: one `'sha256-…'` source per
-//! inline block, and `data:` for each kind of asset that became a data: URL.
+//! Rewrites a standalone HTML document's CSP `<meta>` so its inline `<script>`/`<style>` (by hash) and `data:` assets are allowed.
 
 use crate::mal_prelude::*;
 use std::borrow::Cow;
@@ -20,11 +13,7 @@ use crate::{Chunk, CompileResult, LinkerContext};
 /// ASCII whitespace as CSP defines it (https://w3c.github.io/webappsec-csp/#grammardef-optional-ascii-whitespace).
 const WHITESPACE: &[u8] = b" \t\n\x0c\r";
 
-/// Rewrites the `content` of every `<meta http-equiv="Content-Security-Policy">`
-/// that `HTMLLoader` recorded for the standalone HTML document `chunks[html]`,
-/// now that the contents of the chunks inlined into it are final, and adds
-/// a note to the log for each policy that changed. Returns `None` when the
-/// document has no such tag.
+/// The rewritten `content` of each CSP `<meta>` in `chunks[html]`, with a note logged per change; `None` if it has none.
 pub(crate) fn resolve_for_html_chunk(
     c: &LinkerContext<'_>,
     html: usize,
@@ -46,9 +35,7 @@ pub(crate) fn resolve_for_html_chunk(
     let js_chunk = chunk.get_js_chunk_index_for_html(chunks);
     let css_chunk = chunk.get_css_chunk_index_for_html(chunks);
 
-    // The inline `<script>` / `<style>` this document gets for each chunk
-    // (see `HTMLLoader::standalone_body_script` / `get_head_tags`). A browser
-    // returns before the CSP check for an empty script, so that needs no hash.
+    // One inline block per chunk (`HTMLLoader::standalone_body_script` / `get_head_tags`); an empty one is never CSP-checked.
     let inline_block_hash = |index: Option<usize>| -> Option<HashSource> {
         let index = index?;
         let content = standalone_chunk_contents[index].as_deref()?;
@@ -65,8 +52,7 @@ pub(crate) fn resolve_for_html_chunk(
     let scripts: Vec<HashSource> = inline_block_hash(js_chunk).into_iter().collect();
     let styles: Vec<HashSource> = inline_block_hash(css_chunk).into_iter().collect();
 
-    // Every reference this document, its bundle and its stylesheet make to a
-    // file that standalone mode turns into a data: URL.
+    // Every file this document, its bundle and its stylesheet reference that became a data: URL.
     let parse_graph = c.parse_graph();
     let loaders = parse_graph.input_files.items_loader();
     let urls_for_css = parse_graph.ast.items_url_for_css();
@@ -86,8 +72,7 @@ pub(crate) fn resolve_for_html_chunk(
                 continue;
             }
             let loader = loaders[target];
-            // JS only sees a URL for file-loader imports; HTML attributes and
-            // CSS `url()` take the data: URL of anything that is not code.
+            // JS gets a URL only from file-loader imports; HTML and CSS inline anything that is not code.
             let becomes_data_url = if importer_is_js {
                 loader.should_copy_for_bundling()
             } else {
@@ -124,8 +109,7 @@ pub(crate) fn resolve_for_html_chunk(
     let resolved = content_security_policies
         .iter()
         .map(|value| {
-            // `value` is the attribute as written, character references
-            // included. The browser parses the decoded text.
+            // `value` is the attribute as written; the browser parses it with character references decoded.
             let Some(rewrite) = rewrite(&decode_character_references(value), &inlined) else {
                 return value.clone();
             };
@@ -328,8 +312,7 @@ struct Rewrite {
     summary: Vec<u8>,
 }
 
-/// Returns the rewritten policy, or `None` when `policy` already allows
-/// everything in `inlined` (or blocks it on purpose with `'none'`).
+/// `None` when `policy` already allows everything in `inlined`, or blocks it on purpose with `'none'`.
 fn rewrite(policy: &[u8], inlined: &InlinedContent<'_>) -> Option<Rewrite> {
     if inlined.scripts.is_empty() && inlined.styles.is_empty() && !inlined.data_urls.any() {
         return None;
@@ -351,10 +334,7 @@ fn rewrite(policy: &[u8], inlined: &InlinedContent<'_>) -> Option<Rewrite> {
     let mut appended: Vec<u8> = Vec::new();
     let mut summary: Vec<u8> = Vec::new();
 
-    // (directive, its fallbacks, what it must allow). `*-src-elem` (CSP3)
-    // takes precedence over `*-src` in browsers that know it, so when a page
-    // uses it the hash goes there too, but it is never introduced.
-    // https://w3c.github.io/webappsec-csp/#directive-fallback-list
+    // (directive, fallbacks, need); `*-src-elem` (CSP3) wins over `*-src` where supported, so it gets the hash too but is never introduced.
     const DEFAULT_SRC: &[&[u8]] = &[b"default-src"];
     let kinds = inlined.data_urls;
     let needs: [(&[u8], &[&[u8]], Need<'_>, bool); 8] = [
@@ -427,13 +407,11 @@ fn rewrite(policy: &[u8], inlined: &InlinedContent<'_>) -> Option<Rewrite> {
             additions[index].extend_from_slice(&sources);
             continue;
         }
-        // Split a dedicated directive off the fallback so the fallback, and
-        // everything else that inherits it, stays as written.
+        // Split a directive off the fallback so the fallback and what else inherits it stay as written.
         appended.extend_from_slice(b"; ");
         appended.extend_from_slice(name);
         for source in effective.sources() {
-            // Keywords other than 'self', nonces and hashes only mean
-            // something to scripts and styles.
+            // Keywords other than 'self', nonces and hashes only apply to scripts and styles.
             if matches!(need, Need::Data)
                 && source.starts_with(b"'")
                 && !strings::eql_case_insensitive_ascii_check_length(source, b"'self'")
@@ -458,8 +436,7 @@ fn rewrite(policy: &[u8], inlined: &InlinedContent<'_>) -> Option<Rewrite> {
         out.extend_from_slice(directive.raw);
         out.extend_from_slice(&additions[i]);
     }
-    // Something was restricted, so there is at least one directive for
-    // `appended`'s leading "; " to follow.
+    // Something was restricted, so `directives` is non-empty and `appended`'s "; " has a predecessor.
     out.extend_from_slice(&appended);
     Some(Rewrite {
         policy: out,

--- a/src/bundler/linker_context/standaloneHtmlCsp.rs
+++ b/src/bundler/linker_context/standaloneHtmlCsp.rs
@@ -1,0 +1,464 @@
+//! `<meta http-equiv="Content-Security-Policy">` in standalone HTML.
+//!
+//! A policy written for the multi-file site (`default-src 'self'`) blocks the
+//! single-file output: the bundle becomes an inline `<script>`, the
+//! stylesheet an inline `<style>`, and every asset a `data:` URL, and none of
+//! those match `'self'`. The policy is rewritten with the narrowest
+//! additions that let the inlined content load: one `'sha256-…'` source per
+//! inline block, and `data:` for each kind of asset that became a data: URL.
+
+use crate::mal_prelude::*;
+use std::borrow::Cow;
+use std::io::Write as _;
+
+use bstr::BStr;
+use bun_core::strings;
+
+use crate::chunk::{Content, CssImportOrderKind, IntermediateOutput};
+use crate::{Chunk, CompileResult, LinkerContext};
+
+/// ASCII whitespace as CSP defines it (https://w3c.github.io/webappsec-csp/#grammardef-optional-ascii-whitespace).
+const WHITESPACE: &[u8] = b" \t\n\x0c\r";
+
+/// Rewrites the `content` of every `<meta http-equiv="Content-Security-Policy">`
+/// that `HTMLLoader` recorded for the standalone HTML document `chunks[html]`,
+/// now that the contents of the chunks inlined into it are final, and adds
+/// a note to the log for each policy that changed. Returns `None` when the
+/// document has no such tag.
+pub(crate) fn resolve_for_html_chunk(
+    c: &LinkerContext<'_>,
+    html: usize,
+    chunks: &[Chunk],
+    standalone_chunk_contents: &[Option<Box<[u8]>>],
+) -> Option<Box<[Box<[u8]>]>> {
+    let chunk = &chunks[html];
+    let Some(CompileResult::Html {
+        content_security_policies,
+        ..
+    }) = chunk.compile_results_for_chunk.iter().next()
+    else {
+        return None;
+    };
+    if content_security_policies.is_empty() {
+        return None;
+    }
+
+    let js_chunk = chunk.get_js_chunk_index_for_html(chunks);
+    let css_chunk = chunk.get_css_chunk_index_for_html(chunks);
+
+    // The inline `<script>` / `<style>` this document gets for each chunk
+    // (see `HTMLLoader::standalone_body_script` / `get_head_tags`). A browser
+    // returns before the CSP check for an empty script, so that needs no hash.
+    let inline_block_hash = |index: Option<usize>| -> Option<HashSource> {
+        let index = index?;
+        let content = standalone_chunk_contents[index].as_deref()?;
+        if content.is_empty() {
+            return None;
+        }
+        Some(hash_source(
+            &IntermediateOutput::sha256_escaping_closing_tags(
+                content,
+                chunks[index].closing_tag_for_content(),
+            ),
+        ))
+    };
+    let scripts: Vec<HashSource> = inline_block_hash(js_chunk).into_iter().collect();
+    let styles: Vec<HashSource> = inline_block_hash(css_chunk).into_iter().collect();
+
+    // Every reference this document, its bundle and its stylesheet make to a
+    // file that standalone mode turns into a data: URL.
+    let parse_graph = c.parse_graph();
+    let loaders = parse_graph.input_files.items_loader();
+    let urls_for_css = parse_graph.ast.items_url_for_css();
+    let import_records = c.graph.ast.items_import_records();
+    let mut data_urls = DataUrlKinds::default();
+    let mut visit = |source_index: u32, importer_is_js: bool| {
+        let Some(records) = import_records.get(source_index as usize) else {
+            return;
+        };
+        for record in records.as_slice() {
+            if record.source_index.is_invalid() {
+                continue;
+            }
+            let target = record.source_index.get() as usize;
+            let url = urls_for_css[target];
+            if url.is_empty() {
+                continue;
+            }
+            let loader = loaders[target];
+            // JS only sees a URL for file-loader imports; HTML attributes and
+            // CSS `url()` take the data: URL of anything that is not code.
+            let becomes_data_url = if importer_is_js {
+                loader.should_copy_for_bundling()
+            } else {
+                !(loader.is_javascript_like() || loader.is_css())
+            };
+            if becomes_data_url {
+                data_urls.add_data_url(url);
+            }
+        }
+    };
+    visit(chunk.entry_point.source_index(), false);
+    if let Some(Content::Javascript(js)) = js_chunk.map(|i| &chunks[i].content) {
+        for &source_index in js.files_in_chunk_order.iter() {
+            visit(source_index, true);
+        }
+    }
+    if let Some(Content::Css(css)) = css_chunk.map(|i| &chunks[i].content) {
+        for order in css.imports_in_chunk_in_order.iter() {
+            if let CssImportOrderKind::SourceIndex(source_index) = &order.kind {
+                visit(source_index.get(), false);
+            }
+        }
+    }
+
+    let inlined = InlinedContent {
+        scripts: &scripts,
+        styles: &styles,
+        data_urls,
+    };
+    let pretty_path = parse_graph.input_files.items_source()
+        [chunk.entry_point.source_index() as usize]
+        .path
+        .pretty;
+    let resolved = content_security_policies
+        .iter()
+        .map(|value| {
+            // `value` is the attribute as written, character references
+            // included. The browser parses the decoded text.
+            let Some(rewrite) = rewrite(&decode_character_references(value), &inlined) else {
+                return value.clone();
+            };
+
+            let mut note: Vec<u8> = Vec::new();
+            write!(
+                &mut note,
+                "{}: added {} in its <meta http-equiv=\"Content-Security-Policy\"> for the content this build inlined",
+                BStr::new(pretty_path),
+                BStr::new(&rewrite.summary),
+            )
+            .ok();
+            c.log_disjoint().add_msg(bun_ast::Msg {
+                kind: bun_ast::Kind::Note,
+                data: bun_ast::Data {
+                    text: Cow::Owned(note),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+
+            let mut out = Vec::with_capacity(rewrite.policy.len() + 16);
+            for &byte in rewrite.policy.iter() {
+                match byte {
+                    b'&' => out.extend_from_slice(b"&amp;"),
+                    b'"' => out.extend_from_slice(b"&quot;"),
+                    _ => out.push(byte),
+                }
+            }
+            out.into_boxed_slice()
+        })
+        .collect();
+    Some(resolved)
+}
+
+/// `raw` with its `&…;` character references decoded.
+fn decode_character_references(raw: &[u8]) -> Cow<'_, [u8]> {
+    let Some(first) = strings::index_of_char_usize(raw, b'&') else {
+        return Cow::Borrowed(raw);
+    };
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(&raw[..first]);
+    let mut rest = &raw[first..];
+    let mut utf8 = [0u8; 8];
+    while !rest.is_empty() {
+        // `rest` starts with `&`.
+        let reference_len = rest[1..]
+            .iter()
+            .take(48)
+            .position(|&b| !(b.is_ascii_alphanumeric() || b == b'#'))
+            .map(|name_len| name_len + 2)
+            .filter(|&len| len > 2 && rest[len - 1] == b';');
+        match reference_len
+            .and_then(|len| bun_md::helpers::decode_entity_to_utf8(&rest[..len], &mut utf8))
+        {
+            Some(decoded) => {
+                out.extend_from_slice(decoded);
+                rest = &rest[reference_len.unwrap()..];
+            }
+            None => {
+                out.push(b'&');
+                rest = &rest[1..];
+            }
+        }
+        let next = strings::index_of_char_usize(rest, b'&').unwrap_or(rest.len());
+        out.extend_from_slice(&rest[..next]);
+        rest = &rest[next..];
+    }
+    Cow::Owned(out)
+}
+
+/// `'sha256-` + 44 base64 chars + `'`.
+const HASH_SOURCE_LEN: usize = 8 + 44 + 1;
+type HashSource = [u8; HASH_SOURCE_LEN];
+
+fn hash_source(digest: &[u8; 32]) -> HashSource {
+    let mut out = [0u8; HASH_SOURCE_LEN];
+    out[..8].copy_from_slice(b"'sha256-");
+    let n = bun_base64::encode(&mut out[8..8 + 44], digest);
+    debug_assert_eq!(n, 44);
+    out[HASH_SOURCE_LEN - 1] = b'\'';
+    out
+}
+
+/// Which fetch directives the inlined `data:` URLs fall under.
+#[derive(Clone, Copy, Default)]
+struct DataUrlKinds {
+    /// `img-src`: `<img>`, icons, posters, CSS images.
+    image: bool,
+    /// `font-src`
+    font: bool,
+    /// `media-src`: `<video>`, `<audio>`, `<source>`.
+    media: bool,
+    /// `manifest-src`: `<link rel="manifest">`.
+    manifest: bool,
+}
+
+impl DataUrlKinds {
+    /// Classifies one `data:<mime>;base64,…` URL by its MIME type.
+    fn add_data_url(&mut self, url: &[u8]) {
+        let Some(rest) = url.strip_prefix(b"data:".as_slice()) else {
+            return;
+        };
+        if rest.starts_with(b"image/") {
+            self.image = true;
+        } else if rest.starts_with(b"font/")
+            || rest.starts_with(b"application/font-")
+            || rest.starts_with(b"application/x-font-")
+            || rest.starts_with(b"application/vnd.ms-fontobject")
+        {
+            self.font = true;
+        } else if rest.starts_with(b"video/") || rest.starts_with(b"audio/") {
+            self.media = true;
+        } else if rest.starts_with(b"application/manifest+json") {
+            self.manifest = true;
+        }
+    }
+
+    fn any(&self) -> bool {
+        self.image || self.font || self.media || self.manifest
+    }
+}
+
+/// What the standalone document inlines, as CSP source expressions.
+struct InlinedContent<'a> {
+    /// One hash per inline `<script>` block, in document order.
+    scripts: &'a [HashSource],
+    /// One hash per inline `<style>` block.
+    styles: &'a [HashSource],
+    data_urls: DataUrlKinds,
+}
+
+struct Directive<'a> {
+    /// The directive as written, without surrounding whitespace.
+    raw: &'a [u8],
+    name: &'a [u8],
+    /// Source list text after the name, trimmed.
+    value: &'a [u8],
+}
+
+impl<'a> Directive<'a> {
+    fn parse(raw: &'a [u8]) -> Option<Self> {
+        let raw = strings::trim(raw, WHITESPACE);
+        if raw.is_empty() {
+            return None;
+        }
+        let name_end = strings::index_of_any(raw, WHITESPACE).unwrap_or(raw.len());
+        Some(Directive {
+            raw,
+            name: &raw[..name_end],
+            value: strings::trim(&raw[name_end..], WHITESPACE),
+        })
+    }
+
+    fn sources(&self) -> impl Iterator<Item = &'a [u8]> {
+        strings::tokenize_any(self.value, WHITESPACE)
+    }
+
+    fn has_source(&self, source: &[u8]) -> bool {
+        self.sources()
+            .any(|s| strings::eql_case_insensitive_ascii_check_length(s, source))
+    }
+
+    fn is_none(&self) -> bool {
+        let mut sources = self.sources();
+        matches!(sources.next(), Some(s) if strings::eql_case_insensitive_ascii_check_length(s, b"'none'"))
+            && sources.next().is_none()
+    }
+
+    /// A nonce or hash in the list makes browsers ignore `'unsafe-inline'`.
+    fn has_nonce_or_hash(&self) -> bool {
+        self.sources().any(|s| {
+            strings::starts_with_case_insensitive_ascii(s, b"'nonce-")
+                || strings::starts_with_case_insensitive_ascii(s, b"'sha256-")
+                || strings::starts_with_case_insensitive_ascii(s, b"'sha384-")
+                || strings::starts_with_case_insensitive_ascii(s, b"'sha512-")
+        })
+    }
+
+    fn allows_inline(&self) -> bool {
+        self.has_source(b"'unsafe-inline'") && !self.has_nonce_or_hash()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Need<'a> {
+    /// Inline `<script>` / `<style>` blocks with these hashes.
+    Inline(&'a [HashSource]),
+    /// `data:` URLs.
+    Data,
+}
+
+struct Rewrite {
+    policy: Vec<u8>,
+    /// "<sources> to <directive>, …" for the build note.
+    summary: Vec<u8>,
+}
+
+/// Returns the rewritten policy, or `None` when `policy` already allows
+/// everything in `inlined` (or blocks it on purpose with `'none'`).
+fn rewrite(policy: &[u8], inlined: &InlinedContent<'_>) -> Option<Rewrite> {
+    if inlined.scripts.is_empty() && inlined.styles.is_empty() && !inlined.data_urls.any() {
+        return None;
+    }
+
+    let directives: Vec<Directive<'_>> = strings::split(policy, b";")
+        .filter_map(Directive::parse)
+        .collect();
+    // Per the spec a repeated directive name is ignored after its first use.
+    let find = |name: &[u8]| -> Option<usize> {
+        directives
+            .iter()
+            .position(|d| strings::eql_case_insensitive_ascii_check_length(d.name, name))
+    };
+
+    // Sources to add to an existing directive, indexed like `directives`.
+    let mut additions: Vec<Vec<u8>> = (0..directives.len()).map(|_| Vec::new()).collect();
+    // New directives, each split off the fallback that governs it today.
+    let mut appended: Vec<u8> = Vec::new();
+    let mut summary: Vec<u8> = Vec::new();
+
+    // (directive, its fallbacks, what it must allow). `*-src-elem` (CSP3)
+    // takes precedence over `*-src` in browsers that know it, so when a page
+    // uses it the hash goes there too, but it is never introduced.
+    // https://w3c.github.io/webappsec-csp/#directive-fallback-list
+    const DEFAULT_SRC: &[&[u8]] = &[b"default-src"];
+    let kinds = inlined.data_urls;
+    let needs: [(&[u8], &[&[u8]], Need<'_>, bool); 8] = [
+        (b"script-src-elem", &[], Need::Inline(inlined.scripts), true),
+        (
+            b"script-src",
+            DEFAULT_SRC,
+            Need::Inline(inlined.scripts),
+            true,
+        ),
+        (b"style-src-elem", &[], Need::Inline(inlined.styles), true),
+        (
+            b"style-src",
+            DEFAULT_SRC,
+            Need::Inline(inlined.styles),
+            true,
+        ),
+        (b"img-src", DEFAULT_SRC, Need::Data, kinds.image),
+        (b"font-src", DEFAULT_SRC, Need::Data, kinds.font),
+        (b"media-src", DEFAULT_SRC, Need::Data, kinds.media),
+        (b"manifest-src", DEFAULT_SRC, Need::Data, kinds.manifest),
+    ];
+
+    for (name, fallbacks, need, present) in needs {
+        if !present {
+            continue;
+        }
+        let own = find(name);
+        // The directive that governs this kind of content today.
+        let Some(index) = own.or_else(|| fallbacks.iter().find_map(|f| find(f))) else {
+            // Nothing restricts it.
+            continue;
+        };
+        let effective = &directives[index];
+        if effective.is_none() {
+            // `'none'` blocked this content on the multi-file site too.
+            continue;
+        }
+
+        let mut sources: Vec<u8> = Vec::new();
+        match need {
+            Need::Inline(hashes) => {
+                if effective.allows_inline() {
+                    continue;
+                }
+                for hash in hashes {
+                    if !effective.has_source(hash) {
+                        sources.push(b' ');
+                        sources.extend_from_slice(hash);
+                    }
+                }
+            }
+            Need::Data => {
+                if !effective.has_source(b"data:") {
+                    sources.extend_from_slice(b" data:");
+                }
+            }
+        }
+        if sources.is_empty() {
+            continue;
+        }
+        if !summary.is_empty() {
+            summary.extend_from_slice(b", ");
+        }
+        summary.extend_from_slice(&sources[1..]);
+        summary.extend_from_slice(b" to ");
+        summary.extend_from_slice(name);
+
+        if own.is_some() {
+            additions[index].extend_from_slice(&sources);
+            continue;
+        }
+        // Split a dedicated directive off the fallback so the fallback, and
+        // everything else that inherits it, stays as written.
+        appended.extend_from_slice(b"; ");
+        appended.extend_from_slice(name);
+        for source in effective.sources() {
+            // Keywords other than 'self', nonces and hashes only mean
+            // something to scripts and styles.
+            if matches!(need, Need::Data)
+                && source.starts_with(b"'")
+                && !strings::eql_case_insensitive_ascii_check_length(source, b"'self'")
+            {
+                continue;
+            }
+            appended.push(b' ');
+            appended.extend_from_slice(source);
+        }
+        appended.extend_from_slice(&sources);
+    }
+
+    if summary.is_empty() {
+        return None;
+    }
+
+    let mut out: Vec<u8> = Vec::with_capacity(policy.len() + appended.len() + 2 * HASH_SOURCE_LEN);
+    for (i, directive) in directives.iter().enumerate() {
+        if i > 0 {
+            out.extend_from_slice(b"; ");
+        }
+        out.extend_from_slice(directive.raw);
+        out.extend_from_slice(&additions[i]);
+    }
+    // Something was restricted, so there is at least one directive for
+    // `appended`'s leading "; " to follow.
+    out.extend_from_slice(&appended);
+    Some(Rewrite {
+        policy: out,
+        summary,
+    })
+}

--- a/src/md/helpers.rs
+++ b/src/md/helpers.rs
@@ -224,7 +224,7 @@ pub use bun_core::strings::eql_case_insensitive_ascii_check_length as ascii_case
 
 /// Find an HTML entity starting at `start` (which must point to '&').
 /// Returns the end position (one past the ';') or null if no valid entity found.
-pub(crate) fn find_entity(content: &[u8], start: usize) -> Option<usize> {
+pub fn find_entity(content: &[u8], start: usize) -> Option<usize> {
     if start + 2 >= content.len() {
         return None;
     }

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -626,7 +626,7 @@ console.log(message);`,
         "index.html": `<!doctype html><html><head>
 <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
 </head><body><script src="./app.js"></script></body></html>`,
-        "app.js": `document.title = "</script><script>alert(1)</script>";`,
+        "app.js": `document.title = "</script><script>alert(1)</script>" + "<!-- x -->";`,
       });
 
       const { html } = await buildStandalone(String(dir));
@@ -634,6 +634,39 @@ console.log(message);`,
       const script = inlineScript(html)!;
       expect(script).toContain("<\\/script>");
       expect(policies(html)).toEqual([`script-src 'self' ${sha256(script)}`]);
+    });
+
+    test("CRLF and CR are written as LF, which is what the browser hashes", async () => {
+      // The HTML tokenizer turns CRLF and lone CR into LF before the text of
+      // an inline <script>/<style> exists, so a hash over raw CR bytes never
+      // matches. The CSS printer keeps CRLF inside /*! */ comments, and
+      // banner/footer text is written as given.
+      using dir = tempDir("compile-browser-csp-crlf", {
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+<link rel="stylesheet" href="./a.css"></head><body><script src="./app.js"></script></body></html>`,
+        "a.css": "/*! license\r\n * line 2\r\n */\r\nbody { color: red }\r\n",
+        "app.js": "/*! license\r\n * line 2 */\r\nconsole.log(`a\r\nb`);\r\n",
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/index.html`],
+        compile: true,
+        target: "browser",
+        banner: "/* banner\r\n * line 2 */\r",
+        footer: "// footer\rend",
+      });
+      expect(result.success).toBe(true);
+      const html = await result.outputs[0].text();
+      const script = inlineScript(html)!;
+      const style = inlineStyle(html)!;
+      expect(script).toContain("banner\n * line 2 */\n");
+      expect(script).toContain("// footer\nend");
+      expect(style).toContain("license\n * line 2\n */");
+      expect(html).not.toContain("\r");
+      expect(policies(html)).toEqual([
+        `default-src 'self'; script-src 'self' ${sha256(script)}; style-src 'self' ${sha256(style)}`,
+      ]);
     });
 
     test("every policy in the document is rewritten, other http-equiv metas are not", async () => {

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -578,13 +578,14 @@ console.log(message);`,
     test("existing directives are extended in place and satisfied ones are left alone", async () => {
       using dir = tempDir("compile-browser-csp-existing", {
         "index.html": `<!doctype html><html><head>
-<meta http-equiv="content-security-policy" content=" Script-Src 'self' https://cdn.example.com ;style-src 'unsafe-inline'; img-src * ; font-src 'self' data:; media-src 'none';;">
-<link rel="stylesheet" href="./a.css"></head>
+<meta http-equiv="content-security-policy" content=" Script-Src 'self' https://cdn.example.com ;style-src 'unsafe-inline'; img-src * ; font-src 'self' data:; media-src 'none'; manifest-src ;;">
+<link rel="stylesheet" href="./a.css"><link rel="manifest" href="./app.webmanifest"></head>
 <body><video src="./v.mp4"></video><script src="./app.js"></script></body></html>`,
         "a.css": `@font-face { font-family: f; src: url(./f.woff2); } body { background: url("./i.png"); }`,
         "f.woff2": "not really a font",
         "i.png": png,
         "v.mp4": "not really a video",
+        "app.webmanifest": `{ "name": "app" }`,
         "app.js": `console.log("app");`,
       });
 
@@ -593,14 +594,16 @@ console.log(message);`,
       expect(html).toContain('url("data:font/woff2;base64,');
       expect(html).toContain('url("data:image/png;base64,');
       expect(html).toContain('<video src="data:video/mp4;base64,');
+      expect(html).toContain('<link rel="manifest" href="data:application/manifest+json;base64,');
 
       // script-src: hash appended (directive names are case-insensitive).
       // style-src: 'unsafe-inline' already allows the <style>.
       // img-src: `*` does not match data:, so it is added.
       // font-src: already lists data:.
-      // media-src 'none': the video was blocked on the multi-file site too.
+      // media-src 'none', manifest-src with no sources: blocked on the
+      // multi-file site too, so they stay that way.
       expect(policies(html)).toEqual([
-        `Script-Src 'self' https://cdn.example.com ${sha256(script)}; style-src 'unsafe-inline'; img-src * data:; font-src 'self' data:; media-src 'none'`,
+        `Script-Src 'self' https://cdn.example.com ${sha256(script)}; style-src 'unsafe-inline'; img-src * data:; font-src 'self' data:; media-src 'none'; manifest-src`,
       ]);
     });
 
@@ -672,7 +675,7 @@ document.querySelector("img").src = logo;`,
       using dir = tempDir("compile-browser-csp-entities", {
         // What a server-side renderer that escapes `'` leaves behind.
         "index.html": `<!doctype html><html><head>
-<meta http-equiv="Content-Security-Policy" content="default-src &#x27;self&#x27;; style-src &#39;unsafe-inline&#39;; script-src 'self' &quot;">
+<meta http-equiv="Content-Security-Policy" content="default-src &#x27;self&#x27;; style-src &#39;unsafe-inline&#39;; script-src 'self' &quot;; report-uri /csp?a&##;b&amp;c&bogus;">
 <link rel="stylesheet" href="./a.css"></head><body><script src="./app.js"></script></body></html>`,
         "a.css": `body { color: red }`,
         "app.js": `console.log("app");`,
@@ -681,9 +684,11 @@ document.querySelector("img").src = logo;`,
       const script = inlineScript(html)!;
       // 'unsafe-inline' is recognized through the references, so style-src
       // gets no hash (a hash would turn 'unsafe-inline' off). The rewritten
-      // value is re-escaped for the double-quoted attribute.
+      // value is re-escaped for the double-quoted attribute. `&` sequences
+      // that are not a reference stay literal text, so their `;` separates
+      // directives like any other.
       expect(policies(html)).toEqual([
-        `default-src 'self'; style-src 'unsafe-inline'; script-src 'self' &quot; ${sha256(script)}`,
+        `default-src 'self'; style-src 'unsafe-inline'; script-src 'self' &quot; ${sha256(script)}; report-uri /csp?a&amp;##; b&amp;c&amp;bogus`,
       ]);
     });
 

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -522,6 +522,189 @@ console.log(message);`,
     expect(html).toContain("</script>");
   });
 
+  // A <meta http-equiv="Content-Security-Policy"> written for the multi-file
+  // site (`'self'`) blocks the inline <script>/<style> and data: URLs the
+  // standalone document is made of. The policy is rewritten with a hash per
+  // inline block and `data:` for the kinds of asset that were inlined.
+  describe.concurrent("Content-Security-Policy meta", () => {
+    const png = Buffer.from("89504e470d0a1a0a", "hex");
+    const sha256 = (text: string) => `'sha256-${new Bun.CryptoHasher("sha256").update(text).digest("base64")}'`;
+    const policies = (html: string) =>
+      [...html.matchAll(/http-equiv="content-security-policy"\s+content="([^"]*)"/gi)].map(m => m[1]);
+    const inlineScript = (html: string) => /<script type="module">([\s\S]*?)<\/script>/.exec(html)?.[1];
+    const inlineStyle = (html: string) => /<style>([\s\S]*?)<\/style>/.exec(html)?.[1];
+
+    async function buildStandalone(dir: string) {
+      const result = await Bun.build({
+        entrypoints: [`${dir}/index.html`],
+        compile: true,
+        target: "browser",
+      });
+      expect(result.success).toBe(true);
+      expect(result.outputs).toHaveLength(1);
+      return { html: await result.outputs[0].text(), logs: result.logs };
+    }
+
+    test("default-src 'self' gets a directive per kind of inlined content", async () => {
+      using dir = tempDir("compile-browser-csp-default-src", {
+        "index.html": `<!doctype html><html><head><meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+<link rel="stylesheet" href="./a.css"></head>
+<body><img src="./i.png"><script type="module" src="./app.js"></script></body></html>`,
+        "a.css": `body { background: rgb(1, 2, 3) }`,
+        "i.png": png,
+        "app.js": `document.documentElement.setAttribute("data-ran", "1");`,
+      });
+
+      const { html, logs } = await buildStandalone(String(dir));
+      const script = inlineScript(html)!;
+      const style = inlineStyle(html)!;
+      expect(script).toContain("data-ran");
+      expect(style).toContain("background");
+      expect(html).toContain('<img src="data:image/png;base64,');
+
+      // default-src itself stays as written so everything else still
+      // inherits 'self'; each kind of inlined content gets its own directive.
+      expect(policies(html)).toEqual([
+        `default-src 'self'; script-src 'self' ${sha256(script)}; style-src 'self' ${sha256(style)}; img-src 'self' data:`,
+      ]);
+      // The build says what it added.
+      expect(logs.map(log => log.level)).toEqual(["note"]);
+      expect(logs[0].message).toEndWith(
+        `index.html: added ${sha256(script)} to script-src, ${sha256(style)} to style-src, data: to img-src in its <meta http-equiv="Content-Security-Policy"> for the content this build inlined`,
+      );
+    });
+
+    test("existing directives are extended in place and satisfied ones are left alone", async () => {
+      using dir = tempDir("compile-browser-csp-existing", {
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="content-security-policy" content=" Script-Src 'self' https://cdn.example.com ;style-src 'unsafe-inline'; img-src * ; font-src 'self' data:; media-src 'none';;">
+<link rel="stylesheet" href="./a.css"></head>
+<body><video src="./v.mp4"></video><script src="./app.js"></script></body></html>`,
+        "a.css": `@font-face { font-family: f; src: url(./f.woff2); } body { background: url("./i.png"); }`,
+        "f.woff2": "not really a font",
+        "i.png": png,
+        "v.mp4": "not really a video",
+        "app.js": `console.log("app");`,
+      });
+
+      const { html } = await buildStandalone(String(dir));
+      const script = inlineScript(html)!;
+      expect(html).toContain('url("data:font/woff2;base64,');
+      expect(html).toContain('url("data:image/png;base64,');
+      expect(html).toContain('<video src="data:video/mp4;base64,');
+
+      // script-src: hash appended (directive names are case-insensitive).
+      // style-src: 'unsafe-inline' already allows the <style>.
+      // img-src: `*` does not match data:, so it is added.
+      // font-src: already lists data:.
+      // media-src 'none': the video was blocked on the multi-file site too.
+      expect(policies(html)).toEqual([
+        `Script-Src 'self' https://cdn.example.com ${sha256(script)}; style-src 'unsafe-inline'; img-src * data:; font-src 'self' data:; media-src 'none'`,
+      ]);
+    });
+
+    test("a nonce or hash next to 'unsafe-inline' still needs the hash", async () => {
+      using dir = tempDir("compile-browser-csp-nonce", {
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="Content-Security-Policy" content="script-src 'unsafe-inline' 'nonce-abc123'">
+</head><body><script nonce="abc123" src="./app.js"></script></body></html>`,
+        "app.js": `console.log("app");`,
+      });
+
+      const { html } = await buildStandalone(String(dir));
+      const script = inlineScript(html)!;
+      // Browsers ignore 'unsafe-inline' when a nonce or hash is present.
+      expect(policies(html)).toEqual([`script-src 'unsafe-inline' 'nonce-abc123' ${sha256(script)}`]);
+    });
+
+    test("the hash covers the escaped <\\/script> text the browser sees", async () => {
+      using dir = tempDir("compile-browser-csp-escape", {
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self'">
+</head><body><script src="./app.js"></script></body></html>`,
+        "app.js": `document.title = "</script><script>alert(1)</script>";`,
+      });
+
+      const { html } = await buildStandalone(String(dir));
+      expect(html.split("</script>").length - 1).toBe(1);
+      const script = inlineScript(html)!;
+      expect(script).toContain("<\\/script>");
+      expect(policies(html)).toEqual([`script-src 'self' ${sha256(script)}`]);
+    });
+
+    test("every policy in the document is rewritten, other http-equiv metas are not", async () => {
+      using dir = tempDir("compile-browser-csp-multiple", {
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; img-src 'self'; report-uri /csp?a=1&amp;b=2">
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'strict-dynamic'">
+</head><body><img><script src="./app.js"></script></body></html>`,
+        "app.js": `import logo from "./logo.png";
+document.querySelector("img").src = logo;`,
+        "logo.png": png,
+      });
+
+      const { html } = await buildStandalone(String(dir));
+      const script = inlineScript(html)!;
+      // An image that only JS references still becomes a data: URL.
+      expect(script).toContain('"data:image/png;base64,');
+      expect(html).toContain('<meta http-equiv="X-UA-Compatible" content="IE=edge">');
+      expect(policies(html)).toEqual([
+        `default-src 'none'; script-src 'self' ${sha256(script)}; img-src 'self' data:; report-uri /csp?a=1&amp;b=2`,
+        `script-src 'self' 'strict-dynamic' ${sha256(script)}`,
+      ]);
+    });
+
+    test("a policy that does not restrict the inlined content is left as written", async () => {
+      using dir = tempDir("compile-browser-csp-unrelated", {
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="Content-Security-Policy" content=" upgrade-insecure-requests;;object-src  'none' ">
+</head><body><script src="./app.js"></script></body></html>`,
+        "app.js": `console.log("app");`,
+      });
+      const { html, logs } = await buildStandalone(String(dir));
+      expect(policies(html)).toEqual([` upgrade-insecure-requests;;object-src  'none' `]);
+      expect(logs).toEqual([]);
+    });
+
+    test("character references in the attribute are decoded before the policy is read", async () => {
+      using dir = tempDir("compile-browser-csp-entities", {
+        // What a server-side renderer that escapes `'` leaves behind.
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="Content-Security-Policy" content="default-src &#x27;self&#x27;; style-src &#39;unsafe-inline&#39;; script-src 'self' &quot;">
+<link rel="stylesheet" href="./a.css"></head><body><script src="./app.js"></script></body></html>`,
+        "a.css": `body { color: red }`,
+        "app.js": `console.log("app");`,
+      });
+      const { html } = await buildStandalone(String(dir));
+      const script = inlineScript(html)!;
+      // 'unsafe-inline' is recognized through the references, so style-src
+      // gets no hash (a hash would turn 'unsafe-inline' off). The rewritten
+      // value is re-escaped for the double-quoted attribute.
+      expect(policies(html)).toEqual([
+        `default-src 'self'; style-src 'unsafe-inline'; script-src 'self' &quot; ${sha256(script)}`,
+      ]);
+    });
+
+    test("a non-standalone HTML build leaves the policy alone", async () => {
+      using dir = tempDir("compile-browser-csp-regular-build", {
+        "index.html": `<!doctype html><html><head>
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+</head><body><script src="./app.js"></script></body></html>`,
+        "app.js": `console.log("app");`,
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/index.html`],
+        outdir: `${dir}/out`,
+      });
+      expect(result.success).toBe(true);
+      const html = await Bun.file(result.outputs.find(o => o.path.endsWith(".html"))!.path).text();
+      expect(html).toContain(`<meta http-equiv="Content-Security-Policy" content="default-src 'self'">`);
+    });
+  });
+
   // https://github.com/oven-sh/bun/issues/32114
   describe.concurrent("sourcemaps", () => {
     const fixture = {


### PR DESCRIPTION
### Problem
- `bun build --compile --target=browser` inlines scripts, styles and assets into one file, but copies `<meta http-equiv="Content-Security-Policy" content="default-src 'self'">` verbatim. `'self'` does not match inline blocks or `data:` URLs, so the page blocks its own content: "Executing inline script violates the following Content Security Policy directive". The unbundled site runs.
- The HTML pass (`generateCompileResultForHtmlChunk.rs`) never looked at `<meta>`. A hash cannot be added by hand: it depends on the output.

### Fix
- `HTMLLoader` records the policy and leaves a `QueryKind::ContentSecurityPolicy` placeholder. Once the JS and CSS chunks are printed, `generate_chunks_in_parallel` rewrites the policy (`standaloneHtmlCsp.rs`) and the placeholder is filled like the other standalone pieces.
- It adds a `'sha256-...'` of the inline `<script>` and `<style>` to the directives that govern them, and `data:` to `img-src`, `font-src`, `media-src`, `manifest-src` for the kinds of asset inlined. A kind that only `default-src` governs gets its own directive. `'unsafe-inline'`, `data:` and `'none'` are left alone. A build note lists the additions.
- One walker in `Chunk.rs` produces the inline text for the byte count, the copy and the hash: `</script` becomes `<\/script`, and CRLF or CR becomes LF as the HTML tokenizer makes it, so the bytes written are the bytes the browser hashes. Chrome loads the output with 0 violations and suggests the same hashes for the old output. Pages without a CSP meta and other build modes are unchanged.
- Verified: `test/bundler/standalone.test.ts` (9 new tests, 7 fail on 1.4.3), the bundler HTML suites, `test/bake/dev/html.test.ts`.

### Background
- Standalone HTML is assembled from pieces: the lol-html pass runs before sibling chunks are printed and leaves placeholders, later filled with chunk contents and `data:` URLs.
- CSP allows an inline block by `'unsafe-inline'`, a nonce, or a `'sha256-...'` of its text. A hash turns `'unsafe-inline'` off in its directive, so none is added beside one.

<details><summary>Notes</summary>

- Reported through an automated differential run over generated projects: 0 of 96 pages with a CSP meta ran as standalone output, 96 of 96 ran unbundled.
- Old output in Chrome 152 over loopback HTTP: `<html>` and 3 violations (inline style, data: image, inline script). New output: `<html data-ran="1">`, 0 violations. A stricter page (`default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'`) with a CSS font, a CSS background image, an icon and a JS image import also loads with 0 violations.
- CR handling: the CSS printer keeps CRLF inside `/*! */` comments and `--banner`/`--footer` text is written as given, so CR bytes reached the inline blocks. The HTML tokenizer normalizes them to LF before CSP hashing, so a hash over the raw bytes did not match (verified in Chrome: blocked before the normalization commit, 0 violations after). Writing LF is what the browser does anyway, so the JS and CSS are unchanged in meaning.
- #42013 rewrites the same escaper in `Chunk.rs` (it adds the `<!--` escape as `HtmlInlineContext`). The two conflict there by design: whichever lands second keeps one writer that does the `</script` and `<!--` escapes plus the CR normalization, and the hash goes through it. The `<!-- x -->` case in the escape test guards that.
- An absent fetch directive falls back to `default-src`, so a new `script-src` copies the `default-src` sources first and external scripts the page still loads keep working.
- lol-html returns attribute values with character references intact. The policy is decoded before parsing (a server-rendered page may carry `&#x27;self&#x27;`), malformed references stay literal, and the result is re-escaped for the double-quoted attribute lol-html writes.
- `connect-src` is not touched on purpose. A `fetch()` of an inlined `data:` URL (for example a file-loader `.wasm` import) still needs the author to allow `data:` there. The docs say so.
- An empty inline `<script type="module"></script>` (a page without scripts still gets one today) gets no hash: the HTML spec returns before the CSP check when the source text is empty. An empty source list is treated like `'none'`.
- `*-src-elem` (CSP3) takes precedence over `*-src` where supported, so when a page uses it the hash goes there too. It is never introduced.
- The dev server path returns early in the new handler; `test/bake/dev/html.test.ts` passes. Also ran `bundler_html.test.ts`, `bundler_html_server.test.ts`, `html-import-manifest.test.ts`.
- A second report from the same run (each reference to an asset embeds its own base64 copy) is a docs note that #41937 already carries, so it is not repeated here. #41937 also describes the old CSP behavior in the same file and needs a small update if this lands first.
- A page with no `<meta charset>` decodes the inlined script with the page's fallback encoding instead of UTF-8 (an external module is always UTF-8). That is a separate standalone-mode bug, tracked separately, and it also affects which bytes a browser hashes for non-ASCII scripts.
- A shape check ran before opening. It asked for the rewrite rather than a warning, `data:` limited to the asset directives, no `connect-src`, and a build note. Self-reviewed after opening: 5 concerns raised, 3 addressed here (CR normalization, `<!--` guard test, duplicate docs bullet), 1 handed to a separate change (charset), 1 kept as is: the review preferred a post-pass over the finished document to the placeholder. I kept the placeholder because a post-pass would re-parse a document that can be tens of megabytes of `data:` URLs and would have to tell bun's inline blocks apart from the author's own.

</details>
