### PR TITLE
Blob.slice(): convert start/end as WebIDL [Clamp] long long (round half to even)

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -91,6 +91,17 @@ pub(crate) fn is_valid_blob_type(slice: &[u8]) -> bool {
     slice.iter().all(|&c| matches!(c, 0x20..=0x7E))
 }
 
+/// WebIDL `[Clamp] long long` for a value that is already a Number
+/// (https://webidl.spec.whatwg.org/#abstract-opdef-converttoint): NaN is 0,
+/// anything else clamps to ±(2⁵³ − 1) and rounds to nearest, ties to even.
+fn clamp_to_long_long(number: f64) -> i64 {
+    const MAX_SAFE_INTEGER: f64 = 9007199254740991.0;
+    if number.is_nan() {
+        return 0;
+    }
+    number.clamp(-MAX_SAFE_INTEGER, MAX_SAFE_INTEGER).round_ties_even() as i64
+}
+
 /// Result delivered to `ReadBytesHandler::on_read_bytes`.
 pub enum ReadBytesResult {
     /// global-allocator-owned by the callback.
@@ -1930,7 +1941,7 @@ impl BlobExt for Blob {
         let mut args_iter = jsc::ArgumentsSlice::init(global_this.bun_vm(), &arguments_[..3]);
         if let Some(start_) = args_iter.next_eat() {
             if start_.is_number() {
-                let start = start_.to_int64();
+                let start = clamp_to_long_long(start_.as_number());
                 if start < 0 {
                     relative_start = (start
                         .wrapping_add(i64::try_from(self.size.get()).expect("int cast")))
@@ -1943,7 +1954,7 @@ impl BlobExt for Blob {
 
         if let Some(end_) = args_iter.next_eat() {
             if end_.is_number() {
-                let end = end_.to_int64();
+                let end = clamp_to_long_long(end_.as_number());
                 if end < 0 {
                     relative_end = (end
                         .wrapping_add(i64::try_from(self.size.get()).expect("int cast")))

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -91,9 +91,7 @@ pub(crate) fn is_valid_blob_type(slice: &[u8]) -> bool {
     slice.iter().all(|&c| matches!(c, 0x20..=0x7E))
 }
 
-/// WebIDL `[Clamp] long long` for a value that is already a Number
-/// (https://webidl.spec.whatwg.org/#abstract-opdef-converttoint): NaN is 0,
-/// anything else clamps to ±(2⁵³ − 1) and rounds to nearest, ties to even.
+/// WebIDL `[Clamp] long long` (https://webidl.spec.whatwg.org/#abstract-opdef-converttoint).
 fn clamp_to_long_long(number: f64) -> i64 {
     const MAX_SAFE_INTEGER: f64 = 9007199254740991.0;
     if number.is_nan() {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -99,7 +99,9 @@ fn clamp_to_long_long(number: f64) -> i64 {
     if number.is_nan() {
         return 0;
     }
-    number.clamp(-MAX_SAFE_INTEGER, MAX_SAFE_INTEGER).round_ties_even() as i64
+    number
+        .clamp(-MAX_SAFE_INTEGER, MAX_SAFE_INTEGER)
+        .round_ties_even() as i64
 }
 
 /// Result delivered to `ReadBytesHandler::on_read_bytes`.

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -91,6 +91,38 @@ for (const info of [
     expect(await blob.slice(-3, 4).slice(-2, 3).text()).toBe("F");
     expect(await blob.slice(-blob.size, 4).slice(-blob.size, 3).text()).toBe("Bun");
   });
+
+  // https://w3c.github.io/FileAPI/#dfn-slice: start and end are `[Clamp] long long`,
+  // so a fractional offset rounds to the nearest integer (ties to even) rather than
+  // truncating toward zero.
+  test(`${info.name} converts offsets as [Clamp] long long`, async () => {
+    const blob = info.blob;
+    expect(blob.size).toBe(6); // "BunFoo"
+    const cases: Record<string, [number[], string]> = {
+      "2.5, 5.5": [[2.5, 5.5], "nFoo"],
+      "1.7, 3.2": [[1.7, 3.2], "n"],
+      "1.5": [[1.5], "nFoo"],
+      "-1.5": [[-1.5], "oo"],
+      "0.99999": [[0.99999], "unFoo"],
+      "5.5, 6": [[5.5, 6], ""],
+      "3.5": [[3.5], "oo"],
+      "0, 2.5": [[0, 2.5], "Bu"],
+      "-0.5": [[-0.5], "BunFoo"],
+      "0.5, -2.5": [[0.5, -2.5], "BunF"],
+      "1, Infinity": [[1, Infinity], "unFoo"],
+      "-Infinity, 2": [[-Infinity, 2], "Bu"],
+      "MAX_VALUE, 3": [[Number.MAX_VALUE, 3], ""],
+      "-MAX_VALUE, 3": [[-Number.MAX_VALUE, 3], "Bun"],
+      "NaN, NaN": [[NaN, NaN], ""],
+    };
+    const actual: Record<string, string> = {};
+    const expected: Record<string, string> = {};
+    for (const [label, [args, text]] of Object.entries(cases)) {
+      actual[label] = await blob.slice(...args).text();
+      expected[label] = text;
+    }
+    expect(actual).toEqual(expected);
+  });
 }
 
 test("new Blob", () => {


### PR DESCRIPTION
### Problem
- `Blob.prototype.slice()` truncates a fractional `start`/`end` toward zero. `new Blob(["abcdef"]).slice(2.5, 5.5)` is `"cde"` in Bun (and Node) but `"cdef"` in Chromium, Firefox and Safari. A chunker that does `blob.slice(i * size / n, (i + 1) * size / n)` on a size that `n` does not divide gets different byte ranges than in a browser.
- The File API declares `slice(optional [Clamp] long long start, optional [Clamp] long long end, ...)`. `get_slice` converted both with `JSValue::to_int64()` (`src/runtime/webcore/Blob.rs:1944`), which is a saturating truncation.

### Fix
- Add `clamp_to_long_long(f64) -> i64` in `Blob.rs`: NaN is 0, otherwise clamp to ±(2^53 − 1) and `round_ties_even()`. `get_slice` uses it for a numeric `start` and `end`. Nothing else changes: the `slice(contentType)` string overloads and the handling of non-number arguments stay as they are.
- Correct because this is step 7 of WebIDL [ConvertToInt](https://webidl.spec.whatwg.org/#abstract-opdef-converttoint) for a `[Clamp]` 64-bit type, which is what the browsers run. The eight cases from the report now match Chromium 148 byte for byte.
- Verified: `test/js/web/fetch/blob.test.ts` (new `converts offsets as [Clamp] long long` case for both `new Blob` and `Bun.file()`, 7 of 15 cells fail on stock 1.4.3). Also ran `blob-cow`, `bun-file-read`, `bun-serve-file`, `structured-clone-blob-file`.

### Background
- WebIDL integer types convert a JS Number by truncation by default (`long long x = 2.5` is 2). The `[Clamp]` extended attribute changes two things: out-of-range values clamp to the type's bounds instead of wrapping, and in-range values round to the nearest integer, choosing the even one on a tie (2.5 → 2, 3.5 → 4, -1.5 → -2).
- For 64-bit types the `[Clamp]` bounds are ±(2^53 − 1), not ±2^63, so the result is always exactly representable as a Number.
- `Bun.file().slice()` and `BuildArtifact.slice()` go through the same `Blob::get_slice`, so they pick this up too.

<details><summary>Notes</summary>

- Report: `new Blob(["abcdef"])` with `slice(2.5,5.5) / (1.7,3.2) / (1.5) / (-1.5) / (0.99999) / (5.5,6) / (3.5) / (0,2.5)`. Bun 1.4.2 and Node v26.3.0: `3 "cde"`, `2 "bc"`, `5 "bcdef"`, `1 "f"`, `6 "abcdef"`, `1 "f"`, `3 "def"`, `2 "ab"`. Chromium 148 and this branch: `4 "cdef"`, `1 "c"`, `4 "cdef"`, `2 "ef"`, `5 "bcdef"`, `0 ""`, `2 "ef"`, `2 "ab"`.
- Node (undici's `Blob` is Node's own) has the same truncation, so this moves Bun from the Node side to the browser side of this cell. The spec text is unambiguous here and all three browser engines agree.
- Out of scope, unchanged: a non-number, non-string `start`/`end` (`true`, `null`, an object with `valueOf`) is still ignored rather than passed through `ToNumber`. #33023 covers that conversion together with other constructor coercions. The existing assertions at `blob.test.ts:60-63` (`slice(Symbol(), "-123")` does not throw) still pass.
- ±Infinity already clamped before this change (Rust `as i64` saturates), so those cells are in the test only as a guard.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->