### PR TITLE
node test common: report ASan builds through common.isASan (fixes test-crypto-dh-leak on the asan lane)

### DIFF
--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -308,7 +308,6 @@ const isFreeBSD = process.platform === 'freebsd';
 const isOpenBSD = process.platform === 'openbsd';
 const isLinux = process.platform === 'linux';
 const isMacOS = process.platform === 'darwin';
-const isASan = process.config.variables.asan === 1;
 const isRiscv64 = process.arch === 'riscv64';
 const isDebug = process.features.debug;
 function isPi() {
@@ -1223,7 +1222,21 @@ const common = {
   hasMultiLocalhost,
   invalidArgTypeHelper,
   isAlive,
-  isASan,
+  // Bun reports `process.config.variables.asan` as 0 even in ASan builds (so
+  // node-gyp does not add -fsanitize=address to addons), so ask the runtime.
+  get isASan() {
+    let value = process.config.variables.asan === 1;
+    if (!value && process.versions.bun) {
+      try {
+        const { isASANEnabled } = require('bun:internal-for-testing');
+        value = typeof isASANEnabled === 'function' && !!isASANEnabled();
+      } catch {
+        value = path.basename(process.execPath).includes('bun-asan');
+      }
+    }
+    Object.defineProperty(this, 'isASan', { value, enumerable: true });
+    return value;
+  },
   isDebug,
   isDumbTerminal,
   isFreeBSD,


### PR DESCRIPTION
### What was failing

`test/js/node/test/parallel/test-crypto-dh-leak.js` fails on the `linux x64-asan` lane of every PR build since Sept 6:

```
AssertionError: before=276205568 after=299896832   // delta 23.7 MB, bound is 20 MB
```

### Why

Upstream skips this test under ASan (`if (common.isASan) common.skip('ASan messes with memory measurements')`) because the 5e4-iteration `setPublicKey`/`setPrivateKey` loop frees ~2e5 BIGNUMs that ASan's quarantine keeps resident, so an RSS delta is meaningless there.

In Bun, `common.isASan` was always `false`: it reads `process.config.variables.asan`, which `BunProcess.cpp` deliberately leaves at `0` even when `ASAN_ENABLED` (so node-gyp doesn't add `-fsanitize=address` to addons). So the ASan lane has always run the strict path and passed only on slop — ~15 MB against a 20 MB bound.

#36138 (`util.inspect: freeze builtInObjects`) removed the `Object.getOwnPropertyNames(globalThis)` scrape at `internal/util/inspect` load. That no longer reifies every lazy global during `require('../common')`, so ~9 MB of RSS moved from before the test's `before` sample to inside the measured window. Bisected with the CI `bun-asan` artifacts:

| PR build based on | `before` | `after` | delta |
|---|---|---|---|
| 988ce730e56d (parent of #36138) | 278.2 MB | 293.4 MB | 15.2 MB — pass |
| 4593030feca2 (#36138) | 269.3 MB | 291.8 MB | 22.5 MB — fail |

`after` is unchanged; nothing leaks. Release builds show no growth at 10× the iterations (5e5 → 8.5 MB total).

### Fix

Make `common.isASan` ask the runtime (`require('bun:internal-for-testing').isASANEnabled()`, falling back to the `bun-asan` basename — the same probe `test/harness.ts` uses), as a lazy memoizing getter so the other ~2.8k node tests don't load `bun:internal-for-testing` at startup.

Effect: under Bun ASan builds `test-crypto-dh-leak` and `test-crypto-secure-heap` skip and `test-v8-serialize-leak` takes its ASan branch, exactly as they do under Node's own ASan build. Release/debug-non-asan lanes are unchanged (verified the test still runs and passes on a release build).

`process.config.variables.asan` is left at 0 on purpose; flipping it would make node-gyp compile every napi/v8 test addon with `-fsanitize=address` on that lane.
