### PR TITLE
Reset cursor and mouse modes on every exit that restores termios

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -514,6 +514,8 @@ pub mod windows_stdio {
     }
 
     pub(crate) fn restore() {
+        crate::tty::reset_active_dec_modes();
+
         // SAFETY: PEB access is sound on Windows; handles are valid for process
         // lifetime. `peb()` returns a raw pointer because the OS/CRT mutate the
         // PEB out-of-band (`SetStdHandle`, …), so we must not materialize a
@@ -2831,23 +2833,21 @@ pub fn synchronized() -> Synchronized {
     Synchronized::begin()
 }
 
-pub struct Synchronized;
+/// Writes `SYNCHRONIZED_START` on `begin` and `SYNCHRONIZED_END` (plus a
+/// flush) on `end`/drop.
+pub struct Synchronized {
+    _mode: Option<crate::tty::DecModesGuard>,
+}
 
 impl Synchronized {
     pub(crate) fn begin() -> Synchronized {
-        #[cfg(unix)]
-        {
-            print(format_args!("{}", SYNCHRONIZED_START));
+        Synchronized {
+            _mode: cfg!(unix)
+                .then(|| crate::tty::DecModesGuard::set(crate::tty::dec::SYNCHRONIZED_OUTPUT)),
         }
-        Synchronized
     }
 
-    pub fn end(self) {
-        #[cfg(unix)]
-        {
-            print(format_args!("{}", SYNCHRONIZED_END));
-        }
-    }
+    pub fn end(self) {}
 }
 
 #[cfg(test)]

--- a/src/bun_core/tty.rs
+++ b/src/bun_core/tty.rs
@@ -1,4 +1,5 @@
 use core::ffi::{c_int, c_void};
+use core::sync::atomic::{AtomicU8, Ordering};
 
 /// Terminal size as reported by the tty (`struct winsize` on POSIX).
 #[repr(C)]
@@ -93,4 +94,140 @@ impl Drop for RawModeGuard {
 
 unsafe extern "C" {
     unsafe fn Bun__ttySetMode(fd: c_int, mode: c_int, state: *mut c_void, drain: c_int) -> c_int;
+}
+
+/// DEC private modes (`CSI ? Pm h` / `CSI ? Pm l`) that a CLI widget flips on
+/// stdout's terminal for its lifetime. They are terminal-emulator state, not
+/// termios, so writing the startup termios back at exit does not undo them:
+/// each one needs its inverse sequence written to the terminal.
+pub mod dec {
+    /// `?25`: text cursor hidden.
+    pub const HIDDEN_CURSOR: u8 = 1 << 0;
+    /// `?1000` + `?1006`: mouse button and wheel reporting, SGR-encoded.
+    pub const MOUSE_REPORTING: u8 = 1 << 1;
+    /// `?2026`: synchronized output (the terminal defers rendering).
+    pub const SYNCHRONIZED_OUTPUT: u8 = 1 << 2;
+}
+
+/// `(mode bit, set sequence, reset sequence)` for every [`dec`] mode.
+const DEC_MODES: [(u8, &[u8], &[u8]); 3] = [
+    (dec::HIDDEN_CURSOR, b"\x1b[?25l", b"\x1b[?25h"),
+    (
+        dec::MOUSE_REPORTING,
+        b"\x1b[?1000h\x1b[?1006h",
+        b"\x1b[?1000l\x1b[?1006l",
+    ),
+    (dec::SYNCHRONIZED_OUTPUT, b"\x1b[?2026h", b"\x1b[?2026l"),
+];
+
+/// The [`dec`] modes currently set on stdout's terminal. Atomic because
+/// [`reset_active_dec_modes`] reads it from signal context.
+static ACTIVE_DEC_MODES: AtomicU8 = AtomicU8::new(0);
+
+/// RAII guard over a set of [`dec`] modes on stdout's terminal. `set` writes
+/// the set sequences through the buffered stdout writer; `Drop` writes the
+/// reset sequences and flushes. In between, the modes are recorded in
+/// [`ACTIVE_DEC_MODES`], so an exit that never runs `Drop` (SIGINT/SIGTERM,
+/// a crash, `Global::exit`, console Ctrl+C on Windows) still resets them: see
+/// [`reset_active_dec_modes`].
+#[must_use = "the modes are reset when the guard drops"]
+pub struct DecModesGuard(u8);
+
+impl DecModesGuard {
+    pub fn set(modes: u8) -> Self {
+        ACTIVE_DEC_MODES.fetch_or(modes, Ordering::Relaxed);
+        for (bit, set, _) in DEC_MODES {
+            if modes & bit != 0 {
+                crate::output::print_bytes(set);
+            }
+        }
+        Self(modes)
+    }
+}
+
+impl Drop for DecModesGuard {
+    fn drop(&mut self) {
+        for (bit, _, reset) in DEC_MODES {
+            if self.0 & bit != 0 {
+                crate::output::print_bytes(reset);
+            }
+        }
+        // Flush before clearing the bits: until the reset bytes reach the
+        // terminal, a signal must still find the modes marked active.
+        crate::output::flush();
+        ACTIVE_DEC_MODES.fetch_and(!self.0, Ordering::Relaxed);
+    }
+}
+
+/// Writes the reset sequence of every mode in [`ACTIVE_DEC_MODES`] directly
+/// to stdout (when it is a terminal) and clears the set. Every exit path that
+/// writes the startup termios back calls this (`bun_restore_stdio()` on POSIX,
+/// `windows_stdio::restore()` on Windows). Some of those run inside a signal
+/// handler, so this is async-signal-safe: an atomic swap, a stack buffer, and
+/// `write(2)`.
+pub fn reset_active_dec_modes() {
+    let active = ACTIVE_DEC_MODES.swap(0, Ordering::Relaxed);
+    if active == 0 || !crate::output::is_stdout_tty() {
+        return;
+    }
+    let mut buf = [0u8; 64];
+    let mut len = 0;
+    for (bit, _, reset) in DEC_MODES {
+        if active & bit != 0 {
+            buf[len..len + reset.len()].copy_from_slice(reset);
+            len += reset.len();
+        }
+    }
+    write_stdout_raw(&buf[..len]);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn Bun__ttyResetActiveDecModes() {
+    reset_active_dec_modes();
+}
+
+#[cfg(unix)]
+fn write_stdout_raw(mut bytes: &[u8]) {
+    // SAFETY: plain libc calls on stack-local, fully initialized values.
+    unsafe {
+        // A background job writing to a TOSTOP terminal gets SIGTTOU, whose
+        // default action stops the process mid-exit. With it blocked the
+        // write fails with EIO instead.
+        let mut ttou: libc::sigset_t = crate::ffi::zeroed();
+        let mut old: libc::sigset_t = crate::ffi::zeroed();
+        libc::sigemptyset(&raw mut ttou);
+        libc::sigaddset(&raw mut ttou, libc::SIGTTOU);
+        libc::pthread_sigmask(libc::SIG_BLOCK, &raw const ttou, &raw mut old);
+        while !bytes.is_empty() {
+            let rc = libc::write(libc::STDOUT_FILENO, bytes.as_ptr().cast(), bytes.len());
+            if rc < 0 {
+                if crate::ffi::errno() == libc::EINTR {
+                    continue;
+                }
+                break;
+            }
+            bytes = &bytes[rc as usize..];
+        }
+        libc::pthread_sigmask(libc::SIG_SETMASK, &raw const old, core::ptr::null_mut());
+    }
+}
+
+#[cfg(windows)]
+fn write_stdout_raw(bytes: &[u8]) {
+    use crate::windows_sys as w;
+    let Some(handle) = w::GetStdHandle(w::STD_OUTPUT_HANDLE) else {
+        return;
+    };
+    let mut written: w::DWORD = 0;
+    // SAFETY: `bytes` outlives the synchronous call; `lpOverlapped` may be
+    // null for a non-OVERLAPPED handle.
+    unsafe {
+        let _ = w::kernel32::WriteFile(
+            handle,
+            bytes.as_ptr(),
+            bytes.len() as w::DWORD,
+            &raw mut written,
+            core::ptr::null_mut(),
+        );
+    }
 }

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -58,6 +58,10 @@ extern "C" fn Bun__onPosixSignal(number: i32) {
             && WATCH_MODE_KILL_SIGNAL.load(Ordering::Relaxed) != 0
             && WATCH_SIGINT_LISTENERS.load(Ordering::Acquire) == 0
         {
+            // This handler replaced `onExitSignal` (c-bindings.cpp), so it owns
+            // writing the startup termios back; `_exit` skips the atexit hook
+            // that would. Async-signal-safe (tcsetattr + write).
+            bun_core::Output::source::stdio::restore();
             // SAFETY: `_exit(2)` is async-signal-safe and takes no pointers.
             unsafe { libc::_exit(0) };
         }

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -578,6 +578,9 @@ extern "C" ssize_t pwritev2(int fd, const struct iovec* iov, int iovcnt,
 #endif
 
 extern "C" void Bun__onExit();
+// bun_core::tty: async-signal-safe; writes the inverse of any DEC private
+// modes (hidden cursor, mouse reporting, ...) a CLI widget still has set.
+extern "C" void Bun__ttyResetActiveDecModes();
 extern "C" int32_t bun_stdio_tty[3];
 #if !OS(WINDOWS)
 static termios termios_to_restore_later[3];
@@ -599,6 +602,7 @@ extern "C" void bun_restore_stdio()
 {
 
 #if !OS(WINDOWS)
+    Bun__ttyResetActiveDecModes();
 
     // Only suppress the restore when Bun is a pipeline producer (stdout is a
     // pipe, not a TTY) and it didn't touch termios itself. That's the #29592

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -83,14 +83,9 @@ impl InitCommand {
             bstr::BStr::new(label),
         );
 
-        if colors {
-            Output::print(format_args!("\x1b[?25l")); // hide cursor
-        }
-        scopeguard::defer! {
-            if colors {
-                Output::print(format_args!("\x1b[?25h")); // show cursor
-            }
-        };
+        // Hide the cursor until this returns or the process exits.
+        let _cursor =
+            colors.then(|| bun_core::tty::DecModesGuard::set(bun_core::tty::dec::HIDDEN_CURSOR));
 
         let mut selected: C = C::DEFAULT;
         let mut initial_draw = true;

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -1326,19 +1326,13 @@ impl UpdateInteractiveCommand {
         Output::print(format_args!("\x1B[1A\x1B[2K")); // Move up one line and clear it too
         Output::flush();
 
-        // Enable mouse tracking for scrolling (if terminal supports it)
-        if colors {
-            Output::print(format_args!("\x1b[?25l")); // hide cursor
-            Output::print(format_args!("\x1b[?1000h")); // Enable basic mouse tracking
-            Output::print(format_args!("\x1b[?1006h")); // Enable SGR extended mouse mode
-        }
-        scopeguard::defer! {
-            if colors {
-                Output::print(format_args!("\x1b[?25h")); // show cursor
-                Output::print(format_args!("\x1b[?1000l")); // Disable mouse tracking
-                Output::print(format_args!("\x1b[?1006l")); // Disable SGR extended mouse mode
-            }
-        }
+        // Hide the cursor and enable mouse reporting (for wheel scrolling)
+        // until this returns or the process exits.
+        let _modes = colors.then(|| {
+            bun_core::tty::DecModesGuard::set(
+                bun_core::tty::dec::HIDDEN_CURSOR | bun_core::tty::dec::MOUSE_REPORTING,
+            )
+        });
 
         let mut initial_draw = true;
         let mut reprint_menu = true;

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -137,6 +137,50 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, "package.json"))).toBe(false);
   });
 
+  // The template menu hides the cursor while it is up. A signal exit writes
+  // the startup termios back but the hidden cursor is terminal state, not
+  // termios: the exit path has to write `CSI ? 25 h` itself.
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    test.skipIf(isWindows)(`bun init shows the cursor again when ${signal} ends the template menu`, async () => {
+      await using temp = tempDir("bun-init-" + signal.toLowerCase(), {});
+
+      const decoder = new TextDecoder();
+      let output = "";
+      const hidden = Promise.withResolvers<void>();
+      const closed = Promise.withResolvers<void>();
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "init"],
+        cwd: String(temp),
+        // Colors on (the tty default), otherwise the menu leaves the cursor alone.
+        env: { ...initEnv, NO_COLOR: undefined },
+        terminal: {
+          cols: 80,
+          rows: 24,
+          data(_, chunk: Uint8Array) {
+            output += decoder.decode(chunk, { stream: true });
+            if (output.includes("\x1b[?25l")) hidden.resolve();
+          },
+          exit() {
+            closed.resolve();
+          },
+        },
+      });
+      const exitedEarly = proc.exited.then(code => {
+        throw new Error(`bun init exited before the menu (code ${code}):\n${output}`);
+      });
+      exitedEarly.catch(() => {});
+      await Promise.race([hidden.promise, exitedEarly]);
+
+      proc.kill(signal);
+      await proc.exited;
+      await closed.promise;
+
+      expect(output.slice(output.lastIndexOf("\x1b[?25l"))).toContain("\x1b[?25h");
+      expect(proc.signalCode).toBe(signal);
+      expect(fs.existsSync(path.join(temp, "package.json"))).toBe(false);
+    });
+  }
+
   test("bun init in folder", async () => {
     await using temp = tempDir("bun-init-in-folder", {
       "mydir": {

--- a/test/cli/update_interactive_formatting.test.ts
+++ b/test/cli/update_interactive_formatting.test.ts
@@ -234,6 +234,62 @@ describe.concurrent("bun update --interactive", () => {
     }
   });
 
+  // The picker hides the cursor and turns on SGR mouse reporting. Key-driven
+  // exits undo both, but a signal (supervisor kill, `timeout 60 bun update -i`,
+  // CI cancel) ends the process through the exit-signal handler, which only
+  // wrote termios back: the shell was left typing `^[[<0;41;12M` on every
+  // click, with no cursor.
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    it.skipIf(isWindows)(`should reset cursor and mouse modes when ${signal} ends the picker`, async () => {
+      await using dir = tempDir("update-interactive-" + signal.toLowerCase(), {
+        "bunfig.toml": bunfig(),
+        "package.json": JSON.stringify({
+          name: "test-project",
+          version: "1.0.0",
+          dependencies: { "no-deps": "1.0.0" },
+        }),
+      });
+      await install(dir);
+
+      const decoder = new TextDecoder();
+      let output = "";
+      const shown = Promise.withResolvers<void>();
+      const closed = Promise.withResolvers<void>();
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "update", "--interactive", "--latest", "--dry-run"],
+        cwd: String(dir),
+        // Colors on (the tty default), otherwise the picker sets no modes.
+        env: { ...bunEnv, NO_COLOR: undefined },
+        terminal: {
+          cols: 120,
+          rows: 30,
+          data(_, chunk: Uint8Array) {
+            output += decoder.decode(chunk, { stream: true });
+            if (output.includes("\x1b[?1006h")) shown.resolve();
+          },
+          exit() {
+            closed.resolve();
+          },
+        },
+      });
+      const exitedEarly = proc.exited.then(code => {
+        throw new Error(`bun update -i exited before the picker (code ${code}):\n${output}`);
+      });
+      exitedEarly.catch(() => {});
+      await Promise.race([shown.promise, exitedEarly]);
+
+      proc.kill(signal);
+      await proc.exited;
+      await closed.promise;
+
+      const afterShown = output.slice(output.lastIndexOf("\x1b[?1006h"));
+      expect(afterShown).toContain("\x1b[?25h");
+      expect(afterShown).toContain("\x1b[?1000l");
+      expect(afterShown).toContain("\x1b[?1006l");
+      expect(proc.signalCode).toBe(signal);
+    });
+  }
+
   it("should update packages when 'a' (select all) is used", async () => {
     await using dir = tempDir("update-interactive-select-all", {
       "bunfig.toml": bunfig(),

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -129,6 +129,49 @@ setInterval(() => {}, 1000);
   10000,
 );
 
+// `bun --watch` owns SIGINT (node parity: the watcher exits 0 on it). Its
+// handler `_exit`s from signal context, past the exit hook that writes the
+// startup termios back, so a script in raw mode (setRawMode, a keypress UI)
+// that a process group orchestrator or `kill -INT` ends left the shell with
+// `-echo -icanon -isig`.
+it.skipIf(isWindows)("--watch writes the startup termios back when SIGINT ends it", async () => {
+  using dir = tempDir("watch-sigint-termios", {
+    "raw.js": `process.stdin.setRawMode(true); console.log("RAW-ON");`,
+  });
+
+  const ICANON = process.platform === "darwin" ? 0x100 : 0x2;
+  const ECHO = 0x8;
+  const decoder = new TextDecoder();
+  let output = "";
+  const rawOn = Promise.withResolvers<void>();
+  await using terminal = new Bun.Terminal({
+    cols: 80,
+    rows: 24,
+    data(_, chunk: Uint8Array) {
+      output += decoder.decode(chunk, { stream: true });
+      if (output.includes("RAW-ON")) rawOn.resolve();
+    },
+  });
+  expect(terminal.localFlags & (ICANON | ECHO)).toBe(ICANON | ECHO);
+
+  watchee = spawn({
+    cmd: [bunExe(), "--watch", "raw.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    terminal,
+  });
+  const exitedEarly = watchee.exited.then(code => {
+    throw new Error(`watchee exited before going raw (code ${code}):\n${output}`);
+  });
+  exitedEarly.catch(() => {});
+  await Promise.race([rawOn.promise, exitedEarly]);
+  expect(terminal.localFlags & (ICANON | ECHO)).toBe(0);
+
+  watchee.kill("SIGINT");
+  expect(await watchee.exited).toBe(0);
+  expect(terminal.localFlags & (ICANON | ECHO)).toBe(ICANON | ECHO);
+});
+
 // While one thread is inside execve(2), Linux fails every clone(CLONE_FS) in
 // the process with EAGAIN until the exec has killed the other threads
 // (fs/exec.c check_unsafe_exec, kernel/fork.c copy_fs). The --watch reload


### PR DESCRIPTION
### Problem
- `bun update -i` hides the cursor and enables SGR mouse reporting (`ESC[?25l ESC[?1000h ESC[?1006h`). A SIGINT or SIGTERM sent to the pid exits through `onExitSignal` (`src/jsc/bindings/c-bindings.cpp`), which writes the startup termios back but never `ESC[?25h ESC[?1000l ESC[?1006l`. The shell then types `^[[<0;41;12M` on every click, with no cursor. Same for the `bun init` menu's `?25h`, and for a console Ctrl+C on Windows (#30890).
- `bun --watch <script>` + SIGINT calls `_exit(0)` from `Bun__onPosixSignal` (`src/jsc/PosixSignalHandle.rs:57`, since #34660). That handler replaced `onExitSignal`, so nothing wrote termios back: a watched script in raw mode left the shell `-echo -icanon -isig`.

### Fix
- `bun_core::tty::DecModesGuard` sets the modes, records them in one `AtomicU8`, resets them on drop. `reset_active_dec_modes()` writes the resets for what is still recorded with a plain `write(2)`, from inside `bun_restore_stdio()` and `windows_stdio::restore()`, the hooks every exit path already calls (the Windows console Ctrl+C handler too).
- The two pickers and `Output::synchronized()` use the guard. The `--watch` SIGINT exit calls `stdio::restore()` before `_exit(0)`.
- Verified: new pty tests in `update_interactive_formatting.test.ts`, `init/init.test.ts` and `watch/watch.test.ts` fail on 1.4.3 and pass here. The three files pass in full. Windows Ctrl+C checked by hand (Notes). Self-reviewed: 4 concerns raised, 4 addressed.

### Background
- termios is kernel tty state that `tcsetattr` restores. Cursor visibility and mouse reporting are DEC private modes: terminal emulator state that only a written `CSI ? n h/l` changes.
- `onExitSignal` is Bun's SIGINT/SIGTERM handler: restore termios, re-raise. In raw mode Ctrl-C is a byte the picker reads, so only outside signals take this path.
- `bun --watch` owns SIGINT for node parity: the watcher exits 0.

Fixes #30890. Supersedes #30891.

<details><summary>Notes</summary>

- `reset_active_dec_modes()` is async-signal-safe: an atomic swap, a 64-byte stack buffer, `write(2)` with SIGTTOU blocked (a background job on a TOSTOP terminal gets EIO instead of a stop). It only writes when stdout is a terminal, so a `FORCE_COLOR` pipe consumer never gets a blocking write from a signal handler.
- `DecModesGuard::drop` flushes before it clears the bits. Until the reset bytes reach the terminal a signal still finds the modes recorded. A reset written twice is harmless.
- Windows: the picker keeps `ENABLE_PROCESSED_INPUT`, so a console Ctrl+C raises `CTRL_C_EVENT`. `Ctrlhandler` calls `Bun__restoreWindowsStdio`, which now writes the resets with `WriteFile` before the default handler ends the process. Checked by hand on Windows Server 2019: a sibling process in the same console reads `GetConsoleCursorInfo` after `GenerateConsoleCtrlEvent` ends `bun init` at the menu. `bVisible` is true with this change and false on 1.4.3. ConPTY output cannot show this (conhost re-renders and emits its own `?25l`/`?25h`, and it does not turn a written `\x03` into `CTRL_C_EVENT`), so there is no automated Windows test.
- Relation to #30891: that PR fixed the picker case with a prompt-scoped module that installs its own `sigaction` handler (POSIX) and `SetConsoleCtrlHandler` (Windows), each with a hardcoded restore string and its own `_exit`. This change keeps one handler. The modes are data that the existing `onExitSignal` -> `bun_restore_stdio()` funnel reads, so the crash handler, `Global::exit`, `reload_process` and the Windows Ctrl handler are covered by the same line, and a new widget only has to hold a guard.
- The `--watch` hunk is an independent regression from #34660 (the watch-mode SIGINT fast exit). It rides along because it is the same class (an exit path that skips the termios restore) and uses the same call `onExitSignal` already makes from signal context.
- #41505 and #38843 edit the same `bun_restore_stdio()` / `onExitSignal` region. The overlap is textual only (adjacent lines); whichever lands second needs a one-line rebase.
- `?2026` (synchronized output): `Output::synchronized()` now records the mode per frame, so a kill in the middle of a frame also writes `ESC[?2026l`. The render loop already flushed after every frame, so the flush in the guard's drop adds no write.
- Also ran `test/js/bun/terminal/terminal-spawn.test.ts`, `update_interactive_snapshots.test.ts` and `update_interactive_install.test.ts` locally (Linux x64 debug+ASAN).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts, test/cli/update_interactive_formatting.test.ts, test/cli/init/init.test.ts

<!-- robobun:evidence:end -->