### PR TITLE
bundler: do not emit a node polyfill as a --target=browser entry point

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -426,13 +426,13 @@ impl<'a> Transpiler<'a> {
             entry_point,
             bun_ast::ImportKind::EntryPointBuild,
         ) {
-            Ok(r) if !r.flags.is_external() => return Ok(r),
             // A data: URL whose MIME type is not code; there is no module in it.
-            Ok(r) if r.path_pair.primary.is_data_url() => {
+            Ok(r) if r.flags.is_external() && r.path_pair.primary.is_data_url() => {
                 Err(resolver::Error::ModuleNotFound.into())
             }
-            // A builtin. `reject_unbundleable_entry_point` reports it unless the name is also a file.
-            Ok(builtin) => Ok(builtin),
+            // `reject_unbundleable_entry_point` reports a builtin unless the name is also a file.
+            Ok(builtin) if Self::entry_point_is_builtin(&builtin) => Ok(builtin),
+            Ok(r) => return Ok(r),
             Err(err) => Err(err.into()),
         };
 
@@ -451,13 +451,23 @@ impl<'a> Transpiler<'a> {
                 &prefixed,
                 bun_ast::ImportKind::EntryPointBuild,
             ) {
-                if !r.flags.is_external() {
+                if !Self::entry_point_is_builtin(&r) {
                     return Ok(r);
                 }
             }
             // return the original result
         }
         first
+    }
+
+    /// `--external` skips entry points, so an external result is a builtin that `--target=bun/node`
+    /// keeps as an import. `--target=browser` resolves a builtin to its polyfill, or to a disabled
+    /// stub when it has none. A Bake framework module shares the "node" namespace and is bundled.
+    fn entry_point_is_builtin(resolved: &resolver::Result) -> bool {
+        let path = &resolved.path_pair.primary;
+        resolved.flags.is_external()
+            || (path.namespace == b"node"
+                && (path.is_disabled || path.text.starts_with(NodeFallbackModules::IMPORT_PATH)))
     }
 
     /// Resolve an entry-point specifier, busting the directory cache and
@@ -538,23 +548,15 @@ impl<'a> Transpiler<'a> {
         }
     }
 
-    /// A disabled module imports as `{}` and an external one stays an import. An entry point has
-    /// nothing to emit in either case. `--external` skips entry points, so external means builtin.
+    /// An entry point is bundled from the user's own source. A builtin has none: it stays an import
+    /// or becomes Bun's polyfill or stub (see `entry_point_is_builtin`). A module that a "browser"
+    /// map disabled imports as `{}` and has nothing to emit either.
     fn reject_unbundleable_entry_point(
         &self,
         resolved: resolver::Result,
         entry_point: &[u8],
     ) -> crate::Result<resolver::Result> {
-        let is_builtin = if resolved.flags.is_external() {
-            true
-        } else if resolved.path_const().is_some() {
-            return Ok(resolved);
-        } else {
-            // Stubbed builtins carry the "node" namespace; anything else came from a "browser" map.
-            resolved.path_pair.primary.namespace == b"node"
-        };
-
-        if is_builtin {
+        if Self::entry_point_is_builtin(&resolved) {
             self.log_mut().add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,
@@ -563,6 +565,8 @@ impl<'a> Transpiler<'a> {
                     bstr::BStr::new(entry_point)
                 ),
             );
+        } else if resolved.path_const().is_some() {
+            return Ok(resolved);
         } else {
             self.log_mut().add_error_fmt(
                 None,

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -502,6 +502,67 @@ describe("bundler", () => {
       ],
     },
   });
+  itBundled("browser/EntryPointIsNodeBuiltinPolyfilledForBrowser", {
+    // "util" has a browser polyfill. The polyfill replaces an import of the
+    // builtin. It is not something to emit as the entry point itself.
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: {},
+    entryPointsRaw: ["util", "node:util"],
+    target: "browser",
+    bundleErrors: {
+      "<bun>": [
+        `Cannot use "util" as an entry point: it resolves to a builtin module`,
+        `Cannot use "node:util" as an entry point: it resolves to a builtin module`,
+      ],
+    },
+  });
+  // A bare entry point named like a builtin is retried as "./<name>" first, as
+  // it is under --target=bun (edgecase/EntryPointNamedLikeBuiltinIsALocalFile).
+  itBundled("browser/EntryPointNamedLikePolyfilledBuiltinIsALocalFile", {
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: {
+      "/util.ts": `console.log("local util");`,
+    },
+    entryPointsRaw: ["util"],
+    outfile: "/out.js",
+    target: "browser",
+    run: {
+      file: "/out.js",
+      stdout: "local util",
+    },
+  });
+  itBundled("browser/EntryPointNamedLikeStubbedBuiltinIsALocalFile", {
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: {
+      "/fs.ts": `console.log("local fs");`,
+    },
+    entryPointsRaw: ["fs"],
+    outfile: "/out.js",
+    target: "browser",
+    run: {
+      file: "/out.js",
+      stdout: "local fs",
+    },
+  });
+  // "fs/<subpath>" is stubbed like "fs" itself, so a shell-expanded `bun build fs/*.ts`
+  // from a source directory named "fs" hit the builtin error (the layout in #8009).
+  itBundled("browser/EntryPointInDirectoryNamedLikeStubbedBuiltin", {
+    skipOnEsbuild: true,
+    backend: "cli",
+    files: {
+      "/fs/read.ts": `console.log("fs/read.ts");`,
+    },
+    entryPointsRaw: ["fs/read.ts"],
+    outfile: "/out.js",
+    target: "browser",
+    run: {
+      file: "/out.js",
+      stdout: "fs/read.ts",
+    },
+  });
 
   // unsure: do we want polyfills or no-op stuff like node:* has
   // right now all error except bun:wrap which errors at resolve time, but is included if external


### PR DESCRIPTION
### Problem
- With the default `--target=browser`, `bun build util` next to a `util.ts` emits the `node:util` browser polyfill as the entry point, and `bun build fs/read.ts` from a directory named `fs` fails with `Cannot use "fs/read.ts" as an entry point: it resolves to a builtin module`. A polyfill name with no local file (`bun build events`) is emitted, not rejected. `--target=bun` gets all three right.
- Cause: `Transpiler::_resolve_entry_point` (`src/bundler/transpiler.rs:429`). Since #39811 it retries a bare builtin name as `./name`, but only for the external result of the bun and node targets. The browser target returns a polyfill as an ordinary file (`src/resolver/resolver.rs:1887`), and `fs` or `fs/*` as a disabled stub.

### Fix
- A new `entry_point_is_builtin` covers the three shapes of a builtin: external (bun, node), polyfill, and disabled stub (browser).
- Every target tries a bare builtin name as `./name` first and otherwise fails with that error. Imports do not change: only entry point resolution calls these functions.
- Verified: `test/bundler/bundler_browser.test.ts` (4 new cases, each fails on 1.4.3-canary f42e98025). Also `bundler_edgecase`, `bun-build-api`, `bundler/cli`, `worker-entry-point`, `bake/dev/production`.
- Self-reviewed: 3 concerns raised, 2 addressed, 1 (a resolver-owned builtin flag) deferred, see the notes.

### Background
- For `--target=browser` the resolver maps 23 builtin names (`src/resolver/node_fallbacks.rs`) to polyfills at `/bun-vfs$$/node_modules/<name>/index.js`, in the `node` path namespace. `fs` has no polyfill and becomes a disabled path there.
- Bake framework modules (`bun-framework-react/client.tsx`) share the `node` namespace and are real entry points of `bun build --app`. So the check cannot use the namespace alone.

<details><summary>Notes</summary>

Found by reading `_resolve_entry_point` after #39811, not from a user report. The `fs/*.ts` layout appears in #8009.

Behaviour on 1.4.3-canary f42e98025 and with this change, in a directory with `util.ts`, `fs/read.ts`, and no `events.ts`:

```sh
bun build util --outfile a.js        # before: "// node:util" polyfill, 13.5 KB   after: builds util.ts
bun build node:util                  # before: the polyfill                      after: Cannot use "node:util" as an entry point: it resolves to a builtin module
bun build events                     # before: the events polyfill, exit 0       after: the same error for "events", exit 1
bun build fs/read.ts                 # before: the builtin error                 after: builds fs/read.ts
bun build fs          (fs.ts exists) # before: the builtin error                 after: builds fs.ts (as --target=bun does)
bun build ./uses-util.ts             # imports "util": polyfill inlined, unchanged
bun build util --target=bun          # builds util.ts, unchanged
```

The polyfill exists to replace an `import "util"` inside browser code. As the entry point it carries no user code, so no target should emit it.

A bare entry point is a package path to the resolver. The `./name` retry in `_resolve_entry_point` is what lets `bun build foo` mean `./foo.ts`.

Related open PRs. #41806 makes the resolver try a bare build entry point as a relative path before a package path. That covers the cases where the local file exists, for every target, but a polyfill name with no local file would still be emitted. The two compose in either order. #41163 rewrites the disabled-stub arm of `reject_unbundleable_entry_point` around a `DisabledReason` on the resolver result. Whichever of the two lands second should leave one classifier for builtin, stub, and browser-field results, ideally a flag the resolver sets where it builds them (`resolver.rs:1153`, `:1890`, `:1911`, `:1925`) instead of the path-shape check here. #38752 routes `--no-bundle` entry points through `resolve_entry_point`, which would pick this up. #35212 touches the same resolver block for `--external` and guards it with `!kind.is_entry_point()`.

`bun-build-api.test.ts`: the two `bytecode` cases and the "thousands of times" case time out on a debug build with and without this change. `bundler/cli.test.ts`: the three `--compile` cases need `--timeout 120000` on a debug build. `test/bake/dev/production.test.ts` passes with `--timeout 60000` on the debug build (several cases take 4 to 6 s there). It exercises the Bake built-in framework modules as entry points.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_browser.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-mod
... (truncated)

release without fix: 4 failed, 2 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [43.13ms]
(pass) bundler > browser/NodeBuffer#12272 [26.14ms]
(pass) bundler > browser/NodeFS [15.66ms]
(pass) bundler > browser/NodeTTY [12.86ms]
(pass) bundler > browser/NodeEventsOnce [16.07ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [14.66ms]
(pass) bundler > browser/NodePolyfills [184.13ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [13.16ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [15.00ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [14.78ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [17.26ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [6.76ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [6.62ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldOnlyAppliesToBrowserTarget [15.84ms]
(pass) bundler > browser/EntryPointDisabledByPackageMainBrowserField [5.51ms]
(pass) bundler > browser/EntryPointIsNodeBui
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1530.14ms]
(pass) bundler > browser/NodeBuffer#12272 [897.38ms]
(pass) bundler > browser/NodeFS [382.66ms]
(pass) bundler > browser/NodeTTY [459.29ms]
(pass) bundler > browser/NodeEventsOnce [523.98ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [447.03ms]
(pass) bundler > browser/NodePolyfills [7352.24ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [510.74ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [463.19ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [399.92ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [478.56ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [330.68ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [282.26ms]
(pass) bundler > browser/EntryPointDisab
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5ea487a4af
  features     baseline

23 deps, 131 codegen, 1172 objects in 820ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[5/1244] gen ErrorCode+*.h
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 20ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch zlib
[zlib] up to date
[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] gen .bind.ts → GeneratedBindings.cpp
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/buil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs            | 38 ++++++++++++----------
 test/bundler/bundler_browser.test.ts | 61 ++++++++++++++++++++++++++++++++++++
 2 files changed, 82 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/bundler/transpiler.rs                 4      5      9
test/bundler/bundler_browser.test.ts      2      3      9
```

</details>

<!-- robobun:evidence:end -->