### PR TITLE
js_parser: emit TypeScript `export =` last, keep `module.exports` reads after a reassignment

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -294,6 +294,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
 
                     if !p.is_control_flow_dead && id.ref_.eql(p.module_ref) {
+                        // Earlier `module.exports` reads may already be rewritten to `exports`,
+                        // even when named exports were deoptimized by something else since.
+                        if name == b"exports"
+                            && identifier_opts.assign_target() != js_ast::AssignTarget::None
+                        {
+                            p.commonjs_module_exports_assigned_deoptimized = true;
+                        }
+
                         // Rewrite "module.require()" to "require()" for Webpack compatibility.
                         // See https://github.com/webpack/webpack/pull/7750 for more info.
                         // This also makes correctness a little easier.
@@ -301,9 +309,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             p.ignore_usage(p.module_ref);
                             return Some(p.value_for_require(name_loc));
                         } else if !p.commonjs_named_exports_deoptimized && name == b"exports" {
-                            if identifier_opts.assign_target() != js_ast::AssignTarget::None {
-                                p.commonjs_module_exports_assigned_deoptimized = true;
-                            }
 
                             // Detect if we are doing
                             //

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -309,7 +309,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             p.ignore_usage(p.module_ref);
                             return Some(p.value_for_require(name_loc));
                         } else if !p.commonjs_named_exports_deoptimized && name == b"exports" {
-
                             // Detect if we are doing
                             //
                             //  module.exports = {

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -294,8 +294,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
 
                     if !p.is_control_flow_dead && id.ref_.eql(p.module_ref) {
-                        // Earlier `module.exports` reads may already be rewritten to `exports`,
-                        // even when named exports were deoptimized by something else since.
+                        // Undoes earlier `module.exports` -> `exports` rewrites at print time.
                         if name == b"exports"
                             && identifier_opts.assign_target() != js_ast::AssignTarget::None
                         {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1014,7 +1014,6 @@ impl<'a> Parser<'a> {
             }
 
             // TypeScript emits "export = value;" as a trailing "module.exports = value;".
-            // Not `after`: the `module.exports = require()` redirect scan reads `parts`.
             let mut export_equals_parts = BumpVec::<js_ast::Part>::new_in(arena);
 
             // When tree shaking is enabled, each top-level statement is potentially a separate part.

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1013,6 +1013,13 @@ impl<'a> Parser<'a> {
                 }
             }
 
+            // TypeScript "export = value;" becomes "module.exports = value;". TypeScript
+            // moves this statement to the end when it generates code, so its part is
+            // visited in source order but placed after every other statement's part.
+            // Merged into `parts` right after the loop (not via `after`) so the
+            // `module.exports = require()` redirect scan below still sees it.
+            let mut export_equals_parts = BumpVec::<js_ast::Part>::new_in(arena);
+
             // When tree shaking is enabled, each top-level statement is potentially a separate part.
             for stmt in stmts.iter() {
                 match &stmt.data {
@@ -1111,12 +1118,18 @@ impl<'a> Parser<'a> {
                         // Advance the shared-slice cursor past this enum's scopes.
                         p.scope_order_to_visit = &p.scope_order_to_visit[enum_scope_count..];
                     }
+                    js_ast::StmtData::SExportEquals(_) => {
+                        let sliced = arena.alloc_slice_copy(&[*stmt]);
+                        p.append_part(&mut export_equals_parts, sliced)?;
+                    }
                     _ => {
                         let sliced = arena.alloc_slice_copy(&[*stmt]);
                         p.append_part(&mut parts, sliced)?;
                     }
                 }
             }
+
+            parts.append(&mut export_equals_parts);
         }
 
         visit_tracer.end();

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1013,11 +1013,8 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            // TypeScript "export = value;" becomes "module.exports = value;". TypeScript
-            // moves this statement to the end when it generates code, so its part is
-            // visited in source order but placed after every other statement's part.
-            // Merged into `parts` right after the loop (not via `after`) so the
-            // `module.exports = require()` redirect scan below still sees it.
+            // TypeScript emits "export = value;" as a trailing "module.exports = value;".
+            // Not `after`: the `module.exports = require()` redirect scan reads `parts`.
             let mut export_equals_parts = BumpVec::<js_ast::Part>::new_in(arena);
 
             // When tree shaking is enabled, each top-level statement is potentially a separate part.

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -158,6 +158,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::ExportEquals,
     ) -> Result<(), Error> {
         // "module.exports = value"
+        // The synthesized `module.exports` target is not visited, so apply the same
+        // deoptimizations `maybe_rewrite_property_access` applies to a hand-written
+        // assignment: other `module.exports` reads must not print as `exports`.
+        p.commonjs_module_exports_assigned_deoptimized = true;
+        p.deoptimize_common_js_named_exports();
         // Evaluate lhs before visiting the rhs
         // (`module_exports` builds via `new_expr`, `visit_expr` mutates parser state).
         let lhs = p.module_exports(stmt.loc);

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -158,9 +158,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::ExportEquals,
     ) -> Result<(), Error> {
         // "module.exports = value"
-        // The synthesized `module.exports` target is not visited, so apply the same
-        // deoptimizations `maybe_rewrite_property_access` applies to a hand-written
-        // assignment: other `module.exports` reads must not print as `exports`.
+        // The synthesized target is not visited; deoptimize as a written assignment would.
         p.commonjs_module_exports_assigned_deoptimized = true;
         p.deoptimize_common_js_named_exports();
         // Evaluate lhs before visiting the rhs

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: TypeScript `export = value` is emitted as the last statement of the module.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -779,6 +779,38 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
+  itBundled("cjs2esm/ModuleExportsRenamingAssignAfterNamedExportsDeOpt", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.cjs';
+        lib.check();
+      `,
+      "/lib.cjs": /* js */ `
+        let w = () => [typeof module.exports, module.exports === exports]; // keep as is
+        this.xyz = 123; // deoptimizes named exports before the assignment below is visited
+        module.exports = function f() {};
+        module.exports.check = () => console.log(JSON.stringify(w()));
+      `,
+    },
+    run: {
+      stdout: '["function",false]',
+    },
+  });
+  itBundled("cjs2esm/ModuleExportsRenamingTypeScriptExportEquals", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.ts';
+        lib.check();
+      `,
+      "/lib.ts": /* ts */ `
+        let w = () => [typeof module.exports, module.exports === exports]; // keep as is
+        export = { check: () => console.log(JSON.stringify(w())) };
+      `,
+    },
+    run: {
+      stdout: '["object",false]',
+    },
+  });
   itBundled("cjs2esm/ModuleExportsRenamingAssignExportsDeOpt", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -357,6 +357,56 @@ describe("bundler", () => {
       stdout: `[123,null]`,
     },
   });
+  // TypeScript emits "module.exports = value" as the last statement of the
+  // module, so reads of module.exports before the end see the original object
+  // and reads after it see the assigned value, not `exports`.
+  itBundled("ts/ExportEqualsIsMovedToEnd", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import './function.cts'
+        import './namespace.cts'
+        import './enum.cts'
+      `,
+      "/function.cts": /* ts */ `
+        const before = typeof module.exports
+        export = function handler() { return 1 }
+        console.log('function.cts:', JSON.stringify([before, typeof module.exports]))
+        queueMicrotask(() => console.log('function.cts (later):', typeof module.exports, module.exports === exports))
+      `,
+      "/namespace.cts": /* ts */ `
+        namespace N { export const x = 1 }
+        export = N
+        console.log('namespace.cts:', JSON.stringify(module.exports))
+      `,
+      "/enum.cts": /* ts */ `
+        enum E { A = 1 }
+        export = E
+        console.log('enum.cts:', JSON.stringify(module.exports))
+        enum E { B = 2 }
+      `,
+    },
+    run: {
+      stdout: `
+        function.cts: ["object","object"]
+        namespace.cts: {}
+        enum.cts: {}
+        function.cts (later): function false
+      `,
+    },
+  });
+  itBundled("ts/ExportEqualsIsMovedToEndFormatCJS", {
+    files: {
+      "/entry.cts": /* ts */ `
+        const before = typeof module.exports
+        export = function handler() { return 1 }
+        console.log(JSON.stringify([before, typeof module.exports]))
+      `,
+    },
+    format: "cjs",
+    run: {
+      stdout: `["object","object"]`,
+    },
+  });
   itBundled("ts/ExportNamespace", {
     files: {
       "/a.ts": /* ts */ `

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -195,6 +195,65 @@ describe("with statement", () => {
   });
 });
 
+// TypeScript emits "module.exports = value" as the last statement of the
+// module, so reads of module.exports before the end see the original object
+// and the final export is still the assigned value.
+describe.concurrent('TypeScript "export =" is assigned after the last statement', () => {
+  const cases: Record<string, { mod: string; expected: string }> = {
+    "function expression": {
+      mod: `
+        const before = typeof module.exports;
+        export = function handler() { return 1 };
+        console.log(JSON.stringify([before, typeof module.exports]));
+      `,
+      expected: '["object","object"]\nfunction\n',
+    },
+    "namespace": {
+      mod: `
+        namespace N { export const x = 1 }
+        export = N;
+        console.log(JSON.stringify(module.exports));
+      `,
+      expected: '{}\n{"x":1}\n',
+    },
+    "between merged enum declarations": {
+      mod: `
+        enum E { A = 1 }
+        export = E;
+        console.log(JSON.stringify(module.exports));
+        enum E { B = 2 }
+      `,
+      expected: '{}\n{"1":"A","2":"B","A":1,"B":2}\n',
+    },
+  };
+
+  for (const [name, { mod, expected }] of Object.entries(cases)) {
+    test(name, async () => {
+      using dir = tempDir("export-equals", {
+        "mod.cts": mod,
+        "main.cts": `
+          const m = require("./mod.cts");
+          console.log(typeof m === "function" ? typeof m : JSON.stringify(m));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.cts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toBe(expected);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  }
+});
+
 test("math.pow", () => {
   function foo1(foo) {
     return 10 ** (foo / 20);


### PR DESCRIPTION
### Problem
- `bun run x.cts` and bundled `bun build` assigned TypeScript `export = value` to `module.exports` in place. tsc, esbuild, `bun build --no-bundle` and `Bun.Transpiler` emit `module.exports = value` as the last statement. A read of `module.exports` after that line saw a different object per lane.
- Cause: the tree-shaking path in `_parse` (`src/js_parser/parse/parse_entry.rs:1022`) makes each top-level statement its own part and had no `SExportEquals` arm. The move-to-end in `visit_stmts` (`src/js_parser/visit/mod.rs:1556`) then reorders inside a one-statement part only. `bun run` and the bundler take that path.
- Related: in ESM bundles, earlier `module.exports` reads printed as `exports`, which is stale after a reassignment. `s_export_equals` never recorded the assignment. A hand-written `module.exports = value` recorded it only while named exports were optimizable (`src/js_parser/fold.rs:296`).

### Fix
- Append `export =` parts after every other part, like esbuild's `after` list. They are still visited in source order.
- Record a `module.exports` assignment unconditionally. `s_export_equals` applies the same deoptimization as a hand-written assignment.
- Bump the runtime transpiler cache version: output changes for the same input.
- Verified: `esbuild/ts.test.ts` (`ts/ExportEqualsIsMovedToEnd*`), `runtime-transpiler.test.ts`, `bundler_cjs2esm.test.ts` (`ModuleExportsRenaming*`), all failing on stock bun. Self-reviewed: 3 concerns raised, 3 addressed.

### Background
- `export = value` is TypeScript's CommonJS export form. tsc lowers it to `module.exports = value;` after every other statement.
- With `tree_shaking` off (`--no-bundle`, `Bun.Transpiler`) all top-level statements form one part. With it on each statement is its own part.
- When bundling to ESM, the parser rewrites `module.exports` reads to `E::Special::ModuleExports`. The printer emits `exports` for it unless the file assigned `module.exports`.

<details><summary>Notes</summary>

Found by differential testing of generated `.cts` programs against tsc and esbuild. No user report.

Repro (stock bun 1.4.3-canary):

```ts
// x.cts
const before = typeof module.exports;
export = function handler() { return 1 };
console.log(JSON.stringify([before, typeof module.exports]));
```

- `bun x.cts`, `bun build --target=node --format=cjs x.cts`: `["object","function"]`
- tsc (module CommonJS) + node, esbuild `--format=cjs`, `bun build --no-bundle x.cts`, `Bun.Transpiler`: `["object","object"]`

The same happens with `export = N` (a namespace) or `export = E` between two merged `enum E` blocks. tsc-clean `export = Foo; class Foo {}` hit a TDZ `ReferenceError` when bundled.

Stale `exports` reads, ESM bundle of a non-entry file:

```ts
// lib.cts
export = function handler() { return 1 };
queueMicrotask(() => console.log(typeof module.exports)); // printed `typeof exports` -> "object"
```

```js
// lib.cjs
const get = () => module.exports;
this;                               // deoptimizes named exports first
module.exports = function f() {};
console.log(get() === module.exports, typeof get()); // node: true function, bundled: false object
```

The new `export_equals_parts` list is merged into `parts` right after the statement loop instead of through the pre-existing `after` list, which merges at the very end of `_parse`. The `module.exports = require(...)` redirect and the `module.exports = ns` to `export *` conversion scan `parts` only, so a file whose only statement is `export = require("./lib")` keeps the redirect.

`append_part` does not depend on the destination list, and nothing else pushes to `parts` between the loop and the final merge, so the resulting order is the same as esbuild's.

Other suites run: all of `test/bundler/esbuild/ts.test.ts`, `bundler_cjs2esm.test.ts`, `bundler_cjs.test.ts`, `bundler_edgecase.test.ts`, `transpiler/transpiler.test.js`, `extra.test.ts -t CommonJSSymbol`, `default.test.ts -t ThisWithES6Syntax`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/runtime-transpiler.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_
... (truncated)

release without fix: 7 failed, 16 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [27.11ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [13.46ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [18.79ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [15.09ms]
(pass) bundler > cjs2esm/ExportsFunction [22.62ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [12.38ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [21.02ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [14.43ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [14.27ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [17.14ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [18.48ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [17.89ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [31.15ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [18.69ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [26.14ms]
(pass) bundler > cjs2esm/Unwrap
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 16 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/runtime-transpiler.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [766.84ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [410.09ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [381.12ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [331.01ms]
(pass) bundler > cjs2esm/ExportsFunction [336.89ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [353.62ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [332.34ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [456.32ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [471.49ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [404.19ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [374.41ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduct
... (truncated)

release with fix: 16 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 683ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/fold.rs                              | 11 ++--
 src/js_parser/parse/parse_entry.rs                 |  9 ++++
 src/js_parser/visit/visit_stmt.rs                  |  3 ++
 src/jsc/RuntimeTranspilerCache.rs                  |  3 +-
 test/bundler/bundler_cjs2esm.test.ts               | 32 ++++++++++++
 test/bundler/esbuild/ts.test.ts                    | 50 ++++++++++++++++++
 test/bundler/transpiler/runtime-transpiler.test.ts | 59 ++++++++++++++++++++++
 7 files changed, 162 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js_parser/fold.rs                                   3      3     16
src/js_parser/parse/parse_entry.rs                      8      5     16
src/js_parser/visit/visit_stmt.rs                       3      2     16
src/jsc/RuntimeTranspilerCache.rs                       1      1     16
test/bundler/bundler_cjs2esm.test.ts                    1      1      5
test/bundler/esbuild/ts.test.ts                         2      3      9
test/bundler/transpiler/runtime-transpiler.test.ts      1      1      6
```

</details>

<!-- robobun:evidence:end -->