### PR TITLE
worker: resolve a relative specifier from the cwd at construction

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -469,9 +469,8 @@ impl<'a> Transpiler<'a> {
         self.resolve_entry_point_from(top_level_dir, entry_point)
     }
 
-    /// [`Self::resolve_entry_point`] with a relative or bare `entry_point`
-    /// resolved from the absolute directory `source_dir` instead of the
-    /// current working directory.
+    /// [`Self::resolve_entry_point`], but a relative or bare `entry_point`
+    /// resolves from the absolute `source_dir` instead of the cwd.
     pub fn resolve_entry_point_from(
         &mut self,
         source_dir: &[u8],

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -419,10 +419,13 @@ impl<'a> Transpiler<'a> {
         }
     }
 
-    fn _resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
-        let top_level_dir = self.fs().top_level_dir;
+    fn _resolve_entry_point(
+        &mut self,
+        source_dir: &[u8],
+        entry_point: &[u8],
+    ) -> crate::Result<resolver::Result> {
         let first = match self.resolver.resolve_with_framework(
-            top_level_dir,
+            source_dir,
             entry_point,
             bun_ast::ImportKind::EntryPointBuild,
         ) {
@@ -446,11 +449,10 @@ impl<'a> Transpiler<'a> {
             prefixed.extend_from_slice(entry_point);
             // `Resolver::resolve` interns the path internally,
             // so the heap buffer can drop after the call.
-            if let Ok(r) = self.resolver.resolve(
-                top_level_dir,
-                &prefixed,
-                bun_ast::ImportKind::EntryPointBuild,
-            ) {
+            if let Ok(r) =
+                self.resolver
+                    .resolve(source_dir, &prefixed, bun_ast::ImportKind::EntryPointBuild)
+            {
                 if !r.flags.is_external() {
                     return Ok(r);
                 }
@@ -463,7 +465,19 @@ impl<'a> Transpiler<'a> {
     /// Resolve an entry-point specifier, busting the directory cache and
     /// retrying once on failure before reporting the error to the log.
     pub fn resolve_entry_point(&mut self, entry_point: &[u8]) -> crate::Result<resolver::Result> {
-        match self._resolve_entry_point(entry_point) {
+        let top_level_dir = self.fs().top_level_dir;
+        self.resolve_entry_point_from(top_level_dir, entry_point)
+    }
+
+    /// [`Self::resolve_entry_point`] with a relative or bare `entry_point`
+    /// resolved from the absolute directory `source_dir` instead of the
+    /// current working directory.
+    pub fn resolve_entry_point_from(
+        &mut self,
+        source_dir: &[u8],
+        entry_point: &[u8],
+    ) -> crate::Result<resolver::Result> {
+        match self._resolve_entry_point(source_dir, entry_point) {
             Ok(r) => self.reject_unbundleable_entry_point(r, entry_point),
             Err(err) => {
                 let mut cache_bust_buf = bun_paths::path_buffer_pool::get();
@@ -476,9 +490,7 @@ impl<'a> Transpiler<'a> {
                 // so compute `busted` directly instead.
                 let busted: bool = 'name: {
                     // Neither buster name below would fit `cache_bust_buf`.
-                    if self.fs().top_level_dir.len() + entry_point.len() + 4
-                        > bun_paths::MAX_PATH_BYTES
-                    {
+                    if source_dir.len() + entry_point.len() + 4 > bun_paths::MAX_PATH_BYTES {
                         break 'name false;
                     }
                     if bun_paths::is_absolute(entry_point) {
@@ -502,12 +514,11 @@ impl<'a> Transpiler<'a> {
 
                     // `".."` needs no platform separator rewrite.
                     let parts: [&[u8]; 2] = [entry_point, b".."];
-                    let top_level_dir = self.fs().top_level_dir;
 
                     let buster_name = bun_paths::resolve_path::join_abs_string_buf_z::<
                         bun_paths::platform::Auto,
                     >(
-                        top_level_dir, &mut cache_bust_buf[..], &parts
+                        source_dir, &mut cache_bust_buf[..], &parts
                     );
                     self.resolver.bust_dir_cache(
                         bun_paths::string_paths::without_trailing_slash_windows_path(
@@ -518,7 +529,7 @@ impl<'a> Transpiler<'a> {
 
                 // Only re-query if we previously had something cached.
                 if busted {
-                    if let Ok(result) = self._resolve_entry_point(entry_point) {
+                    if let Ok(result) = self._resolve_entry_point(source_dir, entry_point) {
                         return self.reject_unbundleable_entry_point(result, entry_point);
                     }
                     // ignore this error, we will print the original error

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -83,9 +83,8 @@ pub struct WebWorker {
     exec_argv_len: usize,
     inherit_exec_argv: bool,
     unresolved_specifier: Box<[u8]>,
-    /// The working directory when `new Worker()` ran. `spin()` resolves
-    /// `unresolved_specifier` from it, so a `process.chdir()` between
-    /// construction and thread start does not change which module loads.
+    /// The cwd when `new Worker()` ran; `unresolved_specifier` resolves from
+    /// it, not from wherever a later `process.chdir()` went.
     cwd: Box<[u8]>,
     preloads: Vec<Box<[u8]>>,
     name: bun_core::ZBox,
@@ -817,10 +816,8 @@ impl WebWorker {
         // `preload: Vec<Box<[u8]>>` — clone the boxes (cheap, ≤handful).
         vm.as_mut().preload.clone_from(&self.preloads);
 
-        // Resolve the entry point on the worker thread (the parent only stored
-        // the raw specifier and its cwd). The returned slice is BORROWED — every
-        // exit from spin() goes through shutdown() which is noreturn, so a
-        // `defer free` here would never run anyway.
+        // Resolve the entry point here, from the cwd `create()` captured. The
+        // returned slice is BORROWED; every exit below ends in `shutdown()`.
         let mut resolve_error = BunString::EMPTY;
         let vm_log = vm.log_mut().unwrap();
         // SAFETY: `vm_ptr` is the live worker-thread VM.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -83,6 +83,10 @@ pub struct WebWorker {
     exec_argv_len: usize,
     inherit_exec_argv: bool,
     unresolved_specifier: Box<[u8]>,
+    /// The working directory when `new Worker()` ran. `spin()` resolves
+    /// `unresolved_specifier` from it, so a `process.chdir()` between
+    /// construction and thread start does not change which module loads.
+    cwd: Box<[u8]>,
     preloads: Vec<Box<[u8]>>,
     name: bun_core::ZBox,
 
@@ -304,6 +308,10 @@ impl WebWorker {
         log!("[{}] create", this_context_id);
 
         let spec_slice = specifier_str.to_utf8();
+        // Copied, not borrowed: `process.chdir()` rewrites the buffer behind
+        // `top_level_dir` in place.
+        // SAFETY: `parent` is the calling thread's live VM.
+        let cwd: Box<[u8]> = Box::from(unsafe { (*parent).top_level_dir() });
         let mut temp_log = bun_ast::Log::default();
         // SAFETY: `parent` is the calling thread's live VM (BACKREF); borrows
         // are scoped to each statement.
@@ -336,7 +344,13 @@ impl WebWorker {
             // SAFETY: `parent` is the live VM on the calling (parent) thread;
             // `resolve_entry_point_specifier` takes the raw pointer.
             if let Some(preload) = unsafe {
-                resolve_entry_point_specifier(parent, utf8_slice.slice(), error_message, temp_log)
+                resolve_entry_point_specifier(
+                    parent,
+                    &cwd,
+                    utf8_slice.slice(),
+                    error_message,
+                    temp_log,
+                )
             } {
                 preloads.push(preload.to_vec().into_boxed_slice());
             }
@@ -413,6 +427,7 @@ impl WebWorker {
             exec_argv_len,
             inherit_exec_argv,
             unresolved_specifier: spec_slice.slice().to_vec().into_boxed_slice(),
+            cwd,
             preloads,
             name: if name_str.is_empty() {
                 bun_core::ZBox::default()
@@ -803,15 +818,16 @@ impl WebWorker {
         vm.as_mut().preload.clone_from(&self.preloads);
 
         // Resolve the entry point on the worker thread (the parent only stored
-        // the raw specifier). The returned slice is BORROWED — every exit from
-        // spin() goes through shutdown() which is noreturn, so a `defer free`
-        // here would never run anyway.
+        // the raw specifier and its cwd). The returned slice is BORROWED — every
+        // exit from spin() goes through shutdown() which is noreturn, so a
+        // `defer free` here would never run anyway.
         let mut resolve_error = BunString::EMPTY;
         let vm_log = vm.log_mut().unwrap();
         // SAFETY: `vm_ptr` is the live worker-thread VM.
         let path = match unsafe {
             resolve_entry_point_specifier(
                 vm_ptr,
+                &self.cwd,
                 &self.unresolved_specifier,
                 &mut resolve_error,
                 vm_log,
@@ -1263,9 +1279,9 @@ fn on_unhandled_rejection(
 }
 
 /// Resolve a worker entry-point specifier to a path the module loader can
-/// consume. The returned slice is BORROWED — it aliases `str`, the
-/// standalone module graph, or the resolver's arena; the caller must NOT
-/// free it.
+/// consume; a relative or bare `str` resolves from `cwd`. The returned slice
+/// is BORROWED — it aliases `str`, the standalone module graph, or the
+/// resolver's arena; the caller must NOT free it.
 ///
 /// # Safety
 /// `parent` must point at this thread's live `VirtualMachine`. Passed as a raw
@@ -1274,6 +1290,7 @@ fn on_unhandled_rejection(
 /// the single expression.
 unsafe fn resolve_entry_point_specifier<'s>(
     parent: *mut VirtualMachine,
+    cwd: &[u8],
     str: &'s [u8],
     error_message: &mut BunString,
     log: &mut bun_ast::Log,
@@ -1317,7 +1334,9 @@ unsafe fn resolve_entry_point_specifier<'s>(
     let global = unsafe { (*parent).global };
     // SAFETY: same as above — `parent`'s `transpiler` is mutated only on its
     // owning thread (the caller's thread per fn contract).
-    let resolved_entry_point = match unsafe { (*parent).transpiler.resolve_entry_point(str) } {
+    let resolved_entry_point = match unsafe {
+        (*parent).transpiler.resolve_entry_point_from(cwd, str)
+    } {
         Ok(r) => r,
         Err(_) => {
             // `global` valid for VM lifetime; safe ZST-handle deref (panics on null).

--- a/test/js/web/workers/worker-entry-point.test.ts
+++ b/test/js/web/workers/worker-entry-point.test.ts
@@ -46,7 +46,9 @@ describe.concurrent("package.json imports alias as the entry point", () => {
     expect(stderr).toBe("");
     expect(stdout).toBe("message: hi\nclosed\n");
     expect(exitCode).toBe(0);
-  });
+    // LeakSanitizer's check at exit costs 4-5 s of wall time on a debug ASAN build by itself (`bun -e 1`
+    // with detect_leaks=1 takes as long), which is the whole default budget.
+  }, 30_000);
 
   test("an alias of a builtin fires the error event", async () => {
     // `new Worker("node:fs")` fails to resolve. An alias of a builtin resolves to the builtin marked
@@ -63,6 +65,43 @@ describe.concurrent("package.json imports alias as the entry point", () => {
     expect(stdout).toBe(
       'error: BuildMessage: Cannot use "#fs" as an entry point: it resolves to a builtin module\nclosed\n',
     );
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.concurrent("relative specifier resolves from the cwd at construction", () => {
+  // The worker thread resolves the specifier some time after `new Worker()` returns. A process.chdir()
+  // in between must not change which file the specifier names. Several workers are created back to
+  // back so that the later threads have not resolved anything yet when chdir runs.
+  test.each(["Worker", "worker_threads.Worker"])("%s: process.chdir() right after new Worker()", async kind => {
+    const post =
+      kind === "Worker" ? `postMessage(where);` : `require("node:worker_threads").parentPort.postMessage(where);`;
+    const { stdout, stderr, exitCode } = await runWorkerFixture({
+      "worker.js": `const where = "top"; ${post}`,
+      "other/worker.js": `const where = "other"; ${post}`,
+      "main.js": `
+        const WorkerClass = ${kind === "Worker" ? `globalThis.Worker` : `require("node:worker_threads").Worker`};
+        function start() {
+          const worker = new WorkerClass("./worker.js");
+          return new Promise(resolve => {
+            const done = value => { resolve(value); worker.terminate(); };
+            if (WorkerClass === globalThis.Worker) {
+              worker.onmessage = event => done(event.data);
+              worker.onerror = event => done("error: " + event.message);
+            } else {
+              worker.on("message", done);
+              worker.on("error", error => done("error: " + error.message));
+            }
+          });
+        }
+        const before = [start(), start(), start(), start()];
+        process.chdir("other");
+        const after = start();
+        Promise.all([...before, after]).then(results => console.log(JSON.stringify(results)));
+      `,
+    });
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(["top", "top", "top", "top", "other"]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/web/workers/worker-entry-point.test.ts
+++ b/test/js/web/workers/worker-entry-point.test.ts
@@ -69,39 +69,46 @@ describe.concurrent("package.json imports alias as the entry point", () => {
   });
 });
 
-describe.concurrent("relative specifier resolves from the cwd at construction", () => {
+describe.concurrent("relative specifier and preload resolve from the cwd at construction", () => {
   // The worker thread resolves the specifier some time after `new Worker()` returns. A process.chdir()
-  // in between must not change which file the specifier names. Several workers are created back to
-  // back so that the later threads have not resolved anything yet when chdir runs.
-  test.each(["Worker", "worker_threads.Worker"])("%s: process.chdir() right after new Worker()", async kind => {
-    const post =
-      kind === "Worker" ? `postMessage(where);` : `require("node:worker_threads").parentPort.postMessage(where);`;
-    const { stdout, stderr, exitCode } = await runWorkerFixture({
-      "worker.js": `const where = "top"; ${post}`,
-      "other/worker.js": `const where = "other"; ${post}`,
-      "main.js": `
-        const WorkerClass = ${kind === "Worker" ? `globalThis.Worker` : `require("node:worker_threads").Worker`};
-        function start() {
-          const worker = new WorkerClass("./worker.js");
-          return new Promise(resolve => {
-            const done = value => { resolve(value); worker.terminate(); };
-            if (WorkerClass === globalThis.Worker) {
-              worker.onmessage = event => done(event.data);
-              worker.onerror = event => done("error: " + event.message);
-            } else {
-              worker.on("message", done);
-              worker.on("error", error => done("error: " + error.message));
-            }
-          });
-        }
-        const before = [start(), start(), start(), start()];
-        process.chdir("other");
-        const after = start();
-        Promise.all([...before, after]).then(results => console.log(JSON.stringify(results)));
-      `,
+  // in between must not change which file the specifier (or a relative `preload`) names. Several
+  // workers are created back to back so that the later threads have not resolved anything yet when
+  // chdir runs.
+  describe.each(["Worker", "worker_threads.Worker"])("%s", kind => {
+    test("process.chdir() right after new Worker()", async () => {
+      const post =
+        kind === "Worker"
+          ? `postMessage(where + " " + globalThis.preloaded);`
+          : `require("node:worker_threads").parentPort.postMessage(where + " " + globalThis.preloaded);`;
+      const { stdout, stderr, exitCode } = await runWorkerFixture({
+        "preload.js": `globalThis.preloaded = "top";`,
+        "worker.js": `const where = "top"; ${post}`,
+        "other/preload.js": `globalThis.preloaded = "other";`,
+        "other/worker.js": `const where = "other"; ${post}`,
+        "main.js": `
+          const WorkerClass = ${kind === "Worker" ? `globalThis.Worker` : `require("node:worker_threads").Worker`};
+          function start() {
+            const worker = new WorkerClass("./worker.js", { preload: "./preload.js" });
+            return new Promise(resolve => {
+              const done = value => { resolve(value); worker.terminate(); };
+              if (WorkerClass === globalThis.Worker) {
+                worker.onmessage = event => done(event.data);
+                worker.onerror = event => done("error: " + event.message);
+              } else {
+                worker.on("message", done);
+                worker.on("error", error => done("error: " + error.message));
+              }
+            });
+          }
+          const before = [start(), start(), start(), start()];
+          process.chdir("other");
+          const after = start();
+          Promise.all([...before, after]).then(results => console.log(JSON.stringify(results)));
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["top top", "top top", "top top", "top top", "other other"]);
+      expect(exitCode).toBe(0);
     });
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout)).toEqual(["top", "top", "top", "top", "other"]);
-    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `new Worker("./w.js")` then `process.chdir("other")` loads `./w.js` or `other/w.js` depending on timing. On 1.4.3, four workers created back to back and then a `chdir`: workers 2 to 4 load the wrong file every run. `node:worker_threads` too, unlike Node.
- The cause: `spin()` in `src/jsc/web_worker.rs` resolves the specifier on the worker thread with `Transpiler::resolve_entry_point`, which reads the live `FileSystem.top_level_dir`. `process.chdir()` rewrites that buffer.

### Fix
- `WebWorker::create()`, which runs inside the constructor on the parent thread, copies the cwd. `spin()` resolves the specifier from that copy through a new `Transpiler::resolve_entry_point_from(source_dir, entry_point)`. `resolve_entry_point` delegates to it, so other callers do not change.
- Resolution stays on the worker thread, so a missing module is still the worker's `error` event (#18768 moved it there for that reason). Preloads use the same cwd.
- Verified: `test/js/web/workers/worker-entry-point.test.ts` (two new tests, both fail on 1.4.3), plus the `workers/`, `worker_threads` and `compile/Worker*` suites.
- Self-reviewed: 4 concerns, all answered under Notes: three sibling live-cwd reads left out on purpose (`Bun.build` entry points, the worker's `tsconfig.json` and `.env` lookups) and the test budget below.

### Background
- `FileSystem` (`src/resolver/lib.rs`) is a process-global singleton. Its `top_level_dir` starts as the startup cwd. Entry points (`bun ./file.js`, `new Worker("./file.js")`) resolve against it.
- The worker thread builds its `VirtualMachine`, then resolves and loads the entry point, after `new Worker()` has returned and in parallel with the parent.
- The existing LSAN test in the file gets a 30 s budget: LeakSanitizer's exit check alone takes 4 to 5 s on a debug ASAN build.

<details><summary>Notes</summary>

- Repro on 1.4.3 (Linux x64), from a directory with `w.mjs` and `other/w.mjs` that post `import.meta.url`:
  ```js
  const workers = [];
  for (let i = 0; i < 4; i++) workers.push(new Worker("./w.mjs"));
  process.chdir("other");
  // -> ["TOP","OTHER","OTHER","OTHER"] every run; node:worker_threads the same; node: all TOP
  ```
  With a single worker the wrong file loads in about 1 of 8 runs: the first `new Worker()` in a process spends about 2 ms in one-time setup after the thread is spawned, so that thread usually wins. Every later constructor returns in well under the thread's startup time and loses.
- Why not resolve the whole entry point in `create()`: that is what the code did before #18768, which moved it to the worker thread so that a specifier that does not resolve is reported through the `error` event and exit code 1 (as in Node) instead of a synchronous throw. Capturing the cwd keeps that and removes the one piece of mutable process state the result depended on.
- `top_level_dir` is copied into a `Box<[u8]>`, not borrowed: after the first `chdir` it points into `top_level_dir_buf`, which the next `chdir` overwrites in place.
- `data:`, `blob:`, absolute paths, `file:` URLs and embedded (`--compile`) entry points do not read the cwd and are unchanged.
- Left out on purpose, sibling reads of the live cwd:
  - `Bun.build({ entrypoints: ["./a.ts"] })` resolves its entry points on the bundle thread through `Transpiler::resolve_entry_point` (`src/bundler/bundle_v2.rs`), so a `chdir` right after the call has the same race. That is a different API whose `outdir` and `root` handling reads the cwd too, and it overlaps #40372. `resolve_entry_point_from` is the seam a follow-up would use.
  - The worker thread also reads `top_level_dir` while it builds its transpiler: the root `tsconfig.json` in `configure_linker` and `.env` discovery in `run_env_loader` (`src/bundler/transpiler.rs`). Those pick the worker's transpiler settings, not which module loads, and the right base for them is arguably the startup project root (what the main thread used), not any later cwd. That question belongs with #40372, so this PR does not change them.
- Related open PRs in this area: #41837 (resolve a string specifier from the calling file first, a behaviour change; its cwd fallback still resolves on the worker thread), #41471 (capture a `blob:` entry at construction), #36584 (torn cwd reads across threads), #40372 (one `bun_core::cwd`; it keeps entry points on the live cwd, so this race stays relevant after it).
- Suites run locally on the debug ASAN build: `test/js/web/workers/{worker-entry-point,worker,worker_blob}.test.ts`, `test/js/node/worker_threads/worker_threads.test.ts`, `test/bundler/bundler_compile.test.ts -t Worker`. `worker.test.ts` "terminate() while fs.readFile completions keep arriving" times out at 5 s on this machine with and without the change.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/workers/worker-entry-point.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelo
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (50627ea36)

test/js/web/workers/worker-entry-point.test.ts:
(pass) package.json imports alias as the entry point > an alias of a builtin fires the error event [10.38ms]
(pass) package.json imports alias as the entry point > the worker runs and its thread exits without leaking [12.49ms]
(pass) relative specifier and preload resolve from the cwd at construction > Worker > process.chdir() right after new Worker() [13.89ms]
(pass) relative specifier and preload resolve from the cwd at construction > worker_threads.Worker > process.chdir() right after new Worker() [42.19ms]

 4 pass
 0 fail
 12 expect() calls
Ran 4 tests across 1 file. [133.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/workers/worker-entry-point.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/workers/worker-entry-point.test.ts:
(pass) package.json imports alias as the entry point > an alias of a builtin fires the error event [539.87ms]
(pass) relative specifier and preload resolve from the cwd at construction > Worker > process.chdir() right after new Worker() [737.36ms]
(pass) relative specifier and preload resolve from the cwd at construction > worker_threads.Worker > process.chdir() right after new Worker() [2513.72ms]
(pass) package.json imports alias as the entry point > the worker runs and its thread exits without leaking [4157.37ms]

 4 pass
 0 fail
 12 expect() calls
Ran 4 tests across 1 file. [6.60s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 771ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs                      | 40 +++++++++++++--------
 src/jsc/web_worker.rs                          | 34 +++++++++++++-----
 test/js/web/workers/worker-entry-point.test.ts | 48 +++++++++++++++++++++++++-
 3 files changed, 97 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/bundler/transpiler.rs                           5      6     24
src/jsc/web_worker.rs                               6      9     24
test/js/web/workers/worker-entry-point.test.ts      3      4     24
```

</details>

<!-- robobun:evidence:end -->