### PR TITLE
install: warn when a required dependency is skipped for the target os/cpu

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -43,8 +43,8 @@ use crate::analytics;
 use crate::bun_bunfig::Arguments as Command;
 use crate::bun_progress::{Node as ProgressNode, Progress};
 use crate::lockfile::tree::{
-    DependencyFilter, filter_dependency_or_workspace, is_filtered_dependency_or_workspace,
-    warn_unsupported_platform,
+    DependencyFilter, UnsupportedPlatform, filter_dependency_or_workspace,
+    is_filtered_dependency_or_workspace, warn_unsupported_platform,
 };
 use crate::lockfile::{self, Lockfile};
 use crate::package_manager::{self, PackageManager, WorkspaceFilter, run_tasks};
@@ -235,7 +235,7 @@ pub(crate) fn build_store(
     let string_buf = &lockfile.buffers.string_bytes[..];
 
     let mut nodes: store::node::List = store::node::List::default();
-    let mut unsupported_platform: Vec<PackageID> = Vec::new();
+    let mut unsupported_platform = UnsupportedPlatform::default();
 
     // DFS so a deduplicated node's full subtree (and therefore its `peers`)
     // is finalized before any later sibling encounters it.
@@ -702,10 +702,8 @@ pub(crate) fn build_store(
                 ) {
                     DependencyFilter::Keep => {}
                     DependencyFilter::Skip => continue,
-                    DependencyFilter::SkipUnsupportedPlatform => {
-                        if !unsupported_platform.contains(&pkg_id) {
-                            unsupported_platform.push(pkg_id);
-                        }
+                    DependencyFilter::SkipUnsupportedPlatform { direct } => {
+                        unsupported_platform.insert(pkg_id, direct);
                         continue;
                     }
                 }

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -42,7 +42,10 @@ use bun_wyhash::{Wyhash, Wyhash11};
 use crate::analytics;
 use crate::bun_bunfig::Arguments as Command;
 use crate::bun_progress::{Node as ProgressNode, Progress};
-use crate::lockfile::tree::is_filtered_dependency_or_workspace;
+use crate::lockfile::tree::{
+    DependencyFilter, filter_dependency_or_workspace, is_filtered_dependency_or_workspace,
+    warn_unsupported_platform,
+};
 use crate::lockfile::{self, Lockfile};
 use crate::package_manager::{self, PackageManager, WorkspaceFilter, run_tasks};
 use crate::package_manager_real::ProgressStrings;
@@ -232,6 +235,7 @@ pub(crate) fn build_store(
     let string_buf = &lockfile.buffers.string_bytes[..];
 
     let mut nodes: store::node::List = store::node::List::default();
+    let mut unsupported_platform: Vec<PackageID> = Vec::new();
 
     // DFS so a deduplicated node's full subtree (and therefore its `peers`)
     // is finalized before any later sibling encounters it.
@@ -686,7 +690,8 @@ pub(crate) fn build_store(
             }
 
             for &dep_id in &dep_ids_sort_buf {
-                if is_filtered_dependency_or_workspace(
+                let pkg_id = resolutions[dep_id as usize];
+                match filter_dependency_or_workspace(
                     dep_id,
                     entry.pkg_id,
                     workspace_filters,
@@ -695,10 +700,15 @@ pub(crate) fn build_store(
                     lockfile,
                     resolutions,
                 ) {
-                    continue;
+                    DependencyFilter::Keep => {}
+                    DependencyFilter::Skip => continue,
+                    DependencyFilter::SkipUnsupportedPlatform => {
+                        if !unsupported_platform.contains(&pkg_id) {
+                            unsupported_platform.push(pkg_id);
+                        }
+                        continue;
+                    }
                 }
-
-                let pkg_id = resolutions[dep_id as usize];
                 let dep = &dependencies[dep_id as usize];
 
                 // TODO: handle duplicate dependencies. should be similar logic
@@ -1128,6 +1138,7 @@ pub(crate) fn build_store(
     Ok(Store {
         entries: store_entries,
         nodes,
+        unsupported_platform,
     })
 }
 
@@ -1162,6 +1173,16 @@ pub(crate) fn install_isolated_packages(
         packages_to_install,
         timings,
     )?;
+    // `packages_to_install` is the security scanner pre-pass; the full
+    // install that follows reports these.
+    if packages_to_install.is_none() {
+        warn_unsupported_platform(
+            manager.log_mut(),
+            lockfile,
+            manager,
+            &store.unsupported_platform,
+        );
+    }
 
     let global_store_path: Option<Vec<u8>> = if manager.options.enable.global_virtual_store() {
         'global_store_path: {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1171,8 +1171,7 @@ pub(crate) fn install_isolated_packages(
         packages_to_install,
         timings,
     )?;
-    // `packages_to_install` is the security scanner pre-pass; the full
-    // install that follows reports these.
+    // `Some(packages_to_install)` is the security scanner pre-pass, not the install
     if packages_to_install.is_none() {
         warn_unsupported_platform(
             manager.log_mut(),

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -26,6 +26,8 @@ pub struct Store {
     /// Accessed from multiple threads
     pub(crate) entries: entry::List,
     pub(crate) nodes: node::List,
+    /// Required dependencies left out for an `os`/`cpu` mismatch (deduplicated).
+    pub(crate) unsupported_platform: Vec<PackageID>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -26,8 +26,7 @@ pub struct Store {
     /// Accessed from multiple threads
     pub(crate) entries: entry::List,
     pub(crate) nodes: node::List,
-    /// Required dependencies left out for an `os`/`cpu` mismatch (deduplicated).
-    pub(crate) unsupported_platform: Vec<PackageID>,
+    pub(crate) unsupported_platform: crate::lockfile::tree::UnsupportedPlatform,
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1354,8 +1354,7 @@ impl Lockfile {
             workspace_filters,
             packages_to_install,
         )?;
-        // `packages_to_install` is the security scanner pre-pass; the full
-        // install that follows reports these.
+        // `Some(packages_to_install)` is the security scanner pre-pass, not the install
         if packages_to_install.is_none() {
             tree::warn_unsupported_platform(log, self, manager, &hoisted.unsupported_platform);
         }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1405,7 +1405,7 @@ impl Lockfile {
             late_bound_optional_peer: false,
             list: Default::default(),
             sort_buf: Default::default(),
-            unsupported_platform: Vec::new(),
+            unsupported_platform: Default::default(),
         };
 
         Tree::default().process_subtree(tree::ROOT_DEP_ID, tree::INVALID_ID, &mut builder)?;

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1331,10 +1331,14 @@ impl<'a> Cloner<'a> {
 impl Lockfile {
     /// Re-hoists while a pass bound an optional peer late; a reload has that binding up front.
     pub(crate) fn resolve(&mut self, log: &mut bun_ast::Log) -> Result<(), tree::SubtreeError> {
-        while self.hoist::<{ tree::BuilderMethod::Resolvable }>(log, None, true, &[], None)? {}
+        while self
+            .hoist::<{ tree::BuilderMethod::Resolvable }>(log, None, true, &[], None)?
+            .late_bound_optional_peer
+        {}
         Ok(())
     }
 
+    /// The install's tree build (`bun prune` calls `hoist` directly).
     pub(crate) fn filter(
         &mut self,
         log: &mut bun_ast::Log,
@@ -1343,17 +1347,22 @@ impl Lockfile {
         workspace_filters: &[WorkspaceFilter],
         packages_to_install: Option<&[PackageID]>,
     ) -> Result<(), tree::SubtreeError> {
-        self.hoist::<{ tree::BuilderMethod::Filter }>(
+        let hoisted = self.hoist::<{ tree::BuilderMethod::Filter }>(
             log,
             Some(manager),
             install_root_dependencies,
             workspace_filters,
             packages_to_install,
         )?;
+        // `packages_to_install` is the security scanner pre-pass; the full
+        // install that follows reports these.
+        if packages_to_install.is_none() {
+            tree::warn_unsupported_platform(log, self, manager, &hoisted.unsupported_platform);
+        }
         Ok(())
     }
 
-    /// Sets `buffers.trees`/`hoisted_dependencies`; returns `Builder::late_bound_optional_peer`.
+    /// Sets `buffers.trees`/`hoisted_dependencies`.
     pub(crate) fn hoist<const METHOD: tree::BuilderMethod>(
         &mut self,
         log: &mut bun_ast::Log,
@@ -1363,7 +1372,7 @@ impl Lockfile {
         install_root_dependencies: bool,
         workspace_filters: &[WorkspaceFilter],
         packages_to_install: Option<&[PackageID]>,
-    ) -> Result<bool, tree::SubtreeError> {
+    ) -> Result<tree::Hoisted, tree::SubtreeError> {
         let slice = self.packages.slice();
 
         // Only the install applies the barrier, so the saved tree does not depend on it.
@@ -1396,6 +1405,7 @@ impl Lockfile {
             late_bound_optional_peer: false,
             list: Default::default(),
             sort_buf: Default::default(),
+            unsupported_platform: Vec::new(),
         };
 
         Tree::default().process_subtree(tree::ROOT_DEP_ID, tree::INVALID_ID, &mut builder)?;
@@ -1412,10 +1422,13 @@ impl Lockfile {
         }
 
         let cleaned = builder.clean()?;
-        let late_bound_optional_peer = builder.late_bound_optional_peer;
+        let hoisted = tree::Hoisted {
+            late_bound_optional_peer: builder.late_bound_optional_peer,
+            unsupported_platform: core::mem::take(&mut builder.unsupported_platform),
+        };
         self.buffers.trees = cleaned.trees;
         self.buffers.hoisted_dependencies = cleaned.dep_ids;
-        Ok(late_bound_optional_peer)
+        Ok(hoisted)
     }
 }
 

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -699,8 +699,7 @@ pub(crate) fn filter_dependency_or_workspace(
     }
 }
 
-/// One warning per direct dependency and one summary line for the transitive
-/// ones, so a required dependency never goes missing silently.
+/// One warning per direct dependency, one summary line for all transitive ones.
 pub(crate) fn warn_unsupported_platform(
     log: &mut bun_ast::Log,
     lockfile: &Lockfile,
@@ -748,9 +747,7 @@ pub(crate) fn warn_unsupported_platform(
         );
     }
 
-    // Dependencies of dependencies get one line in total: a lockfile written
-    // by an old bun can list a package's optional platform builds as plain
-    // dependencies, and those must not bury the output.
+    // one line in total: old bun lockfiles list esbuild's platform builds as plain dependencies
     if !skipped.transitive.is_empty() {
         const LISTED: usize = 3;
         let count = skipped.transitive.len();

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -444,8 +444,7 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
     pub(crate) packages_to_install: Option<&'a [PackageID]>,
     /// Workspace package ids that are hoisting barriers (self-contained node_modules).
     pub(crate) self_contained: Vec<PackageID>,
-    /// Required dependencies left out for an `os`/`cpu` mismatch (deduplicated).
-    pub(crate) unsupported_platform: Vec<PackageID>,
+    pub(crate) unsupported_platform: UnsupportedPlatform,
 }
 
 pub struct BuilderEntry {
@@ -468,8 +467,7 @@ pub(crate) struct CleanResult {
 pub(crate) struct Hoisted {
     /// An optional peer got bound after its dependent was placed; see `Lockfile::resolve`.
     pub late_bound_optional_peer: bool,
-    /// Required dependencies left out for an `os`/`cpu` mismatch (deduplicated).
-    pub unsupported_platform: Vec<PackageID>,
+    pub unsupported_platform: UnsupportedPlatform,
 }
 
 impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
@@ -552,8 +550,32 @@ pub(crate) enum DependencyFilter {
     Keep,
     Skip,
     /// A required dependency that is left out only because the package's
-    /// `os`/`cpu` does not match the install target.
-    SkipUnsupportedPlatform,
+    /// `os`/`cpu` does not match the install target. `direct`: the dependent
+    /// is the root package or a workspace.
+    SkipUnsupportedPlatform {
+        direct: bool,
+    },
+}
+
+/// Required dependencies left out for an `os`/`cpu` mismatch, deduplicated.
+#[derive(Default)]
+pub(crate) struct UnsupportedPlatform {
+    pub direct: Vec<PackageID>,
+    pub transitive: Vec<PackageID>,
+}
+
+impl UnsupportedPlatform {
+    pub(crate) fn insert(&mut self, pkg_id: PackageID, direct: bool) {
+        if self.direct.contains(&pkg_id) {
+            return;
+        }
+        if direct {
+            self.transitive.retain(|&id| id != pkg_id);
+            self.direct.push(pkg_id);
+        } else if !self.transitive.contains(&pkg_id) {
+            self.transitive.push(pkg_id);
+        }
+    }
 }
 
 pub(crate) fn is_filtered_dependency_or_workspace(
@@ -669,24 +691,31 @@ pub(crate) fn filter_dependency_or_workspace(
     if filtered || dep.behavior.is_optional() || dep.behavior.is_optional_peer() {
         return DependencyFilter::Skip;
     }
-    DependencyFilter::SkipUnsupportedPlatform
+    DependencyFilter::SkipUnsupportedPlatform {
+        direct: matches!(
+            parent_res.tag,
+            crate::resolution::Tag::Root | crate::resolution::Tag::Workspace
+        ),
+    }
 }
 
-/// One warning per package in `pkg_ids` (the `SkipUnsupportedPlatform` set of
-/// an install), so a required dependency never goes missing silently.
+/// One warning per direct dependency and one summary line for the transitive
+/// ones, so a required dependency never goes missing silently.
 pub(crate) fn warn_unsupported_platform(
     log: &mut bun_ast::Log,
     lockfile: &Lockfile,
     manager: &PackageManager,
-    pkg_ids: &[PackageID],
+    skipped: &UnsupportedPlatform,
 ) {
+    use core::fmt::Write as _;
+
     let pkgs = lockfile.packages.slice();
     let pkg_names = pkgs.items_name();
     let pkg_metas = pkgs.items_meta();
     let pkg_resolutions = pkgs.items_resolution();
     let string_buf = lockfile.buffers.string_bytes.as_slice();
 
-    for &pkg_id in pkg_ids {
+    for &pkg_id in &skipped.direct {
         let meta = &pkg_metas[pkg_id as usize];
         let mut wants = String::new();
         let mut target = String::new();
@@ -715,6 +744,44 @@ pub(crate) fn warn_unsupported_platform(
                 pkg_resolutions[pkg_id as usize].fmt(string_buf, bun_core::fmt::PathSep::Auto),
                 wants,
                 target,
+            ),
+        );
+    }
+
+    // Dependencies of dependencies get one line in total: a lockfile written
+    // by an old bun can list a package's optional platform builds as plain
+    // dependencies, and those must not bury the output.
+    if !skipped.transitive.is_empty() {
+        const LISTED: usize = 3;
+        let count = skipped.transitive.len();
+        let mut names = String::new();
+        for (i, &pkg_id) in skipped.transitive.iter().take(LISTED).enumerate() {
+            if i > 0 {
+                names.push_str(", ");
+            }
+            let _ = write!(
+                names,
+                "{}@{}",
+                pkg_names[pkg_id as usize].fmt(string_buf),
+                pkg_resolutions[pkg_id as usize].fmt(string_buf, bun_core::fmt::PathSep::Auto),
+            );
+        }
+        if count > LISTED {
+            let _ = write!(names, " and {} more", count - LISTED);
+        }
+        log.add_warning_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "{} {} of other packages {} not installed: unsupported platform ({})",
+                count,
+                if count == 1 {
+                    "dependency"
+                } else {
+                    "dependencies"
+                },
+                if count == 1 { "was" } else { "were" },
+                names,
             ),
         );
     }
@@ -819,10 +886,8 @@ impl Tree {
                 ) {
                     DependencyFilter::Keep => {}
                     DependencyFilter::Skip => continue,
-                    DependencyFilter::SkipUnsupportedPlatform => {
-                        if !builder.unsupported_platform.contains(&pkg_id) {
-                            builder.unsupported_platform.push(pkg_id);
-                        }
+                    DependencyFilter::SkipUnsupportedPlatform { direct } => {
+                        builder.unsupported_platform.insert(pkg_id, direct);
                         continue;
                     }
                 }

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -9,6 +9,7 @@ use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
 
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::{DepSorter, DependencyIDList, DependencyIDSlice, Lockfile};
+use crate::npm as Npm;
 use crate::package_manager::{PackageManager, WorkspaceFilter};
 use crate::{
     Dependency, DependencyID, PackageID, PackageNameHash, Resolution, invalid_dependency_id,
@@ -443,6 +444,8 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
     pub(crate) packages_to_install: Option<&'a [PackageID]>,
     /// Workspace package ids that are hoisting barriers (self-contained node_modules).
     pub(crate) self_contained: Vec<PackageID>,
+    /// Required dependencies left out for an `os`/`cpu` mismatch (deduplicated).
+    pub(crate) unsupported_platform: Vec<PackageID>,
 }
 
 pub struct BuilderEntry {
@@ -460,6 +463,13 @@ bun_collections::multi_array_columns! {
 pub(crate) struct CleanResult {
     pub trees: Vec<Tree>,
     pub dep_ids: Vec<DependencyID>,
+}
+
+pub(crate) struct Hoisted {
+    /// An optional peer got bound after its dependent was placed; see `Lockfile::resolve`.
+    pub late_bound_optional_peer: bool,
+    /// Required dependencies left out for an `os`/`cpu` mismatch (deduplicated).
+    pub unsupported_platform: Vec<PackageID>,
 }
 
 impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
@@ -537,9 +547,15 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 // is_filtered_dependency_or_workspace
 // ──────────────────────────────────────────────────────────────────────────
 
-// `Builder` holds a live `&mut [PackageID]` over the resolutions buffer (see
-// `Builder.lockfile` safety contract), so callers must thread `resolutions`
-// explicitly to avoid an aliasing read through the shared `&Lockfile`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DependencyFilter {
+    Keep,
+    Skip,
+    /// A required dependency that is left out only because the package's
+    /// `os`/`cpu` does not match the install target.
+    SkipUnsupportedPlatform,
+}
+
 pub(crate) fn is_filtered_dependency_or_workspace(
     dep_id: DependencyID,
     parent_pkg_id: PackageID,
@@ -549,13 +565,36 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     lockfile: &Lockfile,
     resolutions: &[PackageID],
 ) -> bool {
+    filter_dependency_or_workspace(
+        dep_id,
+        parent_pkg_id,
+        workspace_filters,
+        install_root_dependencies,
+        manager,
+        lockfile,
+        resolutions,
+    ) != DependencyFilter::Keep
+}
+
+// `Builder` holds a live `&mut [PackageID]` over the resolutions buffer (see
+// `Builder.lockfile` safety contract), so callers must thread `resolutions`
+// explicitly to avoid an aliasing read through the shared `&Lockfile`.
+pub(crate) fn filter_dependency_or_workspace(
+    dep_id: DependencyID,
+    parent_pkg_id: PackageID,
+    workspace_filters: &[WorkspaceFilter],
+    install_root_dependencies: bool,
+    manager: &PackageManager,
+    lockfile: &Lockfile,
+    resolutions: &[PackageID],
+) -> DependencyFilter {
     let pkg_id = resolutions[dep_id as usize];
     if (pkg_id as usize) >= lockfile.packages.len() {
         let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
         if dep.behavior.is_optional_peer() {
-            return false;
+            return DependencyFilter::Keep;
         }
-        return true;
+        return DependencyFilter::Skip;
     }
 
     let pkgs = lockfile.packages.slice();
@@ -566,58 +605,119 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
     let parent_res = &pkg_resolutions[parent_pkg_id as usize];
 
-    if pkg_metas[pkg_id as usize].is_disabled(manager.options.cpu, manager.options.os) {
-        if manager.options.log_level.is_verbose() {
-            let meta = &pkg_metas[pkg_id as usize];
-            let name = lockfile.str(&pkg_names[pkg_id as usize]);
-            if !meta.os.is_match(manager.options.os) && !meta.arch.is_match(manager.options.cpu) {
-                bun_core::pretty_errorln!(
-                    "<d>Skip installing<r> <b>{}<r> <d>- cpu & os mismatch<r>",
-                    bstr::BStr::new(name)
-                );
-            } else if !meta.os.is_match(manager.options.os) {
-                bun_core::pretty_errorln!(
-                    "<d>Skip installing<r> <b>{}<r> <d>- os mismatch<r>",
-                    bstr::BStr::new(name)
-                );
-            } else if !meta.arch.is_match(manager.options.cpu) {
-                bun_core::pretty_errorln!(
-                    "<d>Skip installing<r> <b>{}<r> <d>- cpu mismatch<r>",
-                    bstr::BStr::new(name)
-                );
-            }
+    let unsupported_platform =
+        pkg_metas[pkg_id as usize].is_disabled(manager.options.cpu, manager.options.os);
+    if unsupported_platform && manager.options.log_level.is_verbose() {
+        let meta = &pkg_metas[pkg_id as usize];
+        let name = lockfile.str(&pkg_names[pkg_id as usize]);
+        if !meta.os.is_match(manager.options.os) && !meta.arch.is_match(manager.options.cpu) {
+            bun_core::pretty_errorln!(
+                "<d>Skip installing<r> <b>{}<r> <d>- cpu & os mismatch<r>",
+                bstr::BStr::new(name)
+            );
+        } else if !meta.os.is_match(manager.options.os) {
+            bun_core::pretty_errorln!(
+                "<d>Skip installing<r> <b>{}<r> <d>- os mismatch<r>",
+                bstr::BStr::new(name)
+            );
+        } else if !meta.arch.is_match(manager.options.cpu) {
+            bun_core::pretty_errorln!(
+                "<d>Skip installing<r> <b>{}<r> <d>- cpu mismatch<r>",
+                bstr::BStr::new(name)
+            );
         }
-        return true;
     }
 
-    if dep.behavior.is_bundled() {
-        return true;
-    }
+    let filtered = 'filtered: {
+        if dep.behavior.is_bundled() {
+            break 'filtered true;
+        }
 
-    let dep_features = match parent_res.tag {
-        crate::resolution::Tag::Root
-        | crate::resolution::Tag::Workspace
-        | crate::resolution::Tag::Folder => manager.options.local_package_features,
-        _ => manager.options.remote_package_features,
+        let dep_features = match parent_res.tag {
+            crate::resolution::Tag::Root
+            | crate::resolution::Tag::Workspace
+            | crate::resolution::Tag::Folder => manager.options.local_package_features,
+            _ => manager.options.remote_package_features,
+        };
+
+        if !dep.behavior.is_enabled(dep_features) {
+            break 'filtered true;
+        }
+
+        if parent_pkg_id != 0 {
+            break 'filtered false;
+        }
+
+        if !dep.behavior.is_workspace() {
+            break 'filtered !install_root_dependencies;
+        }
+
+        if manager.summary.pruned_workspaces.contains(&dep.name_hash) {
+            break 'filtered true;
+        }
+
+        !WorkspaceFilter::is_selected(workspace_filters, pkg_id)
     };
 
-    if !dep.behavior.is_enabled(dep_features) {
-        return true;
+    if !unsupported_platform {
+        return if filtered {
+            DependencyFilter::Skip
+        } else {
+            DependencyFilter::Keep
+        };
     }
-
-    if parent_pkg_id != 0 {
-        return false;
+    if filtered || dep.behavior.is_optional() || dep.behavior.is_optional_peer() {
+        return DependencyFilter::Skip;
     }
+    DependencyFilter::SkipUnsupportedPlatform
+}
 
-    if !dep.behavior.is_workspace() {
-        return !install_root_dependencies;
+/// One warning per package in `pkg_ids` (the `SkipUnsupportedPlatform` set of
+/// an install), so a required dependency never goes missing silently.
+pub(crate) fn warn_unsupported_platform(
+    log: &mut bun_ast::Log,
+    lockfile: &Lockfile,
+    manager: &PackageManager,
+    pkg_ids: &[PackageID],
+) {
+    let pkgs = lockfile.packages.slice();
+    let pkg_names = pkgs.items_name();
+    let pkg_metas = pkgs.items_meta();
+    let pkg_resolutions = pkgs.items_resolution();
+    let string_buf = lockfile.buffers.string_bytes.as_slice();
+
+    for &pkg_id in pkg_ids {
+        let meta = &pkg_metas[pkg_id as usize];
+        let mut wants = String::new();
+        let mut target = String::new();
+        if !meta.os.is_match(manager.options.os) {
+            wants.push_str("os ");
+            let _ = Npm::Negatable::to_json(meta.os, &mut wants);
+            target.push_str("os ");
+            let _ = Npm::Negatable::to_json(manager.options.os, &mut target);
+        }
+        if !meta.arch.is_match(manager.options.cpu) {
+            if !wants.is_empty() {
+                wants.push(' ');
+                target.push(' ');
+            }
+            wants.push_str("cpu ");
+            let _ = Npm::Negatable::to_json(meta.arch, &mut wants);
+            target.push_str("cpu ");
+            let _ = Npm::Negatable::to_json(manager.options.cpu, &mut target);
+        }
+        log.add_warning_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "{}@{} was not installed: unsupported platform (wants {}, current {})",
+                pkg_names[pkg_id as usize].fmt(string_buf),
+                pkg_resolutions[pkg_id as usize].fmt(string_buf, bun_core::fmt::PathSep::Auto),
+                wants,
+                target,
+            ),
+        );
     }
-
-    if manager.summary.pruned_workspaces.contains(&dep.name_hash) {
-        return true;
-    }
-
-    !WorkspaceFilter::is_selected(workspace_filters, pkg_id)
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -708,7 +808,7 @@ impl Tree {
 
             // filter out disabled dependencies
             if METHOD == BuilderMethod::Filter {
-                if is_filtered_dependency_or_workspace(
+                match filter_dependency_or_workspace(
                     dep_id,
                     parent_pkg_id,
                     builder.workspace_filters,
@@ -717,7 +817,14 @@ impl Tree {
                     lockfile,
                     &*builder.resolutions,
                 ) {
-                    continue;
+                    DependencyFilter::Keep => {}
+                    DependencyFilter::Skip => continue,
+                    DependencyFilter::SkipUnsupportedPlatform => {
+                        if !builder.unsupported_platform.contains(&pkg_id) {
+                            builder.unsupported_platform.push(pkg_id);
+                        }
+                        continue;
+                    }
                 }
 
                 // unresolved packages are skipped when filtering. they already had

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -750,12 +750,18 @@ where
         if dependency_id == INVALID_PACKAGE_ID {
             continue;
         }
-        if cfg!(debug_assertions) {
-            had_printed_new_install = true;
-        }
 
         let dependency = &dependencies_buffer[dependency_id as usize];
         let package_id = resolutions_buffer[dependency_id as usize];
+        // skipped for this os/cpu; the install already warned about it
+        if (package_id as usize) < pkg_metas.len()
+            && pkg_metas[package_id as usize].is_disabled(this.options.cpu, this.options.os)
+        {
+            continue;
+        }
+        if cfg!(debug_assertions) {
+            had_printed_new_install = true;
+        }
         let bin = bins[package_id as usize];
         let resolution = &resolved[package_id as usize];
 

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -753,17 +753,22 @@ where
 
         let dependency = &dependencies_buffer[dependency_id as usize];
         let package_id = resolutions_buffer[dependency_id as usize];
-        // skipped for this os/cpu; the install already warned about it
-        if (package_id as usize) < pkg_metas.len()
-            && pkg_metas[package_id as usize].is_disabled(this.options.cpu, this.options.os)
-        {
+        let resolution = &resolved[package_id as usize];
+        if pkg_metas[package_id as usize].is_disabled(this.options.cpu, this.options.os) {
+            printed_installed_update_request = true;
+            bun_core::write_pretty!(
+                writer,
+                ENABLE_ANSI_COLORS,
+                "<r><yellow>skipped<r> <b>{s}<r><d>@{f}<r> <d>(unsupported platform)<r>\n",
+                bstr::BStr::new(dependency.name.slice(string_buf)),
+                resolution.fmt(string_buf, PathSep::Posix),
+            )?;
             continue;
         }
         if cfg!(debug_assertions) {
             had_printed_new_install = true;
         }
         let bin = bins[package_id as usize];
-        let resolution = &resolved[package_id as usize];
 
         match bin.tag {
             bin::Tag::None | bin::Tag::Dir => {

--- a/test/cli/install/bun-install-cpu-os.test.ts
+++ b/test/cli/install/bun-install-cpu-os.test.ts
@@ -665,12 +665,18 @@ describe("bun install --cpu and --os flags", () => {
     },
   );
 
-  it("bun add does not report a dependency skipped for the target platform as installed", async () => {
+  // `bun add` used to print `installed dep-win32-only@1.0.0` for a package it
+  // had skipped. It now says `skipped`; a required one also gets the warning,
+  // an optional one only the `skipped` row.
+  it.each([
+    ["dependencies", [] as string[]],
+    ["optionalDependencies", ["--optional"]],
+  ])("bun add reports a dependency skipped for the target platform as skipped (%s)", async (field, flags) => {
     setHandler(platformWarningRegistry());
     await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "test-platform-add", version: "1.0.0" }));
 
     await using proc = spawn({
-      cmd: [bunExe(), "add", "dep-win32-only@1.0.0", "--os", "linux", "--cpu", "x64"],
+      cmd: [bunExe(), "add", "dep-win32-only@1.0.0", ...flags, "--os", "linux", "--cpu", "x64"],
       cwd: package_dir,
       env: bunEnv,
       stdout: "pipe",
@@ -679,13 +685,16 @@ describe("bun install --cpu and --os flags", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).not.toContain("error:");
-    expect(stderr.split("\n").filter(line => line.startsWith("warn:"))).toEqual([
-      `warn: dep-win32-only@1.0.0 was not installed: unsupported platform (wants os "win32", current os "linux")`,
-    ]);
+    expect(stderr.split("\n").filter(line => line.startsWith("warn:"))).toEqual(
+      field === "dependencies"
+        ? [`warn: dep-win32-only@1.0.0 was not installed: unsupported platform (wants os "win32", current os "linux")`]
+        : [],
+    );
     expect(stdout).not.toContain("installed dep-win32-only");
+    expect(stdout).toContain("skipped dep-win32-only@1.0.0 (unsupported platform)");
     expect((await readdirSorted(join(package_dir, "node_modules"))).filter(name => !name.startsWith("."))).toEqual([]);
-    // the dependency is still recorded, as for an optional dependency on another platform
-    expect(JSON.parse(await Bun.file(join(package_dir, "package.json")).text()).dependencies).toEqual({
+    // the dependency is still recorded in package.json
+    expect(JSON.parse(await Bun.file(join(package_dir, "package.json")).text())[field]).toEqual({
       "dep-win32-only": "1.0.0",
     });
     expect(exitCode).toBe(0);

--- a/test/cli/install/bun-install-cpu-os.test.ts
+++ b/test/cli/install/bun-install-cpu-os.test.ts
@@ -604,4 +604,57 @@ describe("bun install --cpu and --os flags", () => {
     // Should skip x64 dep and install other CPU deps
     expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".cache", "dep-arm64", "dep-ppc64"]);
   });
+
+  // A required dependency that is dropped for the target platform must not go
+  // missing silently (npm: EBADPLATFORM, pnpm: warning). Optional ones stay quiet.
+  it.each(["hoisted", "isolated"])(
+    "warns for each required dependency skipped for the target platform (%s linker)",
+    async linker => {
+      const urls: string[] = [];
+      setHandler(
+        dummyRegistry(urls, {
+          "1.0.0": { os: ["win32"] },
+          "2.0.0": { cpu: ["arm64", "ppc64"], os: ["!linux"] },
+          "3.0.0": {},
+          "4.0.0": { cpu: ["s390x"] },
+        }),
+      );
+
+      await writeFile(
+        join(package_dir, "package.json"),
+        JSON.stringify({
+          name: "test-platform-warning",
+          version: "1.0.0",
+          dependencies: { "dep-win32-only": "1.0.0", "dep-universal": "3.0.0" },
+          devDependencies: { "dep-not-linux": "2.0.0" },
+          optionalDependencies: { "dep-s390x-only": "4.0.0" },
+        }),
+      );
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install", "--os", "linux", "--cpu", "x64", "--linker", linker],
+        cwd: package_dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).not.toContain("error:");
+      expect(
+        stderr
+          .split("\n")
+          .filter(line => line.startsWith("warn:"))
+          .sort(),
+      ).toEqual([
+        `warn: dep-not-linux@2.0.0 was not installed: unsupported platform (wants os "!linux" cpu [ "arm64", "ppc64", ], current os "linux" cpu "x64")`,
+        `warn: dep-win32-only@1.0.0 was not installed: unsupported platform (wants os "win32", current os "linux")`,
+      ]);
+      expect(stdout).not.toContain("dep-win32-only");
+      expect((await readdirSorted(join(package_dir, "node_modules"))).filter(name => !name.startsWith("."))).toEqual([
+        "dep-universal",
+      ]);
+      expect(exitCode).toBe(0);
+    },
+  );
 });

--- a/test/cli/install/bun-install-cpu-os.test.ts
+++ b/test/cli/install/bun-install-cpu-os.test.ts
@@ -606,26 +606,29 @@ describe("bun install --cpu and --os flags", () => {
   });
 
   // A required dependency that is dropped for the target platform must not go
-  // missing silently (npm: EBADPLATFORM, pnpm: warning). Optional ones stay quiet.
+  // missing silently (npm fails with EBADPLATFORM; pnpm warns and installs it
+  // anyway). Optional ones stay quiet. Every package name below resolves
+  // against this one version table; a skipped package needs no tarball.
+  const platformWarningRegistry = () =>
+    dummyRegistry([], {
+      "1.0.0": { os: ["win32"] },
+      "2.0.0": { cpu: ["arm64", "ppc64"], os: ["!linux"] },
+      "3.0.0": {},
+      "4.0.0": { cpu: ["s390x"] },
+      // served from dep-universal-3.0.0.tgz; its own dependencies are win32-only
+      "5.0.0": { as: "3.0.0", dependencies: { "dep-win32-only": "1.0.0", "transitive-win32-only": "1.0.0" } },
+    });
+
   it.each(["hoisted", "isolated"])(
     "warns for each required dependency skipped for the target platform (%s linker)",
     async linker => {
-      const urls: string[] = [];
-      setHandler(
-        dummyRegistry(urls, {
-          "1.0.0": { os: ["win32"] },
-          "2.0.0": { cpu: ["arm64", "ppc64"], os: ["!linux"] },
-          "3.0.0": {},
-          "4.0.0": { cpu: ["s390x"] },
-        }),
-      );
-
+      setHandler(platformWarningRegistry());
       await writeFile(
         join(package_dir, "package.json"),
         JSON.stringify({
           name: "test-platform-warning",
           version: "1.0.0",
-          dependencies: { "dep-win32-only": "1.0.0", "dep-universal": "3.0.0" },
+          dependencies: { "dep-win32-only": "1.0.0", "dep-universal": "5.0.0" },
           devDependencies: { "dep-not-linux": "2.0.0" },
           optionalDependencies: { "dep-s390x-only": "4.0.0" },
         }),
@@ -641,12 +644,16 @@ describe("bun install --cpu and --os flags", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).not.toContain("error:");
+      // one line per direct dependency (dep-win32-only is also a dependency of
+      // dep-universal, and is reported once, as direct), one summary line for
+      // the dependencies of dependencies, nothing for the optional one
       expect(
         stderr
           .split("\n")
           .filter(line => line.startsWith("warn:"))
           .sort(),
       ).toEqual([
+        `warn: 1 dependency of other packages was not installed: unsupported platform (transitive-win32-only@1.0.0)`,
         `warn: dep-not-linux@2.0.0 was not installed: unsupported platform (wants os "!linux" cpu [ "arm64", "ppc64", ], current os "linux" cpu "x64")`,
         `warn: dep-win32-only@1.0.0 was not installed: unsupported platform (wants os "win32", current os "linux")`,
       ]);
@@ -657,4 +664,30 @@ describe("bun install --cpu and --os flags", () => {
       expect(exitCode).toBe(0);
     },
   );
+
+  it("bun add does not report a dependency skipped for the target platform as installed", async () => {
+    setHandler(platformWarningRegistry());
+    await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "test-platform-add", version: "1.0.0" }));
+
+    await using proc = spawn({
+      cmd: [bunExe(), "add", "dep-win32-only@1.0.0", "--os", "linux", "--cpu", "x64"],
+      cwd: package_dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("error:");
+    expect(stderr.split("\n").filter(line => line.startsWith("warn:"))).toEqual([
+      `warn: dep-win32-only@1.0.0 was not installed: unsupported platform (wants os "win32", current os "linux")`,
+    ]);
+    expect(stdout).not.toContain("installed dep-win32-only");
+    expect((await readdirSorted(join(package_dir, "node_modules"))).filter(name => !name.startsWith("."))).toEqual([]);
+    // the dependency is still recorded, as for an optional dependency on another platform
+    expect(JSON.parse(await Bun.file(join(package_dir, "package.json")).text()).dependencies).toEqual({
+      "dep-win32-only": "1.0.0",
+    });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun install` drops a **regular** dependency whose registry manifest `os`/`cpu` excludes the host without a word: exit 0, a normal `+ bar@1.0.0 / 1 package installed` summary, lockfile saved, nothing in `node_modules`. `bun add onlywin` even prints `installed onlywin@1.0.0`. The app then fails at runtime with module-not-found. npm fails such an install with `EBADPLATFORM`; pnpm warns and installs it anyway.
- The cause is `is_filtered_dependency_or_workspace` (`src/install/lockfile/Tree.rs`), the edge filter shared by the hoisted tree builder and the isolated store builder. Its `Meta::is_disabled(cpu, os)` check runs before any look at the dependency's behavior, so required, dev and peer edges are skipped the same way as `optionalDependencies`, and the only trace is a `Skip installing` line under `--verbose`. The `bun add` summary in `tree_printer.rs` prints every matched add request with no platform check.

### Fix
- Split the filter into `filter_dependency_or_workspace`, which returns `Keep`, `Skip`, or `SkipUnsupportedPlatform { direct }` (a platform mismatch on an edge that is not optional, not an optional peer, not bundled, enabled for the install's features, and past the root/workspace gates; `direct` when the dependent is the root or a workspace). `is_filtered_dependency_or_workspace` keeps its `bool` contract for the other callers.
- The hoisted builder (`process_subtree`, `METHOD == Filter`) and the isolated `build_store` main queue collect those packages, deduplicated. `Lockfile::filter` and `install_isolated_packages` then warn through the install log: one line per direct dependency (`warn: onlywin@1.0.0 was not installed: unsupported platform (wants os "win32", current os "linux")`) and one summary line for all transitive ones (`warn: 2 dependencies of other packages were not installed: unsupported platform (a@1.0.0, b@1.0.0)`). The `bun add` summary prints `skipped <pkg>@<version> (unsupported platform)` instead of `installed <pkg>` for a package skipped this way (required or optional).
- Exit code, lockfile, summary counts, and the silent skip for optional dependencies are unchanged. `bun prune` (which calls `hoist` directly) and the security scanner pre-pass (`packages_to_install`) do not warn.
- Verified: `test/cli/install/bun-install-cpu-os.test.ts` ("warns for each required dependency skipped for the target platform" for both linkers, covering direct, dev, transitive, optional and dedupe, plus "bun add reports a dependency skipped for the target platform as skipped" for `dependencies` and `--optional`; all fail on bun 1.4.3). The rest of that file, the `bun-prune.test.ts` platform cases, `bun-add.test.ts`, `isolated-install.test.ts`, and the optional-dependency cases in `bun-install-registry.test.ts` pass.

### Background
- A package's `os`/`cpu` arrays become bitmasks on `Package.meta` (`Negatable<OperatingSystem|Architecture>`). `Meta::is_disabled` compares them with the install target, which is the host unless `--os`/`--cpu` override it.
- Both linkers walk the lockfile's dependency graph from the root and ask the shared filter whether to place each edge. A skipped edge is simply not visited, so no later stage (download, summary) knows about it. That is why the message has to come from the tree build.
- Install warnings go through `manager.log` (`add_warning_fmt`), which `install_with_manager` prints after the linker runs and which `--silent` suppresses. "incorrect peer dependency" uses the same path.

<details><summary>Notes</summary>

Repro on bun 1.4.3 (loopback registry; `onlywin` has `os:["win32"]`, `notlinux` `os:["!linux"]`, `cpubad` `cpu:["sparc"]`, `bar` nothing; all four in `dependencies`):

```
$ bun install; echo rc=$?; ls node_modules
+ bar@1.0.0
1 package installed
rc=0
bar
# npm 11: npm error code EBADPLATFORM ... Unsupported platform for onlywin@1.0.0: wanted {"os":"win32"}   rc=1
```

With this PR (same fixture, `--os linux --cpu x64`):

```
warn: onlywin@1.0.0 was not installed: unsupported platform (wants os "win32", current os "linux")
warn: notlinux@1.0.0 was not installed: unsupported platform (wants os "!linux", current os "linux")
warn: cpubad@1.0.0 was not installed: unsupported platform (wants cpu "none", current cpu "x64")
+ bar@1.0.0
```

(`cpu:["sparc"]` is not a value bun recognizes, so it is stored as `none`, the same spelling `bun.lock` uses.) The `wants` text reuses `Negatable::to_json`, the formatter `bun.lock` uses for its `os`/`cpu` fields, so a multi-value list prints as `[ "arm64", "ppc64", ]`.

Why transitive skips get one summary line instead of one line each: a lockfile written by an old bun can list a package's optional platform builds (esbuild's, for example) as plain `dependencies`; four such lockfiles are committed in this repo (`bench/`, `packages/bun-release/`). One line per package would bury the output of every install there; one summary line keeps the signal without the flood, and still names the first three packages.

Why a warning and not npm's hard error: bun documents `bun install --os/--cpu` for cross-target installs, `bun prune --os` round-trips through the same filter, and the legacy lockfiles above would break. An exit-code change there needs an escape hatch and a maintainer decision; the warning closes the "vanished without a word" gap without one. The skip itself was never scoped to optional dependencies on purpose: the `--cpu`/`--os` help text, #22850, and the esbuild/SWC comment in `determine_preinstall_state` all describe it as an optional-dependency feature.

Self-reviewed. Addressed: the `bun add` "installed" contradiction, the transitive-noise concern for legacy lockfiles, dedupe, and the pnpm wording. Not addressed here: #41936 adds a different diagnostics parameter to the same `Lockfile::hoist`/`build_store` signatures; whichever lands second should merge the two into one channel, which is a mechanical rebase either way.
</details>
