### PR TITLE
FormData: give the Files it creates a lastModified of now

### DIFF
--- a/src/jsc/bindings/blob.h
+++ b/src/jsc/bindings/blob.h
@@ -6,7 +6,7 @@
 
 namespace WebCore {
 
-extern "C" void* Blob__dupeFromJS(JSC::EncodedJSValue impl);
+extern "C" void* Blob__dupeFromJSForFormData(JSC::EncodedJSValue impl);
 extern "C" void* Blob__dupe(void* impl);
 extern "C" void* Blob__getDataPtr(JSC::EncodedJSValue blob);
 extern "C" size_t Blob__getSize(JSC::EncodedJSValue blob);
@@ -48,9 +48,10 @@ public:
         return m_impl.get();
     }
 
+    // The value of a new FormData entry: https://xhr.spec.whatwg.org/#create-an-entry
     static RefPtr<Blob> create(JSC::JSValue impl)
     {
-        return createAdopted(Blob__dupeFromJS(JSValue::encode(impl)));
+        return createAdopted(Blob__dupeFromJSForFormData(JSValue::encode(impl)));
     }
 
     static RefPtr<Blob> create(std::span<const uint8_t> bytes, JSC::JSGlobalObject* globalThis)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4055,14 +4055,28 @@ impl URLSearchParamsConverter {
 // C-exported helpers
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Copies a JS `Blob` into the value of a new FormData entry
+/// (`WebCore::Blob::create(JSValue)`, from `append`/`set`). Per
+/// <https://xhr.spec.whatwg.org/#create-an-entry> a value that is not a
+/// `File` becomes a new `File`, so it gets the `new File()` default
+/// `lastModified` of now; a `File` keeps its own. `Blob__setAsFile` applies
+/// the entry's filename.
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob>> {
-    let this = Blob::from_js(value)?;
+pub(crate) extern "C" fn Blob__dupeFromJSForFormData(value: JSValue) -> Option<NonNull<Blob>> {
+    let source = Blob::from_js(value)?;
     // SAFETY: `from_js` returns a live heap pointer when Some.
-    Some(
-        NonNull::new(Blob__dupe(unsafe { &*this }))
-            .expect("Blob__dupe returns a fresh heap allocation"),
-    )
+    let source = unsafe { &*source };
+    let entry =
+        NonNull::new(Blob__dupe(source)).expect("Blob__dupe returns a fresh heap allocation");
+    if !source.is_jsdom_file.get() {
+        // SAFETY: `entry` is a fresh allocation that nothing else references yet.
+        let entry = unsafe { entry.as_ref() };
+        entry.is_jsdom_file.set(true);
+        entry
+            .last_modified
+            .set(bun_core::time::milli_timestamp() as f64);
+    }
+    Some(entry)
 }
 
 #[unsafe(no_mangle)]

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4055,12 +4055,8 @@ impl URLSearchParamsConverter {
 // C-exported helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Copies a JS `Blob` into the value of a new FormData entry
-/// (`WebCore::Blob::create(JSValue)`, from `append`/`set`). Per
-/// <https://xhr.spec.whatwg.org/#create-an-entry> a value that is not a
-/// `File` becomes a new `File`, so it gets the `new File()` default
-/// `lastModified` of now; a `File` keeps its own. `Blob__setAsFile` applies
-/// the entry's filename.
+/// The value of a new FormData entry (<https://xhr.spec.whatwg.org/#create-an-entry>):
+/// a source that is not a `File` becomes a new `File`, whose `lastModified` defaults to now.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__dupeFromJSForFormData(value: JSValue) -> Option<NonNull<Blob>> {
     let source = Blob::from_js(value)?;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4055,8 +4055,7 @@ impl URLSearchParamsConverter {
 // C-exported helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The value of a new FormData entry (<https://xhr.spec.whatwg.org/#create-an-entry>):
-/// a source that is not a `File` becomes a new `File`, whose `lastModified` defaults to now.
+/// FormData "create an entry": a non-`File` source becomes a new `File`, `lastModified` = now.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__dupeFromJSForFormData(value: JSValue) -> Option<NonNull<Blob>> {
     let source = Blob::from_js(value)?;

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -163,6 +163,8 @@ pub(crate) fn to_js_from_multipart_data(
     struct Wrapper<'a> {
         global: &'a JSGlobalObject,
         form: &'a mut DOMFormData,
+        /// The `new File()` default `lastModified` for every file part.
+        now: f64,
     }
 
     impl<'a> Wrapper<'a> {
@@ -173,7 +175,12 @@ pub(crate) fn to_js_from_multipart_data(
             if field.is_file {
                 let filename_str = field.filename.slice(buf);
 
+                // > Each part whose `Content-Disposition` header contains a
+                // > `filename` parameter must be parsed into an entry whose
+                // > value is a `File` object
                 let mut blob = Blob::create(value_str, wrap.global, false);
+                blob.is_jsdom_file.set(true);
+                blob.last_modified.set(wrap.now);
                 let filename = EncodedSlice::utf8(filename_str);
 
                 if !field.content_type.is_empty() {
@@ -227,7 +234,11 @@ pub(crate) fn to_js_from_multipart_data(
     }
 
     {
-        let mut wrap = Wrapper { global, form };
+        let mut wrap = Wrapper {
+            global,
+            form,
+            now: bun_core::time::milli_timestamp() as f64,
+        };
 
         if let Err(e) = for_each_multipart_entry(input, boundary, &mut wrap, Wrapper::on_entry) {
             scoped_log!(FormData, "failed to parse multipart data");

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -175,9 +175,7 @@ pub(crate) fn to_js_from_multipart_data(
             if field.is_file {
                 let filename_str = field.filename.slice(buf);
 
-                // > Each part whose `Content-Disposition` header contains a
-                // > `filename` parameter must be parsed into an entry whose
-                // > value is a `File` object
+                // A part with a `filename` is a new `File`.
                 let mut blob = Blob::create(value_str, wrap.global, false);
                 blob.is_jsdom_file.set(true);
                 blob.last_modified.set(wrap.now);

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -425,21 +425,28 @@ describe("FormData", () => {
     form.append("epoch", new File(["x"], "e.txt", { lastModified: 0 }));
     const after = now();
 
+    const first: Record<string, number> = {};
     for (const name of ["blob", "named", "set"]) {
-      expect(lastModified(form, name)).toBeWithin(before, after + 1);
-      // Fixed when the entry is created, not read on each get().
-      expect(lastModified(form, name)).toBe(lastModified(form, name));
+      first[name] = lastModified(form, name);
+      expect(first[name]).toBeWithin(before, after + 1);
     }
     expect(lastModified(form, "file")).toBe(12345);
     expect(lastModified(form, "renamed")).toBe(12345);
     expect(lastModified(form, "epoch")).toBe(0);
+
+    // The value is fixed when the entry is created, not read on each get():
+    // once the millisecond clock has moved on, get() still returns it.
+    while (now() <= after) {}
+    for (const name of ["blob", "named", "set"]) {
+      expect(lastModified(form, name)).toBe(first[name]);
+    }
 
     // Every File out of the multipart parser is new.
     const parsed = await new Response(form).formData();
     const afterParse = now();
     for (const name of ["blob", "named", "set", "file", "renamed", "epoch"]) {
       expect(parsed.get(name)).toBeInstanceOf(File);
-      expect(lastModified(parsed, name)).toBeWithin(before, afterParse + 1);
+      expect(lastModified(parsed, name)).toBeWithin(after + 1, afterParse + 1);
     }
   });
 

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -407,6 +407,42 @@ describe("FormData", () => {
     }
   });
 
+  // https://xhr.spec.whatwg.org/#create-an-entry: a Blob value becomes a *new*
+  // File, so it takes the `new File()` default lastModified (now). A File value
+  // keeps its own lastModified, with or without a filename override.
+  it("gives the Files it creates a lastModified of now", async () => {
+    const lastModified = (form: FormData, name: string) => (form.get(name) as File).lastModified;
+    // Same clock as the default under test.
+    const now = () => new File([], "").lastModified;
+
+    const before = now();
+    const form = new FormData();
+    form.append("blob", new Blob(["x"]));
+    form.append("named", new Blob(["x"]), "n.bin");
+    form.set("set", new Blob(["x"]), "s.bin");
+    form.append("file", new File(["x"], "f.txt", { lastModified: 12345 }));
+    form.append("renamed", new File(["x"], "f.txt", { lastModified: 12345 }), "r.txt");
+    form.append("epoch", new File(["x"], "e.txt", { lastModified: 0 }));
+    const after = now();
+
+    for (const name of ["blob", "named", "set"]) {
+      expect(lastModified(form, name)).toBeWithin(before, after + 1);
+      // Fixed when the entry is created, not read on each get().
+      expect(lastModified(form, name)).toBe(lastModified(form, name));
+    }
+    expect(lastModified(form, "file")).toBe(12345);
+    expect(lastModified(form, "renamed")).toBe(12345);
+    expect(lastModified(form, "epoch")).toBe(0);
+
+    // Every File out of the multipart parser is new.
+    const parsed = await new Response(form).formData();
+    const afterParse = now();
+    for (const name of ["blob", "named", "set", "file", "renamed", "epoch"]) {
+      expect(parsed.get(name)).toBeInstanceOf(File);
+      expect(lastModified(parsed, name)).toBeWithin(before, afterParse + 1);
+    }
+  });
+
   it("file upload on HTTP server (receive)", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
### Problem
- Every `File` that FormData creates itself has `lastModified === 0`: Blob-valued entries from `append`/`set`, and every file part from the multipart parser (every `req.formData()` upload). undici and the spec give `Date.now()`.
- The cause: neither path writes `last_modified`. `append`/`set` dupe the JS value in `Blob__dupeFromJS` (`src/runtime/webcore/Blob.rs:4058`), the parser builds a fresh `Blob` (`src/runtime/webcore/FormData.rs:176`), and `Blob__setAsFile` later sets only the File flag and name.

### Fix
- `append`/`set`: the entry dupe (renamed `Blob__dupeFromJSForFormData`, its only use) checks the *source* value. If it is not a File, the dupe becomes a File with `lastModified` = now. A File's own value carries over.
- Multipart parser: each file part is marked a File with `lastModified` = now when it is built.
- Correct per [create an entry](https://xhr.spec.whatwg.org/#create-an-entry): a non-File value becomes a *new* File, and `new File()` defaults `lastModified` to now. undici stamps it at `append` time too.
- Verified: `test/js/web/html/FormData.test.ts` (the new test fails on 1.4.3-canary), plus the multipart, body and blob suites. Self-reviewed: 5 concerns raised, 4 addressed by a reshape that does not overlap #30328, #32431 or #35079 (see Notes).

### Background
- A FormData entry holds a `WebCore::Blob` (`src/jsc/bindings/blob.h`): a C++ wrapper around a dupe of the Rust `Blob`, plus the entry's filename. `get()` dupes it again into a fresh JS object.
- Native code has no separate `File` class. A `File` is a `Blob` with `is_jsdom_file` set, and its `lastModified` is the plain `last_modified` field.
- `Bun.file()`-backed entries are unaffected: their getter reads the file's mtime.

<details><summary>Notes</summary>

Repro from the report:

```js
const fd = new FormData();
fd.append("b", new Blob(["x"]));
fd.append("bn", new Blob(["x"]), "n.bin");
fd.append("f", new File(["x"], "f.txt", { lastModified: 12345 }));
const lm = v => (Math.abs(v.lastModified - Date.now()) < 5000 ? "~now" : v.lastModified);
console.log("in-process :", lm(fd.get("b")), lm(fd.get("bn")), lm(fd.get("f")));
const back = await new Response(fd).formData();
console.log("round-trip :", lm(back.get("b")), lm(back.get("bn")), lm(back.get("f")));
```

Before: `0 0 12345` / `0 0 0`. After (and node): `~now ~now 12345` / `~now ~now ~now`.

Other engines differ on *when* now is read (Chromium: at `get()`, WebKit: at each `lastModified` read, undici: at `append`). None report 0. Stamping at entry creation is the deterministic choice and the one undici makes. The timestamp comes from the same clock as Bun's `File` constructor default, which is what the test compares against.

Relation to open PRs in this area. An earlier shape of this change moved the whole File promotion out of `toJS(WebCore::Blob&)` into `DOMFormData::append`/`set`, which also stopped WebSocket `binaryType = "blob"` messages from being `instanceof File`. #30328 (File gets its own prototype) already rewrites those same `toJS` and `DOMFormData` lines, carries that WebSocket fix with a test, and changes `dupe()` to clear `is_jsdom_file`. So this PR leaves `blob.cpp`, `DOMFormData.cpp` and `Blob__setAsFile` alone, and reads "was the value a File" from the source object before the dupe, which stays correct with or without #30328. The "renamed" and "epoch" assertions in the new test pin the File-keeps-its-own-value case either way. The naming side of the same spec step (`"blob"` default name, filename override of a File's own name) is #32431 / #35079 and is not touched here.

Suites run on the debug build: FormData.test.ts (150 pass), FormData-multipart-serialization, form-data-set-append, body, body-clone, blob, websocket-blob, FormData-file-error-leak (663 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (99ae647e0)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.07ms]
(pass) FormData > should be able to append a Blob [0.19ms]
(pass) FormData > should be able to set a Blob [0.10ms]
(pass) FormData > should be able to set a string [0.05ms]
(pass) FormData > should get filename from file [0.07ms]
(pass) FormData > should use the correct filenames [0.08ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.39ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.82ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.05ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.06ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.03ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.08ms]
(pass) FormData > should be able to append a Blob [7.99ms]
(pass) FormData > should be able to set a Blob [5.72ms]
(pass) FormData > should be able to set a string [2.58ms]
(pass) FormData > should get filename from file [3.70ms]
(pass) FormData > should use the correct filenames [4.76ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [13.07ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [28.77ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.72ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [4.72ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [2.11ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.05ms]
(pass) FormData > should parse multipart/form-data (sim
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 738ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/blob.h           |  5 +++--
 src/runtime/webcore/Blob.rs       | 21 +++++++++++++------
 src/runtime/webcore/FormData.rs   | 11 +++++++++-
 test/js/web/html/FormData.test.ts | 43 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 71 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/jsc/bindings/blob.h                2      3     14
src/runtime/webcore/Blob.rs           10      6     14
src/runtime/webcore/FormData.rs        3      3     14
test/js/web/html/FormData.test.ts      4      3     13
```

</details>

<!-- robobun:evidence:end -->