### PR TITLE
Worker: throw a SyntaxError for a script URL that does not parse

### DIFF
--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -65,22 +65,45 @@ Worker::Worker(ScriptExecutionContext& context, WorkerOptions&& options)
 {
 }
 
+// A URL Standard scheme followed by ':'. At least two characters, so that a Windows drive path such as
+// "C:\worker.js" does not count as one.
+static bool hasURLSchemePrefix(const String& string)
+{
+    size_t colon = string.find(':');
+    if (colon == notFound || colon < 2 || !isASCIIAlpha(string[0]))
+        return false;
+    for (size_t i = 1; i < colon; ++i) {
+        UChar c = string[i];
+        if (!isASCIIAlphanumeric(c) && c != '+' && c != '-' && c != '.')
+            return false;
+    }
+    return true;
+}
+
+ExceptionOr<String> Worker::resolveScriptURL(const String& url)
+{
+    if (!hasURLSchemePrefix(url))
+        return String { url };
+    WTF::URL urlObject { url };
+    if (!urlObject.isValid())
+        return Exception { SyntaxError, makeString("Invalid URL: \""_s, url, '"') };
+    if (urlObject.protocolIsFile())
+        return urlObject.fileSystemPath();
+    return String { url };
+}
+
 ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const String& urlInit, WorkerOptions&& options)
 {
     ASSERT(context.isContextThread());
 
-    String url = urlInit;
-    if (url.startsWith("file://"_s)) {
-        WTF::URL urlObject { url };
-        if (!urlObject.isValid())
-            return Exception { TypeError, makeString("Invalid file URL: \""_s, urlInit, '"') };
-        url = urlObject.fileSystemPath();
-    }
+    auto url = resolveScriptURL(urlInit);
+    if (url.hasException())
+        return url.releaseException();
 
     auto worker = adoptRef(*new Worker(context, WTF::move(options)));
     worker->suspendIfNeeded();
 
-    auto started = worker->m_contextProxy->startWorkerGlobalScope(url);
+    auto started = worker->m_contextProxy->startWorkerGlobalScope(url.returnValue());
     if (started.hasException())
         return started.releaseException();
     return worker;

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -51,6 +51,11 @@ public:
     static ExceptionOr<Ref<Worker>> create(ScriptExecutionContext&, const String& url, WorkerOptions&&);
     ~Worker();
 
+    // HTML: the constructor parses its script URL and throws a SyntaxError when that fails. Bun also
+    // accepts paths and module specifiers, so a string with no URL scheme is returned unchanged for the
+    // resolver; a file: URL becomes its filesystem path. Used for the entry point and for each preload.
+    static ExceptionOr<String> resolveScriptURL(const String&);
+
     // ActiveDOMObject.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -124,12 +124,10 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
     Vector<BunString> preloadModules;
     preloadModules.reserveInitialCapacity(m_options.preloadModules.size());
     for (auto& str : m_options.preloadModules) {
-        if (str.startsWith("file://"_s)) {
-            WTF::URL urlObject = WTF::URL(str);
-            if (!urlObject.isValid())
-                return Exception { TypeError, makeString("Invalid file URL: \""_s, str, '"') };
-            str = urlObject.fileSystemPath();
-        }
+        auto resolved = Worker::resolveScriptURL(str);
+        if (resolved.hasException())
+            return resolved.releaseException();
+        str = resolved.releaseReturnValue();
         preloadModules.append(Bun::toString(str));
     }
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -701,34 +701,31 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
-    test(
-      "terminate() while fs.readFile completions keep arriving",
-      async () => {
-        using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "-e",
-            `const src = \`import { readFile } from "node:fs";
+    test("terminate() while fs.readFile completions keep arriving", async () => {
+      using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
+      // Each round boots 4 workers; a debug build spends ~0.5s per round, so it runs fewer.
+      const rounds = isDebug ? 4 : 12;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const src = \`import { readFile } from "node:fs";
              let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
              postMessage("busy")\`;
            const url = URL.createObjectURL(new Blob([src]));
-           for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
+           for (let r = 0; r < ${rounds}; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
              const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 10) })));
            console.log("PASS");`,
-            path.join(String(dir), "f.bin"),
-          ],
-          env: bunEnv,
-          stdout: "pipe",
-          stderr: "inherit",
-        });
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-        expect(stdout).toBe("PASS\n");
-        expect(exitCode).toBe(0);
-      },
-      // 48 worker boots: a debug build on a loaded machine needs more than the default 5s.
-      isDebug ? 30_000 : 5_000,
-    );
+          path.join(String(dir), "f.bin"),
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("PASS\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -701,29 +701,34 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
-    test("terminate() while fs.readFile completions keep arriving", async () => {
-      using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `const src = \`import { readFile } from "node:fs";
+    test(
+      "terminate() while fs.readFile completions keep arriving",
+      async () => {
+        using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const src = \`import { readFile } from "node:fs";
              let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
              postMessage("busy")\`;
            const url = URL.createObjectURL(new Blob([src]));
            for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
              const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 10) })));
            console.log("PASS");`,
-          path.join(String(dir), "f.bin"),
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "inherit",
-      });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(stdout).toBe("PASS\n");
-      expect(exitCode).toBe(0);
-    });
+            path.join(String(dir), "f.bin"),
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "inherit",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).toBe("PASS\n");
+        expect(exitCode).toBe(0);
+      },
+      // 48 worker boots: a debug build on a loaded machine needs more than the default 5s.
+      isDebug ? 30_000 : 5_000,
+    );
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -20,13 +20,15 @@ describe("web worker", () => {
 
   describe("preload", () => {
     test("invalid file URL", async () => {
-      expect(() => new Worker("file://:!:!:!!!!", {})).toThrow(/Invalid file URL/);
-      expect(
-        () =>
-          new Worker(import.meta.url, {
-            preload: ["file://:!:!:!!!!", "file://:!:!:!!!!2"],
-          }),
-      ).toThrow(/Invalid file URL/);
+      // The entry point and each preload go through the same check: a SyntaxError, as for any
+      // script URL that does not parse.
+      for (const construct of [
+        () => new Worker("file://:!:!:!!!!", {}),
+        () => new Worker(import.meta.url, { preload: ["file://:!:!:!!!!", "file://:!:!:!!!!2"] }),
+      ]) {
+        expect(construct).toThrow(SyntaxError);
+        expect(construct).toThrow('Invalid URL: "file://:!:!:!!!!"');
+      }
     });
 
     test("string", async () => {
@@ -381,6 +383,28 @@ describe("web worker", () => {
       worker.addEventListener("error", () => order.push("error"));
       await once(worker, "close");
       expect(order).toEqual(["open", "error"]);
+    });
+  });
+
+  // HTML: scriptURL is parsed first and a parse failure is a synchronous SyntaxError. Bun also
+  // accepts plain paths and module specifiers, so only a string that starts with a URL scheme is
+  // held to URL syntax; everything else goes to the resolver unchanged.
+  describe("script URL validation", () => {
+    test("a URL with a scheme that does not parse throws a SyntaxError", () => {
+      for (const url of ["http://[", "https://exa mple.com/worker.js", "file://:!:!:!!!!"]) {
+        expect(() => new Worker(url)).toThrow(SyntaxError);
+        expect(() => new Worker(import.meta.url, { preload: [url] })).toThrow(SyntaxError);
+      }
+    });
+
+    // A URL that parses (here with a scheme nothing can load) is not a constructor error: as in
+    // browsers the failure arrives later as an error event.
+    test("a URL that parses but cannot be loaded is reported through the error event", async () => {
+      const worker = new Worker("zzz://x/y.mjs");
+      const closed = once(worker, "close");
+      const [err] = await once(worker, "error");
+      expect(err.message).toContain("ModuleNotFound");
+      await closed;
     });
   });
 


### PR DESCRIPTION
### Problem
- `new Worker("http://[")` does not throw. The string goes to the module resolver and comes back later as an `error` event with `BuildMessage: ModuleNotFound resolving "http://["`. HTML's Worker constructor parses `scriptURL` first and throws a `SyntaxError` when parsing fails (WPT `workers/constructors/Worker-constructor.html`).
- `Worker::create` (`Worker.cpp`) and the preload loop in `WorkerMessagingProxy::startWorkerGlobalScope` each had a copy of the only URL handling there was: `file://` strings were parsed and an invalid one threw a `TypeError` ("Invalid file URL"). Nothing else was parsed.

### Fix
- Add `Worker::resolveScriptURL` and call it from both sites. If the string starts with a URL scheme, it must parse as a WHATWG URL or the constructor throws `SyntaxError: Invalid URL: "..."`. A `file:` URL becomes its filesystem path, as before. Any other valid URL (`blob:`, `data:`, `https:`, `node:`) passes through unchanged.
- A string with no scheme (`./w.ts`, `pkg/worker`, `/abs/w.js`, `C:\w.js`) is a path or module specifier for Bun's resolver, not a relative URL, and is left alone. The scheme check needs two or more characters before the `:`, so a Windows drive letter never counts.
- Correct because WHATWG parsing of a string that already has a scheme only fails for malformed input (bad host, port, or IPv6 literal). Every such string failed before too, just later and asynchronously. `""` and `zzz://x/y.mjs` parse fine, so they keep reporting through the `error` event, which is also what browsers do.
- Verified: `test/js/web/workers/worker.test.ts` ("script URL validation", and the updated "invalid file URL" preload test). Both fail on 1.4.3. Also ran the rest of that file, `worker_blob.test.ts` and `worker-entry-point.test.ts`.

### Background
- Bun's `new Worker(specifier)` takes more than URLs: relative and absolute paths, bare package specifiers, `package.json` `imports` aliases. The worker thread resolves the string with the module resolver, so the constructor cannot treat every argument as a URL relative to a base the way a browser does.
- `ExceptionCode::SyntaxError` becomes a plain JS `SyntaxError` in Bun, not a `DOMException` (`JSDOMExceptionHandling.cpp`, the same house rule `new WebSocket("http://[")` follows).

<details><summary>Notes</summary>

- From an HTML-conformance sweep of the global Worker. The close-code fix (#41969) and the option-enum validation (#41981) ship separately.
- Adjacent but not addressed: #28861 (`file://./w.mjs` parses as a valid URL with host `.` and loads `/w.mjs`). That is a valid URL, so it is not a parse failure; #28862 proposes a host check for it and would now live inside `resolveScriptURL`.
- `node:worker_threads` is unaffected: `validateWorkerFilename` in `worker_threads.ts` only lets absolute paths, `./` and `../` paths, and `URL` objects (converted to paths or `data:` strings) reach the native constructor.

</details>
