### PR TITLE
Bun.Cookie.parse: follow RFC 6265 for Max-Age syntax and over-long attribute values

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -7,6 +7,7 @@
 #include <wtf/text/StringToIntegerConversion.h>
 #include <JavaScriptCore/DateConversion.h>
 #include <JavaScriptCore/DateInstance.h>
+#include <JavaScriptCore/MathCommon.h>
 #include "HTTPParsers.h"
 namespace WebCore {
 
@@ -49,6 +50,22 @@ ExceptionOr<Ref<Cookie>> Cookie::create(const String& name, const String& value,
         return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
     }
     return adoptRef(*new Cookie(name, value, domain, path, expires, secure, sameSite, httpOnly, maxAge, partitioned));
+}
+
+// RFC 6265 section 5.2.2: Max-Age is ["-"]1*DIGIT. Any other value ("1.5", "+5", "5s")
+// makes a user agent ignore the attribute. A value too large to represent is clamped,
+// not ignored, so clamp to the largest integer a JS number holds exactly.
+static std::optional<double> parseMaxAge(StringView attributeValue)
+{
+    bool isNegative = attributeValue.startsWith('-');
+    auto digits = isNegative ? attributeValue.substring(1) : attributeValue;
+    if (digits.isEmpty() || !digits.containsOnly<isASCIIDigit>())
+        return std::nullopt;
+
+    double magnitude = 0;
+    for (auto digit : digits.codeUnits())
+        magnitude = std::min(magnitude * 10 + (digit - '0'), JSC::maxSafeInteger());
+    return isNegative ? -magnitude : magnitude;
 }
 
 ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
@@ -103,6 +120,9 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
                 attributeValue = emptyString();
             }
 
+            if (attributeValue.length() > maxAttributeValueLength)
+                continue;
+
             // RFC 6265 5.2: each attribute is recorded independently, last occurrence wins.
             // Max-Age's precedence over Expires (5.3) governs the computed expiry time, so it
             // must not drop the Expires attribute, and must not depend on attribute order.
@@ -128,9 +148,8 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
                     }
                 }
             } else if (attributeName == "max-age"_s) {
-                if (auto parsed = WTF::parseIntegerAllowingTrailingJunk<int64_t>(attributeValue); parsed.has_value()) {
-                    maxAge = static_cast<double>(parsed.value());
-                }
+                if (auto parsed = parseMaxAge(attributeValue))
+                    maxAge = *parsed;
             } else if (attributeName == "secure"_s) {
                 secure = true;
             } else if (attributeName == "httponly"_s) {

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -52,9 +52,7 @@ ExceptionOr<Ref<Cookie>> Cookie::create(const String& name, const String& value,
     return adoptRef(*new Cookie(name, value, domain, path, expires, secure, sameSite, httpOnly, maxAge, partitioned));
 }
 
-// RFC 6265 section 5.2.2: Max-Age is ["-"]1*DIGIT. Any other value ("1.5", "+5", "5s")
-// makes a user agent ignore the attribute. A value too large to represent is clamped,
-// not ignored, so clamp to the largest integer a JS number holds exactly.
+// RFC 6265 section 5.2.2: ["-"]1*DIGIT or the attribute is ignored. Too many digits clamp, like a user agent does.
 static std::optional<double> parseMaxAge(StringView attributeValue)
 {
     bool isNegative = attributeValue.startsWith('-');

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -37,6 +37,9 @@ class Cookie : public RefCounted<Cookie> {
 public:
     ~Cookie();
     static constexpr int64_t emptyExpiresAtValue = std::numeric_limits<int64_t>::min();
+    // RFC 6265bis section 5.6: a user agent ignores a cookie attribute whose value is longer than this.
+    static constexpr unsigned maxAttributeValueLength = 1024;
+
     static ExceptionOr<Ref<Cookie>> create(const String& name, const String& value,
         const String& domain, const String& path,
         int64_t expires, bool secure, CookieSameSite sameSite,

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -150,6 +150,76 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(cookie.expires).toEqual(new Date("Thu, 02 Jan 2031 00:00:00 GMT"));
   });
 
+  // RFC 6265 section 5.2.2: Max-Age is ["-"]1*DIGIT. A user agent ignores any other value,
+  // so "Max-Age=1.5" is a session cookie in a browser, not one that lives for 1 second.
+  test("Cookie.parse ignores a Max-Age that is not an integer", () => {
+    for (const value of ["1.5", "60.7", "+60", "60abc", "0x10", "1e3", "", "-", "--1", " ", "six"]) {
+      const cookie = Bun.Cookie.parse(`a=b; Max-Age=${value}; Secure`);
+      expect(cookie.maxAge).toBeUndefined();
+      expect(cookie.secure).toBe(true);
+      expect(cookie.isExpired()).toBe(false);
+    }
+    // An ignored Max-Age leaves an earlier valid one, and Expires, in place.
+    const cookie = Bun.Cookie.parse("a=b; Max-Age=60; Expires=Tue, 01 Jun 2027 00:00:00 GMT; Max-Age=60.7");
+    expect(cookie.maxAge).toBe(60);
+    expect(cookie.expires).toEqual(new Date("Tue, 01 Jun 2027 00:00:00 GMT"));
+
+    for (const [value, expected] of [
+      ["0", 0],
+      ["-1", -1],
+      ["007", 7],
+      ["34560000", 34560000],
+    ] as const) {
+      expect(Bun.Cookie.parse(`a=b; Max-Age=${value}`).maxAge).toBe(expected);
+    }
+    expect(Bun.Cookie.parse("a=b; Max-Age=-0").isExpired()).toBe(true);
+  });
+
+  // A user agent clamps a Max-Age it cannot represent instead of ignoring it, so a huge
+  // value is a long-lived cookie, not a session cookie.
+  test("Cookie.parse clamps an out-of-range Max-Age", () => {
+    const huge = Bun.Cookie.parse("a=b; Max-Age=99999999999999999999");
+    expect(huge.maxAge).toBe(Number.MAX_SAFE_INTEGER);
+    expect(huge.isExpired()).toBe(false);
+    expect(huge.serialize()).toBe("a=b; Path=/; Max-Age=9007199254740991; SameSite=Lax");
+    expect(Bun.Cookie.parse("a=b; Max-Age=9007199254740992").maxAge).toBe(Number.MAX_SAFE_INTEGER);
+    expect(Bun.Cookie.parse("a=b; Max-Age=9007199254740991").maxAge).toBe(Number.MAX_SAFE_INTEGER);
+
+    const negative = Bun.Cookie.parse("a=b; Max-Age=-99999999999999999999");
+    expect(negative.maxAge).toBe(-Number.MAX_SAFE_INTEGER);
+    expect(negative.isExpired()).toBe(true);
+  });
+
+  // RFC 6265bis section 5.6: a user agent ignores a cookie attribute whose value is longer
+  // than 1024 octets, so a browser stores such a cookie with the default Path / host-only.
+  test("Cookie.parse ignores an attribute value longer than 1024 characters", () => {
+    const path1024 = "/" + Buffer.alloc(1023, "p").toString();
+    const path1025 = path1024 + "p";
+    // 16 labels of 63 characters, each with a dot in front, is exactly 1024.
+    const labels = Array.from({ length: 16 }, () => Buffer.alloc(63, "d").toString()).join(".");
+    const domain1024 = "." + labels;
+    const domain1025 = "d." + labels;
+
+    const kept = Bun.Cookie.parse(`a=b; Path=${path1024}; Domain=${domain1024}`);
+    expect(kept.path).toBe(path1024);
+    expect(kept.domain).toBe(domain1024);
+
+    expect(Bun.Cookie.parse(`a=b; Path=${path1025}; Domain=${domain1025}; Secure`).toJSON()).toEqual({
+      name: "a",
+      value: "b",
+      path: "/",
+      secure: true,
+      sameSite: "lax",
+      httpOnly: false,
+      partitioned: false,
+    });
+    // An earlier value of the same attribute is kept, a later one still wins.
+    expect(Bun.Cookie.parse(`a=b; Path=/short; Path=${path1025}`).path).toBe("/short");
+    expect(Bun.Cookie.parse(`a=b; Path=${path1025}; Path=/short`).path).toBe("/short");
+    expect(Bun.Cookie.parse(`a=b; Domain=example.com; Domain=${domain1025}`).domain).toBe("example.com");
+    expect(Bun.Cookie.parse(`a=b; Max-Age=${Buffer.alloc(1025, "9")}`).maxAge).toBeUndefined();
+  });
+
   test("Cookie.parse reads every attribute in any order", () => {
     const attributes = [
       "Max-Age=3600",


### PR DESCRIPTION
### Problem
- `Bun.Cookie.parse("b=1; Max-Age=1.5").maxAge` is `1`, so the object says the cookie lives for 1 second. RFC 6265 section 5.2.2 says a Max-Age that is not `[-]DIGITS` is ignored, and Chromium stores `b` as a session cookie. `Max-Age=60abc` and `Max-Age=+60` read as `60` the same way.
- `Bun.Cookie.parse("a=1; Max-Age=99999999999999999999").maxAge` is `undefined` (a session cookie), because `parseIntegerAllowingTrailingJunk<int64_t>` overflows and the attribute is dropped. A user agent clamps instead, so Chromium keeps a persistent cookie.
- `Bun.Cookie.parse("a=b; Path=/" + "p".repeat(1100)).path` is the 1101-byte path. RFC 6265bis section 5.6 tells a user agent to ignore an attribute value longer than 1024 octets, and Chromium stores that cookie with `path: "/"`. Same for `Domain` (host-only). All three live in the `Cookie::parse` attribute loop in `src/jsc/bindings/Cookie.cpp`.

### Fix
- `Cookie::parse` reads Max-Age with a small `parseMaxAge` that accepts only `[-]DIGITS` and clamps the magnitude to `Number.MAX_SAFE_INTEGER`, so the value stays an exact integer and re-serializes as digits.
- The loop skips any attribute whose value is longer than `Cookie::maxAttributeValueLength` (1024) before it looks at the name, so a later valid occurrence still wins and an earlier one is kept.
- No new throw. The write side is untouched: `new Bun.Cookie(...)` still accepts a long path and a fractional `maxAge` (see Notes).
- Verified: three new tests in `test/js/bun/cookie/cookie-map.test.ts` fail on 1.4.3 and pass here. All of `test/js/bun/cookie/`, `test/js/bun/http/bun-serve-cookies.test.ts`, `test/js/bun/util/cookie.test.js` and `test/js/web/fetch/cookies.test.ts` pass. Self-reviewed: 10 concerns raised, 8 addressed by cutting this PR down to the parse loop, 2 answered in Notes.

### Background
- `Bun.Cookie` is the object behind `req.cookies.set()` in `Bun.serve` routes and behind `Bun.CookieMap`. `serialize()` produces a `Set-Cookie` line and `Bun.Cookie.parse()` reads one back into the same fields, so an app can reason about what a browser will store.
- RFC 6265 section 5.2 is the algorithm a user agent runs on a `Set-Cookie` line. An attribute it cannot parse is ignored, not fatal: the cookie is still stored with the default for that attribute (`Path`: the request's directory, `Domain`: host-only, `Max-Age`: fall back to `Expires`, else a session cookie).
- RFC 6265bis is the draft that Chromium, Firefox and Safari track. Section 5.6 adds the 1024-octet limit per attribute value.

<details><summary>Notes</summary>

- This comes from a Chromium-jar differential run over `Bun.Cookie`, not from a user report.
- The first revision of this PR also made the constructor, setters, `CookieMap.set` and `CookieMap.delete` throw for a path or domain longer than 1024 characters, and reshaped the validators to carry the message. Review feedback: that is a new cap on an application-controlled value and a separate decision, and the validator reshape collided with #32982, #35232 and #32267. So that part moved to its own PR, #42047, and this one touches only the parse loop.
- Round trip: `new Bun.Cookie("a", "b", { maxAge: 1.5 }).serialize()` still emits `Max-Age=1.5`, and `parse()` now reads that back as no Max-Age (before: `1`). That is what a browser does with it. Rejecting or flooring a fractional `maxAge` on the write side is #32967.
- `Max-Age=+60` used to parse as 60 and is now ignored. The RFC grammar allows only `-`. Chromium happens to accept `+` and Firefox's `%lld` scan accepts more, so following the grammar is the rule with no list of exceptions.
- #41960 edits the `path` and `samesite` branches of the same loop. The two diffs merge cleanly in `Cookie.cpp`; only the test insertion point in `cookie-map.test.ts` needs a trivial rebase for whichever lands second.
- `<wtf/text/StringToIntegerConversion.h>` is now unused in this file but left in place to keep the include block stable for the sibling PRs.

</details>
