### PR TITLE
Worker: validate the type and credentials options as WebIDL enumerations

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -661,7 +661,9 @@ declare module "bun" {
     ref?: boolean;
 
     /**
-     * In Bun, this does nothing.
+     * `"classic"` or `"module"`. Any other value throws a `TypeError`, as in browsers.
+     *
+     * Otherwise this has no effect in Bun: every worker runs as an ES module.
      */
     type?: Bun.WorkerType | undefined;
 
@@ -683,7 +685,9 @@ declare module "bun" {
     env?: Record<string, string> | (typeof import("node:worker_threads"))["SHARE_ENV"] | undefined;
 
     /**
-     * In Bun, this does nothing.
+     * `"omit"`, `"same-origin"` or `"include"`. Any other value throws a `TypeError`, as in browsers.
+     *
+     * Otherwise this has no effect in Bun: worker scripts are not fetched with credentials.
      */
     credentials?: import("undici-types").RequestCredentials | undefined;
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -134,6 +134,22 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSWorkerPrototype, JSWorkerPrototype::Base);
 
 using JSWorkerDOMConstructor = JSDOMConstructor<JSWorker>;
 
+// A WebIDL enumeration member of WorkerOptions: absent or undefined passes, anything else must
+// stringify to one of `allowed` or a TypeError is thrown and false returned.
+static bool validateEnumerationOption(JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& throwScope, JSValue value, ASCIILiteral name, std::span<const ASCIILiteral> allowed)
+{
+    if (!value || value.isUndefined())
+        return true;
+    auto string = value.toWTFString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, false);
+    for (auto literal : allowed) {
+        if (string == literal)
+            return true;
+    }
+    Bun::ERR::INVALID_ARG_VALUE(throwScope, lexicalGlobalObject, name, "must be one of: "_s, value, allowed);
+    return false;
+}
+
 template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -183,32 +199,18 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
             }
         }
 
+        // Valid values have no further effect (every worker is an ES module, nothing is fetched with
+        // credentials). node:worker_threads has neither option and keeps ignoring them.
         if (options.kind == WorkerOptions::Kind::Web) {
-            // WebIDL: `type` is a WorkerType and `credentials` a RequestCredentials enumeration, so any
-            // other value is a TypeError. Every Bun worker runs as an ES module and nothing is fetched
-            // with credentials, so a valid value has no further effect. node:worker_threads has neither
-            // option and must keep ignoring them.
             static constexpr ASCIILiteral workerTypes[] = { "classic"_s, "module"_s };
             static constexpr ASCIILiteral requestCredentials[] = { "omit"_s, "same-origin"_s, "include"_s };
-            auto validateEnumeration = [&](JSValue value, ASCIILiteral name, std::span<const ASCIILiteral> allowed) -> bool {
-                if (!value || value.isUndefined())
-                    return true;
-                auto string = value.toWTFString(lexicalGlobalObject);
-                RETURN_IF_EXCEPTION(throwScope, false);
-                for (auto literal : allowed) {
-                    if (string == literal)
-                        return true;
-                }
-                Bun::ERR::INVALID_ARG_VALUE(throwScope, globalObject, name, "must be one of: "_s, value, allowed);
-                return false;
-            };
             auto typeValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->type);
             RETURN_IF_EXCEPTION(throwScope, {});
-            if (!validateEnumeration(typeValue, "options.type"_s, workerTypes))
+            if (!validateEnumerationOption(lexicalGlobalObject, throwScope, typeValue, "options.type"_s, workerTypes))
                 return {};
             auto credentialsValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "credentials"_s));
             RETURN_IF_EXCEPTION(throwScope, {});
-            if (!validateEnumeration(credentialsValue, "options.credentials"_s, requestCredentials))
+            if (!validateEnumerationOption(lexicalGlobalObject, throwScope, credentialsValue, "options.credentials"_s, requestCredentials))
                 return {};
         }
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -183,6 +183,35 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
             }
         }
 
+        if (options.kind == WorkerOptions::Kind::Web) {
+            // WebIDL: `type` is a WorkerType and `credentials` a RequestCredentials enumeration, so any
+            // other value is a TypeError. Every Bun worker runs as an ES module and nothing is fetched
+            // with credentials, so a valid value has no further effect. node:worker_threads has neither
+            // option and must keep ignoring them.
+            static constexpr ASCIILiteral workerTypes[] = { "classic"_s, "module"_s };
+            static constexpr ASCIILiteral requestCredentials[] = { "omit"_s, "same-origin"_s, "include"_s };
+            auto validateEnumeration = [&](JSValue value, ASCIILiteral name, std::span<const ASCIILiteral> allowed) -> bool {
+                if (!value || value.isUndefined())
+                    return true;
+                auto string = value.toWTFString(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(throwScope, false);
+                for (auto literal : allowed) {
+                    if (string == literal)
+                        return true;
+                }
+                Bun::ERR::INVALID_ARG_VALUE(throwScope, globalObject, name, "must be one of: "_s, value, allowed);
+                return false;
+            };
+            auto typeValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->type);
+            RETURN_IF_EXCEPTION(throwScope, {});
+            if (!validateEnumeration(typeValue, "options.type"_s, workerTypes))
+                return {};
+            auto credentialsValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "credentials"_s));
+            RETURN_IF_EXCEPTION(throwScope, {});
+            if (!validateEnumeration(credentialsValue, "options.credentials"_s, requestCredentials))
+                return {};
+        }
+
         auto miniModeValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "smol"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
         if (miniModeValue) {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -384,6 +384,47 @@ describe("web worker", () => {
     });
   });
 
+  // WebIDL: WorkerOptions.type is a WorkerType and .credentials a RequestCredentials enumeration, so
+  // any other value is a TypeError at construction. Valid values have no further effect in Bun.
+  describe("type and credentials options", () => {
+    test.each([
+      [{ type: "zzz" }, "options.type"],
+      [{ type: null }, "options.type"],
+      [{ type: 1 }, "options.type"],
+      [{ credentials: "zzz" }, "options.credentials"],
+    ])("new Worker(url, %j) throws a TypeError", (options, name) => {
+      let error: any;
+      try {
+        new Worker("data:text/javascript,", options as any);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeInstanceOf(TypeError);
+      expect(error.message).toStartWith(`The property '${name}' must be one of:`);
+    });
+
+    test("valid or undefined values are accepted", async () => {
+      for (const options of [
+        { type: "module" },
+        { type: "classic" },
+        { type: undefined },
+        { credentials: "omit" },
+        { credentials: "same-origin" },
+        { credentials: "include" },
+      ] satisfies WorkerOptions[]) {
+        const worker = new Worker("data:text/javascript,", options);
+        await once(worker, "close");
+      }
+    });
+
+    // node:worker_threads has neither option. Unknown keys are ignored there, as in Node.
+    test("worker_threads.Worker does not validate them", async () => {
+      const worker = new wt.Worker(new URL("data:text/javascript,"), { type: "zzz", credentials: "zzz" } as any);
+      const [code] = await once(worker, "exit");
+      expect(code).toBe(0);
+    });
+  });
+
   describe("error event", () => {
     test("is fired with a string of the error", async () => {
       const worker = new Worker("data:text/javascript,throw 5");

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -718,29 +718,34 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
-    test("terminate() while fs.readFile completions keep arriving", async () => {
-      using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `const src = \`import { readFile } from "node:fs";
+    test(
+      "terminate() while fs.readFile completions keep arriving",
+      async () => {
+        using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const src = \`import { readFile } from "node:fs";
              let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
              postMessage("busy")\`;
            const url = URL.createObjectURL(new Blob([src]));
            for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
              const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 10) })));
            console.log("PASS");`,
-          path.join(String(dir), "f.bin"),
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "inherit",
-      });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(stdout).toBe("PASS\n");
-      expect(exitCode).toBe(0);
-    });
+            path.join(String(dir), "f.bin"),
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "inherit",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).toBe("PASS\n");
+        expect(exitCode).toBe(0);
+      },
+      // 48 worker boots: a debug build on a loaded machine needs more than the default 5s.
+      isDebug ? 30_000 : 5_000,
+    );
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -718,34 +718,31 @@ describe("web worker", () => {
 
     // fs completions racing terminate(): whatever completes on the worker
     // after the request must release, not build script values under it.
-    test(
-      "terminate() while fs.readFile completions keep arriving",
-      async () => {
-        using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "-e",
-            `const src = \`import { readFile } from "node:fs";
+    test("terminate() while fs.readFile completions keep arriving", async () => {
+      using dir = tempDir("worker-readfile-churn", { "f.bin": Buffer.alloc(65536, 7) });
+      // Each round boots 4 workers; a debug build spends ~0.5s per round, so it runs fewer.
+      const rounds = isDebug ? 4 : 12;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const src = \`import { readFile } from "node:fs";
              let n = 0; (function pump(){ while (n < 16) { n++; readFile(\${JSON.stringify(process.argv[1])}, () => { n--; setImmediate(pump) }) } })();
              postMessage("busy")\`;
            const url = URL.createObjectURL(new Blob([src]));
-           for (let r = 0; r < 12; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
+           for (let r = 0; r < ${rounds}; r++) await Promise.all(Array.from({ length: 4 }, (_, i) => new Promise(res => {
              const w = new Worker(url); w.addEventListener("close", res); w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 10) })));
            console.log("PASS");`,
-            path.join(String(dir), "f.bin"),
-          ],
-          env: bunEnv,
-          stdout: "pipe",
-          stderr: "inherit",
-        });
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-        expect(stdout).toBe("PASS\n");
-        expect(exitCode).toBe(0);
-      },
-      // 48 worker boots: a debug build on a loaded machine needs more than the default 5s.
-      isDebug ? 30_000 : 5_000,
-    );
+          path.join(String(dir), "f.bin"),
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("PASS\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `new Worker(url, { type: "zzz" })` and `new Worker(url, { credentials: "zzz" })` are accepted and the worker runs. In the HTML spec both `WorkerOptions` members are WebIDL enumerations (`WorkerType`: `"classic" | "module"`, `RequestCredentials`: `"omit" | "same-origin" | "include"`), so browsers and Deno throw a `TypeError` for any other value.
- `JSWorkerDOMConstructor::construct` (`src/jsc/bindings/webcore/JSWorker.cpp`) never read either option.

### Fix
- For `WorkerOptions::Kind::Web` only, read `type` and `credentials`. A present, non-`undefined` value is converted with `ToString` (WebIDL enum conversion) and must be one of the enumeration's strings, else the constructor throws `ERR_INVALID_ARG_VALUE` (a `TypeError` whose message starts with `The property 'options.type' must be one of:`). This constructor already reports a bad `options.env` through the sibling `ERR_INVALID_ARG_TYPE`.
- `node:worker_threads` calls the same native constructor with a third argument (`Kind::Node`). Node has neither option and ignores unknown keys, so that path is untouched.
- Valid values still change nothing: every Bun worker is an ES module and no worker script is fetched with credentials. The `bun-types` JSDoc for both options said "In Bun, this does nothing" and now states the accepted values and that they are otherwise ignored.
- Verified: `test/js/web/workers/worker.test.ts` ("type and credentials options": four invalid values fail on 1.4.3, valid and `undefined` values construct, `worker_threads.Worker` ignores both). Also ran the env/argv/preload tests in that file and `bun test test/integration/bun-types/bun-types.test.ts`.

### Background
- The global `Worker` constructor is hand-written C++ rather than generated from IDL, so dictionary members get no automatic WebIDL conversion; each option is read with `getIfPropertyExists` and validated by hand.
- `WorkerOptions::Kind` is how the native side tells `new Worker()` (`Web`) from `node:worker_threads` (`Node`).

<details><summary>Notes</summary>

- From an HTML-conformance sweep of the global Worker; the script-URL `SyntaxError` (#41974) and the close code after `terminate()` (#41969) ship separately, and #41818 fixes the other Worker declarations in bun-types.
- Error shape: WebIDL only requires a `TypeError`. This uses Bun's Node-style `ERR_INVALID_ARG_VALUE` (a `TypeError` with a `code`) for consistency with the rest of this constructor; say so if a plain `TypeError` with a browser-style message is preferred.
- `null` is not treated as "absent": per WebIDL dictionary conversion only `undefined` falls back to the default, and `String(null)` is not a member of either enumeration, which matches Chrome and Firefox.

</details>
