### PR TITLE
valkey: finish the handshake's SELECT before reporting the client connected

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -719,6 +719,7 @@ impl JSValkeyClient {
                     valkey::TLS::None
                 },
                 database,
+                pending_hello: None,
                 flags: valkey::ConnectionFlags {
                     enable_auto_reconnect: options.enable_auto_reconnect,
                     enable_offline_queue: options.enable_offline_queue,
@@ -822,6 +823,7 @@ impl JSValkeyClient {
                 }),
                 tls,
                 database: client.database,
+                pending_hello: None,
                 flags: valkey::ConnectionFlags {
                     enable_offline_queue: if sub_ctx.is_subscriber {
                         sub_ctx.original_enable_offline_queue

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -30,6 +30,8 @@ bun_output::define_scoped_log!(debug, Redis, visible);
 /// Connection flags to track Valkey client state
 pub struct ConnectionFlags {
     pub(crate) is_manually_closed: bool,
+    /// HELLO was accepted and the reply to the handshake's `SELECT` is still
+    /// due. The client stays `Connecting` until it arrives.
     pub(crate) is_selecting_db_internal: bool,
     pub(crate) enable_offline_queue: bool,
     pub(crate) enable_auto_reconnect: bool,
@@ -81,7 +83,8 @@ pub enum Status {
     NeverConnected,
     Disconnected,
     Connecting,
-    /// Socket open and HELLO accepted.
+    /// Socket open and handshake accepted: HELLO, then SELECT when the URL
+    /// names a database.
     Connected,
 }
 
@@ -259,6 +262,9 @@ pub struct ValkeyClient {
     pub(crate) password: Box<[u8]>,
     pub(crate) username: Box<[u8]>,
     pub(crate) database: u32,
+    /// The accepted HELLO reply, held while the handshake's SELECT reply is
+    /// due so that `on_valkey_connect` still receives it.
+    pub(crate) pending_hello: Option<RESPValue>,
     pub(crate) address: Address,
     pub(crate) protocol: Protocol,
 
@@ -665,6 +671,8 @@ impl ValkeyClient {
         // pending activity in `update_poll_ref` and keeps the event loop alive.
         self.read_buffer.clear_and_free();
         self.reply_scanner.reset();
+        self.flags.is_selecting_db_internal = false;
+        self.pending_hello = None;
 
         // A manual close or a failure the client detected itself: no retry.
         if self.flags.is_manually_closed || self.flags.failed {
@@ -702,7 +710,6 @@ impl ValkeyClient {
         );
 
         self.flags.is_reconnecting = true;
-        self.flags.is_selecting_db_internal = false;
 
         self.reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed)?;
 
@@ -1003,11 +1010,7 @@ impl ValkeyClient {
             }
             RESPValue::SimpleString(str_) => {
                 if str_.as_ref() == b"OK" {
-                    self.status = Status::Connected;
-                    self.flags.is_reconnecting = false;
-                    self.retry_attempts = 0;
-                    self.on_valkey_connect(value)?;
-                    return Ok(());
+                    return self.hello_accepted(value);
                 }
                 self.fail(
                     b"Authentication failed (unexpected response)",
@@ -1042,11 +1045,7 @@ impl ValkeyClient {
                 }
 
                 // Authentication successful via HELLO
-                self.status = Status::Connected;
-                self.flags.is_reconnecting = false;
-                self.retry_attempts = 0;
-                self.on_valkey_connect(value)?;
-                Ok(())
+                self.hello_accepted(value)
             }
             _ => {
                 self.fail(
@@ -1058,52 +1057,55 @@ impl ValkeyClient {
         }
     }
 
+    /// `authenticate()` writes `SELECT` right behind `HELLO`, so when the URL
+    /// names a database the handshake has one more reply to go.
+    fn hello_accepted(&mut self, value: &mut RESPValue) -> JsResult<()> {
+        if self.database > 0 {
+            self.flags.is_selecting_db_internal = true;
+            self.pending_hello = Some(core::mem::replace(value, RESPValue::Null));
+            return Ok(());
+        }
+        self.handshake_complete(value)
+    }
+
+    fn handle_select_response(&mut self, value: &mut RESPValue) -> JsResult<()> {
+        self.flags.is_selecting_db_internal = false;
+        let mut hello = self.pending_hello.take().unwrap_or(RESPValue::Null);
+        match value {
+            RESPValue::Error(err) => self.fail(err, RedisError::ServerError),
+            RESPValue::SimpleString(ok) if ok.as_ref() == b"OK" => {
+                debug!("SELECT {} successful", self.database);
+                self.handshake_complete(&mut hello)
+            }
+            _ => self.fail(
+                b"SELECT command failed with non-OK response",
+                RedisError::InvalidResponse,
+            ),
+        }
+    }
+
+    /// The one place a connection becomes `Connected`: `onconnect`, the
+    /// `connect()` promise, the queue drain and the auto-flusher all key off it,
+    /// so nothing is written ahead of a handshake reply that is still due.
+    fn handshake_complete(&mut self, hello: &mut RESPValue) -> JsResult<()> {
+        self.status = Status::Connected;
+        self.flags.is_reconnecting = false;
+        self.retry_attempts = 0;
+        self.on_valkey_connect(hello)
+    }
+
     /// Handle Valkey protocol response
     fn handle_response(&mut self, value: &mut RESPValue) -> JsResult<()> {
-        // Special handling for the initial HELLO response
+        // Replies to the handshake are not paired with anything in the command queue.
         if self.status != Status::Connected {
-            self.handle_hello_response(value)?;
-
-            // We've handled the HELLO response without consuming anything from the command queue
+            if self.flags.is_selecting_db_internal {
+                self.handle_select_response(value)?;
+            } else {
+                self.handle_hello_response(value)?;
+            }
             return Ok(());
         }
 
-        // Handle initial SELECT response
-        if self.flags.is_selecting_db_internal {
-            self.flags.is_selecting_db_internal = false;
-
-            return match value {
-                RESPValue::Error(err_str) => {
-                    self.fail(err_str, RedisError::InvalidCommand)?;
-                    Ok(())
-                }
-                RESPValue::SimpleString(ok_str) => {
-                    if ok_str.as_ref() != b"OK" {
-                        // SELECT returned something other than "OK"
-                        self.fail(
-                            b"SELECT command failed with non-OK response",
-                            RedisError::InvalidResponse,
-                        )?;
-                        return Ok(());
-                    }
-
-                    // SELECT was successful.
-                    debug!("SELECT {} successful", self.database);
-                    // Connection is now fully ready on the specified database.
-                    // If any commands were queued while waiting for SELECT, try to send them.
-                    self.send_next_command();
-                    Ok(())
-                }
-                _ => {
-                    // Unexpected response type for SELECT
-                    self.fail(
-                        b"Received non-SELECT response while in the SELECT state.",
-                        RedisError::InvalidResponse,
-                    )?;
-                    Ok(())
-                }
-            };
-        }
         // Check if this is a subscription push message that might not need a promise pair
         let mut should_consume_promise_pair = true;
         let mut pair_maybe: Option<command::PromisePair> = None;
@@ -1269,7 +1271,8 @@ impl ValkeyClient {
             return Ok(());
         }
 
-        // If using a specific database, send SELECT command
+        // If using a specific database, send SELECT right behind HELLO; its
+        // reply completes the handshake (`hello_accepted`).
         if self.database > 0 {
             let mut int_buf = [0u8; 64];
             let db_str = bun_core::fmt::int_as_bytes(&mut int_buf, self.database);
@@ -1282,7 +1285,6 @@ impl ValkeyClient {
                 self.fail(b"Failed to write SELECT command", RedisError::OutOfMemory)?;
                 return Ok(());
             }
-            self.flags.is_selecting_db_internal = true;
         }
         Ok(())
     }
@@ -1298,6 +1300,7 @@ impl ValkeyClient {
         // after a previous connection exhausted retries (#29925).
         self.flags.failed = false;
         self.flags.is_selecting_db_internal = false;
+        self.pending_hello = None;
         if matches!(self.socket, AnySocket::SocketTcp(_)) {
             // if is tcp, we need to start the connection process
             // if is tls, we need to wait for the handshake to complete
@@ -1316,7 +1319,7 @@ impl ValkeyClient {
     /// Test whether we are ready to run "normal" RESP commands, such as
     /// get/set, pub/sub, etc.
     fn connection_ready(&self) -> bool {
-        self.status == Status::Connected && !self.flags.is_selecting_db_internal
+        self.status == Status::Connected
     }
 
     /// Process queued commands in the offline queue

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -30,7 +30,7 @@ bun_output::define_scoped_log!(debug, Redis, visible);
 /// Connection flags to track Valkey client state
 pub struct ConnectionFlags {
     pub(crate) is_manually_closed: bool,
-    /// HELLO was accepted and the reply to the handshake's `SELECT` is still
+    /// The handshake wrote a `SELECT` behind `HELLO` and its reply is still
     /// due. The client stays `Connecting` until it arrives.
     pub(crate) is_selecting_db_internal: bool,
     pub(crate) enable_offline_queue: bool,
@@ -263,7 +263,8 @@ pub struct ValkeyClient {
     pub(crate) username: Box<[u8]>,
     pub(crate) database: u32,
     /// The accepted HELLO reply, held while the handshake's SELECT reply is
-    /// due so that `on_valkey_connect` still receives it.
+    /// due so that `on_valkey_connect` still receives it. While it is held,
+    /// the next reply is the SELECT's.
     pub(crate) pending_hello: Option<RESPValue>,
     pub(crate) address: Address,
     pub(crate) protocol: Protocol,
@@ -1057,20 +1058,22 @@ impl ValkeyClient {
         }
     }
 
-    /// `authenticate()` writes `SELECT` right behind `HELLO`, so when the URL
-    /// names a database the handshake has one more reply to go.
+    /// When `authenticate()` wrote a `SELECT` behind `HELLO`, the handshake has
+    /// one more reply to go.
     fn hello_accepted(&mut self, value: &mut RESPValue) -> JsResult<()> {
-        if self.database > 0 {
-            self.flags.is_selecting_db_internal = true;
+        if self.flags.is_selecting_db_internal {
             self.pending_hello = Some(core::mem::replace(value, RESPValue::Null));
             return Ok(());
         }
         self.handshake_complete(value)
     }
 
-    fn handle_select_response(&mut self, value: &mut RESPValue) -> JsResult<()> {
+    fn handle_select_response(
+        &mut self,
+        mut hello: RESPValue,
+        value: &mut RESPValue,
+    ) -> JsResult<()> {
         self.flags.is_selecting_db_internal = false;
-        let mut hello = self.pending_hello.take().unwrap_or(RESPValue::Null);
         match value {
             RESPValue::Error(err) => self.fail(err, RedisError::ServerError),
             RESPValue::SimpleString(ok) if ok.as_ref() == b"OK" => {
@@ -1098,10 +1101,9 @@ impl ValkeyClient {
     fn handle_response(&mut self, value: &mut RESPValue) -> JsResult<()> {
         // Replies to the handshake are not paired with anything in the command queue.
         if self.status != Status::Connected {
-            if self.flags.is_selecting_db_internal {
-                self.handle_select_response(value)?;
-            } else {
-                self.handle_hello_response(value)?;
+            match self.pending_hello.take() {
+                Some(hello) => self.handle_select_response(hello, value)?,
+                None => self.handle_hello_response(value)?,
             }
             return Ok(());
         }
@@ -1285,6 +1287,7 @@ impl ValkeyClient {
                 self.fail(b"Failed to write SELECT command", RedisError::OutOfMemory)?;
                 return Ok(());
             }
+            self.flags.is_selecting_db_internal = true;
         }
         Ok(())
     }

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -879,7 +879,7 @@ describe("Valkey: Recovering After fail()", () => {
     }
   });
 
-  test("a rejected SELECT after an accepted HELLO fails the connection once and connect() from onclose dials again", async () => {
+  test("a rejected SELECT after an accepted HELLO fails the handshake once and connect() from onclose dials again", async () => {
     // HELLO and SELECT are written together, and both replies come back in one
     // read: connection 1 accepts HELLO and rejects SELECT, connection 2 accepts both.
     const fake = helloServer({
@@ -888,10 +888,25 @@ describe("Valkey: Recovering After fail()", () => {
     const port = await fake.listen();
     const client = new RedisClient(`redis://127.0.0.1:${port}/1`, { autoReconnect: true });
     try {
-      const closes: { message: string; connected: boolean; connections: number }[] = [];
+      const closes: { message: string; connected: boolean; connections: number; connects: number }[] = [];
       let secondConnect: Promise<string> | undefined;
+      // The handshake is HELLO and then SELECT, so nothing may report the
+      // client connected in between: a command sent from there would be
+      // pipelined behind a SELECT the server is about to reject and run
+      // against database 0.
+      let connects = 0;
+      const sentFromOnconnect: Promise<string>[] = [];
+      client.onconnect = () => {
+        connects++;
+        sentFromOnconnect.push(
+          client.ping().then(
+            () => "resolved",
+            (err: Error & { code: string }) => `${err.code}: ${err.message}`,
+          ),
+        );
+      };
       client.onclose = err => {
-        closes.push({ message: err.message, connected: client.connected, connections: fake.connections });
+        closes.push({ message: err.message, connected: client.connected, connections: fake.connections, connects });
         secondConnect ??= client.connect().then(
           () => "connected",
           (err: Error) => `rejected: ${err.message}`,
@@ -902,15 +917,23 @@ describe("Valkey: Recovering After fail()", () => {
         () => "resolved",
         (err: Error & { code: string }) => `${err.code}: ${err.message}`,
       );
-      // connect() settles on the accepted HELLO, before the SELECT reply is
-      // read, so it resolves; the failure that follows is reported by onclose.
-      await client.connect();
-      expect(await queued).toBe("ERR_REDIS_INVALID_COMMAND: ERR DB index is out of range");
+      const firstConnect = await client.connect().then(
+        () => "resolved",
+        (err: Error & { code: string }) => `rejected: ${err.code}`,
+      );
       // The rejection is a failure the client detected, so there is no retry
       // even with autoReconnect on: onclose fires once and the only second
-      // connection is the one dialed from it.
-      expect(closes).toEqual([{ message: "Connection closed", connected: false, connections: 1 }]);
+      // connection is the one dialed from it. onconnect first runs for that one.
+      expect({ firstConnect, queued: await queued, closes }).toEqual({
+        firstConnect: "rejected: ERR_REDIS_CONNECTION_CLOSED",
+        queued: "ERR_REDIS_SERVER_ERROR: ERR DB index is out of range",
+        closes: [{ message: "Connection closed", connected: false, connections: 1, connects: 0 }],
+      });
       expect(await secondConnect).toBe("connected");
+      expect({ connects, sentFromOnconnect: await Promise.all(sentFromOnconnect) }).toEqual({
+        connects: 1,
+        sentFromOnconnect: ["resolved"],
+      });
       expect(await client.ping()).toBe("PONG");
       expect(fake.connections).toBe(2);
     } finally {
@@ -2141,6 +2164,118 @@ describe("Valkey: Recovering After fail()", () => {
       expect(bytesRead).toBeGreaterThan(drained);
     } finally {
       client.close();
+    }
+  });
+});
+
+// With a database in the URL the handshake is HELLO and then SELECT. The
+// client is connected once both are accepted, not in between.
+describe("Valkey: Handshake SELECT", () => {
+  // Answers HELLO (with a RESP3 map), PING and SET as they arrive, but holds
+  // the reply to SELECT until `answerSelect()` is called. `events` records, in
+  // order, when SELECT was answered and whether a SET got in ahead of that.
+  function selectServer() {
+    const events: string[] = [];
+    const selectArrived = Promise.withResolvers<net.Socket>();
+    let selectAnswered = false;
+    const server = net.createServer(socket => {
+      const state = { buffer: Buffer.alloc(0) };
+      socket.on("data", chunk => {
+        state.buffer = Buffer.concat([state.buffer, chunk]);
+        for (const [name] of readCommands(state)) {
+          switch (name.toUpperCase()) {
+            case "HELLO":
+              socket.write("%2\r\n+server\r\n+redis\r\n+proto\r\n:3\r\n");
+              break;
+            case "SELECT":
+              selectArrived.resolve(socket);
+              break;
+            case "SET":
+              events.push(`SET arrived ${selectAnswered ? "after" : "before"} SELECT was answered`);
+              socket.write("+OK\r\n");
+              break;
+            default:
+              socket.write("+PONG\r\n");
+          }
+        }
+      });
+      socket.on("error", () => {});
+    });
+    return {
+      server,
+      events,
+      selectArrived: selectArrived.promise,
+      answerSelect: async () => {
+        const socket = await selectArrived.promise;
+        selectAnswered = true;
+        events.push("SELECT answered");
+        socket.write("+OK\r\n");
+      },
+      listen: async () => {
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        return (server.address() as net.AddressInfo).port;
+      },
+    };
+  }
+
+  test("connected, onconnect and connect() wait for the SELECT reply, and so does the first command", async () => {
+    const fake = selectServer();
+    const port = await fake.listen();
+    // No database: this one's handshake is HELLO alone. Its round trips are
+    // what turns the event loop below.
+    const control = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: false });
+    const client = new RedisClient(`redis://127.0.0.1:${port}/2`, { autoReconnect: false });
+    try {
+      await control.connect();
+      let set: Promise<unknown> | undefined;
+      client.onconnect = () => {
+        fake.events.push("onconnect");
+        set = client.set("key", "value");
+      };
+      const connected = client.connect().then(() => fake.events.push("connect() resolved"));
+      await fake.selectArrived;
+      // The stub answered HELLO when it arrived, ahead of SELECT, and now sits
+      // on SELECT. Each round trip on the control connection takes the event
+      // loop through at least two polls, so after these the client has long
+      // read that HELLO reply and done whatever it does on it.
+      for (let i = 0; i < 5; i++) await control.ping();
+      const connectedBeforeSelect = client.connected;
+      await fake.answerSelect();
+      await connected;
+      await set;
+      expect({ connectedBeforeSelect, events: fake.events }).toEqual({
+        connectedBeforeSelect: false,
+        events: ["SELECT answered", "onconnect", "connect() resolved", "SET arrived after SELECT was answered"],
+      });
+    } finally {
+      client.close();
+      control.close();
+      fake.server.close();
+    }
+  });
+
+  test("a SELECT reply that never comes is bounded by connectionTimeout", async () => {
+    const fake = selectServer();
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}/2`, { autoReconnect: false, connectionTimeout: 200 });
+    try {
+      const queued = client.get("key").then(
+        () => "resolved",
+        (err: Error & { code: string }) => err.code,
+      );
+      const connect = await client.connect().then(
+        () => "resolved",
+        (err: Error & { code: string }) => `rejected: ${err.code}`,
+      );
+      expect({ connect, connected: client.connected }).toEqual({
+        connect: "rejected: ERR_REDIS_CONNECTION_CLOSED",
+        connected: false,
+      });
+      expect(await queued).toBe("ERR_REDIS_CONNECTION_TIMEOUT");
+    } finally {
+      client.close();
+      fake.server.close();
     }
   });
 });


### PR DESCRIPTION
### Problem
- With a database in the URL (`redis://host/3`) the client writes `HELLO` and `SELECT 3` together, but became `Connected` on the HELLO reply: `connect()` resolved, `onconnect` ran and the auto-flusher drained the queue with the SELECT reply still due.
- A command sent from there was pipelined behind the SELECT. When the server rejected the SELECT (`ERR DB index is out of range`, cluster mode), the command had already run on database 0 and got its error.
- Cause: `handle_hello_response` (`src/runtime/valkey_jsc/valkey.rs`) set `Status::Connected` before the SELECT reply, and `on_auto_flush` gates on that status.

### Fix
- The client stays `Connecting` until the SELECT reply. `handshake_complete` is the one place that sets `Connected`, so `connected`, `onconnect`, `connect()` and the auto-flusher wait for it. `pending_hello` keeps the HELLO reply for `connect()`. This is the rule @alii set when closing #34829.
- A rejected SELECT fails the handshake with `ERR_REDIS_SERVER_ERROR` and the server's text (was `ERR_REDIS_INVALID_COMMAND`, #39573 moved the other server error replies). `connectionTimeout` now bounds a SELECT reply that never comes.
- Verified: `test/js/valkey/reliability/connection-failures.test.ts` (two new tests, one updated, all fail on stock bun), the docker-free `test/js/valkey` suites, redis 8.0.2.

### Background
- The handshake is `HELLO 3 [AUTH user pass]`, then `SELECT n` when the URL names a database, in one flush. Replies pair with commands by order.
- The auto-flusher is a deferred task that writes queued commands to the socket. Deferred tasks drain between two replies read in one chunk, so what `onconnect` sent went out before the SELECT reply was handled.

<details><summary>Notes</summary>

- Repro against redis 8.0.2 with `redis://127.0.0.1:6379/99`: `await client.connect()` resolves with `connected === true`, `client.set(k, v)` rejects with `ERR DB index is out of range`, and a second client on db 0 reads `v` back from `k`.
- Shape: no new state enum beside `Status` (#34829's closing note). `authenticate()` is the one place that decides whether a SELECT goes out with the handshake and marks it in the existing `is_selecting_db_internal`. `pending_hello` is the held HELLO reply, and while it is held the next reply is the SELECT's. The planned fold of the handshake phases into one connection enum can move both into its SELECT-phase variant. `handshake_complete()` is the single `Connected` transition for it to absorb.
- `connect()` and `onclose` still report the generic `ERR_REDIS_CONNECTION_CLOSED` "Connection closed" for a failed handshake. #39542 makes them carry the real reason (the server's SELECT error here) and will want a small rebase over the updated SELECT test.
- #41829 retries an attempt whose handshake fails while `Connecting`. With both changes, a rejected handshake SELECT is retried under `autoReconnect` like a rejected HELLO, and is terminal without it. The "no retry" comment in the updated test describes main and moves with #41829.
- #41645 (remember a runtime `SELECT` across reconnect) and #36071 (stray frames before HELLO) touch the same functions. Neither changes when the client becomes `Connected`. #41645 changes the SELECT predicate in `authenticate()` only, which is the one place this PR reads it.
- The updated test is @alii's "a rejected SELECT after an accepted HELLO" from #39511. Its comment documented that `connect()` settled on HELLO before the SELECT reply. It now asserts that `connect()` rejects, that `onconnect` does not run for the failed handshake, and that a `ping()` sent from `onconnect` on the next connection resolves.
- The ordering test holds the SELECT reply in the stub and uses round trips on a second client (no database, so its handshake is HELLO alone) to turn the event loop. On stock bun it records `SET arrived before SELECT was answered` and `connected === true` before the SELECT reply.
- Before this change a server that never answered the handshake's SELECT left the client `Connected` with its commands queued for good (the idle timer, off by default, was the only bound).
- With `enableOfflineQueue: false`, a command issued while the SELECT reply is pending is now rejected like any other command on a client that is not connected yet. Before, it was accepted and flushed early.
- Self-reviewed: 4 concerns raised, 4 addressed (single SELECT predicate, no extra state enum, #34829 ruling cited, composition with #39542/#41829/#41645 stated).
- `valkey-gc.test.ts` "RESP map keys are not leaked" times out at 5 s on this container's debug build with and without the change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/valkey/reliability/connection-failures.test.ts

<!-- robobun:evidence:end -->