### PR TITLE
Worker: report close code 0 when the parent terminates a Web Worker

### DIFF
--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -543,11 +543,12 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal(int32_t exitCode, 
     ASSERT(m_scriptExecutionContext && m_scriptExecutionContext->isContextThread());
     Ref protectedThis { *this };
 
-    // node:worker_threads: a worker stopped by its parent once it was running reports 1 unless it
-    // called process.exit() itself (a process.exitCode it merely set is not used, as in Node). The
-    // Web Worker's 'close' event keeps 0 for that case (documented).
-    if (m_options.kind == WorkerOptions::Kind::Node && stoppedByParent)
-        exitCode = 1;
+    // A worker stopped by its parent that never called process.exit() did not choose an exit code
+    // (a process.exitCode it merely set is not used, as in Node). node:worker_threads reports 1 for
+    // that case like Node; the Web Worker's 'close' event reports 0 (documented), whether the
+    // terminate() landed while the entry module was still loading or once the loop was idle.
+    if (stoppedByParent)
+        exitCode = m_options.kind == WorkerOptions::Kind::Node ? 1 : 0;
 
     // Closing while 'close' dispatches so handlers observe threadId == -1 / !isOnline() but a
     // postMessage() from inside them is still accepted and dropped (browser/Node behaviour).

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -543,12 +543,11 @@ void WorkerMessagingProxy::workerGlobalScopeDestroyedInternal(int32_t exitCode, 
     ASSERT(m_scriptExecutionContext && m_scriptExecutionContext->isContextThread());
     Ref protectedThis { *this };
 
-    // A worker stopped by its parent that never called process.exit() did not choose an exit code
-    // (a process.exitCode it merely set is not used, as in Node). node:worker_threads reports 1 for
-    // that case like Node; the Web Worker's 'close' event reports 0 (documented), whether the
-    // terminate() landed while the entry module was still loading or once the loop was idle.
-    if (stoppedByParent)
-        exitCode = m_options.kind == WorkerOptions::Kind::Node ? 1 : 0;
+    // node:worker_threads: a worker stopped by its parent once it was running reports 1 unless it
+    // called process.exit() itself (a process.exitCode it merely set is not used, as in Node). The
+    // Web Worker's 'close' event keeps 0 for that case (documented).
+    if (m_options.kind == WorkerOptions::Kind::Node && stoppedByParent)
+        exitCode = 1;
 
     // Closing while 'close' dispatches so handlers observe threadId == -1 / !isOnline() but a
     // postMessage() from inside them is still accepted and dropped (browser/Node behaviour).

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -864,7 +864,11 @@ impl WebWorker {
             Ok(p) => p,
             Err(_) => {
                 // process.exit() may have run during load; don't clobber its code.
-                if !self.exit_called.load(Ordering::Relaxed) {
+                // A load cut short by the parent's terminate() did not fail either:
+                // the worker chose no exit code, and the proxy reports that per kind.
+                if !self.exit_called.load(Ordering::Relaxed)
+                    && !self.termination_requested_by_parent()
+                {
                     vm.as_mut().exit_handler.exit_code = 1;
                 }
                 self.flush_logs(vm);
@@ -1091,6 +1095,16 @@ impl WebWorker {
     pub fn stopped_by_parent(&self) -> bool {
         self.terminated_by_parent.load(Ordering::Relaxed)
             && !self.exit_called.load(Ordering::Relaxed)
+    }
+
+    /// The parent's `terminate()` is what asked this thread to stop. Worker
+    /// thread, while the VM handle is still published. Read under the handle's
+    /// lock: `request_termination` sets `requested_terminate` and then
+    /// `terminated_by_parent` while holding it, so a thread that already saw
+    /// the former cannot read a stale `false` here.
+    fn termination_requested_by_parent(&self) -> bool {
+        let _handle = self.vm_handle.lock();
+        self.terminated_by_parent.load(Ordering::Relaxed)
     }
 
     /// process.exit() inside the worker. Worker-thread only.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -863,9 +863,7 @@ impl WebWorker {
         let promise = match vm.as_mut().load_entry_point_for_web_worker(path) {
             Ok(p) => p,
             Err(_) => {
-                // process.exit() may have run during load; don't clobber its code.
-                // A load cut short by the parent's terminate() did not fail either:
-                // the worker chose no exit code, and the proxy reports that per kind.
+                // Neither a process.exit() during load nor the parent's terminate() is a load failure.
                 if !self.exit_called.load(Ordering::Relaxed)
                     && !self.termination_requested_by_parent()
                 {
@@ -1097,11 +1095,9 @@ impl WebWorker {
             && !self.exit_called.load(Ordering::Relaxed)
     }
 
-    /// The parent's `terminate()` is what asked this thread to stop. Worker
-    /// thread, while the VM handle is still published. Read under the handle's
-    /// lock: `request_termination` sets `requested_terminate` and then
-    /// `terminated_by_parent` while holding it, so a thread that already saw
-    /// the former cannot read a stale `false` here.
+    /// The parent's `terminate()` asked this thread to stop. Worker thread. Taken under the
+    /// `vm_handle` lock that `request_termination` holds while it sets both flags, so a thread
+    /// that already saw `requested_terminate` never reads a stale `false` here.
     fn termination_requested_by_parent(&self) -> bool {
         let _handle = self.vm_handle.lock();
         self.terminated_by_parent.load(Ordering::Relaxed)

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -695,34 +695,31 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
-    test(
-      "terminate() while fs.readFile completions keep arriving",
-      async () => {
-        using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "-e",
-            `const src = \`import { readFile } from "node:fs";
+    test("terminate() while fs.readFile completions keep arriving", async () => {
+      using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
+      // Each round boots 4 workers; a debug build spends ~0.5s per round, so it runs fewer.
+      const rounds = isDebug ? 4 : 12;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const src = \`import { readFile } from "node:fs";
              let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
              postMessage("busy")\`;
            const url = URL.createObjectURL(new Blob([src]));
-           for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
+           for (let r = 0; r < ${rounds}; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
              const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 10) })));
            console.log("PASS");`,
-            path.join(String(dir), "f.bin"),
-          ],
-          env: bunEnv,
-          stdout: "pipe",
-          stderr: "inherit",
-        });
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-        expect(stdout).toBe("PASS\n");
-        expect(exitCode).toBe(0);
-      },
-      // 48 worker boots: a debug build on a loaded machine needs more than the default 5s.
-      isDebug ? 30_000 : 5_000,
-    );
+          path.join(String(dir), "f.bin"),
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("PASS\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -695,29 +695,34 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
-    test("terminate() while fs.readFile completions keep arriving", async () => {
-      using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `const src = \`import { readFile } from "node:fs";
+    test(
+      "terminate() while fs.readFile completions keep arriving",
+      async () => {
+        using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const src = \`import { readFile } from "node:fs";
              let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
              postMessage("busy")\`;
            const url = URL.createObjectURL(new Blob([src]));
            for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
              const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 10) })));
            console.log("PASS");`,
-          path.join(String(dir), "f.bin"),
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "inherit",
-      });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(stdout).toBe("PASS\n");
-      expect(exitCode).toBe(0);
-    });
+            path.join(String(dir), "f.bin"),
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "inherit",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).toBe("PASS\n");
+        expect(exitCode).toBe(0);
+      },
+      // 48 worker boots: a debug build on a loaded machine needs more than the default 5s.
+      isDebug ? 30_000 : 5_000,
+    );
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -510,6 +510,24 @@ describe("web worker", () => {
       w.terminate();
     });
 
+    // The 'close' code is what the worker passed to process.exit(), or 0. A worker stopped by its
+    // parent did not choose one, whether terminate() lands while the entry module is still
+    // evaluating or once its loop is idle.
+    test.each([
+      // The first message is posted from the entry's top-level code, which then never yields.
+      ["busy evaluating its entry module", "postMessage('up'); for (;;) {}"],
+      // A reply to a parent message comes from the worker's event loop, after the entry has loaded.
+      ["idle in its event loop", "self.onmessage = () => postMessage('up'); setInterval(() => {}, 1000)"],
+    ])("close code is 0 after terminate() of a worker that is %s", async (_, body) => {
+      const w = new Worker("data:text/javascript," + encodeURIComponent(body));
+      w.postMessage("ping");
+      await once(w, "message");
+      const closed = once(w, "close");
+      w.terminate();
+      const [event] = await closed;
+      expect({ code: event.code, wasClean: event.wasClean }).toEqual({ code: 0, wasClean: true });
+    });
+
     // As in browsers and Node: not an error, the message is dropped.
     test("postMessage() to a terminated worker is a no-op", async () => {
       const w = new Worker("data:text/javascript,postMessage('up')");


### PR DESCRIPTION
### Problem
- The `close` event code after `worker.terminate()` depends on timing. A worker stopped while it still evaluates its entry module reports `{ code: 1, wasClean: false }`. A worker stopped once its loop is idle reports `{ code: 0, wasClean: true }`. A `terminate()` about 30 ms after `new Worker()` gives a mix of both.
- docs/runtime/workers.mdx says the `CloseEvent` "contains the exit code passed to `process.exit()`, or 0 if it closed for another reason".
- The 1 comes from the entry-load path in `src/jsc/web_worker.rs`: `load_entry_point_for_web_worker` returns `Err(WorkerTerminated)` once the parent asked for termination, and the `Err` arm set `exit_code = 1` as if the load had failed. The idle loop breaks out without touching `exit_code`.

### Fix
- The `Err` arm no longer sets `exit_code = 1` when the parent's `terminate()` is what cut the load short (`termination_requested_by_parent()`). It still does for a real load failure, and still leaves a `process.exit()` code alone.
- `termination_requested_by_parent()` reads `terminated_by_parent` under the `vm_handle` lock. `request_termination` (parent thread) sets `requested_terminate` and then `terminated_by_parent` while it holds that lock, so a worker that already saw the request cannot read a stale `false`.
- The proxy is unchanged: `node:worker_threads` still reports 1 for a worker its parent stopped, as Node does. A Web Worker now reports the untouched 0. A code the worker chose itself (an uncaught error's 1, an unsettled top-level await's 13, `process.exit(n)`) is never overwritten.
- Verified: `test/js/web/workers/worker.test.ts` ("close code is 0 after terminate() ..."). The busy case fails on 1.4.3 with `{ code: 1, wasClean: false }`, and 40 alternating busy/idle runs on this build all give 0. Also ran the other terminate tests in that file and the terminate/exit-code tests in `test/js/node/worker_threads/worker_threads.test.ts` (still expect 1).

### Background
- A worker thread reports its exit through `WebWorker__workerGlobalScopeDestroyed(proxy, exit_code, stopped_by_parent)`. The proxy (`WorkerMessagingProxy`, parent thread) turns that into the `close` event for the global `Worker` and the `exit` event for `node:worker_threads`, and already maps "stopped by parent" to Node's 1 for `Kind::Node`.
- `requested_terminate` is set by the parent's `terminate()`, by an exiting ancestor, or by the worker itself (`process.exit()`, an uncaught error). `terminated_by_parent` is the subset "the parent asked while the VM was live", which is the case that must not count as a failure.

<details><summary>Notes</summary>

- From an HTML-conformance sweep of the global Worker. The constructor validation items ship separately (#41974, #41981).
- The first revision decided in the proxy (`stoppedByParent` forces 0 for `Kind::Web`). Review pointed out that `stoppedByParent` only excludes `process.exit()`, so a `terminate()` that raced a resolve failure or an unsettled top-level await would have turned their 1 or 13 into 0. Fixing the producer avoids that.

</details>
