### PR TITLE
sql(postgres): announce binary format for a Bind parameter only when it is binary-encoded

### DIFF
--- a/src/sql/postgres/protocol/FieldDescription.rs
+++ b/src/sql/postgres/protocol/FieldDescription.rs
@@ -1,5 +1,5 @@
 use crate::postgres::any_postgres_error::AnyPostgresError;
-use crate::postgres::postgres_types::{self as types, Int4, Short};
+use crate::postgres::postgres_types::{self as types, Int4};
 use crate::postgres::protocol::new_reader::NewReader;
 use crate::shared::column_identifier::ColumnIdentifier;
 
@@ -13,9 +13,7 @@ pub struct FieldDescription {
 
 impl FieldDescription {
     pub fn type_tag(&self) -> types::Tag {
-        // `types::Tag` is a `#[repr(transparent)] struct(Short)` newtype over
-        // the OID, so wrap the truncated value directly.
-        types::Tag(self.type_oid as Short)
+        types::Tag::from_oid(self.type_oid)
     }
 
     pub(crate) fn decode_internal<Container: super::new_reader::ReaderContext>(

--- a/src/sql/postgres/protocol/NewWriter.rs
+++ b/src/sql/postgres/protocol/NewWriter.rs
@@ -34,6 +34,24 @@ impl<C: WriterContext> LengthWriter<C> {
     }
 }
 
+/// A run of Int16 format codes written as text (0) up front and flipped to
+/// binary (1) per slot afterwards, so Bind can decide each parameter's format
+/// while encoding its value instead of in a separate earlier pass.
+#[derive(Copy, Clone)]
+pub struct FormatCodes<C: WriterContext> {
+    index: usize,
+    count: u16,
+    context: NewWriter<C>,
+}
+
+impl<C: WriterContext> FormatCodes<C> {
+    pub fn set_binary(self, slot: usize) -> Result<(), AnyPostgresError> {
+        debug_assert!(slot < usize::from(self.count));
+        self.context
+            .pwrite(&1u16.to_be_bytes(), self.index + slot * 2)
+    }
+}
+
 impl<C: WriterContext> NewWriter<C> {
     #[inline]
     pub fn write(self, data: &[u8]) -> Result<(), AnyPostgresError> {
@@ -46,6 +64,22 @@ impl<C: WriterContext> NewWriter<C> {
         self.int4(0)?;
         Ok(LengthWriter {
             index: i,
+            context: self,
+        })
+    }
+
+    pub fn format_codes(self, count: u16) -> Result<FormatCodes<C>, AnyPostgresError> {
+        let index = self.offset();
+        const TEXT: [u8; 64] = [0; 64];
+        let mut remaining = usize::from(count) * 2;
+        while remaining > 0 {
+            let n = remaining.min(TEXT.len());
+            self.write(&TEXT[..n])?;
+            remaining -= n;
+        }
+        Ok(FormatCodes {
+            index,
+            count,
             context: self,
         })
     }

--- a/src/sql/postgres/protocol/NewWriter.rs
+++ b/src/sql/postgres/protocol/NewWriter.rs
@@ -34,9 +34,7 @@ impl<C: WriterContext> LengthWriter<C> {
     }
 }
 
-/// A run of Int16 format codes written as text (0) up front and flipped to
-/// binary (1) per slot afterwards, so Bind can decide each parameter's format
-/// while encoding its value instead of in a separate earlier pass.
+/// A run of Int16 format codes, written as text (0); `set_binary` flips one slot to binary (1).
 #[derive(Copy, Clone)]
 pub struct FormatCodes<C: WriterContext> {
     index: usize,

--- a/src/sql/postgres/types/Tag.rs
+++ b/src/sql/postgres/types/Tag.rs
@@ -56,7 +56,7 @@
 //  varbit                                |  1562 |     1563
 //  numeric                               |  1700 |     1231
 
-use super::int_types::short as Short;
+use super::int_types::{Int4, short as Short};
 
 // Non-exhaustive: any `short` value is a valid `Tag`. A `#[repr(i16)] enum`
 // cannot hold arbitrary values, so model as a transparent newtype with
@@ -179,6 +179,12 @@ pg_tags! {
 }
 
 impl Tag {
+    /// The one OID-to-`Tag` mapping. An OID above `Short::MAX` is a user-defined type: text.
+    pub fn from_oid(oid: Int4) -> Tag {
+        Short::try_from(oid).map_or(Tag::text, Tag)
+    }
+
+    /// Types `DataCell` decodes from binary, for result columns. Bind parameters have a shorter encoder list.
     pub fn is_binary_format_supported(self) -> bool {
         match self {
             // TODO: .int2_array, .float8_array,

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1268,13 +1268,7 @@ impl<'a> Putter<'a> {
         if IS_RAW {
             *cell = SQLDataCell::raw(optional_bytes);
         } else {
-            let tag = if (types::short::MAX as u32) < oid {
-                types::Tag::text
-            } else {
-                // types::Tag is `#[repr(transparent)] struct Tag(pub Short)` —
-                // construct directly, no transmute needed.
-                types::Tag(oid as types::short)
-            };
+            let tag = field.type_tag();
             *cell = if let Some(data) = optional_bytes {
                 from_bytes(
                     (field.binary || self.binary) && tag.is_binary_format_supported(),

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -124,11 +124,24 @@ pub(crate) fn write_bind<Context: WriterContext>(
             writer.write(str.to_utf8().slice())?;
         } else {
             // Text format: the server's input parser for the type accepts or rejects it.
-            let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
-            if str.tag() == bun_core::Tag::Dead {
-                return Err(AnyPostgresError::OutOfMemory);
+            // A Date goes as ISO 8601, which the date/time types parse; `String(date)` is
+            // locale-dependent text that PostgreSQL rejects. An Invalid Date has no ISO form
+            // and goes as "Invalid Date", which the server rejects like any other bad literal.
+            let mut iso_buf = [0u8; 64];
+            let iso = if value.is_date() {
+                value.to_iso_string(global, &mut iso_buf)
+            } else {
+                None
+            };
+            if let Some(iso) = iso {
+                writer.write(iso)?;
+            } else {
+                let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
+                if str.tag() == bun_core::Tag::Dead {
+                    return Err(AnyPostgresError::OutOfMemory);
+                }
+                writer.write(str.to_utf8().slice())?;
             }
-            writer.write(str.to_utf8().slice())?;
         }
         l.write_excluding_self()?;
 

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -4,7 +4,7 @@ use bun_core::fmt as bun_fmt;
 
 use bun_sql::postgres::PostgresProtocol as protocol;
 use bun_sql::postgres::PostgresTypes as types;
-use bun_sql::postgres::PostgresTypes::{AnyPostgresError, Int4, Short};
+use bun_sql::postgres::PostgresTypes::{AnyPostgresError, Int4};
 use bun_sql::postgres::Status;
 use bun_sql::postgres::protocol::{ReaderContext, WriterContext};
 
@@ -88,8 +88,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
         let tag = match parameter_fields.get(i) {
             // An extra value goes as text; the server reports the count mismatch (08P01).
             None => types::Tag::text,
-            // OIDs above `Short::MAX` are user-defined types and are bound as text.
-            Some(&oid) => Short::try_from(oid).map_or(types::Tag::text, types::Tag),
+            Some(&oid) => types::Tag::from_oid(oid),
         };
         if value.is_empty_or_undefined_or_null() {
             bun_core::scoped_log!(Postgres, "  -> NULL");

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -230,7 +230,7 @@ fn exact_int4(value: JSValue) -> Option<i32> {
     let double = value.as_number();
     let fits =
         double.trunc() == double && double >= f64::from(i32::MIN) && double <= f64::from(i32::MAX);
-    fits.then(|| double as i32)
+    fits.then_some(double as i32)
 }
 
 pub(crate) fn write_query<Context: WriterContext>(

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -72,77 +72,29 @@ pub(crate) fn write_bind<Context: WriterContext>(
 
     let len: u16 = u16::try_from(parameter_fields.len()).expect("int cast");
 
-    // The number of parameter format codes that follow (denoted C
-    // below). This can be zero to indicate that there are no
-    // parameters or that the parameters all use the default format
-    // (text); or one, in which case the specified format code is
-    // applied to all parameters; or it can equal the actual number
-    // of parameters.
+    // One format code per parameter. Each starts as text and is flipped to
+    // binary below by the same branch that writes the binary bytes, so the
+    // code always describes what was actually sent.
     writer.short(len)?;
-
-    let mut iter = QueryBindingIterator::init(values_array, columns_value, global)
-        .map_err(js_error_to_postgres)?;
-    for i in 0..(len as usize) {
-        let parameter_field = parameter_fields[i];
-        let is_custom_type = (Short::MAX as Int4) < parameter_field;
-        let tag: types::Tag = if is_custom_type {
-            types::Tag::text
-        } else {
-            types::Tag(Short::try_from(parameter_field).unwrap())
-        };
-
-        let force_text = is_custom_type
-            || (tag.is_binary_format_supported()
-                && 'brk: {
-                    iter.to(i as u32);
-                    if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-                        break 'brk value.is_string();
-                    }
-                    if iter.any_failed() {
-                        return Err(AnyPostgresError::InvalidQueryBinding);
-                    }
-                    break 'brk false;
-                });
-
-        if force_text {
-            // If they pass a value as a string, let's avoid attempting to
-            // convert it to the binary representation. This minimizes the room
-            // for mistakes on our end, such as stripping the timezone
-            // differently than what Postgres does when given a timestamp with
-            // timezone.
-            writer.short(0)?;
-            continue;
-        }
-
-        writer.short(tag.format_code())?;
-    }
+    let format_codes = writer.format_codes(len)?;
 
     // The number of parameter values that follow (possibly zero). This
     // must match the number of parameters needed by the query.
     writer.short(len)?;
 
     bun_core::scoped_log!(Postgres, "Bind: {} ({} args)", bun_fmt::quote(name), len);
-    iter.to(0);
+    let mut iter = QueryBindingIterator::init(values_array, columns_value, global)
+        .map_err(js_error_to_postgres)?;
     let mut i: usize = 0;
     while let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-        let tag: types::Tag = 'brk: {
-            if i >= len as usize {
-                // parameter in array but not in parameter_fields
-                // this is probably a bug a bug in bun lets return .text here so the server will send a error 08P01
-                // with will describe better the error saying exactly how many parameters are missing and are expected
-                // Example:
-                // SQL error: PostgresError: bind message supplies 0 parameters, but prepared statement "PSELECT * FROM test_table WHERE id=$1 .in$0" requires 1
-                // errno: "08P01",
-                // code: "ERR_POSTGRES_SERVER_ERROR"
-                break 'brk types::Tag::text;
-            }
-            let parameter_field = parameter_fields[i];
-            let is_custom_type = (Short::MAX as Int4) < parameter_field;
-            break 'brk if is_custom_type {
-                types::Tag::text
-            } else {
-                types::Tag(Short::try_from(parameter_field).unwrap())
-            };
+        let tag = match parameter_fields.get(i) {
+            // More values than the statement has parameters. Send it as text;
+            // the server then reports the count mismatch (08P01 "bind message
+            // supplies N parameters, but prepared statement ... requires M").
+            None => types::Tag::text,
+            // OIDs above `Short::MAX` are user-defined types, which only have
+            // a text representation here anyway.
+            Some(&oid) => Short::try_from(oid).map_or(types::Tag::text, types::Tag),
         };
         if value.is_empty_or_undefined_or_null() {
             bun_core::scoped_log!(Postgres, "  -> NULL");
@@ -154,87 +106,44 @@ pub(crate) fn write_bind<Context: WriterContext>(
         }
         bun_core::scoped_log!(Postgres, "  -> {}", tag.tag_name().unwrap_or("(unknown)"));
 
-        // If they pass a value as a string, let's avoid attempting to
-        // convert it to the binary representation. This minimizes the room
-        // for mistakes on our end, such as stripping the timezone
-        // differently than what Postgres does when given a timestamp with
-        // timezone.
-        let effective_tag = if tag.is_binary_format_supported() && value.is_string() {
-            types::Tag::text
+        let l = writer.length()?;
+        if write_binary_parameter(global, tag, value, writer)? {
+            if i < usize::from(len) {
+                format_codes.set_binary(i)?;
+            }
+        } else if tag == types::Tag::bytea && !value.is_string() {
+            // No text fallback here: bytea's text input accepts any string, so
+            // `String(value)` would store unrelated bytes instead of rejecting.
+            let received = JSGlobalObject::determine_specific_type(global, value)
+                .map_err(js_error_to_postgres)?;
+            return Err(js_error_to_postgres(global.throw_value(
+                global.ERR_INVALID_ARG_TYPE(format_args!(
+                    "Query parameter ${} of type bytea must be a Buffer, TypedArray, ArrayBuffer or string. Received {}",
+                    i + 1,
+                    received,
+                )),
+            )));
+        } else if matches!(tag, types::Tag::json | types::Tag::jsonb) {
+            let str = value
+                .json_stringify_fast(global)
+                .map_err(js_error_to_postgres)?;
+            writer.write(str.to_utf8().slice())?;
         } else {
-            tag
-        };
-        match effective_tag {
-            types::Tag::jsonb | types::Tag::json => {
-                // Use jsonStringifyFast for SIMD-optimized serialization
-                let str = value
-                    .json_stringify_fast(global)
-                    .map_err(js_error_to_postgres)?;
-                let slice = str.to_utf8();
-                let l = writer.length()?;
-                writer.write(slice.slice())?;
-                l.write_excluding_self()?;
+            // Text format: the server parses it by the parameter's type, the
+            // same as a literal from any text-protocol client, and rejects
+            // what it cannot parse.
+            let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
+            if str.tag() == bun_core::Tag::Dead {
+                return Err(AnyPostgresError::OutOfMemory);
             }
-            types::Tag::bool => {
-                let l = writer.length()?;
-                writer.write(&[value.to_boolean() as u8])?;
-                l.write_excluding_self()?;
-            }
-            types::Tag::timestamp | types::Tag::timestamptz => {
-                let l = writer.length()?;
-                writer.int8(
-                    crate::postgres::types::date::from_js(global, value)
-                        .map_err(js_error_to_postgres)?,
-                )?;
-                l.write_excluding_self()?;
-            }
-            types::Tag::bytea => {
-                let Some(buf) = value.as_array_buffer(global) else {
-                    let received = JSGlobalObject::determine_specific_type(global, value)
-                        .map_err(js_error_to_postgres)?;
-                    return Err(js_error_to_postgres(global.throw_value(
-                        global.ERR_INVALID_ARG_TYPE(format_args!(
-                            "Query parameter ${} of type bytea must be a Buffer, TypedArray, ArrayBuffer or string. Received {}",
-                            i + 1,
-                            received,
-                        )),
-                    )));
-                };
-                let bytes = buf.byte_slice();
-                let l = writer.length()?;
-                bun_core::scoped_log!(Postgres, "    {} bytes", bytes.len());
-                writer.write(bytes)?;
-                l.write_excluding_self()?;
-            }
-            types::Tag::int4 => {
-                let l = writer.length()?;
-                writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
-                l.write_excluding_self()?;
-            }
-            types::Tag::int4_array => {
-                let l = writer.length()?;
-                writer.int4(value.coerce::<i32>(global).map_err(js_error_to_postgres)? as u32)?;
-                l.write_excluding_self()?;
-            }
-            types::Tag::float8 => {
-                let l = writer.length()?;
-                writer.f64(value.to_number(global).map_err(js_error_to_postgres)?)?;
-                l.write_excluding_self()?;
-            }
-
-            _ => {
-                let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
-                if str.tag() == bun_core::Tag::Dead {
-                    return Err(AnyPostgresError::OutOfMemory);
-                }
-                let slice = str.to_utf8();
-                let l = writer.length()?;
-                writer.write(slice.slice())?;
-                l.write_excluding_self()?;
-            }
+            writer.write(str.to_utf8().slice())?;
         }
+        l.write_excluding_self()?;
 
         i += 1;
+    }
+    if iter.any_failed() {
+        return Err(AnyPostgresError::InvalidQueryBinding);
     }
 
     let mut any_non_text_fields: bool = false;
@@ -259,6 +168,70 @@ pub(crate) fn write_bind<Context: WriterContext>(
 
     length.write()?;
     Ok(())
+}
+
+/// Writes `value` in PostgreSQL's binary format and returns `true` when the
+/// value is the JS class that the binary encoder for `tag` represents exactly.
+/// Writes nothing and returns `false` for every other pairing (a Date bound to
+/// an `int4` parameter, a string bound to anything, a type with no encoder
+/// here); the caller decides between text and an error for those.
+fn write_binary_parameter<Context: WriterContext>(
+    global: &JSGlobalObject,
+    tag: types::Tag,
+    value: JSValue,
+    writer: protocol::NewWriter<Context>,
+) -> Result<bool, AnyPostgresError> {
+    match tag {
+        types::Tag::bool if value.is_boolean() => {
+            writer.write(&[value.as_boolean() as u8])?;
+        }
+        types::Tag::int4 => {
+            let Some(int) = exact_int4(value) else {
+                return Ok(false);
+            };
+            writer.int4(int as u32)?;
+        }
+        types::Tag::float8 if value.is_number() => {
+            writer.f64(value.as_number())?;
+        }
+        types::Tag::bytea => {
+            let Some(buf) = value.as_array_buffer(global) else {
+                return Ok(false);
+            };
+            bun_core::scoped_log!(Postgres, "    {} bytes", buf.byte_slice().len());
+            writer.write(buf.byte_slice())?;
+        }
+        types::Tag::timestamp | types::Tag::timestamptz => {
+            let ms = if value.is_date() {
+                value.get_unix_timestamp()
+            } else if value.is_number() {
+                value.as_number()
+            } else {
+                return Ok(false);
+            };
+            // NaN is an Invalid Date; as text the server's error names it.
+            if ms.is_nan() {
+                return Ok(false);
+            }
+            writer.int8(crate::postgres::types::date::from_unix_ms(ms))?;
+        }
+        _ => return Ok(false),
+    }
+    Ok(true)
+}
+
+/// The `i32` a JS number holds exactly, if any.
+fn exact_int4(value: JSValue) -> Option<i32> {
+    if value.is_int32() {
+        return Some(value.as_int32());
+    }
+    if !value.is_number() {
+        return None;
+    }
+    let double = value.as_number();
+    let fits =
+        double.trunc() == double && double >= f64::from(i32::MIN) && double <= f64::from(i32::MAX);
+    fits.then(|| double as i32)
 }
 
 pub(crate) fn write_query<Context: WriterContext>(

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -124,9 +124,6 @@ pub(crate) fn write_bind<Context: WriterContext>(
             writer.write(str.to_utf8().slice())?;
         } else {
             // Text format: the server's input parser for the type accepts or rejects it.
-            // A Date goes as ISO 8601, which the date/time types parse; `String(date)` is
-            // locale-dependent text that PostgreSQL rejects. An Invalid Date has no ISO form
-            // and goes as "Invalid Date", which the server rejects like any other bad literal.
             let mut iso_buf = [0u8; 64];
             let iso = if value.is_date() {
                 value.to_iso_string(global, &mut iso_buf)
@@ -134,6 +131,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 None
             };
             if let Some(iso) = iso {
+                // A valid Date: ISO 8601 parses as date/timestamp(tz); `String(date)` never does.
                 writer.write(iso)?;
             } else {
                 let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -72,9 +72,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
 
     let len: u16 = u16::try_from(parameter_fields.len()).expect("int cast");
 
-    // One format code per parameter. Each starts as text and is flipped to
-    // binary below by the same branch that writes the binary bytes, so the
-    // code always describes what was actually sent.
+    // One format code per parameter, all text until a binary write below flips its slot.
     writer.short(len)?;
     let format_codes = writer.format_codes(len)?;
 
@@ -88,12 +86,9 @@ pub(crate) fn write_bind<Context: WriterContext>(
     let mut i: usize = 0;
     while let Some(value) = iter.next().map_err(js_error_to_postgres)? {
         let tag = match parameter_fields.get(i) {
-            // More values than the statement has parameters. Send it as text;
-            // the server then reports the count mismatch (08P01 "bind message
-            // supplies N parameters, but prepared statement ... requires M").
+            // An extra value goes as text; the server reports the count mismatch (08P01).
             None => types::Tag::text,
-            // OIDs above `Short::MAX` are user-defined types, which only have
-            // a text representation here anyway.
+            // OIDs above `Short::MAX` are user-defined types and are bound as text.
             Some(&oid) => Short::try_from(oid).map_or(types::Tag::text, types::Tag),
         };
         if value.is_empty_or_undefined_or_null() {
@@ -112,8 +107,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 format_codes.set_binary(i)?;
             }
         } else if tag == types::Tag::bytea && !value.is_string() {
-            // No text fallback here: bytea's text input accepts any string, so
-            // `String(value)` would store unrelated bytes instead of rejecting.
+            // No text fallback: bytea's input accepts any string, so `String(value)` would be stored.
             let received = JSGlobalObject::determine_specific_type(global, value)
                 .map_err(js_error_to_postgres)?;
             return Err(js_error_to_postgres(global.throw_value(
@@ -129,9 +123,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 .map_err(js_error_to_postgres)?;
             writer.write(str.to_utf8().slice())?;
         } else {
-            // Text format: the server parses it by the parameter's type, the
-            // same as a literal from any text-protocol client, and rejects
-            // what it cannot parse.
+            // Text format: the server's input parser for the type accepts or rejects it.
             let str = BunString::from_js(value, global).map_err(js_error_to_postgres)?;
             if str.tag() == bun_core::Tag::Dead {
                 return Err(AnyPostgresError::OutOfMemory);
@@ -170,11 +162,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
     Ok(())
 }
 
-/// Writes `value` in PostgreSQL's binary format and returns `true` when the
-/// value is the JS class that the binary encoder for `tag` represents exactly.
-/// Writes nothing and returns `false` for every other pairing (a Date bound to
-/// an `int4` parameter, a string bound to anything, a type with no encoder
-/// here); the caller decides between text and an error for those.
+/// Writes `value` in binary and returns `true` only when its JS class is what `tag`'s encoder represents exactly.
 fn write_binary_parameter<Context: WriterContext>(
     global: &JSGlobalObject,
     tag: types::Tag,

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -78,10 +78,7 @@ fn components_to_ms_utc(
         .ok()
 }
 
-/// `ms` is a non-NaN JS time value in milliseconds: a valid `Date`'s, or a
-/// number bound to a timestamp parameter. ±Infinity round-trip the ±Infinity
-/// the decoder produces back to DT_NOEND / DT_NOBEGIN (`f64::INFINITY as i64`
-/// would saturate to i64::MAX and the arithmetic below would overflow).
+/// A non-NaN JS time value to Postgres microseconds; ±Infinity become DT_NOEND / DT_NOBEGIN.
 pub(crate) fn from_unix_ms(ms: f64) -> i64 {
     debug_assert!(!ms.is_nan());
     if ms == f64::INFINITY {

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -1,4 +1,4 @@
-use crate::jsc::{JSGlobalObject, JSValue, JsResult, bun_string_jsc};
+use crate::jsc::JSGlobalObject;
 
 // Postgres stores timestamp and timestampz as microseconds since 2000-01-01
 // This is a signed 64-bit integer.
@@ -78,29 +78,19 @@ fn components_to_ms_utc(
         .ok()
 }
 
-pub(crate) fn from_js(global_object: &JSGlobalObject, value: JSValue) -> JsResult<i64> {
-    let double_value = if value.is_date() {
-        value.get_unix_timestamp()
-    } else if value.is_number() {
-        value.as_number()
-    } else if value.is_string() {
-        let str = value.to_bun_string(global_object).expect("unreachable");
-        bun_string_jsc::parse_date(&str, global_object)?
-    } else {
-        return Ok(0);
-    };
-
-    // Round-trip the ±Infinity the decoder produces back to DT_NOEND /
-    // DT_NOBEGIN; otherwise `f64::INFINITY as i64` saturates to i64::MAX and
-    // the subtract/multiply below overflows.
-    if double_value == f64::INFINITY {
-        return Ok(i64::MAX);
+/// `ms` is a non-NaN JS time value in milliseconds: a valid `Date`'s, or a
+/// number bound to a timestamp parameter. ±Infinity round-trip the ±Infinity
+/// the decoder produces back to DT_NOEND / DT_NOBEGIN (`f64::INFINITY as i64`
+/// would saturate to i64::MAX and the arithmetic below would overflow).
+pub(crate) fn from_unix_ms(ms: f64) -> i64 {
+    debug_assert!(!ms.is_nan());
+    if ms == f64::INFINITY {
+        return i64::MAX;
     }
-    if double_value == f64::NEG_INFINITY {
-        return Ok(i64::MIN);
+    if ms == f64::NEG_INFINITY {
+        return i64::MIN;
     }
-    let unix_timestamp: i64 = double_value as i64;
-    Ok(unix_timestamp
+    (ms as i64)
         .saturating_sub(POSTGRES_EPOCH_DATE)
-        .saturating_mul(US_PER_MS))
+        .saturating_mul(US_PER_MS)
 }

--- a/src/sql_jsc/shared/QueryBindingIterator.rs
+++ b/src/sql_jsc/shared/QueryBindingIterator.rs
@@ -43,15 +43,4 @@ impl<'a> QueryBindingIterator<'a> {
             Self::Objects(iter) => iter.any_failed,
         }
     }
-
-    pub(crate) fn to(&mut self, index: u32) {
-        match self {
-            Self::Array(iter) => iter.i = index,
-            Self::Objects(iter) => {
-                iter.cell_i = index % iter.columns_count;
-                iter.row_i = index / iter.columns_count;
-                iter.current_row = JSValue::ZERO;
-            }
-        }
-    }
 }

--- a/test/js/sql/postgres-bind-parameter-format.test.ts
+++ b/test/js/sql/postgres-bind-parameter-format.test.ts
@@ -15,6 +15,10 @@
 //    int32, NaN, 2000-01-01). bytea is the exception: its text input accepts
 //    any string, so a non-BufferSource value rejects instead
 //    (postgres-bytea-bind.test.ts).
+//  - A Date sent as text is ISO 8601 (`toISOString()`), so a `date` or `text`
+//    slot, and every slot under `prepare: false`, receives a literal the server
+//    parses. Previously it was `Date.prototype.toString()` output, which
+//    PostgreSQL rejects (#29010).
 
 import { SQL } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
@@ -68,6 +72,16 @@ const classMismatch: Case[] = [
   ["ISO instant object -> timestamp", "timestamp", instant, "2026-09-07 10:11:12.345"],
 ];
 
+// A Date in a text-format slot is `toISOString()`. An Invalid Date has no ISO
+// form, so it stays `String(date)` and a typed slot rejects it.
+const dateAsText: Case[] = [
+  ["Date -> date", "date", date, "2026-09-07"],
+  ["Date -> text", "text", date, "2026-09-07T10:11:12.345Z"],
+  ["Date -> timetz", "timetz", date, "22007"],
+  ["Invalid Date -> date", "date", invalidDate, "22007"],
+  ["Invalid Date -> text (unchanged)", "text", invalidDate, "Invalid Date"],
+];
+
 // These were already exact and must stay on the binary encoders.
 const exactClass: Case[] = [
   ["true -> bool", "bool", true, "true"],
@@ -114,17 +128,18 @@ const columns: Record<string, string> = {
   "jsonb": "c_jsonb",
   "json": "c_json",
   "int8": "c_int8",
+  "date": "c_date",
+  "text": "c_text",
+  "timetz": "c_timetz",
 };
 
 describeWithContainer("postgres", { image: "postgres_plain" }, container => {
   let sql: SQL;
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
 
   beforeAll(async () => {
     await container.ready;
-    sql = new SQL({
-      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
-      max: 1,
-    });
+    sql = new SQL({ url: url(), max: 1 });
     await sql`set time zone 'UTC'`;
     await sql.unsafe(
       `create temp table bind_format (${Object.entries(columns)
@@ -160,5 +175,19 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
 
   test("values of the matching class keep their binary encoding", async () => {
     expect(await run(exactClass)).toEqual(exactClass);
+  });
+
+  test("a Date bound as text is ISO 8601 (#29010)", async () => {
+    expect(await run(dateAsText)).toEqual(dateAsText);
+  });
+
+  test("prepare: false sends a Date as ISO 8601 before the server has typed the parameter (#29010)", async () => {
+    // Bind is written together with Parse here, so every parameter is still
+    // untyped (text) when it is encoded.
+    await using unnamed = new SQL({ url: url(), max: 1, prepare: false });
+    await unnamed`set time zone 'UTC'`;
+    const [row] =
+      await unnamed`select ${date}::timestamptz::text as a, ${date}::date::text as b, ${invalidDate}::text as c`;
+    expect(row).toEqual({ a: "2026-09-07 10:11:12.345+00", b: "2026-09-07", c: "Invalid Date" });
   });
 });

--- a/test/js/sql/postgres-bind-parameter-format.test.ts
+++ b/test/js/sql/postgres-bind-parameter-format.test.ts
@@ -19,10 +19,153 @@
 //    slot, and every slot under `prepare: false`, receives a literal the server
 //    parses. Previously it was `Date.prototype.toString()` output, which
 //    PostgreSQL rejects (#29010).
+//
+// The mock-server tests pin the exact Bind bytes (format codes and values) and
+// need no database, so they run on every lane.
 
 import { SQL } from "bun";
-import { afterAll, beforeAll, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
+import {
+  type PgBind,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgDecodeBind,
+  pgMockServer,
+  pgNoData,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+// Stand-in for a decimal.js / big.js style value: not a string, but its text
+// form is what should reach the server.
+class Textual {
+  constructor(public text: string) {}
+  toString() {
+    return this.text;
+  }
+}
+
+/**
+ * Mock backend for one prepared query. Describe is answered with the given
+ * parameter OIDs and result columns, Execute with one `row`. Resolves with
+ * every Bind the client sent and the rows it decoded.
+ */
+async function runAgainstMock(opts: {
+  paramOids: number[];
+  columns?: { name: string; typeOid: number }[];
+  row?: (Buffer | null)[];
+  query: (sql: SQL) => Promise<any>;
+}): Promise<{ binds: PgBind[]; rows: any }> {
+  const binds: PgBind[] = [];
+  const columns = opts.columns ?? [];
+  const { server, port } = await pgMockServer((type, body, socket) => {
+    switch (type) {
+      case "P":
+        return pgParseComplete();
+      case "D":
+        return [pgParameterDescription(opts.paramOids), columns.length ? pgRowDescription(columns) : pgNoData()];
+      case "B":
+        binds.push(pgDecodeBind(body));
+        return pgBindComplete();
+      case "E":
+        return opts.row ? [pgDataRow(opts.row), pgCommandComplete("SELECT 1")] : pgCommandComplete("SELECT 0");
+      case "S":
+        return pgReadyForQuery();
+      case "X":
+        socket.end();
+        break;
+    }
+  });
+  try {
+    await using sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1 });
+    const rows = await opts.query(sql);
+    return { binds, rows };
+  } finally {
+    server.close();
+  }
+}
+
+describe("Bind format codes (mock server)", () => {
+  test("parameters typed numeric, float4, time, int4[] and float4[] are declared and sent as text", async () => {
+    const { binds } = await runAgainstMock({
+      // numeric, float4, time, int4_array, float4_array
+      paramOids: [1700, 700, 1083, 1007, 1021],
+      query: sql =>
+        sql.unsafe("select $1, $2, $3, $4, $5", [
+          new Textual("19.99"),
+          new Textual("1234"),
+          new Textual("12:34:56"),
+          sql.array([1, 2], "INT4"),
+          sql.array([1.5], "REAL"),
+        ]),
+    });
+    expect(binds).toHaveLength(1);
+    expect({
+      paramFormats: binds[0].paramFormats,
+      params: binds[0].params.map(p => p?.toString("latin1")),
+    }).toEqual({
+      paramFormats: [0, 0, 0, 0, 0],
+      params: ["19.99", "1234", "12:34:56", `{"1","2"}`, "{1.5}"],
+    });
+  });
+
+  test("parameters with a binary encoder are declared binary, a string or mismatched class stays text", async () => {
+    const date = new Date("2000-01-01T00:00:01.000Z"); // 1_000_000 us after the Postgres epoch
+    const { binds } = await runAgainstMock({
+      // bool, int4, float8, timestamptz, bytea, int4 (from a string), int4 (2^31), bool (from a Date), date
+      paramOids: [16, 23, 701, 1184, 17, 23, 23, 16, 1082],
+      query: sql =>
+        sql.unsafe("select $1, $2, $3, $4, $5, $6, $7, $8, $9", [
+          true,
+          7,
+          1.5,
+          date,
+          Buffer.from([1, 2]),
+          "8",
+          2 ** 31,
+          date,
+          date,
+        ]),
+    });
+    expect(binds).toHaveLength(1);
+    expect({ paramFormats: binds[0].paramFormats, params: binds[0].params }).toEqual({
+      paramFormats: [1, 1, 1, 1, 1, 0, 0, 0, 0],
+      params: [
+        Buffer.from([1]),
+        Buffer.from([0, 0, 0, 7]),
+        Buffer.from("3ff8000000000000", "hex"),
+        Buffer.from("00000000000f4240", "hex"),
+        Buffer.from([1, 2]),
+        Buffer.from("8"),
+        Buffer.from("2147483648"),
+        Buffer.from("2000-01-01T00:00:01.000Z"),
+        Buffer.from("2000-01-01T00:00:01.000Z"),
+      ],
+    });
+  });
+
+  test("a result column whose OID is above 65535 is requested and decoded as text", async () => {
+    // 65552 = 65536 + 16: a user-defined type whose low 16 bits alias `bool`.
+    const { binds, rows } = await runAgainstMock({
+      paramOids: [23],
+      columns: [
+        { name: "custom", typeOid: 65552 },
+        { name: "n", typeOid: 23 },
+      ],
+      row: [Buffer.from("(42,t)"), Buffer.from([0, 0, 0, 9])],
+      query: sql => sql`select custom, n from t where n = ${9}`,
+    });
+    expect(binds).toHaveLength(1);
+    expect({ resultFormats: binds[0].resultFormats, row: rows[0] }).toEqual({
+      resultFormats: [0, 1],
+      row: { custom: "(42,t)", n: 9 },
+    });
+  });
+});
 
 const date = new Date("2026-09-07T10:11:12.345Z");
 const invalidDate = new Date(NaN);
@@ -189,5 +332,49 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     const [row] =
       await unnamed`select ${date}::timestamptz::text as a, ${date}::date::text as b, ${invalidDate}::text as c`;
     expect(row).toEqual({ a: "2026-09-07 10:11:12.345+00", b: "2026-09-07", c: "Invalid Date" });
+  });
+
+  // The tagged template and the sql(object) helper, each on its own connection
+  // so the temp tables do not collide with `bind_format` above.
+  const connect = () => new SQL({ url: url(), max: 1 });
+
+  test("object bound to a numeric, real or time column is sent as its text form", async () => {
+    await using sql = connect();
+    await sql`create temp table t (n numeric, r real, t time)`;
+    const rows = await sql`
+      insert into t (n, r, t)
+      values (${new Textual("19.99")}, ${new Textual("1234")}, ${new Textual("12:34:56")})
+      returning n::text as n, r::text as r, t::text as t`;
+    expect(rows[0]).toEqual({ n: "19.99", r: "1234", t: "12:34:56" });
+  });
+
+  test("object bound to a $1::numeric / $1::real cast is sent as its text form", async () => {
+    await using sql = connect();
+    const rows = await sql`select ${new Textual("0.1")}::numeric::text as n, ${new Textual("2.5")}::real::text as r`;
+    expect(rows[0]).toEqual({ n: "0.1", r: "2.5" });
+  });
+
+  test("sql.array() in the sql(object) helper works for int4[] and real[] columns", async () => {
+    await using sql = connect();
+    await sql`create temp table t (id int4, ia int4[], ra real[])`;
+    const inserted = await sql`
+      insert into t ${sql({ id: 1, ia: sql.array([1, 2, 3], "INT4"), ra: sql.array([1.5, 2.5], "REAL") })}
+      returning ia::text as ia, ra::text as ra`;
+    expect(inserted[0]).toEqual({ ia: "{1,2,3}", ra: "{1.5,2.5}" });
+
+    const updated = await sql`
+      update t set ${sql({ ia: sql.array([4], "INT4"), ra: sql.array([0.25], "REAL") })}
+      where id = 1
+      returning ia::text as ia, ra::text as ra`;
+    expect(updated[0]).toEqual({ ia: "{4}", ra: "{0.25}" });
+  });
+
+  test("sql.array() passed to sql.unsafe() works for int4[] and real[] parameters", async () => {
+    await using sql = connect();
+    const rows = await sql.unsafe("select $1::int4[]::text as ia, $2::real[]::text as ra", [
+      sql.array([7, 8], "INT4"),
+      sql.array([1.5], "REAL"),
+    ]);
+    expect(rows[0]).toEqual({ ia: "{7,8}", ra: "{1.5}" });
   });
 });

--- a/test/js/sql/postgres-bind-parameter-format.test.ts
+++ b/test/js/sql/postgres-bind-parameter-format.test.ts
@@ -1,0 +1,164 @@
+// How Bun.SQL encodes a Bind parameter once the server has told it the
+// parameter's type (ParameterDescription). Bun leaves the OID unspecified for
+// Date / array / object values, so the server infers the column type, and Bind
+// then has to send bytes that match the format code it announces for that slot.
+//
+// Two things are checked against a real server, by reading the stored value
+// back as text:
+//  - A type with no binary encoder (float4, numeric, time, int4[], float4[]) is
+//    announced and sent as text, so the server parses or rejects it as it would
+//    a literal. Previously these were announced as binary while the bytes were
+//    `String(value)`, which the server read as a garbled binary datum.
+//  - A type that has a binary encoder (bool, int4, float8, timestamp,
+//    timestamptz) uses it only for the JS class it represents exactly. Any other
+//    class is sent as text too, instead of being coerced (truthiness, wrapped
+//    int32, NaN, 2000-01-01). bytea is the exception: its text input accepts
+//    any string, so a non-BufferSource value rejects instead
+//    (postgres-bytea-bind.test.ts).
+
+import { SQL } from "bun";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+const date = new Date("2026-09-07T10:11:12.345Z");
+const invalidDate = new Date(NaN);
+// Stand-ins for userland value types that stringify to a literal the server
+// understands (decimal.js, a Temporal polyfill, a time-of-day class, ...).
+const decimal = { toString: () => "1.50" };
+const timeOfDay = { toString: () => "07:08:09" };
+const instant = { toString: () => "2026-09-07T10:11:12.345Z" };
+const pgArray = { toString: () => "{1.5,2}" };
+
+type Case = [label: string, column: string, value: unknown, expected: string | null];
+
+// `expected` is the stored value cast to text, or the SQLSTATE the server
+// rejects the parameter with: 22P02 invalid_text_representation, 22007
+// invalid_datetime_format, 22003 numeric_value_out_of_range.
+const noBinaryEncoder: Case[] = [
+  ["[1234] -> float4", "float4", [1234], "1234"],
+  ["decimal object -> float4", "float4", decimal, "1.5"],
+  ["Date -> float4", "float4", date, "22P02"],
+  ["decimal object -> numeric", "numeric", decimal, "1.50"],
+  ["[1, 2] -> numeric", "numeric", [1, 2], "22P02"],
+  ["Date -> numeric", "numeric", date, "22P02"],
+  ["time-of-day object -> time", "time", timeOfDay, "07:08:09"],
+  ["Date -> time", "time", date, "22007"],
+  ["[1, 2] -> int4[]", "int4[]", [1, 2], "22P02"],
+  ["array-literal object -> int4[]", "int4[]", { toString: () => "{1,2}" }, "{1,2}"],
+  ["Int32Array -> int4[]", "int4[]", new Int32Array([1, 2]), "22P02"],
+  ["[1.5, 2] -> float4[]", "float4[]", [1.5, 2], "22P02"],
+  ["array-literal object -> float4[]", "float4[]", pgArray, "{1.5,2}"],
+];
+
+const classMismatch: Case[] = [
+  ["Date -> bool", "bool", date, "22P02"],
+  ["{} -> bool", "bool", {}, "22P02"],
+  ["[1, 2] -> bool", "bool", [1, 2], "22P02"],
+  ["Date -> int4", "int4", date, "22P02"],
+  ["[1, 2] -> int4", "int4", [1, 2], "22P02"],
+  ["{} -> int4", "int4", {}, "22P02"],
+  ["Date -> float8", "float8", date, "22P02"],
+  ["[1, 2] -> float8", "float8", [1, 2], "22P02"],
+  ["{} -> float8", "float8", {}, "22P02"],
+  ["[1, 2] -> timestamptz", "timestamptz", [1, 2], "22007"],
+  ["{} -> timestamptz", "timestamptz", {}, "22007"],
+  ["Invalid Date -> timestamptz", "timestamptz", invalidDate, "22007"],
+  ["Invalid Date -> timestamp", "timestamp", invalidDate, "22007"],
+  ["ISO instant object -> timestamptz", "timestamptz", instant, "2026-09-07 10:11:12.345+00"],
+  ["ISO instant object -> timestamp", "timestamp", instant, "2026-09-07 10:11:12.345"],
+];
+
+// These were already exact and must stay on the binary encoders.
+const exactClass: Case[] = [
+  ["true -> bool", "bool", true, "true"],
+  ["false -> bool", "bool", false, "false"],
+  ["7 -> int4", "int4", 7, "7"],
+  ["-2147483648 -> int4", "int4", -2147483648, "-2147483648"],
+  ["2147483647 -> int4", "int4", 2147483647, "2147483647"],
+  ["1.5 -> float8", "float8", 1.5, "1.5"],
+  ["-0 -> float8", "float8", -0, "-0"],
+  ["1e300 -> float8", "float8", 1e300, "1e+300"],
+  ["NaN -> float8", "float8", NaN, "NaN"],
+  ["Infinity -> float8", "float8", Infinity, "Infinity"],
+  ["Uint8Array -> bytea", "bytea", new Uint8Array([1, 2, 3]), "\\x010203"],
+  ["empty Uint8Array -> bytea", "bytea", new Uint8Array(0), "\\x"],
+  ["Buffer -> bytea", "bytea", Buffer.from("hi"), "\\x6869"],
+  ["ArrayBuffer -> bytea", "bytea", new Uint8Array([4, 5]).buffer, "\\x0405"],
+  ["Date -> timestamptz", "timestamptz", date, "2026-09-07 10:11:12.345+00"],
+  ["Date -> timestamp", "timestamp", date, "2026-09-07 10:11:12.345"],
+  ["epoch Date -> timestamptz", "timestamptz", new Date(0), "1970-01-01 00:00:00+00"],
+  ["[1, 2] -> jsonb", "jsonb", [1, 2], "[1, 2]"],
+  ["{a: 1} -> jsonb", "jsonb", { a: 1 }, '{"a": 1}'],
+  ["Date -> json", "json", date, '"2026-09-07T10:11:12.345Z"'],
+  ["123n -> int8", "int8", 123n, "123"],
+  ['"7" -> int4', "int4", "7", "7"],
+  ['"1.5" -> float4', "float4", "1.5", "1.5"],
+  ['"07:08:09" -> time', "time", "07:08:09", "07:08:09"],
+  ['"t" -> bool', "bool", "t", "true"],
+  ["null -> int4", "int4", null, null],
+  ["undefined -> timestamptz", "timestamptz", undefined, null],
+];
+
+const columns: Record<string, string> = {
+  "float4": "c_float4",
+  "numeric": "c_numeric",
+  "time": "c_time",
+  "int4[]": "c_int4_array",
+  "float4[]": "c_float4_array",
+  "bool": "c_bool",
+  "bytea": "c_bytea",
+  "int4": "c_int4",
+  "float8": "c_float8",
+  "timestamptz": "c_timestamptz",
+  "timestamp": "c_timestamp",
+  "jsonb": "c_jsonb",
+  "json": "c_json",
+  "int8": "c_int8",
+};
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  let sql: SQL;
+
+  beforeAll(async () => {
+    await container.ready;
+    sql = new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+    await sql`set time zone 'UTC'`;
+    await sql.unsafe(
+      `create temp table bind_format (${Object.entries(columns)
+        .map(([type, name]) => `${name} ${type}`)
+        .join(", ")})`,
+    );
+  });
+
+  afterAll(() => sql?.close());
+
+  async function run(cases: Case[]) {
+    const actual: Case[] = [];
+    for (const [label, column, value] of cases) {
+      const name = columns[column];
+      const stored = await sql
+        .unsafe(`insert into bind_format (${name}) values ($1) returning ${name}::text as v`, [value])
+        .then(
+          rows => rows[0].v,
+          error => error?.errno ?? String(error),
+        );
+      actual.push([label, column, value, stored]);
+    }
+    return actual;
+  }
+
+  test("parameters of a type with no binary encoder are bound as text", async () => {
+    expect(await run(noBinaryEncoder)).toEqual(noBinaryEncoder);
+  });
+
+  test("a binary encoder is used only for the JS class it encodes exactly", async () => {
+    expect(await run(classMismatch)).toEqual(classMismatch);
+  });
+
+  test("values of the matching class keep their binary encoding", async () => {
+    expect(await run(exactClass)).toEqual(exactClass);
+  });
+});

--- a/test/js/sql/postgres-bind-parameter-format.test.ts
+++ b/test/js/sql/postgres-bind-parameter-format.test.ts
@@ -197,13 +197,22 @@ const noBinaryEncoder: Case[] = [
   ["array-literal object -> float4[]", "float4[]", pgArray, "{1.5,2}"],
 ];
 
+// The value's `String()` form is what the server judges, so `[0]` is `false`
+// and an object whose toString() is a boolean literal is accepted. `valueOf()`
+// is not consulted. Before, ToBoolean / ToInt32 ran: every row stored `true`,
+// a wrapped integer or the valueOf() result.
 const classMismatch: Case[] = [
   ["Date -> bool", "bool", date, "22P02"],
   ["{} -> bool", "bool", {}, "22P02"],
   ["[1, 2] -> bool", "bool", [1, 2], "22P02"],
+  ["function -> bool", "bool", () => false, "22P02"],
+  ["[true] -> bool", "bool", [true], "true"],
+  ["[0] -> bool", "bool", [0], "false"],
+  ["'yes' object -> bool", "bool", { toString: () => "yes" }, "true"],
   ["Date -> int4", "int4", date, "22P02"],
   ["[1, 2] -> int4", "int4", [1, 2], "22P02"],
   ["{} -> int4", "int4", {}, "22P02"],
+  ["valueOf() object -> int4", "int4", { valueOf: () => 5 }, "22P02"],
   ["Date -> float8", "float8", date, "22P02"],
   ["[1, 2] -> float8", "float8", [1, 2], "22P02"],
   ["{} -> float8", "float8", {}, "22P02"],

--- a/test/js/sql/postgres-date-param-text.test.ts
+++ b/test/js/sql/postgres-date-param-text.test.ts
@@ -1,0 +1,93 @@
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+// A JS Date bound to a parameter that Bun sends in Postgres' text format must
+// go out as ISO-8601 (`toISOString()`), not as `Date.prototype.toString()`
+// output ("Mon May 06 2024 07:08:09 GMT+0000 (Coordinated Universal Time)").
+// With the default `prepare: true` the server reports the parameter type before
+// Bind is written: `timestamp`/`timestamptz` are then bound in binary and were
+// already correct, but `date` (and `text`, domains, ...) are bound as text and
+// the server rejected the toString() form with 22007.
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const options = (extra: Partial<Bun.SQL.PostgresOrMySQLOptions> = {}): Bun.SQL.PostgresOrMySQLOptions => ({
+    db: "bun_sql_test",
+    username: "bun_sql_test",
+    host: container.host,
+    port: container.port,
+    max: 1,
+    ...extra,
+  });
+
+  const date = new Date("2024-05-06T07:08:09.123Z");
+
+  test("Date bound to a date parameter", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    // First run prepares the statement (Parse/Describe, then Bind with the
+    // described types); the second run binds against the cached statement.
+    for (let i = 0; i < 2; i++) {
+      const [row] = await sql`SELECT ${date}::date AS d, (${date}::date)::text AS t`;
+      expect(row).toEqual({ d: new Date("2024-05-06T00:00:00.000Z"), t: "2024-05-06" });
+    }
+  });
+
+  test("Date inserted into a date column through every parameter path", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    await sql`CREATE TEMP TABLE date_param (id int, d date)`;
+    await sql`INSERT INTO date_param (id, d) VALUES (1, ${date})`;
+    await sql`INSERT INTO date_param ${sql({ id: 2, d: date })}`;
+    await sql.unsafe(`INSERT INTO date_param (id, d) VALUES (3, $1)`, [date]);
+    expect(await sql`SELECT id, d::text AS d FROM date_param ORDER BY id`).toEqual([
+      { id: 1, d: "2024-05-06" },
+      { id: 2, d: "2024-05-06" },
+      { id: 3, d: "2024-05-06" },
+    ]);
+  });
+
+  test("the calendar date is taken in UTC, whatever the session time zone", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    await sql`SET TIME ZONE 'Pacific/Kiritimati'`; // UTC+14
+    const late = new Date("2024-05-06T23:30:00.000Z");
+    const [row] = await sql`SELECT (${late}::date)::text AS d`;
+    expect(row.d).toBe("2024-05-06");
+    // and a decoded date column value round-trips to the same day
+    const [{ decoded }] = await sql`SELECT '2024-02-29'::date AS decoded`;
+    const [{ again }] = await sql`SELECT (${decoded}::date)::text AS again`;
+    expect(again).toBe("2024-02-29");
+  });
+
+  test("Date bound to a text parameter is its ISO string", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    const [row] = await sql`SELECT ${date}::text AS t`;
+    expect(row.t).toBe("2024-05-06T07:08:09.123Z");
+  });
+
+  test("an invalid Date is left for the server to reject", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    const err = await sql`SELECT ${new Date(NaN)}::date AS d`.catch(e => e);
+    expect(err).toBeInstanceOf(SQL.PostgresError);
+    expect(err.errno).toBe("22007");
+    expect(err.message).toBe('invalid input syntax for type date: "Invalid Date"');
+  });
+
+  test("timestamptz and timestamp parameters are unaffected", async () => {
+    await container.ready;
+    await using sql = new SQL(options());
+    const [row] =
+      await sql`SELECT ${date}::timestamptz AS tz, ${date}::timestamp AS ts, ${"2024-05-06 07:08:09.123+00"}::timestamptz AS s`;
+    expect(row).toEqual({ tz: date, ts: date, s: date });
+  });
+
+  test("prepare: false binds a Date the same way", async () => {
+    await container.ready;
+    await using sql = new SQL(options({ prepare: false }));
+    const [row] = await sql`SELECT (${date}::date)::text AS d, ${date}::timestamptz AS tz, ${date}::text AS t`;
+    expect(row).toEqual({ d: "2024-05-06", tz: date, t: "2024-05-06T07:08:09.123Z" });
+  });
+});

--- a/test/js/sql/wire-frames.test.ts
+++ b/test/js/sql/wire-frames.test.ts
@@ -18,11 +18,43 @@ import {
   pgCopyDone,
   pgCopyOutResponse,
   pgDataRow,
+  pgDecodeBind,
   pgErrorResponse,
   pgMinimalReadyServer,
   pgReadyForQuery,
   pgRowDescription,
 } from "./wire-frames";
+
+test("pgDecodeBind decodes a §55.7 Bind body", () => {
+  // portal "", statement "S1", 2 format codes [1, 0], 2 params (4-byte int4 7, NULL), 1 result format [1]
+  const body = Buffer.from(
+    "\x00S1\x00" +
+      "\x00\x02\x00\x01\x00\x00" +
+      "\x00\x02" +
+      "\x00\x00\x00\x04\x00\x00\x00\x07" +
+      "\xff\xff\xff\xff" +
+      "\x00\x01\x00\x01",
+    "binary",
+  );
+  expect(pgDecodeBind(body)).toEqual({
+    portal: "",
+    statement: "S1",
+    paramFormats: [1, 0],
+    params: [Buffer.from([0, 0, 0, 7]), null],
+    resultFormats: [1],
+  });
+  // 0 format codes means "all text"; 1 code applies to every parameter.
+  const none = Buffer.from(
+    "\x00\x00" + "\x00\x00" + "\x00\x02" + "\x00\x00\x00\x01a\x00\x00\x00\x01b" + "\x00\x00",
+    "binary",
+  );
+  expect(pgDecodeBind(none).paramFormats).toEqual([0, 0]);
+  const one = Buffer.from(
+    "\x00\x00" + "\x00\x01\x00\x01" + "\x00\x02" + "\x00\x00\x00\x01a\x00\x00\x00\x01b" + "\x00\x00",
+    "binary",
+  );
+  expect(pgDecodeBind(one).paramFormats).toEqual([1, 1]);
+});
 
 test("mysqlLenencInt encodes per page_protocol_basic_dt_integers.html", () => {
   expect(mysqlLenencInt(0)).toEqual(Buffer.from([0x00]));

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -231,6 +231,59 @@ export function pgParameterDescription(typeOids: number[]): Buffer {
   return pgRaw("t", body);
 }
 
+// PostgreSQL FE/BE protocol §55.7 NoData: Byte1('n') Int32(4)
+export function pgNoData(): Buffer {
+  return pgRaw("n", Buffer.alloc(0));
+}
+
+export type PgBind = {
+  portal: string;
+  statement: string;
+  /** One per parameter (expanded if the client sent 0 or 1 codes). 0 = text, 1 = binary. */
+  paramFormats: number[];
+  params: (Buffer | null)[];
+  resultFormats: number[];
+};
+
+// PostgreSQL FE/BE protocol §55.7 Bind (frontend): String(portal) String(statement)
+//   Int16(nFormats) Int16[nFormats] Int16(nParams) per param: Int32(len | -1) Byte[len]
+//   Int16(nResultFormats) Int16[nResultFormats]
+// `body` is the message without the type byte and length, as pgReadFrontendMessages hands it out.
+export function pgDecodeBind(body: Buffer): PgBind {
+  let o = 0;
+  const cstring = () => {
+    const end = body.indexOf(0, o);
+    const s = body.toString("utf8", o, end);
+    o = end + 1;
+    return s;
+  };
+  const int16 = () => {
+    const v = body.readInt16BE(o);
+    o += 2;
+    return v;
+  };
+  const portal = cstring();
+  const statement = cstring();
+  const formats: number[] = [];
+  for (let n = int16(), i = 0; i < n; i++) formats.push(int16());
+  const params: (Buffer | null)[] = [];
+  for (let n = int16(), i = 0; i < n; i++) {
+    const len = body.readInt32BE(o);
+    o += 4;
+    if (len === -1) {
+      params.push(null);
+    } else {
+      params.push(Buffer.from(body.subarray(o, o + len)));
+      o += len;
+    }
+  }
+  const resultFormats: number[] = [];
+  for (let n = int16(), i = 0; i < n; i++) resultFormats.push(int16());
+  const paramFormats =
+    formats.length === params.length ? formats : params.map(() => (formats.length === 1 ? formats[0] : 0));
+  return { portal, statement, paramFormats, params, resultFormats };
+}
+
 /**
  * Drain complete PostgreSQL frontend messages from `buffered`, calling
  * onMessage(type, body) for each; returns the leftover bytes. The very first


### PR DESCRIPTION
### Problem
- `write_bind` (`src/sql_jsc/postgres/PostgresRequest.rs`) took each Bind format code from the decode list `Tag::is_binary_format_supported()`, but has binary encoders only for bool, int4, float8, timestamp(tz) and bytea. A `numeric`, `float4`, `time`, `int4[]` or `float4[]` parameter was announced binary and sent as `String(value)`: `[1234]` into `float4` stored `2.5931515e-09`, `sql.array()` into `int4[]` gave 08P01 `insufficient data left in message`.
- The binary arms coerced any class: a Date into `bool` stored `true`. A Date sent as text was `String(date)`, which the server rejects (#29010). `FieldDescription::type_tag()` truncated a result column OID above 65535 to 16 bits.

### Fix
- One pass: format codes start as text, and the branch that writes binary bytes flips its own slot (`FormatCodes::set_binary`).
- One rule for a class mismatch: a binary arm runs only for the class it encodes exactly. Anything else goes as `String(value)` in text format and the server parses or rejects it (a Date into `bool` is 22P02, `[0]` is `false`). #41970 differs here with a client-side throw. A Date in text is ISO 8601. `Tag::from_oid()` is the one OID-to-`Tag` mapping.
- Supersedes #41912 and #41955, tests carried over. Verified: `test/js/sql/postgres-bind-parameter-format.test.ts` (11 of 12 fail on 1.4.3), `postgres-date-param-text.test.ts` (5 of 7), `sql.test.ts`, `sql-prepare-false`, every `postgres-*.test.ts`.

Fixes #29010

### Background
- Parse declares a type OID per parameter, or 0 so that the server infers it and reports it in ParameterDescription. Bun sends 0 for Date, array and object values.
- Bind carries a format code per parameter (0 text, 1 binary), the values, then one per result column. In text, the type's input parser runs.
- `DataCell` decodes numeric, float4, time, int4[] and float4[] from binary. Nothing encodes them.

<details><summary>Notes</summary>

- Consolidation. Three PRs reworked `write_bind` for the same bug. #41912 fixed the format code with a `ParamEncoding` enum on the two-pass structure and unified the OID-to-`Tag` mapping for result columns. #41955 sent a Date in the text arm as ISO 8601. This PR had the format-code fix, the class-exact arms and the Date change. It keeps those and takes from #41912 the `Tag::from_oid()` result-column change, the `pgDecodeBind()` / `pgNoData()` helpers in `wire-frames.ts` and the mock-server tests (commit c2ed427880), and from #41955 its test file. #41912 and #41955 are closed in favor of this PR.
- Class-exact arms: boolean for `bool`, a number that `int4` holds exactly for `int4`, number for `float8`, BufferSource for `bytea`, valid Date or non-NaN number for `timestamp(tz)`. `bytea` keeps the #41889 rejection for anything else, because bytea's text input accepts any string. Numbers, booleans, bigints and typed arrays bind as before: Bun declares their OID in Parse. Only Date, array and object values reach the changed paths.
- Result columns: a user-defined type whose OID aliases a binary-decoded builtin modulo 65536 (for example 65552 = 65536 + 16, `bool`) was requested in binary and then read as text. The mock test `a result column whose OID is above 65535 is requested and decoded as text` covers it.
- Other open PRs on this function. #41970 throws `ERR_INVALID_ARG_TYPE` for a non-boolean bound to `bool`; this PR sends it as text and the server answers 22P02 (or accepts `[true]`, `[0]`, a `toString()` of `yes`). Both stop the silent `true`. The error surface is the one contested cell and a maintainer call: if the client-side throw is wanted, it replaces the fallback of the `bool` arm here. #39452: its Date half is covered here, its JSON-for-objects half under `prepare: false` (#30221) is not. #35508: its `write_bind` hunk is superseded, its `Signature.rs` change (OID 0 for non-integer numbers) is a separate decision. #34707 / #34708 (range checks on the timestamp / int4 arms) are closed: with this PR an out-of-range number or an Invalid Date goes as text and the server rejects it (22003 / 22P02 / 22007), ±Infinity keeps mapping to DT_NOEND / DT_NOBEGIN as #35121 decided, and the partial-Bind rollback they also carried is #34732. #33579 (array literals) rebases onto the single text branch. #40944 (a string bound to `json` / `jsonb` sent verbatim instead of stringified) is unchanged by this PR and becomes a `!value.is_string()` guard on the json branch. The `any_failed()` check after the loop overlaps #40250.
- `valueOf()` is no longer consulted for `int4` / `float8` / `bool` / `timestamptz`: an object goes through `String(value)`. The re-entrancy fixtures in #38231 / #38348 trigger through `valueOf()` on an `::int4` parameter and need a `toString()` hook after this lands.
- `date::from_js` became `from_unix_ms(f64)`. Its string arm was unreachable (strings are bound as text before it) and its catch-all `Ok(0)` was the `2000-01-01`. `QueryBindingIterator::to` existed only for the second pass and is gone, so a getter in `sql(object)` bindings runs once per Bind.
- `any_failed()` is checked once after the loop. Before, it was checked only for binary-typed slots, so a swallowed getter exception with text-typed slots sent a short Bind with the exception pending.
- After any bind-time throw the partial Bind stays in the write buffer (pre-existing, #34732).
- Local `sql.test.ts` (854 tests, PostgreSQL 17, docker gate bypassed): the same 15 environment failures as bun 1.4.3 (md5 / scram roles, prepared transactions, SQL_ASCII, `pg_database` shape) plus `should not timeout in long results` and `query string memory leak test`, which hit their 10 s and 5 s limits on the debug ASAN build. Neither binds a parameter through the changed paths.
- Self-reviewed before consolidation: 6 concerns raised, 5 addressed (see the earlier revisions of this body); the sixth, a shared `Tag::from_oid`, is now in. Self-reviewed after consolidation: 11 concerns raised, 6 addressed (name #40944, close the superseded siblings, state the class-mismatch rule, pin the contested `bool` / `int4` rows, heads-up to #38231 / #38348). Not taken: splitting the result-column hunk into its own PR or widening `Tag` to 32 bits (separate refactors), a Temporal-specific arm, and reading the server-decided rows (`Invalid Date` 22007, `[1234]` into `float4`) as undesigned: they pin the text rule, not an endorsement of each outcome. #41970 stays open for the maintainer call above.

Before, bun 1.4.3 against PostgreSQL 17:

```
[1234] -> float4                       stored 2.5931515e-09
decimal object -> numeric              08P01 insufficient data left in message
sql({ ia: sql.array([1,2], "INT4") })  08P01 insufficient data left in message
Date -> time                           22008
[1.5, 2] -> float4[]                   54000 number of array dimensions (825111852) exceeds the maximum
Date -> bool                           stored true
Date -> int4                           stored 2069477209
{} -> float8                           stored NaN
[1, 2] -> timestamptz                  stored 2000-01-01 00:00:00+00
Invalid Date -> timestamptz            stored 1970-01-01 00:00:00+00
Date -> date                           22007 invalid input syntax for type date: "Mon Sep 07 2026 ..."
```

After: the text cases store the parsed value (`1234`, `1.50`, `{1,2}`, `07:08:09`, `2026-09-07`) or fail with the type's own error (22P02, 22007).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 5 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bind-parameter-format.test.ts test/js/sql/postgres-date-param-text.test.ts test/js/sql/wire-frames.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/wire-frames.test.ts:
(pass) pgDecodeBind decodes a §55.7 Bind body [14.63ms]
(pass) mysqlLenencInt encodes per page_protocol_basic_dt_integers.html [8.77ms]
(pass) pgErrorResponse encodes per §55.7 [6.07ms]
(pass) postgres: pgAuthenticationOk + pgReadyForQuery are accepted by Bun's parser [361.37ms]
(pass) postgres: COPY OUT response frames are consumed and the following result set decodes [222.11ms]
(pass) postgres: pgMinimalReadyServer satisfies connect() [29.78ms]
(pass) mysql: mysqlHandshakeV10 + mysqlOkPacket are accepted by Bun's parser [67.68ms]

test/js/sql/postgres-date-param-text.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
PostgresError: invalid input syntax for type date: "Mon May 06 2024 07:08:09 GMT+0000 (Coordinated Universal Time)"
    errno: "22007",
 severity: "ERROR",
    where: "unnamed portal parameter $1 = '...'",

... (truncated)

release without fix: 16 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/sql/wire-frames.test.ts:
(pass) pgDecodeBind decodes a §55.7 Bind body [0.28ms]
(pass) mysqlLenencInt encodes per page_protocol_basic_dt_integers.html [0.11ms]
(pass) pgErrorResponse encodes per §55.7 [0.10ms]
(pass) postgres: pgAuthenticationOk + pgReadyForQuery are accepted by Bun's parser [6.11ms]
(pass) postgres: COPY OUT response frames are consumed and the following result set decodes [3.31ms]
(pass) postgres: pgMinimalReadyServer satisfies connect() [0.57ms]
(pass) mysql: mysqlHandshakeV10 + mysqlOkPacket are accepted by Bun's parser [1.40ms]

test/js/sql/postgres-date-param-text.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
PostgresError: invalid input syntax for type date: "Mon May 06 2024 07:08:09 GMT+0000 (Coordinated Universal Time)"
    errno: "22007",
 severity: "ERROR",
    where: "unnamed portal parameter $1 = '...'",
     file: "datetime.c",
  routine: "DateTimeParseError",
     code: "ERR_POSTGRES_SERVER_ERROR"

      at wrapPostgresError (internal:sql/postgres:176:27)
      at onRejectPostgresQuery (internal:sql/postgres:204:33)
(fail) postgres > Date bound to a date p
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/postgres-bind-parameter-format.test.ts test/js/sql/postgres-date-param-text.test.ts test/js/sql/wire-frames.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/wire-frames.test.ts:
(pass) pgDecodeBind decodes a §55.7 Bind body [15.73ms]
(pass) mysqlLenencInt encodes per page_protocol_basic_dt_integers.html [8.78ms]
(pass) pgErrorResponse encodes per §55.7 [6.52ms]
(pass) postgres: pgAuthenticationOk + pgReadyForQuery are accepted by Bun's parser [364.53ms]
(pass) postgres: COPY OUT response frames are consumed and the following result set decodes [222.30ms]
(pass) postgres: pgMinimalReadyServer satisfies connect() [29.92ms]
(pass) mysql: mysqlHandshakeV10 + mysqlOkPacket are accepted by Bun's parser [69.92ms]

test/js/sql/postgres-date-param-text.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > Date bound to a date parameter [45.88ms]
(pass) postgres > Date inserted into a date column through every parameter path [64.81ms]
(pass) postgres > the calendar date is taken in UTC, what
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4a958f8c09
  features     baseline

23 deps, 131 codegen, 1172 objects in 659ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [2.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[5/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[6/1244] gen bindgenv2
[7/1244] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 16ms
[8/1244] fetch zlib
[zlib] up to date
[9/1244] fetch tinycc
[tinycc] up to date
[10/1243] 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/postgres/protocol/FieldDescription.rs      |   6 +-
 src/sql/postgres/protocol/NewWriter.rs             |  32 ++
 src/sql/postgres/types/Tag.rs                      |   8 +-
 src/sql_jsc/postgres/DataCell.rs                   |   8 +-
 src/sql_jsc/postgres/PostgresRequest.rs            | 241 ++++++-------
 src/sql_jsc/postgres/types/date.rs                 |  33 +-
 src/sql_jsc/shared/QueryBindingIterator.rs         |  11 -
 test/js/sql/postgres-bind-parameter-format.test.ts | 389 +++++++++++++++++++++
 test/js/sql/postgres-date-param-text.test.ts       |  93 +++++
 test/js/sql/wire-frames.test.ts                    |  32 ++
 test/js/sql/wire-frames.ts                         |  53 +++
 11 files changed, 725 insertions(+), 181 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/sql/postgres/protocol/FieldDescription.rs           0      0     21
src/sql/postgres/protocol/NewWriter.rs                  2      2     21
src/sql/postgres/types/Tag.rs                           1      0     21
src/sql_jsc/postgres/DataCell.rs                        0      0     21
src/sql_jsc/postgres/PostgresRequest.rs                 6     13     21
src/sql_jsc/postgres/types/date.rs                      2      4     21
src/sql_jsc/shared/QueryBindingIterator.rs              1      1     21
test/js/sql/postgres-bind-parameter-format.test.ts      1      3     19
test/js/sql/postgres-date-param-text.test.ts            1      0      6
test/js/sql/wire-frames.test.ts                         1      0      4
test/js/sql/wire-frames.ts                              0      0     21
```

</details>

<!-- robobun:evidence:end -->
