### PR TITLE
Bun.Cookie.parse: let a later empty Path or unknown SameSite reset the earlier one

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -111,8 +111,12 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
                     domain = attributeValue.convertToASCIILowercase();
                 }
             } else if (attributeName == "path"_s) {
+                // 5.2.4: unlike an empty Domain or a bad Expires, which are ignored, an empty or
+                // relative Path still counts and selects the default-path.
                 if (!attributeValue.isEmpty() && attributeValue.startsWith('/'))
                     path = attributeValue;
+                else
+                    path = "/"_s;
             } else if (attributeName == "expires"_s && !attributeValue.isEmpty()) {
                 if (!attributeValue.is8Bit()) [[unlikely]] {
                     auto asLatin1 = attributeValue.latin1();
@@ -138,12 +142,14 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
             } else if (attributeName == "partitioned"_s) {
                 partitioned = true;
             } else if (attributeName == "samesite"_s) {
+                // RFC 6265bis 5.6.7: an unknown or empty value records "Default" enforcement (Lax
+                // here) rather than being ignored, so it still overrides an earlier SameSite.
                 if (WTF::equalIgnoringASCIICase(attributeValue, "strict"_s))
                     sameSite = CookieSameSite::Strict;
-                else if (WTF::equalIgnoringASCIICase(attributeValue, "lax"_s))
-                    sameSite = CookieSameSite::Lax;
                 else if (WTF::equalIgnoringASCIICase(attributeValue, "none"_s))
                     sameSite = CookieSameSite::None;
+                else
+                    sameSite = CookieSameSite::Lax;
             }
         }
     }

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -150,6 +150,45 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(cookie.expires).toEqual(new Date("Thu, 02 Jan 2031 00:00:00 GMT"));
   });
 
+  test("Cookie.parse lets a later empty or invalid Path/SameSite reset the earlier one", () => {
+    // RFC 6265 5.2.4: an empty or non-absolute Path selects the default-path, and the
+    // last Path attribute wins (5.3 step 7). Browsers store these with path "/".
+    const paths = ["p=1; Path=/first; Path=", "p=1; Path=/first; Path", "p=1; Path=/first; Path=relative"].map(
+      s => Bun.Cookie.parse(s).path,
+    );
+    expect(paths).toEqual(["/", "/", "/"]);
+    expect(Bun.Cookie.parse("p=1; Path=; Path=/second").path).toBe("/second");
+
+    // RFC 6265bis 5.6.7: an unknown or empty SameSite value means "Default" enforcement
+    // rather than being ignored, so it overrides an earlier SameSite=Strict.
+    const sameSites = [
+      "p=1; Secure; SameSite=Strict; SameSite=Whatever",
+      "p=1; Secure; SameSite=Strict; SameSite=",
+      "p=1; Secure; SameSite=Strict; SameSite",
+      "p=1; Secure; SameSite=None; SameSite=Whatever",
+    ].map(s => Bun.Cookie.parse(s).sameSite);
+    expect(sameSites).toEqual(["lax", "lax", "lax", "lax"]);
+    expect(Bun.Cookie.parse("p=1; Secure; SameSite=Whatever; SameSite=Strict").sameSite).toBe("strict");
+
+    // Unlike Path and SameSite, an empty Domain and an unparseable Expires or Max-Age are
+    // ignored entirely (5.2.1-5.2.3), so the earlier value stands.
+    const ignored = Bun.Cookie.parse(
+      "p=1; Domain=example.com; Expires=Wed, 01 Jan 2031 00:00:00 GMT; Max-Age=60; Domain=; Expires=nonsense; Max-Age=abc",
+    );
+    expect(ignored.toJSON()).toEqual({
+      name: "p",
+      value: "1",
+      domain: "example.com",
+      path: "/",
+      expires: new Date("Wed, 01 Jan 2031 00:00:00 GMT"),
+      maxAge: 60,
+      secure: false,
+      sameSite: "lax",
+      httpOnly: false,
+      partitioned: false,
+    });
+  });
+
   test("Cookie.parse reads every attribute in any order", () => {
     const attributes = [
       "Max-Age=3600",


### PR DESCRIPTION
### Problem
- `Bun.Cookie.parse("p=1; Path=/first; Path=").path` is `"/first"` and `Bun.Cookie.parse("p=1; Secure; SameSite=Strict; SameSite=Whatever").sameSite` is `"strict"`. A browser that receives the same `Set-Cookie` lines stores path `/` and default (Lax) SameSite enforcement. Verified against headless Chromium over `Storage.getCookies`.
- The cause is `Cookie::parse` (`src/jsc/bindings/Cookie.cpp:113` and `:147`). It skips a `Path` attribute whose value is empty or not absolute, and a `SameSite` attribute whose value is not `Strict`, `Lax` or `None`. So an earlier occurrence survives, although the comment above the chain says "last occurrence wins".

### Fix
- A `Path` attribute with an empty or non-absolute value now sets the path to `/`, the default this parser uses when `Path` is absent. A `SameSite` attribute with an unknown or empty value now sets `lax`, this parser's default enforcement.
- Correct because RFC 6265 5.2.4 records such a `Path` as the default-path (it does not ignore it) and 5.3 step 7 takes the last `Path`. RFC 6265bis 5.6.7 records an unknown `SameSite` value as `Default` and the storage model takes the last `SameSite`. An empty `Domain` and an unparseable `Expires` or `Max-Age` stay ignored, as 5.2.1 to 5.2.3 say, and the new test pins that difference.
- Verified: `test/js/bun/cookie/cookie-map.test.ts` (new test fails on stock bun 1.4.3, passes with the fix). Also all of `test/js/bun/cookie/`, `test/js/bun/util/cookie.test.js` and `test/js/bun/http/bun-serve-cookies.test.ts`.

### Background
- `Bun.Cookie.parse` reads one `Set-Cookie` style string into a `Bun.Cookie`. It has no request URL, so `/` stands in for the RFC's default-path, and `lax` stands in for `Default` enforcement (the `CookieSameSite` enum has no separate `Default` member).
- RFC 6265 5.2 processes each attribute into a list and 5.3 reads the last entry per name. Whether a malformed value is "ignored" (dropped from the list) or "recorded with a default" decides whether it can override an earlier good value. The RFC picks "ignored" for `Expires`, `Max-Age` and `Domain`, and "recorded with a default" for `Path` and `SameSite`.

<details><summary>Notes</summary>

Stock bun 1.4.3 output for the probe:

```
parse('p=1; Path=/first; Path=').path                            "/first"   (Chromium: "/")
parse('p=1; Path=/first; Path=noslash').path                     "/first"
parse('p=1; Path=/first; Path').path                             "/first"
parse('p=1; Secure; SameSite=Strict; SameSite=Whatever').sameSite "strict"  (Chromium: unspecified/default)
parse('p=1; SameSite=Strict; SameSite=').sameSite                "strict"
parse('p=1; Domain=a.com; Domain=').domain                       "a.com"    (correct, 5.2.3 ignores an empty Domain)
parse('p=1; Max-Age=5; Max-Age=abc').maxAge                      5          (correct, 5.2.2 ignores it)
parse('p=1; Expires=<2050 date>; Expires=garbage').expires       2050-06-01 (correct, 5.2.1 ignores it)
```

Chromium's `CanonicalCookie::CanonPathWithString` does the same for `Path`: an empty value or one that does not start with `/` yields the default path, and it is applied to the last `Path` attribute `ParsedCookie` saw.

Related open PRs that touch other parts of the same parser and do not overlap with this change: #35232 (RFC 6265 5.1.1 cookie-date algorithm for `Expires`), #32267 (RangeError for `expires` outside the Date range).

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-map.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [21.90ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [6.82ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [5.72ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [230.64ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.86ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [6.27ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [5.11ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [5.49ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.64ms]
154 |     // RFC 6265 5.2.4: an empty or non-absolute Path selects the default-path, and the
155 |     // last Path attribute wins (5.3 step 7). Bro
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.11ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.09ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.13ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [9.63ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.25ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [0.15ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [0.11ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [0.11ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [0.05ms]
154 |     // RFC 6265 5.2.4: an empty or non-absolute Path selects the default-path, and the
155 |     // last Path attribute wins (5.3 step 7). Browsers store these with path "/".
156 |     const paths = ["p=1; Path=/first; Path=", "p=1; Path=/first; Path", "p=1; Path=/first; Path=relative"].map(
157 |       s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-map.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [20.90ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [8.81ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [6.73ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [201.17ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [7.00ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [6.81ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [7.22ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [6.46ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [2.66ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse lets a later empty or invalid Path/SameSite reset the earlier one [10.30ms]
(pass) Bun.Cookie and
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 816ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 48s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+f7e68dd47
[build] done
bun test v1.4.3-canary.1 (f7e68dd47)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.05ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.08ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [5.42ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [0.07ms]
(pass) Bun.Cookie and Bun.CookieMap > 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/Cookie.cpp           | 10 +++++++--
 test/js/bun/cookie/cookie-map.test.ts | 39 +++++++++++++++++++++++++++++++++++
 2 files changed, 47 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/Cookie.cpp                2      5      6
test/js/bun/cookie/cookie-map.test.ts      1      1      5
```

</details>

<!-- robobun:evidence:end -->