### PR TITLE
bundler: run each HTML <script> as its own error boundary

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -555,7 +555,7 @@ Bun uses `HTMLRewriter` to scan for `<script>` and `<link>` tags in HTML files a
 - Inlines small assets in CSS files into `data:` URLs, reducing the total number of HTTP requests sent over the wire
 </Step>
 <Step title="4. HTML Rewriting">
-- Combines all `<script>` tags into a single `<script>` tag with a content-addressable hash in the URL
+- Combines all `<script>` tags into a single `<script>` tag with a content-addressable hash in the URL. The scripts run in document order. When one of them throws at the top level, Bun reports the error with `reportError()` and the next script still runs.
 - Combines all `<link>` tags into a single `<link>` tag with a content-addressable hash in the URL
 - Outputs a new HTML file
 </Step>

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -106,6 +106,10 @@ bitflags::bitflags! {
         /// chunk's namespace is `{ default: module.exports }`, so the call
         /// reads `.default` to return `module.exports`.
         const CROSS_CHUNK_REQUIRE_DEFAULT = 1 << 18;
+
+        /// The `src` of a `<script>` element in an HTML file, as opposed to a
+        /// `<link>` or an asset reference.
+        const HTML_SCRIPT_SRC = 1 << 19;
     }
 }
 

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -68,7 +68,12 @@ impl<'a> HTMLScanner<'a> {
 }
 
 impl<'a> HTMLScanner<'a> {
-    fn create_import_record(&mut self, input_path: &[u8], kind: ImportKind) -> Result<(), Error> {
+    fn create_import_record(
+        &mut self,
+        input_path: &[u8],
+        kind: ImportKind,
+        flags: ImportRecordFlags,
+    ) -> Result<(), Error> {
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
         let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
@@ -115,7 +120,7 @@ impl<'a> HTMLScanner<'a> {
             loader: None,
             source_index: AstIndex::default(),
             original_path: b"",
-            flags: ImportRecordFlags::default(),
+            flags,
         };
 
         self.import_records.push(record);
@@ -136,13 +141,18 @@ impl<'a> HTMLScanner<'a> {
 
     fn on_tag(
         &mut self,
-        _element: &mut Element<'_, '_>,
+        element: &mut Element<'_, '_>,
         path: &[u8],
         url_attribute: &[u8],
         kind: ImportKind,
     ) {
         let _ = url_attribute;
-        let _ = self.create_import_record(path, kind);
+        let flags = if element.tag_name().eq_ignore_ascii_case("script") {
+            ImportRecordFlags::HTML_SCRIPT_SRC
+        } else {
+            ImportRecordFlags::default()
+        };
+        let _ = self.create_import_record(path, kind, flags);
     }
 
     pub(crate) fn scan(&mut self, input: &[u8]) -> Result<(), Error> {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -934,13 +934,15 @@ impl<'a> LinkerContext<'a> {
                 Vec::with_capacity(parts_col.len());
             for (i, parts) in parts_col.iter().enumerate() {
                 let mut bits = bun_collections::AutoBitSet::init_empty(parts.len())?;
-                // The HTML loader's `ParseTask` builds its synthetic part 1 already
-                // live (so the JS-chunk visitor follows every embedded import record).
                 // `mark_file_live_for_tree_shaking` short-circuits for HTML and never
-                // walks its parts, so seed the bit here to preserve the old
-                // `Part::is_live = true` initializer.
-                if loaders.get(i).is_some_and(|l| *l == Loader::Html) && parts.len() > 1 {
-                    bits.set(1);
+                // walks its parts. The HTML loader's `ParseTask` builds one
+                // statement-less part per import record (so the JS-chunk visitor
+                // follows every embedded `<script src>` in document order), and all
+                // of them are live.
+                if loaders.get(i).is_some_and(|l| *l == Loader::Html) {
+                    for part_index in 1..parts.len() {
+                        bits.set(part_index);
+                    }
                 }
                 parts_live.push(bits);
             }
@@ -2311,6 +2313,65 @@ impl<'a> LinkerContext<'a> {
         }
 
         Ok(true)
+    }
+
+    /// The HTML loader gives each `<script src>` its own statement-less part
+    /// that holds only the import record. A script that resolved to a wrapped
+    /// module runs nothing until its wrapper is called, so print that call where
+    /// the tag was, like `should_remove_import_export_stmt` does for a bare
+    /// `import "./script"`: `require_foo()`, `init_foo()`, or `await init_foo()`.
+    /// Nothing observes the namespace, so the result is not passed to `__toESM`.
+    pub(crate) fn append_html_script_wrapper_calls(
+        &self,
+        stmts: &mut StmtList,
+        part: &Part,
+        ast: &JSAst<'_>,
+    ) -> Result<(), AllocError> {
+        for &import_record_index in part.import_record_indices.slice() {
+            let record = &ast.import_records[import_record_index as usize];
+            if record.kind != ImportKind::Stmt
+                || !record.source_index.is_valid()
+                || record.flags.contains(bun_ast::ImportRecordFlags::IS_UNUSED)
+            {
+                continue;
+            }
+            let other_source_index = record.source_index.get() as usize;
+            let other_flags = self.graph.meta.items_flags()[other_source_index];
+            match other_flags.wrap {
+                WrapKind::None => continue,
+                WrapKind::Cjs => {}
+                WrapKind::Esm => {
+                    if !self.graph.files_live.is_set(other_source_index) {
+                        continue;
+                    }
+                }
+            }
+            let wrapper_ref = self.graph.ast.items_wrapper_ref()[other_source_index];
+            if wrapper_ref.is_empty() {
+                continue;
+            }
+
+            let mut call = Expr::init(
+                E::Call {
+                    target: Expr::init_identifier(wrapper_ref, Loc::EMPTY),
+                    ..Default::default()
+                },
+                Loc::EMPTY,
+            );
+            if other_flags.wrap == WrapKind::Esm && other_flags.is_async_or_has_async_dependency {
+                call = Expr::init(E::Await { value: call }, Loc::EMPTY);
+            }
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(Stmt::alloc(
+                    S::SExpr {
+                        value: call,
+                        ..Default::default()
+                    },
+                    Loc::EMPTY,
+                ))?;
+        }
+        Ok(())
     }
 
     pub(crate) fn print_code_for_file_in_chunk_js(

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -928,23 +928,11 @@ impl<'a> LinkerContext<'a> {
         // Size the per-file part-liveness bitsets now that `scan_imports_and_exports`
         // has finished pushing wrapper / entry-point parts.
         {
-            let loaders = self.parse_graph().input_files.items_loader();
             let parts_col = self.graph.ast.items_parts();
             let mut parts_live: Vec<bun_collections::AutoBitSet> =
                 Vec::with_capacity(parts_col.len());
-            for (i, parts) in parts_col.iter().enumerate() {
-                let mut bits = bun_collections::AutoBitSet::init_empty(parts.len())?;
-                // `mark_file_live_for_tree_shaking` short-circuits for HTML and never
-                // walks its parts. The HTML loader's `ParseTask` builds one
-                // statement-less part per import record (so the JS-chunk visitor
-                // follows every embedded `<script src>` in document order), and all
-                // of them are live.
-                if loaders.get(i).is_some_and(|l| *l == Loader::Html) {
-                    for part_index in 1..parts.len() {
-                        bits.set(part_index);
-                    }
-                }
-                parts_live.push(bits);
+            for parts in parts_col.iter() {
+                parts_live.push(bun_collections::AutoBitSet::init_empty(parts.len())?);
             }
             self.graph.parts_live = parts_live;
         }
@@ -2321,11 +2309,16 @@ impl<'a> LinkerContext<'a> {
     /// the tag was, like `should_remove_import_export_stmt` does for a bare
     /// `import "./script"`: `require_foo()`, `init_foo()`, or `await init_foo()`.
     /// Nothing observes the namespace, so the result is not passed to `__toESM`.
+    /// On a page that isolates its scripts (`html_isolates_scripts`) the call
+    /// goes through `__script` / `__scriptAsync` instead, and a script with
+    /// top-level await is started without `await` so that it does not hold up
+    /// the next one, as in the browser.
     pub(crate) fn append_html_script_wrapper_calls(
         &self,
         stmts: &mut StmtList,
         part: &Part,
         ast: &JSAst<'_>,
+        isolate: bool,
     ) -> Result<(), AllocError> {
         for &import_record_index in part.import_record_indices.slice() {
             let record = &ast.import_records[import_record_index as usize];
@@ -2351,16 +2344,41 @@ impl<'a> LinkerContext<'a> {
                 continue;
             }
 
-            let mut call = Expr::init(
-                E::Call {
-                    target: Expr::init_identifier(wrapper_ref, Loc::EMPTY),
-                    ..Default::default()
-                },
-                Loc::EMPTY,
-            );
-            if other_flags.wrap == WrapKind::Esm && other_flags.is_async_or_has_async_dependency {
-                call = Expr::init(E::Await { value: call }, Loc::EMPTY);
-            }
+            let is_async =
+                other_flags.wrap == WrapKind::Esm && other_flags.is_async_or_has_async_dependency;
+            let wrapper = Expr::init_identifier(wrapper_ref, Loc::EMPTY);
+            let loaders = self.parse_graph().input_files.items_loader();
+            let call = if isolate && Self::is_html_script_record(record, loaders) {
+                // "__script(require_foo)" / "__scriptAsync(init_foo)"
+                let helper: &[u8] = if is_async {
+                    b"__scriptAsync"
+                } else {
+                    b"__script"
+                };
+                let mut args = bun_ast::ExprNodeList::init_capacity(1);
+                args.append_assume_capacity(wrapper);
+                Expr::init(
+                    E::Call {
+                        target: Expr::init_identifier(self.runtime_function(helper), Loc::EMPTY),
+                        args,
+                        ..Default::default()
+                    },
+                    Loc::EMPTY,
+                )
+            } else {
+                let call = Expr::init(
+                    E::Call {
+                        target: wrapper,
+                        ..Default::default()
+                    },
+                    Loc::EMPTY,
+                );
+                if is_async {
+                    Expr::init(E::Await { value: call }, Loc::EMPTY)
+                } else {
+                    call
+                }
+            };
             stmts
                 .inside_wrapper_prefix
                 .append_non_dependency(Stmt::alloc(
@@ -2372,6 +2390,26 @@ impl<'a> LinkerContext<'a> {
                 ))?;
         }
         Ok(())
+    }
+
+    /// A `<script src>` of an HTML file that the page's JS chunk bundles.
+    pub(crate) fn is_html_script_record(record: &ImportRecord, loaders: &[Loader]) -> bool {
+        record
+            .flags
+            .contains(bun_ast::ImportRecordFlags::HTML_SCRIPT_SRC)
+            && record.source_index.is_valid()
+            && loaders[record.source_index.get() as usize].is_javascript_like()
+    }
+
+    /// A page that bundles two or more scripts runs each one as its own error
+    /// boundary (see `Flags::html_script_inline`). A page with one script has
+    /// nothing after it to protect, so its output stays as it was.
+    pub(crate) fn html_isolates_scripts(records: &[ImportRecord], loaders: &[Loader]) -> bool {
+        records
+            .iter()
+            .filter(|record| Self::is_html_script_record(record, loaders))
+            .nth(1)
+            .is_some()
     }
 
     pub(crate) fn print_code_for_file_in_chunk_js(
@@ -3164,6 +3202,15 @@ impl<'a> LinkerContext<'a> {
                         ctx.worklist.push(TreeShakeWork::File(other));
                     }
                 }
+            }
+            // The HTML loader's `ParseTask` builds one statement-less part per
+            // import record. All of them are live, and their dependencies are the
+            // wrappers and runtime helpers `append_html_script_wrapper_calls` uses.
+            for part_index in 1..ctx.parts[source_index as usize].len() {
+                ctx.worklist.push(TreeShakeWork::Part {
+                    part_index: part_index as u32,
+                    source_index,
+                });
             }
             return;
         }

--- a/src/bundler/LinkerGraph.rs
+++ b/src/bundler/LinkerGraph.rs
@@ -150,6 +150,15 @@ pub mod js_meta {
         pub(crate) needs_export_symbol_from_runtime: bool,
         pub(crate) did_wrap_dependencies: bool,
         pub(crate) needs_synthetic_default_export: bool,
+        /// In the browser each `<script>` element is its own error boundary: an
+        /// uncaught error is reported and the page's next script still runs. An
+        /// unwrapped `<script src>` target of a page that bundles two or more
+        /// scripts keeps that by printing its top-level statements inside
+        /// `__script(() => { ... })` (runtime.js) where they stand, declarations
+        /// hoisted out as for a lazily initialized module, so importers and
+        /// dependencies link to it unchanged. (A wrapped target is called through
+        /// `__script` from the HTML file's part instead.)
+        pub(crate) html_script_inline: bool,
         pub(crate) wrap: WrapKind,
     }
     pub use crate::WrapKind as Wrap;

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1231,23 +1231,24 @@ pub mod parse_worker {
                 // gave up on figuring out how to fix it so that
                 // this feature could ship.
                 ast.has_lazy_export = false;
-                // Liveness for this synthetic part is seeded in
-                // `tree_shaking_and_code_splitting` (the per-part bitset
-                // does not exist at parse time).
-                ast.parts.as_mut_slice()[1] = Part {
-                    stmts: ast::StoreSlice::EMPTY,
-                    import_record_indices: {
-                        // Generate a single part that depends on all the import records.
-                        // This is to ensure that we generate a JavaScript bundle containing all the user's code.
-                        let mut import_record_indices = ast::PartImportRecordIndices::init_capacity(
-                            import_records_len as usize,
-                        );
-                        import_record_indices
-                            .extend(0..u32::try_from(import_records_len).expect("int cast"));
-                        import_record_indices
-                    },
-                    ..Default::default()
-                };
+                // One statement-less part per import record, in document order.
+                // The linker prints a part after the files it imports, so a
+                // `<script src>` that resolves to a wrapped module gets its
+                // `require_foo()` / `init_foo()` call at the tag's position
+                // (see `append_html_script_wrapper_calls`). Liveness for these
+                // parts is seeded in `tree_shaking_and_code_splitting` (the
+                // per-part bitset does not exist at parse time).
+                ast.parts.truncate(1);
+                ast.parts.reserve(import_records_len);
+                for import_record_index in 0..u32::try_from(import_records_len).expect("int cast") {
+                    let mut import_record_indices = ast::PartImportRecordIndices::init_capacity(1);
+                    import_record_indices.push(import_record_index);
+                    ast.parts.push(Part {
+                        stmts: ast::StoreSlice::EMPTY,
+                        import_record_indices,
+                        ..Default::default()
+                    });
+                }
 
                 // Try to avoid generating unnecessary ESM <> CJS wrapper code.
                 if output_format == js_parser::options::Format::Esm

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1235,9 +1235,9 @@ pub mod parse_worker {
                 // The linker prints a part after the files it imports, so a
                 // `<script src>` that resolves to a wrapped module gets its
                 // `require_foo()` / `init_foo()` call at the tag's position
-                // (see `append_html_script_wrapper_calls`). Liveness for these
-                // parts is seeded in `tree_shaking_and_code_splitting` (the
-                // per-part bitset does not exist at parse time).
+                // (see `append_html_script_wrapper_calls`). `mark_file_live_step`
+                // marks these parts live (the per-part bitset does not exist at
+                // parse time).
                 ast.parts.truncate(1);
                 ast.parts.reserve(import_records_len);
                 for import_record_index in 0..u32::try_from(import_records_len).expect("int cast") {

--- a/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
+++ b/src/bundler/linker_context/findAllImportedPartsInJSOrder.rs
@@ -354,11 +354,18 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
 
                         // CommonJS files are all-or-nothing so all parts must be contiguous
                         if !can_be_split {
-                            self.parts_prefix.push(PartRange {
+                            let range = PartRange {
                                 source_index: Index::init(source_index),
                                 part_index_begin: 0,
                                 part_index_end: self.parts[source_index as usize].len() as u32,
-                            });
+                            };
+                            if self.flags[source_index as usize].html_script_inline {
+                                // Not wrapped: it runs here, after the files it imports,
+                                // as one `__script(() => {})` closure.
+                                self.part_ranges.push(range);
+                            } else {
+                                self.parts_prefix.push(range);
+                            }
                         }
                     } else {
                         // Post-order, like the files above: another chunk's
@@ -397,8 +404,10 @@ impl<'a, 'ctx> FindImportedPartsVisitor<'a, 'ctx> {
                         )
                     };
 
-                    // Wrapped files can't be split because they are all inside the wrapper
-                    let can_be_split = self.flags[source_index as usize].wrap == Wrap::None;
+                    // Wrapped files can't be split because they are all inside the wrapper,
+                    // and neither can an inline HTML script (one `__script` closure).
+                    let can_be_split = self.flags[source_index as usize].wrap == Wrap::None
+                        && !self.flags[source_index as usize].html_script_inline;
 
                     let parts = self.parts[source_index as usize].as_slice();
                     let parts_live = &self.c.graph.parts_live[source_index as usize];

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -10,7 +10,7 @@ use bun_js_printer::{self as js_printer, PrintResult, PrintResultSuccess};
 use crate::analyze_transpiled_module::ModuleInfo;
 use crate::generic_path_with_pretty_initialized;
 use crate::linker_context_mod::{StmtList, StmtListWhich};
-use crate::options::Format as OutputFormat;
+use crate::options::{Format as OutputFormat, Loader};
 use crate::{Chunk, Index, LinkerContext, Part, PartRange, WrapKind};
 
 use bun_ast::StoreRef;
@@ -237,6 +237,8 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
     let namespace_export_part_index = bun_ast::NAMESPACE_EXPORT_PART_INDEX;
 
+    let is_html = c.parse_graph().input_files.items_loader()[source_index] == Loader::Html;
+
     stmts.reset();
 
     let part_index_for_lazy_default_export: u32 = 'brk: {
@@ -351,6 +353,13 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         if index == wrapper_part_index.get() {
             // Skip the wrapper part because we already handled it above
             needs_wrapper = true;
+            continue;
+        }
+
+        if is_html {
+            if let Err(err) = c.append_html_script_wrapper_calls(stmts, part, &ast) {
+                return PrintResult::Err(err.into());
+            }
             continue;
         }
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -65,6 +65,18 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     // stays scoped to this read view.
     let mut ast = c.graph.ast.get(source_index);
 
+    // An inline HTML script (`Flags::html_script_inline`) is unwrapped for the
+    // rest of the linker. Its statements convert the way a lazily initialized
+    // module's do (imports and declarations hoisted out, the rest inside a
+    // closure), except that the closure runs right where it stands:
+    // `__script(() => { ... })`.
+    let inline_script = flags.html_script_inline;
+    let wrap = if inline_script {
+        WrapKind::Esm
+    } else {
+        flags.wrap
+    };
+
     // For HMR, part generation is entirely special cased.
     // - export wrapping is already done.
     // - imports are split from the main code.
@@ -238,6 +250,11 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     let namespace_export_part_index = bun_ast::NAMESPACE_EXPORT_PART_INDEX;
 
     let is_html = c.parse_graph().input_files.items_loader()[source_index] == Loader::Html;
+    let isolate_html_scripts = is_html
+        && LinkerContext::html_isolates_scripts(
+            ast.import_records.as_slice(),
+            c.parse_graph().input_files.items_loader(),
+        );
 
     stmts.reset();
 
@@ -258,7 +275,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
     // The top-level directive must come first (the non-wrapped case is handled
     // by the chunk generation code, although only for the entry point)
-    if flags.wrap != WrapKind::None
+    if wrap != WrapKind::None
         && ast
             .flags
             .contains(AstFlags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
@@ -306,13 +323,13 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
             ns_part_stmts,
             chunk,
             temp_arena,
-            flags.wrap,
+            wrap,
             &ast,
         ) {
             return PrintResult::Err(err.into());
         }
 
-        match flags.wrap {
+        match wrap {
             WrapKind::Esm => {
                 // Borrowck: `append_slice` borrows `stmts` mutably while
                 // also reading from a sibling field.
@@ -357,7 +374,9 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         }
 
         if is_html {
-            if let Err(err) = c.append_html_script_wrapper_calls(stmts, part, &ast) {
+            if let Err(err) =
+                c.append_html_script_wrapper_calls(stmts, part, &ast, isolate_html_scripts)
+            {
                 return PrintResult::Err(err.into());
             }
             continue;
@@ -516,11 +535,16 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
             part_stmts,
             chunk,
             temp_arena,
-            flags.wrap,
+            wrap,
             &ast,
         ) {
             return PrintResult::Err(err.into());
         }
+    }
+
+    // There is no wrapper part to come across: the closure is emitted below.
+    if inline_script {
+        needs_wrapper = true;
     }
 
     // Hoist all import statements before any normal statements. ES6 imports
@@ -549,7 +573,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
     // Optionally wrap all statements in a closure
     if needs_wrapper {
-        match flags.wrap {
+        match wrap {
             WrapKind::Cjs => {
                 // Only include the arguments that are actually used
                 let mut args: bun_alloc::ArenaVec<'_, G::Arg> =
@@ -863,7 +887,26 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 }
 
                 let inner_len = inner_stmts.len();
-                if inner_len > 0 {
+                if inline_script {
+                    // "__script(() => { ... });"
+                    debug_assert!(!is_async); // a script with top-level await is `CallWrapper`
+                    if inner_len > 0 {
+                        let closure = Expr::init(
+                            E::Arrow {
+                                body: G::FnBody {
+                                    stmts: inner_stmts,
+                                    loc: bun_ast::Loc::EMPTY,
+                                },
+                                ..Default::default()
+                            },
+                            bun_ast::Loc::EMPTY,
+                        );
+                        stmts.append(
+                            StmtListWhich::OutsideWrapperPrefix,
+                            html_script_call(c, b"__script", closure),
+                        );
+                    }
+                } else if inner_len > 0 {
                     // See the comment in needsWrapperRef for why the symbol
                     // is sometimes not generated.
                     debug_assert!(!ast.wrapper_ref.is_empty()); // js_parser's needsWrapperRef thought wrapper was not needed
@@ -999,6 +1042,28 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         part_range.source_index,
         source,
         module_info,
+    )
+}
+
+/// `__script(arg);`: runs one `<script src>` of an HTML page as its own error
+/// boundary (see `Flags::html_script_inline`).
+fn html_script_call(c: &LinkerContext, helper: &[u8], arg: Expr) -> Stmt {
+    let loc = bun_ast::Loc::EMPTY;
+    let mut args = bun_ast::ExprNodeList::init_capacity(1);
+    args.append_assume_capacity(arg);
+    Stmt::alloc(
+        S::SExpr {
+            value: Expr::init(
+                E::Call {
+                    target: Expr::init_identifier(c.runtime_function(helper), loc),
+                    args,
+                    ..Default::default()
+                },
+                loc,
+            ),
+            ..Default::default()
+        },
+        loc,
     )
 }
 

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -680,7 +680,12 @@ pub(crate) fn post_process_js_chunk(
         }
 
         // TODO: metafile
-        newline_before_comment = !compile_result.code().is_empty();
+
+        // Put a newline before the next file path comment. An empty result (a
+        // part range that printed nothing) must not take it away again.
+        if !compile_result.code().is_empty() {
+            newline_before_comment = true;
+        }
     }
     // An entry chunk whose code all lives in shared chunks has no compile results of its own.
     if !preload_registration.is_empty() {

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -208,6 +208,13 @@ pub(crate) fn scan_imports_and_exports(
                 }
             }
 
+            let isolate_html_scripts = output_format != Format::InternalBakeDev
+                && col_ref!(loaders)[id] == Loader::Html
+                && LinkerContext::html_isolates_scripts(
+                    col_ref!(import_records_list)[id].as_slice(),
+                    col_ref!(loaders),
+                );
+
             for (import_record_index, record) in col_ref!(import_records_list)[id]
                 .as_slice()
                 .iter()
@@ -332,6 +339,18 @@ pub(crate) fn scan_imports_and_exports(
                         {
                             col!(exports_kind)[other_file] = ExportsKind::Cjs;
                             col!(flags)[other_file].wrap = WrapKind::Cjs;
+                        }
+
+                        // On a page that isolates its scripts, one with top-level await
+                        // starts at its tag without holding up the next script, and a
+                        // later script that imports it awaits `init_x()`. That takes a
+                        // real lazy-init wrapper (see `Flags::html_script_inline`).
+                        if isolate_html_scripts
+                            && col_ref!(flags)[other_file].is_async_or_has_async_dependency
+                            && col_ref!(flags)[other_file].wrap == WrapKind::None
+                            && LinkerContext::is_html_script_record(record, col_ref!(loaders))
+                        {
+                            col!(flags)[other_file].wrap = WrapKind::Esm;
                         }
                     }
                     ImportKind::Require =>
@@ -472,6 +491,61 @@ pub(crate) fn scan_imports_and_exports(
                         let si = record.source_index.get();
                         if dependency_wrapper.exports_kind[si as usize] == ExportsKind::Cjs {
                             dependency_wrapper.wrap(si);
+                        }
+                    }
+                }
+            }
+
+            // A page that bundles two or more scripts runs each `<script src>` as its
+            // own error boundary (see `Flags::html_script_inline`). A target that the
+            // steps above wrapped is called through `__script` / `__scriptAsync` from
+            // the HTML file's part for that tag (`append_html_script_wrapper_calls`);
+            // every other target prints its top-level statements inside
+            // `__script(() => { ... })` where they stand. Register the helper uses on
+            // the parts that print them. The dev server's module loader does this on
+            // its own.
+            if output_format != Format::InternalBakeDev {
+                for source_index_ in &reachable {
+                    let id = source_index_.get() as usize;
+                    if id >= dependency_wrapper.import_records.len()
+                        || col_ref!(loaders)[id] != Loader::Html
+                    {
+                        continue;
+                    }
+                    let records = dependency_wrapper.import_records[id].as_slice();
+                    if !LinkerContext::html_isolates_scripts(records, col_ref!(loaders)) {
+                        continue;
+                    }
+                    for (import_record_index, record) in records.iter().enumerate() {
+                        if !LinkerContext::is_html_script_record(record, col_ref!(loaders)) {
+                            continue;
+                        }
+                        let other = record.source_index.get();
+                        let flag = dependency_wrapper.flags[other as usize];
+                        if flag.wrap != WrapKind::None {
+                            // `ParseTask` (`Loader::Html`): part `1 + i` holds import record `i`.
+                            let helper: &[u8] = if flag.wrap == WrapKind::Esm
+                                && flag.is_async_or_has_async_dependency
+                            {
+                                b"__scriptAsync"
+                            } else {
+                                b"__script"
+                            };
+                            this.graph.generate_runtime_symbol_import_and_use(
+                                id as u32,
+                                Index::part(1 + import_record_index as u32),
+                                helper,
+                                1,
+                            )?;
+                        } else if !flag.html_script_inline {
+                            dependency_wrapper.flags[other as usize].html_script_inline = true;
+                            let part_index = this.graph.add_part_to_file(other, Part::default())?;
+                            this.graph.generate_runtime_symbol_import_and_use(
+                                other,
+                                Index::part(part_index),
+                                b"__script",
+                                1,
+                            )?;
                         }
                     }
                 }

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -732,6 +732,9 @@ pub(crate) fn scan_imports_and_exports(
             let wrap = flag.wrap;
             let export_kind = col_ref!(exports_kind)[id];
             let source: &Source = &col_ref!(input_files)[id];
+            // An HTML file's `<script src>` records print as bare wrapper calls
+            // (`append_html_script_wrapper_calls`); nothing reads the namespace.
+            let is_html = col_ref!(loaders)[id] == Loader::Html;
 
             let exports_ref = col_ref!(exports_refs)[id];
             let module_ref = col_ref!(module_refs)[id];
@@ -1212,6 +1215,7 @@ pub(crate) fn scan_imports_and_exports(
                         // A same-chunk `import()` of a lifted CommonJS module needs it
                         // too, so that `default` is `module.exports` (the namespace).
                         if kind != ImportKind::Require
+                            && !is_html
                             && (other_export_kind == ExportsKind::Cjs
                                 || (kind == ImportKind::Dynamic
                                     && other_flags.wrap == WrapKind::Esm

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -344,6 +344,25 @@ export var __jsonParse = /* @__PURE__ */ a => JSON.parse(a);
 
 export var __promiseAll = args => Promise.all(args);
 
+// An HTML entry runs each bundled <script> through one of these: a script
+// that throws is reported like an uncaught error and the next script still
+// runs, the same as separate <script> elements in the browser.
+var __reportError = e => (typeof reportError === "function" ? reportError(e) : console.error(e));
+export var __script = init => {
+  try {
+    init();
+  } catch (e) {
+    __reportError(e);
+  }
+};
+export var __scriptAsync = async init => {
+  try {
+    await init();
+  } catch (e) {
+    __reportError(e);
+  }
+};
+
 // React Compiler memo-cache slot sentinels.
 export var __MEMO_CACHE_SENTINEL = /* @__PURE__ */ Symbol.for("react.memo_cache_sentinel");
 export var __EARLY_RETURN_SENTINEL = /* @__PURE__ */ Symbol.for("react.early_return_sentinel");

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2812,6 +2812,10 @@ impl DevServer {
         Ok(array)
     }
 
+    /// The HTML file's pseudo-module imports nothing itself. Its load function
+    /// hands the page's `<script src>` ids, in document order, to
+    /// `hmr.loadScripts` (hmr-module.ts), which runs each one as its own error
+    /// boundary the way the browser runs separate `<script>` elements.
     fn generate_javascript_code_for_html_file(
         &mut self,
         index: bun_ast::Index,
@@ -2827,7 +2831,7 @@ impl DevServer {
             input_file_sources[index.get() as usize].path.pretty,
             w,
         )?;
-        w.extend_from_slice(b": [ [");
+        w.extend_from_slice(b": [ [], [], [], (hmr) => hmr.loadScripts([");
         let mut any = false;
         for import in import_records[index.get() as usize].as_slice() {
             if import.source_index.is_valid() {
@@ -2852,12 +2856,12 @@ impl DevServer {
                 import.path.pretty,
                 w,
             )?;
-            w.extend_from_slice(b", 0,\n");
+            w.extend_from_slice(b",\n");
         }
         if any {
             w.extend_from_slice(b"  ");
         }
-        w.extend_from_slice(b"], [], [], () => {}, false],\n");
+        w.extend_from_slice(b"]), true],\n");
 
         // Avoid-recloning if it is was moved to the heap
         Ok(array.into_boxed_slice())

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -254,11 +254,37 @@ export class HMRModule {
 
   /** Server-only */
   declare builtin: (id: string) => any;
+
+  /** Client-only. Called by the load function of an HTML route's module. */
+  declare loadScripts: (ids: Id[]) => Promise<void>;
 }
 if (side === "server") {
   HMRModule.prototype.builtin = (id: string) =>
     // @ts-expect-error
     import.meta.bakeBuiltin(import.meta.resolve(id));
+}
+if (side === "client") {
+  // The page's `<script src>` tags in document order. Each one is its own
+  // error boundary, like a `<script>` element: a script that throws is
+  // reported as an uncaught error and the next one still runs. A script with
+  // top-level await does not hold up the next one either. `bun build` does
+  // the same through `__script` (runtime.js).
+  const reportScriptError = (e: unknown) => {
+    if (typeof reportError === "function") reportError(e);
+    else console.error(e);
+  };
+  HMRModule.prototype.loadScripts = async function (this: HMRModule, ids: Id[]) {
+    const pending: Promise<unknown>[] = [];
+    for (const id of ids) {
+      try {
+        const mod = loadModuleAsync(id, false, this);
+        if (mod instanceof Promise) pending.push(mod.catch(reportScriptError));
+      } catch (e) {
+        reportScriptError(e);
+      }
+    }
+    await Promise.all(pending);
+  };
 }
 // prettier-ignore
 HMRModule.prototype.indirectHot = new Proxy({}, {

--- a/test/bake/client-fixture.mjs
+++ b/test/bake/client-fixture.mjs
@@ -113,6 +113,17 @@ function createWindow(windowUrl) {
     }
   };
 
+  // happy-dom has no `reportError`. A browser reports an uncaught script error
+  // by firing `error` on the window, then logging it unless a listener cancels it.
+  window.reportError = error => {
+    const event = new window.ErrorEvent("error", {
+      error,
+      message: String(error?.message ?? error),
+      cancelable: true,
+    });
+    if (window.dispatchEvent(event)) window.console.error(error);
+  };
+
   const original_window_fetch = window.fetch;
   window.fetch = async function (url, options) {
     if (typeof url === "string") {

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -53,6 +53,60 @@ devTest("html file is watched", {
   },
 });
 
+// Each <script> element is its own error boundary in the browser: an uncaught
+// error is reported and the next script still runs. A script with top-level
+// await does not hold up the next one either.
+devTest("a script that throws does not stop the page's later scripts", {
+  files: {
+    "index.html": `
+      <!DOCTYPE html><html><head>
+      <script type="module" src="./slow.js"></script>
+      <script src="./widget.js"></script>
+      <script src="./app.js"></script>
+      <script type="module" src="./mod.js"></script>
+      </head><body></body></html>
+    `,
+    "slow.js": `
+      globalThis.trace = ["slow"];
+      await new Promise(resolve => setTimeout(resolve, 0));
+      trace.push("slow resumed");
+      console.log(trace.join(","));
+    `,
+    "widget.js": `
+      trace.push("widget");
+      if (!document.getElementById("widget-slot")) throw new Error("widget mount point missing");
+      trace.push("unreachable");
+    `,
+    "app.js": `
+      trace.push("app");
+    `,
+    "mod.js": `
+      import { value } from "./dep.js";
+      trace.push("mod " + value);
+    `,
+    "dep.js": `
+      export const value = 42;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/", {
+      errors: ["error: widget mount point missing"],
+    });
+    await c.expectMessage("slow,widget,app,mod 42,slow resumed");
+
+    await c.expectReload(async () => {
+      await dev.write(
+        "widget.js",
+        `
+          trace.push("widget");
+        `,
+      );
+    });
+    await c.expectMessage("slow,widget,app,mod 42,slow resumed");
+    await c.expectErrorOverlay([]);
+  },
+});
+
 devTest("image tag", {
   files: {
     "index.html": `

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -249,6 +249,135 @@ export const padZero = (num) => String(num).padStart(2, '0');`,
     },
   });
 
+  // A `<script src>` that bun classifies as CommonJS (a `.cjs` file, a file
+  // that calls `require()`, top-level `this` in a UMD header, `module.exports`
+  // behind a `typeof module` guard) is wrapped in `__commonJS`. The page must
+  // still run it, in document order.
+  itBundled("html/script-src-commonjs", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="./umd.js"></script>
+    <script src="./guarded.js"></script>
+    <script src="./ext.cjs"></script>
+    <script src="./requires.js"></script>
+    <script src="./plain.js"></script>
+  </body>
+</html>`,
+      "/umd.js": `
+(function (root, factory) {
+  root.LIB = factory();
+})(this, function () {
+  return { v: 1 };
+});
+console.log("umd");`,
+      "/guarded.js": `
+console.log("guarded");
+if (typeof module === "object") module.exports = { guarded: true };`,
+      "/ext.cjs": `console.log("cjs extension");`,
+      "/requires.js": `
+const dep = require("./dep.js");
+console.log("requires " + dep);`,
+      "/dep.js": `module.exports = 7;`,
+      "/plain.js": `console.log("plain");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.writeFile("out/run.mjs", `import "./${js}";`);
+    },
+    run: { file: "out/run.mjs", stdout: "umd\nguarded\ncjs extension\nrequires 7\nplain" },
+  });
+
+  // Every `.js` file of a `"type": "commonjs"` package (the `npm init` default)
+  // is classified as CommonJS, so even a plain `console.log` script is wrapped.
+  itBundled("html/script-src-type-commonjs-package", {
+    outdir: "out/",
+    files: {
+      "/package.json": `{ "name": "app", "version": "1.0.0", "type": "commonjs" }`,
+      "/index.html": `<!DOCTYPE html><html><body><script src="./first.js"></script><script src="./second.js"></script></body></html>`,
+      "/first.js": `console.log("first");`,
+      "/second.js": `console.log("second");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.writeFile("out/run.mjs", `import "./${js}";`);
+    },
+    run: { file: "out/run.mjs", stdout: "first\nsecond" },
+  });
+
+  // Same, when the script resolved to a lazily-initialized ES module (here
+  // because another script also `import()`s it): the page calls `init_foo()`,
+  // with `await` when the module uses top-level await.
+  itBundled("html/script-src-lazy-esm", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="./sync.js"></script>
+    <script src="./tla.js"></script>
+    <script src="./main.js"></script>
+  </body>
+</html>`,
+      "/sync.js": `
+export const sync = "sync";
+console.log(sync);`,
+      "/tla.js": `
+export const tla = await Promise.resolve("tla");
+console.log(tla);`,
+      "/main.js": `
+console.log("main");
+const { sync } = await import("./sync.js");
+const { tla } = await import("./tla.js");
+console.log("lazy " + sync + " " + tla);`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.expectFile("out/" + js).toMatch(/init_sync\(\);\s*await init_tla\(\);/);
+      api.writeFile("out/run.mjs", `import "./${js}";`);
+    },
+    run: { file: "out/run.mjs", stdout: "sync\ntla\nmain\nlazy sync tla" },
+  });
+
+  // With code splitting the CommonJS script shared by two pages moves to its
+  // own chunk. Each page imports `require_lib` from it and still calls it. The
+  // page itself never reads the namespace, so it does not import `__toESM`
+  // (two.js does, for its own `import * as`).
+  itBundled("html/script-src-commonjs-splitting", {
+    outdir: "out/",
+    splitting: true,
+    files: {
+      "/one.html": `<!DOCTYPE html><html><body><script src="./lib.js"></script><script src="./one.js"></script></body></html>`,
+      "/two.html": `<!DOCTYPE html><html><body><script src="./lib.js"></script><script src="./two.js"></script></body></html>`,
+      "/lib.js": `
+console.log("lib");
+module.exports = { lib: true };`,
+      "/one.js": `console.log("one");`,
+      "/two.js": `
+import * as ns from "./lib.js";
+console.log("two", ns.default.lib);`,
+    },
+    entryPoints: ["/one.html", "/two.html"],
+    onAfterBundle(api) {
+      for (const page of ["one", "two"]) {
+        const js = api.readFile(`out/${page}.html`).match(/src="\.\/([^"]+\.js)"/)![1];
+        if (page === "one") api.expectFile("out/" + js).not.toContain("__toESM");
+        api.writeFile(`out/run-${page}.mjs`, `import "./${js}";`);
+      }
+    },
+    run: [
+      { file: "out/run-one.mjs", stdout: "lib\none" },
+      { file: "out/run-two.mjs", stdout: "lib\ntwo true" },
+    ],
+  });
+
   // Test CSS imports
   itBundled("html/css-imports", {
     outdir: "out/",

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -311,8 +311,9 @@ console.log("requires " + dep);`,
   });
 
   // Same, when the script resolved to a lazily-initialized ES module (here
-  // because another script also `import()`s it): the page calls `init_foo()`,
-  // with `await` when the module uses top-level await.
+  // because another script also `import()`s it): the page calls `init_foo()`.
+  // A script with top-level await is started at its tag and not awaited, so
+  // the next script runs before it settles, as in the browser.
   itBundled("html/script-src-lazy-esm", {
     outdir: "out/",
     files: {
@@ -340,10 +341,10 @@ console.log("lazy " + sync + " " + tla);`,
     entryPoints: ["/index.html"],
     onAfterBundle(api) {
       const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
-      api.expectFile("out/" + js).toMatch(/init_sync\(\);\s*await init_tla\(\);/);
+      api.expectFile("out/" + js).toMatch(/__script\(init_sync\);\s*__scriptAsync\(init_tla\);/);
       api.writeFile("out/run.mjs", `import "./${js}";`);
     },
-    run: { file: "out/run.mjs", stdout: "sync\ntla\nmain\nlazy sync tla" },
+    run: { file: "out/run.mjs", stdout: "sync\nmain\ntla\nlazy sync tla" },
   });
 
   // With code splitting the CommonJS script shared by two pages moves to its
@@ -376,6 +377,160 @@ console.log("two", ns.default.lib);`,
       { file: "out/run-one.mjs", stdout: "lib\none" },
       { file: "out/run-two.mjs", stdout: "lib\ntwo true" },
     ],
+  });
+
+  // In the browser each <script> element is its own error boundary: an
+  // uncaught error is reported and the next script still runs. The page's
+  // scripts share one output chunk, so each one's top-level statements run
+  // inside `__script(() => { ... })` (runtime.js), which reports and goes on.
+  const runHtmlChunk = /* js */ `
+    import { readdirSync } from "node:fs";
+    globalThis.trace = [];
+    const reported = [];
+    globalThis.reportError = e => reported.push(String(e?.message ?? e));
+    const chunk = readdirSync(import.meta.dir + "/out").find(f => f.endsWith(".js"));
+    await import("./out/" + chunk);
+    // A script with top-level await keeps running after the chunk has evaluated.
+    // Its continuations are microtasks, so they have all settled by the next macrotask.
+    await new Promise(done => setImmediate(done));
+    console.log(JSON.stringify({ trace, reported }));
+  `;
+  for (const minify of [false, true]) {
+    itBundled("html/script-error-boundary" + (minify ? "-minify" : ""), {
+      outdir: "out/",
+      files: {
+        "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="./widget.js"></script>
+    <script src="./app.js"></script>
+    <script type="module" src="./mod.js"></script>
+  </head>
+</html>`,
+        "/widget.js": `
+trace.push("widget");
+globalThis.widgetSlot.appendChild({});
+trace.push("unreachable");`,
+        "/app.js": `trace.push("app");`,
+        "/mod.js": `
+import { value } from "./dep.js";
+trace.push("mod " + value);`,
+        "/dep.js": `export const value = 42;`,
+      },
+      entryPoints: ["/index.html"],
+      minifySyntax: minify,
+      minifyIdentifiers: minify,
+      minifyWhitespace: minify,
+      runtimeFiles: { "/test.mjs": runHtmlChunk },
+      run: {
+        file: "/test.mjs",
+        stdout: `{"trace":["widget","app","mod 42"],"reported":["undefined is not an object (evaluating 'globalThis.widgetSlot.appendChild')"]}`,
+      },
+    });
+  }
+
+  // A script with top-level await does not hold up the page's next script,
+  // and when it rejects, the error is reported once for itself and once for
+  // each later script that imports it, like the browser does. Scripts that do
+  // not depend on it still run.
+  itBundled("html/script-error-boundary-top-level-await", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="./a.js"></script>
+    <script type="module" src="./b.js"></script>
+    <script src="./c.js"></script>
+  </head>
+</html>`,
+      "/a.js": `
+trace.push("a");
+await Promise.resolve();
+trace.push("a resumed");
+throw new Error("a failed");`,
+      "/b.js": `
+import "./a.js";
+trace.push("unreachable");`,
+      "/c.js": `trace.push("c");`,
+    },
+    entryPoints: ["/index.html"],
+    runtimeFiles: { "/test.mjs": runHtmlChunk },
+    run: {
+      file: "/test.mjs",
+      stdout: `{"trace":["a","c","a resumed"],"reported":["a failed","a failed"]}`,
+    },
+  });
+
+  // One closure per script, also when tree shaking drops a statement from the
+  // middle of the file (which splits a flat file's part range in two) and when
+  // a wrapped script sits between flat ones (wrappers print ahead of flat code,
+  // the call stays at the tag's position).
+  itBundled("html/script-error-boundary-one-unit-per-script", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="./a.js"></script>
+    <script src="./umd.js"></script>
+    <script src="./b.js"></script>
+  </head>
+</html>`,
+      "/a.js": `
+trace.push("a1");
+globalThis.widgetSlot.mount();
+function unused() {}
+trace.push("unreachable");`,
+      "/umd.js": `
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) module.exports = factory();
+  else root.lib = factory();
+})(globalThis, function () {
+  trace.push("umd");
+  return {};
+});`,
+      "/b.js": `trace.push("b");`,
+    },
+    entryPoints: ["/index.html"],
+    runtimeFiles: { "/test.mjs": runHtmlChunk },
+    onAfterBundle(api) {
+      const chunk = api.readFile("out/" + api.readFile("out/index.html").match(/src="\.\/(.*\.js)"/)![1]);
+      expect(chunk.match(/__script\(/g)).toHaveLength(3); // one call per tag
+    },
+    run: {
+      file: "/test.mjs",
+      stdout: `{"trace":["a1","umd","b"],"reported":["undefined is not an object (evaluating 'globalThis.widgetSlot.mount')"]}`,
+    },
+  });
+
+  // A page with one script has nothing to isolate it from, so its chunk stays
+  // flat: no lazy-init wrappers, no runtime helpers.
+  itBundled("html/single-script-stays-flat", {
+    outdir: "out/",
+    files: {
+      "/index.html": `<!DOCTYPE html><html><head><script type="module" src="./app.js"></script></head></html>`,
+      "/app.js": `
+import { value } from "./dep.js";
+trace.push("app " + value);`,
+      "/dep.js": `
+export const value = 42;
+trace.push("dep");`,
+    },
+    entryPoints: ["/index.html"],
+    runtimeFiles: { "/test.mjs": runHtmlChunk },
+    onAfterBundle(api) {
+      const chunk = api.readFile("out/" + api.readFile("out/index.html").match(/src="\.\/(.*\.js)"/)![1]);
+      expect(chunk).not.toContain("__esm");
+      expect(chunk).not.toContain("__script");
+    },
+    run: {
+      file: "/test.mjs",
+      stdout: `{"trace":["dep","app 42"],"reported":[]}`,
+    },
   });
 
   // Test CSS imports

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -141,11 +141,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-qjznw47b.js",
+                "path": "./client-c9kjeh05.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "l5IfNVyE54s",
+                  "etag": "7GmzUg4RQCU",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -155,7 +155,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "xh1kdn7wbmI",
+                  "etag": "L1NGVitZslc",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
@@ -325,17 +325,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "Dl7kT6q7eY4",
+                  "etag": "Vr91Jdsy4Zc",
                 },
                 "input": "home.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./home-ey4favse.js",
+                "path": "./home-pzn5vj1q.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "IhvRaM9jGDU",
+                  "etag": "bO9UOC8tMwQ",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -360,17 +360,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "RCRrF1EbBvo",
+                  "etag": "xjiS27vgDE0",
                 },
                 "input": "about.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./about-44bqhv6t.js",
+                "path": "./about-6rjvv0cd.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "2OGqRD6vx54",
+                  "etag": "yq0KRVKuKEY",
                 },
                 "input": "about.html",
                 "isEntry": true,

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -74,6 +74,42 @@ console.log(data);`,
     expect(html).toContain("await");
   });
 
+  // A script that bun classifies as CommonJS (UMD header with top-level `this`,
+  // or a guarded `module.exports`) is wrapped in `__commonJS`. The inlined
+  // module must still run it, in document order.
+  test("runs CommonJS scripts in document order", async () => {
+    using dir = tempDir("compile-browser-cjs-script", {
+      "index.html": `<!DOCTYPE html><html><body><script src="./umd.js"></script><script src="./guarded.js"></script><script src="./plain.js"></script></body></html>`,
+      "umd.js": `(function (root, factory) { root.LIB = factory(); })(this, function () { return { v: 1 }; });
+console.log("umd");`,
+      "guarded.js": `console.log("guarded");
+if (typeof module === "object") module.exports = { guarded: true };`,
+      "plain.js": `console.log("plain");`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/index.html`],
+      compile: true,
+      target: "browser",
+    });
+
+    expect(result.success).toBe(true);
+    const html = await result.outputs[0].text();
+    const script = html.match(/<script type="module">([\s\S]*)<\/script>/)![1];
+    await Bun.write(`${dir}/inlined.mjs`, script);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), `${dir}/inlined.mjs`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("umd\nguarded\nplain\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("escapes </script> in inlined JS", async () => {
     using dir = tempDir("compile-browser-escape-script", {
       "index.html": `<!DOCTYPE html><html><body><script src="./app.js"></script></body></html>`,

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -224,7 +224,7 @@ console.log("How...dashing?");
   "content-length": "316",
   "content-type": "text/javascript;charset=utf-8",
   "date": "<date>",
-  "etag": ""f862dbeedf9b72bc"",
+  "etag": ""c2050d7cfe555369"",
   "sourcemap": "/chunk-HASH.js.map",
 }
 `);

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -178,16 +178,29 @@ test("serve html", async () => {
         .replace(/# debugId=[a-z0-9A-Z]+/g, "# debugId=<debug-id>")
         .replace(/# sourceMappingURL=[^"]+/g, "# sourceMappingURL=<source-mapping-url>"),
     ).toMatchInlineSnapshot(`
-"// script.js
-var count = 0;
-var button = document.getElementById("counter");
-button.addEventListener("click", () => {
-  count++;
-  button.textContent = \`Click me: \${count}\`;
+"var __reportError = (e) => typeof reportError === "function" ? reportError(e) : console.error(e);
+var __script = (init) => {
+  try {
+    init();
+  } catch (e) {
+    __reportError(e);
+  }
+};
+
+// script.js
+var count = 0, button;
+__script(() => {
+  button = document.getElementById("counter");
+  button.addEventListener("click", () => {
+    count++;
+    button.textContent = \`Click me: \${count}\`;
+  });
 });
 
 // dashboard.js
-console.log("How...dashing?");
+__script(() => {
+  console.log("How...dashing?");
+});
 
 //# debugId=<debug-id>
 //# sourceMappingURL=<source-mapping-url>"
@@ -211,7 +224,7 @@ console.log("How...dashing?");
           "let count = 0;\\n      const button = document.getElementById('counter');\\n      button.addEventListener('click', () => {\\n        count++;\\n        button.textContent = \`Click me: \${count}\`;\\n      });",
           "import './script.js';\\n      // Additional dashboard-specific code could go here\\n      console.log(\\"How...dashing?\\")"
         ],
-        "mappings": ";AACM,IAAI,QAAQ;AACZ,IAAM,SAAS,SAAS,eAAe,SAAS;AAChD,OAAO,iBAAiB,SAAS,MAAM;AAAA,EACrC;AAAA,EACA,OAAO,cAAc,aAAa;AAAA,CACnC;;;ACHD,QAAQ,IAAI,gBAAgB;",
+        "mappings": ";;;;;;;;;;IACU,QAAQ,GACN;AAAA;AAAA,WAAS,SAAS,eAAe,SAAS;AAAA,EAChD,OAAO,iBAAiB,SAAS,MAAM;AAAA,IACrC;AAAA,IACA,OAAO,cAAc,aAAa;AAAA,GACnC;AAAA;;;;ECHD,QAAQ,IAAI,gBAAgB;AAAA;",
         "debugId": "<debug-id>",
         "names": []
       }"
@@ -221,10 +234,10 @@ console.log("How...dashing?");
     headers.sourcemap = headers.sourcemap.replace(/chunk-[a-z0-9]+\.js.map/g, "chunk-HASH.js.map");
     expect(headers).toMatchInlineSnapshot(`
 {
-  "content-length": "316",
+  "content-length": "565",
   "content-type": "text/javascript;charset=utf-8",
   "date": "<date>",
-  "etag": ""c2050d7cfe555369"",
+  "etag": ""5e7bc7bee4407d10"",
   "sourcemap": "/chunk-HASH.js.map",
 }
 `);


### PR DESCRIPTION
Draft pending a direction call (see Direction). Stacked on #42026: the first commit is that PR, the second is this change.

### Problem
- An HTML entry point merges every `<script src>` into one `type=module` chunk. In the browser each `<script>` element is its own error boundary: report the error, run the next script. In the merged chunk one top-level throw (or a pending top-level await) stops every later script. Fuzz corpus vs Chromium: 26/26 such pages lost all later scripts.

### Fix
- On a page with two or more bundled scripts, an unwrapped script prints its top-level statements inside `__script(() => { ... })`, in place, with declarations hoisted out as for a lazily initialized module. Importers, dependencies and chunk order are unchanged. `__script` is `try { fn() } catch (e) { reportError(e) }`.
- A script the linker wraps anyway (`__commonJS`, `__esm`) is called from its tag's part (#42026) as `__script(require_x)`. One with top-level await starts as `__scriptAsync(init_x)`, not awaited.
- The dev server starts each script through `hmr.loadScripts` the same way.
- Verified: `test/bundler/bundler_html.test.ts` and `test/bake/dev/html.test.ts` (new cases fail on 1.4.3). Single-script pages are byte-identical.

### Background
- The hoisting is the linker's existing path for an `import()` target without splitting: `let`/`const`/`class` become `var`s outside a closure, functions move out whole.
- `reportError(e)` is the platform's "report the exception": it fires `error` on `window` and logs.

### Direction
This keeps one chunk and one tag and restores only the per-element boundary inside it. The class-level choice is still open, and this draft is the place to make it:
- (A) Per-element output: each `<script src>` becomes its own entry of the page and keeps its tag (rewritten `src`), shared modules fall out of chunking. Gives the error boundary, top-level-await timing, classic vs module (#18770, #21132), order against inline scripts (#27113) and per-tag attributes structurally. A multi-PR series (HTMLScanner, `Loader::Html` part synthesis, `computeChunks`, the HTML rewriter, the dev server route).
- (B) Declare "a page's scripts are one module graph" the contract (Vite and Deno do this): one docs sentence plus a bundler warning on a classic `<script src>`, and close this.
- (C) This PR: emulate the boundary inside the merged chunk. Small, but an emulation with one known gap (below).

<details><summary>Notes</summary>

- Self-reviewed: 5 concerns raised, 3 addressed in code or text (an inline script whose part range was split by a tree-shaken statement printed as two closures, fixed in `findAllImportedPartsInJSOrder.rs` with the `one-unit-per-script` test; the docs sentence narrowed to what holds; the sibling-PR relation stated). The other 2 are the shape question itself (per-element output or a one-module contract instead of in-chunk emulation) and are what the Direction section asks.

- Relation to the sibling PRs from the same fuzz run: #42026 is the base fix alone (a wrapped `<script src>` was never called); this branch carries its commit and puts the boundary on top. #41999 changes top-level-await ordering without the error boundary; this PR covers that case too (`__scriptAsync`, started at the tag, not awaited).
- Cost: pages with 2+ scripts gain `__script(() => {` per script with top-level statements plus about 190 bytes of helpers. The exact-output snapshot in `test/js/bun/http/bun-serve-html.test.ts` ("serve html", two tags, one imports the other) goes from 316 to 565 bytes unminified. A first cut that forced `__esm` wrappers propagated to every dependency and cost 8-21% min+gz on library-heavy two-script pages, so the boundary is non-propagating and printed at the file's own position: no ordering change against today's flat output, and import cycles with a script file behave exactly as before.
- Wrapped files print in the chunk prefix ahead of flat code, so their `__script(require_x)` call comes from the HTML file's per-tag part, which the chunk visitor places at the tag's document position. Verified with `[flat-that-throws, umd, tla, flat]`: runs `first, umd, tla start, last, tla end`.
- Known gap: a later script that `import`s a failed script still runs its body (the browser would fail it too). Its references to the failed script's hoisted functions work, `let`/`const` assigned after the throw read `undefined`. Closing that gap needs a real lazy-init wrapper per script, which is what made the first cut expensive.
- Top-level await: Chromium does not wait for a module script's evaluation promise before running the next element, so `__scriptAsync(init_a)` is not awaited. A later script that imports it awaits `init_a()` inside its own wrapper (only scripts with top-level await get a propagating `__esm` wrapper), and a rejection is reported once per element that depends on it, as in the browser. #42026's `html/script-src-lazy-esm` expectation changes accordingly (`sync, main, tla` instead of `sync, tla, main`).
- The inline flag is per file: a script of a multi-script page that is also bundled elsewhere in the same build (its own entry point, or a single-script page) carries its `__script` boundary there too.
- `link[as=worker][href]` is also an `ImportKind::Stmt` record from HTML; only `<script>` elements are tagged (`ImportRecordFlags::HTML_SCRIPT_SRC` from `HTMLScanner`).
- The HTML file's per-tag parts are now marked live from `mark_file_live_step` instead of pre-seeded, so tree shaking follows their dependencies (the wrappers and the runtime helpers).
- `test/bake/client-fixture.mjs` gains a `reportError` polyfill because happy-dom has none; it dispatches `ErrorEvent` on the window and logs, per the HTML spec.
- Also ran: standalone, bun-serve-html*, html manifest, bake dev html/hot/esm/bundle/css, esbuild/default, esbuild/splitting, bundler_edgecase.

</details>
