### PR TITLE
sql(postgres): reject a non-boolean value bound to a boolean parameter

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -49,6 +49,28 @@ pub enum MessageType {
 /// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
 const MAX_PARAMETERS: usize = u16::MAX as usize;
 
+/// The `ERR_INVALID_ARG_TYPE` a binary encoder arm of `write_bind` throws for a
+/// value it cannot encode as `pg_type`. `index` is the 0-based parameter index.
+fn invalid_bind_value(
+    global: &JSGlobalObject,
+    index: usize,
+    pg_type: &str,
+    expected: &str,
+    value: JSValue,
+) -> AnyPostgresError {
+    let received = match JSGlobalObject::determine_specific_type(global, value) {
+        Ok(received) => received,
+        Err(err) => return js_error_to_postgres(err),
+    };
+    js_error_to_postgres(global.throw_value(global.ERR_INVALID_ARG_TYPE(format_args!(
+        "Query parameter ${} of type {} must be {}. Received {}",
+        index + 1,
+        pg_type,
+        expected,
+        received,
+    ))))
+}
+
 pub(crate) fn write_bind<Context: WriterContext>(
     name: &[u8],
     cursor_name: &BunString,
@@ -176,8 +198,17 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 l.write_excluding_self()?;
             }
             types::Tag::bool => {
+                if !value.is_boolean() {
+                    return Err(invalid_bind_value(
+                        global,
+                        i,
+                        "boolean",
+                        "a boolean or a string",
+                        value,
+                    ));
+                }
                 let l = writer.length()?;
-                writer.write(&[value.to_boolean() as u8])?;
+                writer.write(&[value.as_boolean() as u8])?;
                 l.write_excluding_self()?;
             }
             types::Tag::timestamp | types::Tag::timestamptz => {
@@ -190,15 +221,13 @@ pub(crate) fn write_bind<Context: WriterContext>(
             }
             types::Tag::bytea => {
                 let Some(buf) = value.as_array_buffer(global) else {
-                    let received = JSGlobalObject::determine_specific_type(global, value)
-                        .map_err(js_error_to_postgres)?;
-                    return Err(js_error_to_postgres(global.throw_value(
-                        global.ERR_INVALID_ARG_TYPE(format_args!(
-                            "Query parameter ${} of type bytea must be a Buffer, TypedArray, ArrayBuffer or string. Received {}",
-                            i + 1,
-                            received,
-                        )),
-                    )));
+                    return Err(invalid_bind_value(
+                        global,
+                        i,
+                        "bytea",
+                        "a Buffer, TypedArray, ArrayBuffer or string",
+                        value,
+                    ));
                 };
                 let bytes = buf.byte_slice();
                 let l = writer.length()?;

--- a/test/js/sql/postgres-bool-bind.test.ts
+++ b/test/js/sql/postgres-bool-bind.test.ts
@@ -1,0 +1,113 @@
+// Binding a JS value to a parameter the server types as `boolean` (OID 16): a
+// bool column, `$1::bool`, `where flag = $1`. Bun sends a boolean parameter in
+// binary format, so the value has to be a JS boolean, or a string (sent as
+// text, parsed by the server). Bun declares no type for an object, array, Date
+// or function, the server infers `boolean` from the context, and the binary
+// encoder used to write `ToBoolean(value)`: `[]`, `{ enabled: false }`, an
+// Invalid Date and a Temporal value were all stored as `true` with no error.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const connect = () =>
+    new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+
+  const rejected: [string, unknown, string][] = [
+    ["{ enabled: false }", { enabled: false }, "an instance of Object"],
+    ["[]", [], "an instance of Array"],
+    ["[1, 2]", [1, 2], "an instance of Array"],
+    ["Invalid Date", new Date(NaN), "an instance of Date"],
+    ["Date", new Date(0), "an instance of Date"],
+    [
+      "function",
+      function enabled() {
+        return false;
+      },
+      "function enabled",
+    ],
+    ["Int32Array", new Int32Array([1]), "an instance of Int32Array"],
+  ];
+  if (typeof Temporal !== "undefined") {
+    rejected.push(["Temporal.PlainDate", Temporal.PlainDate.from("2024-05-06"), "an instance of PlainDate"]);
+  }
+
+  // One connection per case: after a bind-time throw the partial Bind message
+  // stays in the write buffer and the next query on that connection fails
+  // (#34732), the same as for the other encoder arms.
+  test.each(rejected)("%s bound to a boolean column rejects instead of storing true", async (_, value, received) => {
+    await container.ready;
+    await using sql = connect();
+    await sql`create temp table bool_bind (id int, b bool)`;
+    const err: any = await sql`insert into bool_bind (id, b) values (${1}, ${value}) returning b`.then(
+      rows => rows,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message).toBe(`Query parameter $2 of type boolean must be a boolean or a string. Received ${received}`);
+  });
+
+  test("a cast and a comparison type the parameter as boolean too", async () => {
+    await container.ready;
+    {
+      await using sql = connect();
+      const err: any = await sql`select ${{ a: 1 }}::bool as v`.then(
+        rows => rows,
+        e => e,
+      );
+      expect(err?.message).toBe(
+        "Query parameter $1 of type boolean must be a boolean or a string. Received an instance of Object",
+      );
+    }
+    {
+      await using sql = connect();
+      const err: any = await sql`select 1 as v where true = ${[]}`.then(
+        rows => rows,
+        e => e,
+      );
+      expect(err?.message).toBe(
+        "Query parameter $1 of type boolean must be a boolean or a string. Received an instance of Array",
+      );
+    }
+  });
+
+  test("booleans, null and strings bound to a boolean column still work", async () => {
+    await container.ready;
+    await using sql = connect();
+    await sql`create temp table bool_bind (id int, b bool)`;
+    const values = [true, false, null, undefined, "t", "f", "true", "false", "yes", "off", "1", "0"];
+    for (const [id, b] of values.entries()) {
+      await sql`insert into bool_bind (id, b) values (${id}, ${b})`;
+    }
+    expect(await sql`select id, b from bool_bind order by id`).toEqual([
+      { id: 0, b: true },
+      { id: 1, b: false },
+      { id: 2, b: null },
+      { id: 3, b: null },
+      { id: 4, b: true },
+      { id: 5, b: false },
+      { id: 6, b: true },
+      { id: 7, b: false },
+      { id: 8, b: true },
+      { id: 9, b: false },
+      { id: 10, b: true },
+      { id: 11, b: false },
+    ]);
+    // A string the server cannot parse as a boolean is still a server error,
+    // and the connection stays usable after it.
+    const err = await sql`insert into bool_bind (id, b) values (99, ${"garbage"})`.catch(e => e);
+    expect([err?.code, err?.errno]).toEqual(["ERR_POSTGRES_SERVER_ERROR", "22P02"]);
+    expect(await sql`select id from bool_bind where b = ${true} order by id`).toEqual([
+      { id: 0 },
+      { id: 4 },
+      { id: 6 },
+      { id: 8 },
+      { id: 10 },
+    ]);
+    expect(await sql`select ${false}::bool as v, ${true}::bool as w`).toEqual([{ v: false, w: true }]);
+  });
+});


### PR DESCRIPTION
### Problem
- Any object bound to a parameter that the server types as `boolean` (a bool column, `$1::bool`, `where flag = $1`) is stored as `true`: `{ enabled: false }`, `[]`, a `Date`, a function. The query succeeds.
- Cause: the binary `bool` arm of `write_bind` (`src/sql_jsc/postgres/PostgresRequest.rs:200`) writes `value.to_boolean()`, JS truthiness. Bun declares OID 0 for these values, the server answers `boolean` from the context, and Bind takes that arm.

### Fix
- The arm encodes only a JS boolean. Any other value throws `ERR_INVALID_ARG_TYPE`: `Query parameter $2 of type boolean must be a boolean or a string. Received an instance of Date`. A string is still sent as text for the server to parse (`'t'`, `'off'`, `'1'`). `null` is still NULL.
- This is the contract #41889 gave the `bytea` arm next to it. One helper, `invalid_bind_value`, now builds the message for both arms.
- Verified: `test/js/sql/postgres-bool-bind.test.ts` (1.4.2 fails 9 of 10), `postgres-bytea-bind.test.ts`, and `sql.test.ts` on a local PostgreSQL 17 (same failures as main, all environment). Self-reviewed: 3 concerns, 2 addressed, 1 declined (Notes).

### Background
- Parse declares a type OID per parameter (0: the server infers it). Describe returns the inferred types. Bind sends each value with a format code (0 text, 1 binary).
- `Signature::generate` declares a type only for numbers, booleans, bigints and byte buffers. Objects, arrays and Dates get OID 0, so the server's answer picks their Bind arm.
- Binary `bool` is one byte, 0 or 1. The text form accepts `t/f/true/false/yes/no/on/off/1/0` and nothing else.

<details><summary>Notes</summary>

Stored value for `insert into t (b bool) values ($1)`, default options, real PostgreSQL:

| value | 1.4.2 | this PR |
|---|---|---|
| `{ enabled: false }`, `{ a: 1 }` | `true` | `ERR_INVALID_ARG_TYPE ... Received an instance of Object` |
| `[]`, `[1, 2]` | `true` | `... Received an instance of Array` |
| `new Date(NaN)`, `new Date(0)` | `true` | `... Received an instance of Date` |
| `function enabled() {}` | `true` | `... Received function enabled` |
| `new Int32Array([1])` | `true` | `... Received an instance of Int32Array` |
| `Temporal.PlainDate.from("2024-05-06")` | `true` | `... Received an instance of PlainDate` |
| `true` / `false` | binary 1 / 0 | unchanged |
| `null` / `undefined` | NULL | unchanged |
| `"t"`, `"off"`, `"1"`, `"garbage"` | text, the server decides (`"garbage"` is 22P02) | unchanged |
| `0` / `1` | declared `int4`, 42804 from the server | unchanged, a number never reaches the bool arm |

Why a client-side error and not a text fallback. An earlier revision of this branch sent a non-boolean as `String(value)` in text format and let the server answer 22P02, the node-postgres behavior. That avoids a throw inside `write_bind`, but it puts `"[object Object]"` on the wire, accepts `[true]` (it stringifies to `"true"`), and gives two adjacent arms two failure contracts after #41889. The positional `TypeError` is the clearer report, so this revision matches #41889.

After any encoder arm throws, the partial Bind message stays in the write buffer and the next query on that connection fails with `ERR_POSTGRES_CONNECTION_CLOSED`. This is pre-existing for every bind-time error (`{ a: 1n }` bound to `jsonb`, the `bytea` arm) and is what #34732 fixes. The test uses one connection per rejecting case so it does not depend on that.

`prepare: false`: the Bind is written before ParameterDescription arrives, so these values take the OID 0 text path (`String(value)`, 22P02 from the server) on the first and on later executions. Unchanged.

Related work on the same function, not part of this PR: #41912 sends parameters that have no binary encoder (`numeric`, `real`, `time`, arrays) as text and restructures the format-code loop. The two changes touch different hunks except the `bool` arm label, and either rebases over the other in a few lines. The `timestamp` and `int4` arms have their own range checks in #34707 and #34708.

Self-review. Raised: (1) the failure contract should match the merged `bytea` arm, addressed by this revision. (2) The first revision's helper left the other arms' coercions in place behind a default, addressed by dropping the helper and keeping the PR to the `bool` arm, the shape #41889 landed in. (3) Fold this into #41912 instead of a separate PR: declined. #41912 is a larger restructure with a different purpose (format codes for types without an encoder), it does not change the `bool` arm, and a per-arm fix of this size rebases over it trivially.

Suites run with the debug build: `postgres-bool-bind`, `postgres-bytea-bind`, `sql-prepare-false`, `sql-postgres-datetime-roundtrip`, `postgres-binary-numeric`, `postgres-datestyle`, `postgres-prepared-pipeline-reorder`, `postgres-simple-query-pipeline`, `sql-reserve-abort`, `sql-onconnect-onclose-throw`, `postgres-multi-statement-fields`, `postgres-listen-notify` (106 pass), and `sql.test.ts` with the docker gate forced open locally (832 pass, 20 fail: md5/scram roles missing, SQL_ASCII encoding, `max_prepared_transactions = 0`, debug-build timeouts, and the timing-based `reserve connection`, all of which fail the same way without this change).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bool-bind.test.ts
bun test v1.4.3 (a3e0ab60c)

test/js/sql/postgres-bool-bind.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
44 |     await sql`create temp table bool_bind (id int, b bool)`;
45 |     const err: any = await sql`insert into bool_bind (id, b) values (${1}, ${value}) returning b`.then(
46 |       rows => rows,
47 |       e => e,
48 |     );
49 |     expect(err).toBeInstanceOf(TypeError);
                     ^
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class TypeError extends Error]
Received value: [
  {
    b: true,
  }, count: 1, command: "INSERT", lastInsertRowid: null, affectedRows: null
]

      at <anonymous> (/workspace/bun/test/js/sql/postgres-bool-bind.test.ts:49:17)
(fail) postgres > { enabled: false } bound to a boolean column rejects instead of storing true [254.66ms]
44 |     await sql`create temp table bool_bind (id int, b bool)`;
45 |     const err: any = await sql`insert into bool_bind (id, b) values (${1}, ${value}) returning 
... (truncated)

release without fix: 9 FAILED
bun test v1.4.2 (744846f84)

test/js/sql/postgres-bool-bind.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
44 |     await sql`create temp table bool_bind (id int, b bool)`;
45 |     const err: any = await sql`insert into bool_bind (id, b) values (${1}, ${value}) returning b`.then(
46 |       rows => rows,
47 |       e => e,
48 |     );
49 |     expect(err).toBeInstanceOf(TypeError);
                     ^
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class TypeError extends Error]
Received value: [
  {
    b: true,
  }, count: 1, command: "INSERT", lastInsertRowid: null, affectedRows: null
]

      at <anonymous> (/workspace/bun/test/js/sql/postgres-bool-bind.test.ts:49:17)
(fail) postgres > { enabled: false } bound to a boolean column rejects instead of storing true [11.79ms]
44 |     await sql`create temp table bool_bind (id int, b bool)`;
45 |     const err: any = await sql`insert into bool_bind (id, b) values (${1}, ${value}) returning b`.then(
46 |       rows => rows,
47 |       e => e,
48 |     );
49 |     expect(err).toBeInstanceOf(TypeError);
                     ^
error: expect(received).toBeInstance
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bool-bind.test.ts
bun test v1.4.3 (a3e0ab60c)

test/js/sql/postgres-bool-bind.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > { enabled: false } bound to a boolean column rejects instead of storing true [248.08ms]
(pass) postgres > [] bound to a boolean column rejects instead of storing true [26.68ms]
(pass) postgres > [1, 2] bound to a boolean column rejects instead of storing true [23.47ms]
(pass) postgres > Invalid Date bound to a boolean column rejects instead of storing true [23.03ms]
(pass) postgres > Date bound to a boolean column rejects instead of storing true [21.72ms]
(pass) postgres > function bound to a boolean column rejects instead of storing true [20.13ms]
(pass) postgres > Int32Array bound to a boolean column rejects instead of storing true [19.78ms]
(pass) postgres > Temporal.PlainDate bound to a boolean column rejects instead of storing true [19.69ms]
(pass) postgres > a cast and a comparison type the parameter as boolean too [48.03ms]
(pass) postgre
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 723ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 37s
[1/4] link bun-profile
[3/4] strip bun
[3/4] bun-profile --revision
1.4.3-canary.1+d52ddaa5e
[build] done
bun test v1.4.3-canary.1 (d52ddaa5e)

test/js/sql/postgres-bool-bind.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > { enabled: false } bound to a boolean column rejects instead of storing true [22.04ms]
(pass) postgres > [] bound to a boolean column rejects instead of storing true [11.13ms]
(pass) postgres > [1, 2] bound to a boolean column rejects instead of storing true [6.19ms]
(pass) postgres > Invalid Date bound to a boolean column rejects instead of storing true [7.24ms]
(pass) postgres > Date bound to a boolean column rejects instead of storing true [5.79ms]
(pass) postgr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/postgres/PostgresRequest.rs |  49 +++++++++++---
 test/js/sql/postgres-bool-bind.test.ts  | 113 ++++++++++++++++++++++++++++++++
 2 files changed, 152 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/sql_jsc/postgres/PostgresRequest.rs      6     10     12
test/js/sql/postgres-bool-bind.test.ts       1      5     11
```

</details>

<!-- robobun:evidence:end -->