### PR TITLE
bundler: drop the `.` before an empty `[ext]` in output name templates

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -959,7 +959,7 @@ With multiple entrypoints, the generated file hierarchy reflects the directory s
 The `naming` field customizes the names and locations of the generated files. It accepts a template string. Bun uses the template for all bundles that correspond to entrypoints and replaces the following tokens with their values:
 
 - `[name]` - The name of the entrypoint file, without the extension.
-- `[ext]` - The extension of the generated bundle.
+- `[ext]` - The extension of the generated file, without the leading `.`. When an asset has no extension, Bun also drops a `.` that comes right before `[ext]` in the template, so `[name]-[hash].[ext]` gives `LICENSE-a1b2c3d4` and not `LICENSE-a1b2c3d4.`.
 - `[hash]` - A hash of the bundle contents: 8 lowercase alphanumeric characters. If two outputs with different contents would print the same characters, both get enough extra characters to differ (as do the outputs that reference them). `[hash9]` through `[hash13]` set a wider minimum; `[hash13]` is the full 64-bit hash.
 - `[dir]` - The relative path from the project root to the parent directory of the source file.
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2193,7 +2193,7 @@ fn path_template_print<W: bun_io::Write>(
     let mut remain: &[u8] = data;
     while let Some(j) = strings::index_of_char(remain, b'[') {
         let j = j as usize;
-        PathTemplate::write_replacing_slashes_on_windows(writer, &remain[0..j])?;
+        let literal = &remain[0..j];
         remain = &remain[j + 1..];
 
         let mut count: isize = 1;
@@ -2214,6 +2214,7 @@ fn path_template_print<W: bun_io::Write>(
 
         if count != 0 {
             // No matching `]`: emit `[` and fall through to write `remain` literally.
+            PathTemplate::write_replacing_slashes_on_windows(writer, literal)?;
             writer.write_all(b"[")?;
             break;
         }
@@ -2222,12 +2223,21 @@ fn path_template_print<W: bun_io::Write>(
 
         let Some((field, hash_len)) = placeholder_field(placeholder) else {
             // Unknown placeholder: keep `[placeholder]` verbatim in the output.
+            PathTemplate::write_replacing_slashes_on_windows(writer, literal)?;
             writer.write_all(b"[")?;
             PathTemplate::write_replacing_slashes_on_windows(writer, placeholder)?;
             writer.write_all(b"]")?;
             remain = &remain[end_len + 1..];
             continue;
         };
+
+        // `[name].[ext]` for a file with no extension is `name`, not `name.`.
+        let literal = if field == PlaceholderField::Ext && ext.is_empty() {
+            literal.strip_suffix(b".").unwrap_or(literal)
+        } else {
+            literal
+        };
+        PathTemplate::write_replacing_slashes_on_windows(writer, literal)?;
 
         match field {
             PlaceholderField::Dir => {
@@ -2315,7 +2325,8 @@ fn write_sanitized_parent_dirs_rewrites_every_dotdot_segment() {
 fn path_template_print_tolerates_malformed_brackets() {
     fn run(template: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
-        path_template_print(&mut out, template, b"D", b"N", b"E", Some(0), b"T", false).unwrap();
+        let hash = Some(bun_core::fmt::ContentHash::short(0));
+        path_template_print(&mut out, template, b"D", b"N", b"E", hash, b"T", false).unwrap();
         out
     }
     // Unterminated known placeholder: used to slice one past the end.
@@ -2357,6 +2368,24 @@ fn path_template_print_tolerates_malformed_brackets() {
     assert_eq!(find_unterminated_placeholder(b"]"), None);
     assert_eq!(find_unterminated_placeholder(b"[dir]/[name].[ext]"), None);
     assert_eq!(find_unterminated_placeholder(b"[foo]-[name].[ext]"), None);
+}
+
+#[cfg(test)]
+#[test]
+fn path_template_print_drops_the_dot_before_an_empty_ext() {
+    fn run(template: &[u8], ext: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let hash = Some(bun_core::fmt::ContentHash::short(0));
+        path_template_print(&mut out, template, b"D", b"N", ext, hash, b"T", false).unwrap();
+        out
+    }
+    assert_eq!(run(b"[name]-[hash].[ext]", b""), b"N-00000000");
+    assert_eq!(run(b"[dir]/[name].[ext]", b""), b"D/N");
+    assert_eq!(run(b"[name].[hash].asset.[ext]", b""), b"N.00000000.asset");
+    // Only a `.` that touches `[ext]` goes; other separators and a non-empty ext are untouched.
+    assert_eq!(run(b"[name]-[ext]", b""), b"N-");
+    assert_eq!(run(b"[ext]/[name]", b""), b"/N");
+    assert_eq!(run(b"[name].[ext]", b"js"), b"N.js");
 }
 
 impl PathTemplate {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -711,13 +711,17 @@ describe("bundler", () => {
         import './foo.file';
         import './1.embed';
         import './2.embed';
+        import './LICENSE' with { type: "file" };
         rmSync('./foo.file', {force: true});
         rmSync('./1.embed', {force: true});
         rmSync('./2.embed', {force: true});
+        rmSync('./LICENSE', {force: true});
         const names = {
           "1.embed": "1.embed",
           "2.embed": "2.embed",
           "foo.file": "foo.file",
+          // No extension: "[name].[ext]" keeps the name as is, with no trailing ".".
+          "LICENSE": "LICENSE",
         }
         // We want to verify it omits source code.
         for (let f of Bun.embeddedFiles) {
@@ -727,13 +731,15 @@ describe("bundler", () => {
           }
         }
 
-        if (Bun.embeddedFiles.length !== 3) throw "fail";
+        if (Bun.embeddedFiles.length !== 4) throw "fail";
         if ((await Bun.file(createRequire(import.meta.url).resolve('./1.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(createRequire(import.meta.url).resolve('./2.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(createRequire(import.meta.url).resolve('./foo.file')).text()).trim() !== "abcd") throw "fail";
+        if ((await Bun.file(createRequire(import.meta.url).resolve('./LICENSE')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(import.meta.require.resolve('./1.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(import.meta.require.resolve('./2.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(import.meta.require.resolve('./foo.file')).text()).trim() !== "abcd") throw "fail";
+        if ((await Bun.file(import.meta.require.resolve('./LICENSE')).text()).trim() !== "abcd") throw "fail";
         console.log("Hello, world!");
       `,
       "/1.embed": /* js */ `
@@ -743,6 +749,9 @@ describe("bundler", () => {
       abcd
     `.trim(),
       "/foo.file": /* js */ `
+      abcd
+    `.trim(),
+      "/LICENSE": /* js */ `
       abcd
     `.trim(),
     },

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -236,6 +236,42 @@ describe("bundler", () => {
       stdout: "./bun/data.file",
     },
   });
+  // A file with no extension: `[ext]` is empty, so the `.` before it in the template is dropped too.
+  itBundled("naming/AssetNamingNoExtension", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import file from "./LICENSE" with { type: "file" };
+        console.log(file);
+      `,
+      "/src/LICENSE": `license text`,
+    },
+    root: "/src",
+    entryPointsRaw: ["./src/entry.js"],
+    onAfterBundle(api) {
+      const files = readdirSync(api.outdir).sort();
+      expect(files).toEqual([expect.stringMatching(/^LICENSE-[0-9a-z]{8}$/), "entry.js"]);
+      api.expectFile("/out/entry.js").toContain(`"./${files[0]}"`);
+    },
+  });
+  itBundled("naming/AssetNamingNoExtensionCustom", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import file from "./data/LICENSE" with { type: "file" };
+        console.log(file);
+      `,
+      "/src/data/LICENSE": `license text`,
+    },
+    root: "/src",
+    assetNaming: "assets/[dir]/[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    onAfterBundle(api) {
+      api.assertFileExists("/out/assets/data/LICENSE");
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "./assets/data/LICENSE",
+    },
+  });
   itBundled("naming/AssetNoOverwrite", {
     todo: true,
     files: {


### PR DESCRIPTION
### Problem
- An extensionless file that goes through the `file` loader (`import p from "./LICENSE" with { type: "file" }`) is copied as `LICENSE-cm3anrzg.`, trailing dot included, and `p` is `"./LICENSE-cm3anrzg."`. With the documented `--compile --asset-naming="[name].[ext]"` recipe the embedded name is `LICENSE.`, so `require.resolve("./LICENSE")` misses it. esbuild gives `LICENSE-JND373DZ`.
- Cause: `path_template_print` (`src/bundler/options.rs:2183`) copies the literal `.` of `[name]-[hash].[ext]` even when `[ext]` expands to nothing.
- Found by inspection, no linked issue. Reach: extensionless `file`-loader assets in `bun build` and `--compile`. Entries and chunks always have an extension.

### Fix
- `path_template_print` writes the literal text before a placeholder once it knows the placeholder. For `[ext]` with an empty extension it drops one `.` from the end of that literal: `LICENSE-cm3anrzg`, `assets/data/LICENSE`.
- A non-empty extension, a `.` that does not touch `[ext]`, unknown placeholders and an unterminated `[` print as before.
- Verified: `bundler_naming.test.ts` (`naming/AssetNamingNoExtension*`) and `bundler_compile.test.ts` (`compile/Bun.embeddedFiles`, now with a `LICENSE` file) fail on stock bun and pass with `bun bd test`. More suites in Notes.
- Self-reviewed: 5 concerns raised, 5 addressed (see Notes).

### Background
- `--entry-naming`, `--chunk-naming`, `--asset-naming` and `Bun.build({ naming })` are output name templates. `path_template_print` expands `[dir]`, `[name]`, `[ext]`, `[hash]`, `[target]` and copies every other byte. `[ext]` has no leading `.`, so the default templates spell it: `./[name]-[hash].[ext]`.
- A copied asset takes `[name]` and `[ext]` from `PathName::init` on its source path (`src/bundler/bundle_v2.rs:4389`). For `LICENSE` the ext is empty. The printed path names the output file, goes into the importing chunk, and keys the `--compile` file table.

<details><summary>Notes</summary>

- Repro on bun 1.4.3:
  ```
  printf 'license text\n' > LICENSE
  printf 'import p from "./LICENSE" with { type: "file" }; console.log(p);\n' > entry.ts
  bun build ./entry.ts --outdir out && ls out
  # entry.js  LICENSE-cm3anrzg.
  ```
  Same with `--loader :file` and a plain import. With this branch: `LICENSE-cm3anrzg`, and `bun build --compile` embeds `/$bunfs/root/LICENSE-cm3anrzg`.
- Other suites run with `bun bd test`: `bundler_loader.test.ts`, `bun-build-api.test.ts` (two bytecode tests time out at 5 s under the debug build on this machine, with and without the change), all of `bundler_compile.test.ts`. The `options.rs` unit tests pass under miri (see below).
- esbuild never meets this case by construction: it appends the extension after template substitution, and only when there is one. Bun spells the `.` in the template text, so the printer is the one place that can handle the empty case for default and custom templates alike.
- `--compile --asset-naming='[name].[ext]'` with `import './LICENSE' with { type: "file" }` on 1.4.3: `Bun.embeddedFiles` names are `["LICENSE.","foo.file"]` and `import.meta.require.resolve('./LICENSE')` resolves to a path next to the executable instead of `/$bunfs/root/LICENSE`. With this branch: `["LICENSE","foo.file"]` and `/$bunfs/root/LICENSE`.
- Windows (checked on Server 2019 with bun 1.4.3): bun creates `out\LICENSE-cm3anrzg.` with the dot on disk through the NT API. Win32 strips a trailing dot from a lookup path, so `cmd /c type out\LICENSE-cm3anrzg.`, PowerShell `Get-Content` and `Remove-Item` all report that the file does not exist. Only a `\\?\` path reaches it.
- Dotfiles are unchanged: `.env` has `PathName` base empty and ext `.env`, so it is copied as `-a3kvfxz5.env`, the same name esbuild gives.
- A source file whose own name ends in a dot (`weird.`) has `PathName` ext `.`, which the asset code also reduces to an empty `[ext]`, so it is now copied as `weird-<hash>` instead of `weird-<hash>.`.
- The DevServer asset path (`ParseTask.rs`, `/_bun/asset/<hex><ext>`) appends the extension with its dot only when present, so it was not affected.
- The pre-existing unit test `path_template_print_tolerates_malformed_brackets` passed `Some(0)` where `Option<ContentHash>` is expected since #41317 and did not compile under `--cfg test`. It now passes `ContentHash::short(0)`. The crate's unit tests only link under miri: `MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -p bun_bundler --lib path_template_print`.
- Review points and what changed: say that this was found by inspection and give the reach (Problem, third bullet), cover the `--compile` `[name].[ext]` recipe with a test (`compile/Bun.embeddedFiles`), only claim the Windows effect after reproducing it (above), keep the rule in the printer and not in a post-render pass (it is), and link the other open PRs in this function: #38366 (`././` segments), #37502 (path length), #34558 (`[dir]` canonicalization). They compose. Whichever lands second needs a small rebase.

</details>
