### PR TITLE
loader: import an empty .md file as "" instead of an empty module

### DIFF
--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -127,7 +127,10 @@ impl Loader {
     }
 
     pub fn handles_empty_file(self) -> bool {
-        matches!(self, Loader::Wasm | Loader::File | Loader::Text)
+        matches!(
+            self,
+            Loader::Wasm | Loader::File | Loader::Text | Loader::Md
+        )
     }
 
     // `to_mime_type` / `from_mime_type` stay in bun_http_types as extension

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -525,6 +525,20 @@ describe("bundler", async () => {
         run: { stdout: '""' },
       });
 
+      itBundled(`${target}/loader-empty-md-file`, {
+        target: target,
+        files: {
+          "/entry.ts": /* js */ `
+          import empty from './empty.md';
+          import blank from './blank.md';
+          console.write(JSON.stringify([empty, blank]));
+        `,
+          "/empty.md": "",
+          "/blank.md": "\n\n  \n",
+        },
+        run: { stdout: '["",""]' },
+      });
+
       itBundled(`${target}/loader-empty-file-loader`, {
         target: target,
         outdir: "/out",

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1363,12 +1363,15 @@ describe.concurrent("importing .md modules", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("empty .md file produces a module with no default export", async () => {
+  test("empty .md file default-exports an empty string", async () => {
     using dir = tempDir("md-import-empty", {
       "empty.md": "",
+      "blank.md": "\n\n  \n",
       "entry.ts": `
-        import html from "./empty.md";
-        console.log(html);
+        import empty from "./empty.md";
+        import blank from "./blank.md";
+        const required = require("./empty.md");
+        console.log(JSON.stringify([empty, blank, required.default]));
       `,
     });
     await using proc = Bun.spawn({
@@ -1377,8 +1380,9 @@ describe.concurrent("importing .md modules", () => {
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("Missing 'default' export");
-    expect(exitCode).not.toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(["", "", ""]);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/resolve/import-empty.test.js
+++ b/test/js/bun/resolve/import-empty.test.js
@@ -16,6 +16,11 @@ it("importing empty text file returns empty string", async () => {
   expect(empty_file_text).toEqual("");
 });
 
+it("importing empty md file returns empty string", async () => {
+  const empty_file_md = (await import("./empty-file", { with: { type: "md" } })).default;
+  expect(empty_file_md).toEqual("");
+});
+
 it("importing empty file with type file returns it path", async () => {
   const empty_file_text = (await import("./empty-file", { with: { type: "file" } })).default;
   expect(empty_file_text).toEqual(empty_file_path);


### PR DESCRIPTION
### Problem
- An empty or whitespace-only `.md` import fails at runtime with `SyntaxError: Missing 'default' export in module '.../e.md'`. `bun build` inlines `var e_default = {};` for the same file. A non-empty `.md` gives the HTML string in both modes, and an empty `.txt` gives `""`.
- The cause is `Loader::handles_empty_file()` (`src/ast/loader.rs:129`). It lists `Wasm | File | Text` but not `Md`. So `Transpiler::parse` (`src/bundler/transpiler.rs:1536`) returns an empty JS module, and `ParseTask` (`src/bundler/ParseTask.rs:2670`) builds a `{}` lazy-export AST, instead of the `Loader::Md` arm.

### Fix
- Add `Loader::Md` to `handles_empty_file()`. Both paths now reach the markdown arm, which renders `""` to `""` and exports it as the default.
- Correct because the documented md loader contract (`docs/runtime/file-types.mdx`) is "renders the file to HTML and returns the HTML as a string", and `Bun.markdown.html("")` is `""`.
- The runtime test from #37071 that expected `Missing 'default' export` recorded the old behavior as coverage, not as a decision. It now asserts `""`.
- Verified: `test/js/bun/md/md-edge-cases.test.ts`, `test/bundler/bundler_loader.test.ts` (`loader-empty-md-file`, three targets), `test/js/bun/resolve/import-empty.test.js`. Each fails on stock bun and passes with this change. Self-reviewed: 0 execution concerns, 6 follow-up suggestions (see Notes).

### Background
- A loader turns a non-JS file into a module. The `md` loader renders markdown to HTML and makes the string the default export.
- The runtime transpiler and the bundler both short-circuit empty and whitespace-only files before they pick a loader arm. `handles_empty_file()` is the opt-out for loaders whose output for an empty file is meaningful (`""` for text, a path for file).

<details><summary>Notes</summary>

- Repro on 1.4.3-canary.1+f42e98025:
  ```sh
  : > e.md
  printf 'import m from "./e.md"; console.log(JSON.stringify(m), typeof m);\n' > t.mjs
  bun ./t.mjs                                   # SyntaxError: Missing 'default' export
  bun build ./t.mjs --outfile o.js && bun o.js  # {} object
  ```
- With a dynamic `import("./e.md")` the old runtime behavior was `default === undefined` instead of a throw, because the namespace object of the empty module has no `default` binding.
- Whitespace-only input: the runtime treats fewer than 33 bytes of `\n\r ` as empty, the bundler uses `is_all_whitespace` with no length cap. Both now render through `bun_md`, which returns `""` for blank lines, so the two modes agree for every whitespace-only file too.
- `bun ./empty.md` (markdown as an entry point) does not go through `handles_empty_file()` and is unchanged (exit 0, no output).
- Full files pass on the debug build: md-edge-cases 84, bundler_loader 62, import-empty 10.
- #38301 also edits `handles_empty_file()` (adds the sqlite loaders). The conflict is one line. #41883 changes the empty-file short-circuit for the data loaders and leaves `.md` to this PR.
- The self-review raised no correctness concerns. Its suggestions were all about a larger follow-up shape: make `handles_empty_file()` an exhaustive `match` so a new loader cannot silently inherit the empty-JS-module default, add a table-driven runtime-vs-`Bun.build` parity test over every loader, and fix the empty `.html` row (today `bun build empty.html` emits `export { empty_default as default };` with no binding). Each suggestion agreed that `Md => true` is the right row under any shape, so they are left for a separate PR rather than folded in here.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_loader.test.ts test/js/bun/md/md-edge-cases.test.ts test/js/bun/resolve/import-empty.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_loader.test.ts:
(pass) bundler > bun loader > bun/loader-yaml-file [21.25ms]
(pass) bundler > bun loader > bun/loader-text-file [10.86ms]
(pass) bundler > bun loader > bun/loader-json-file [9.79ms]
(pass) bundler > bun loader > bun/loader-toml-file [9.62ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-shadowed-temporal-global [9.69ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-imported-temporal-binding [9.69ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-no-bundle [9.10ms]
(pass) bundler > bun loader > bun/loader-toml-datetime [10.42ms]
(pass) bundler > bun loader > bun/loader-text-file [12.96ms]
(pass) bundler > bun loader > bun/loader-xml-file [12.66ms]
(pass) bundler > node loader > bun/loader-yaml-file [13.98ms]
(pass) bundler > node loader > bun/loader-text-file [13.98ms]
(pass) bundler > node loader > bun/loader-json-file [12.72ms]
(pass) bundler > node loader > bun/loader-toml-file [12.00ms]
(pass) bundler > node loader > bun/loader-toml-datetime-shadowed-temporal-global [11.97ms]
(pass) bundler > node loader > bun/loader-toml-datetime-imported-temporal-binding [13.31m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_loader.test.ts test/js/bun/md/md-edge-cases.test.ts test/js/bun/resolve/import-empty.test.js
bun test v1.4.3 (f42e98025)

test/bundler/bundler_loader.test.ts:
(pass) bundler > bun loader > bun/loader-yaml-file [825.71ms]
(pass) bundler > bun loader > bun/loader-text-file [461.17ms]
(pass) bundler > bun loader > bun/loader-json-file [354.53ms]
(pass) bundler > bun loader > bun/loader-toml-file [356.25ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-shadowed-temporal-global [350.85ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-imported-temporal-binding [424.06ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-no-bundle [510.83ms]
(pass) bundler > bun loader > bun/loader-toml-datetime [369.10ms]
(pass) bundler > bun loader > bun/loader-text-file [363.39ms]
(pass) bundler > bun loader > bun/loader-xml-file [416.16ms]
(pass) bundler > node loader > bun/loader-yaml-file [352.40ms]
(pass) bundler > node loader > bun/loader-text-file [436.32ms]
(pass) bundler > node loader > bun/loader-json-fil
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 634ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/loader.rs                        |  5 ++++-
 test/bundler/bundler_loader.test.ts      | 14 ++++++++++++++
 test/js/bun/md/md-edge-cases.test.ts     | 16 ++++++++++------
 test/js/bun/resolve/import-empty.test.js |  5 +++++
 4 files changed, 33 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/ast/loader.rs                             1      2     14
test/bundler/bundler_loader.test.ts           1      1      8
test/js/bun/md/md-edge-cases.test.ts          1      1      5
test/js/bun/resolve/import-empty.test.js      1      1      5
```

</details>

<!-- robobun:evidence:end -->