### PR TITLE
js_parser: rename the TS namespace closure argument when a nested binding shadows it

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6899,6 +6899,78 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Paths without a symbol renamer print the closure argument of a
+    /// TypeScript namespace or enum by its original name. A binding with that
+    /// name inside the body would capture the member references that were
+    /// rewritten to property accesses on the argument:
+    ///
+    ///   namespace N { export let v = 1; export function f(N) { return v } }
+    ///
+    /// must not print `function f(N) { return N.v; }` (tsc prints `N_1.v`).
+    /// Call this once `body` is visited. It renames the argument when a scope
+    /// in `body` declares its name. No scope inside or around `body` declares
+    /// the new name, so the new name captures no reference made inside
+    /// `body`: those are all resolved by now, the unbound ones to members of
+    /// the module scope.
+    #[cold]
+    #[inline(never)]
+    pub(crate) fn rename_namespace_arg_to_avoid_collisions(
+        &mut self,
+        arg_ref: Ref,
+        body: js_ast::StoreRef<Scope>,
+    ) {
+        fn declares(symbols: &[Symbol], scope: &Scope, name: &[u8], except: Ref) -> bool {
+            scope
+                .members
+                .get(name)
+                .is_some_and(|member| !member.ref_.eql(except))
+                || scope.generated.slice().iter().any(|ref_| {
+                    !ref_.eql(except)
+                        && symbols[ref_.inner_index() as usize].original_name.slice() == name
+                })
+        }
+        fn declared_inside(symbols: &[Symbol], scope: &Scope, name: &[u8], except: Ref) -> bool {
+            declares(symbols, scope, name, except)
+                || scope
+                    .children
+                    .slice()
+                    .iter()
+                    .any(|child| declared_inside(symbols, child, name, except))
+        }
+        fn declared_outside(symbols: &[Symbol], body: &Scope, name: &[u8]) -> bool {
+            let mut next = body.parent;
+            while let Some(scope) = next {
+                if declares(symbols, &scope, name, Ref::NONE) {
+                    return true;
+                }
+                next = scope.parent;
+            }
+            false
+        }
+
+        let symbols = self.symbols.as_slice();
+        let name: &'a [u8] = symbols[arg_ref.inner_index() as usize]
+            .original_name
+            .slice();
+        if !declared_inside(symbols, &body, name, arg_ref) {
+            return;
+        }
+        let mut underscores: usize = 1;
+        let renamed: &'a [u8] = loop {
+            let candidate = self
+                .arena
+                .alloc_slice_fill_copy(underscores + name.len(), b'_');
+            candidate[underscores..].copy_from_slice(name);
+            if !declared_inside(symbols, &body, candidate, Ref::NONE)
+                && !declared_outside(symbols, &body, candidate)
+            {
+                break candidate;
+            }
+            underscores += 1;
+        };
+        self.symbols[arg_ref.inner_index() as usize].original_name = js_ast::StoreStr::new(renamed);
+    }
+
     // Large TS namespace/enum lowering body — cold for already-transpiled JS.
     #[cold]
     #[inline(never)]

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6899,15 +6899,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Paths without a renamer print the closure argument of a TS namespace or
-    /// enum by its original name, so once `body` is visited, rename it if a
-    /// scope in `body` declares that name (tsc: `N_1`):
-    ///
-    ///   namespace N { export let v = 1; export function f(N) { return v } }
-    ///
-    /// must not print `function f(N) { return N.v; }`. The new name is declared
-    /// neither inside nor around `body`, so it captures no reference made in
-    /// `body` (all resolved by now, unbound ones as module scope members).
+    /// `namespace N { export let v; function f(N) { v } }`: without a renamer
+    /// `v` would print as `N.v` under the parameter `N`. After `body` is
+    /// visited, rename the closure argument (tsc: `N_1`) to a name that no
+    /// scope inside or around `body` declares.
     #[cold]
     #[inline(never)]
     pub(crate) fn rename_namespace_arg_to_avoid_collisions(

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6899,10 +6899,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// `namespace N { export let v; function f(N) { v } }`: without a renamer
-    /// `v` would print as `N.v` under the parameter `N`. After `body` is
-    /// visited, rename the closure argument (tsc: `N_1`) to a name that no
-    /// scope inside or around `body` declares.
+    /// `namespace N { export let v; function f(N) { v } }` must not print `N.v` under the parameter (tsc: `N_1`).
     #[cold]
     #[inline(never)]
     pub(crate) fn rename_namespace_arg_to_avoid_collisions(

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6899,19 +6899,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Paths without a symbol renamer print the closure argument of a
-    /// TypeScript namespace or enum by its original name. A binding with that
-    /// name inside the body would capture the member references that were
-    /// rewritten to property accesses on the argument:
+    /// Paths without a renamer print the closure argument of a TS namespace or
+    /// enum by its original name, so once `body` is visited, rename it if a
+    /// scope in `body` declares that name (tsc: `N_1`):
     ///
     ///   namespace N { export let v = 1; export function f(N) { return v } }
     ///
-    /// must not print `function f(N) { return N.v; }` (tsc prints `N_1.v`).
-    /// Call this once `body` is visited. It renames the argument when a scope
-    /// in `body` declares its name. No scope inside or around `body` declares
-    /// the new name, so the new name captures no reference made inside
-    /// `body`: those are all resolved by now, the unbound ones to members of
-    /// the module scope.
+    /// must not print `function f(N) { return N.v; }`. The new name is declared
+    /// neither inside nor around `body`, so it captures no reference made in
+    /// `body` (all resolved by now, unbound ones as module scope members).
     #[cold]
     #[inline(never)]
     pub(crate) fn rename_namespace_arg_to_avoid_collisions(

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -407,54 +407,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut arg_ref = Ref::NONE;
         if !opts.is_typescript_declare {
-            // Avoid a collision with the namespace closure argument variable if the
-            // namespace exports a symbol with the same name as the namespace itself:
-            //
-            //   namespace foo {
-            //     export let foo = 123
-            //     console.log(foo)
-            //   }
-            //
-            // TypeScript generates the following code in this case:
-            //
-            //   var foo;
-            //   (function (foo_1) {
-            //     foo_1.foo = 123;
-            //     console.log(foo_1.foo);
-            //   })(foo || (foo = {}));
-            //
-            // SAFETY: current_scope is an arena-owned Scope pointer valid for 'a.
-            if p.current_scope().members.contains_key(name_text) {
-                // Add a "_" to make tests easier to read, since non-bundler tests don't
-                // run the renamer. Keep adding "_" until the argument does not collide
-                // with a symbol declared in the namespace body: paths that skip the
-                // renamer (runtime transpiler, Bun.Transpiler, `bun build --no-bundle`)
-                // print symbols by their original name, so a colliding argument would
-                // re-declare a block-scoped member:
-                //
-                //   namespace m { class m {} class _m {} }
-                //
-                // Candidates are built in the parse arena; the
-                // chosen one becomes the symbol's original name and is freed together
-                // with the rest of the AST arena.
-                let mut underscores: usize = 1;
-                let prefixed: &'a [u8] = loop {
-                    let candidate = p
-                        .arena
-                        .alloc_slice_fill_copy(underscores + name_text.len(), b'_');
-                    candidate[underscores..].copy_from_slice(name_text);
-                    if !p.current_scope().members.contains_key(candidate) {
-                        break candidate;
-                    }
-                    underscores += 1;
-                };
-                arg_ref = p.new_symbol(SymbolKind::Hoisted, prefixed);
-            } else {
-                // Not a member: a reference to the name inside the namespace
-                // resolves to a merged sibling's export of that name first.
-                arg_ref = p.new_symbol(SymbolKind::Hoisted, name_text);
-            }
-            // Named in this scope so that no binding inside shadows it.
+            // The closure argument is not a member of the namespace scope: a
+            // reference to the name inside the namespace resolves to a merged
+            // sibling's export of that name first. It is in `generated` so the
+            // renamer sees it; `rename_namespace_arg_to_avoid_collisions` (visit
+            // pass) renames it if a binding inside the body has the same name.
+            arg_ref = p.new_symbol(SymbolKind::Hoisted, name_text);
             VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             ts_namespace.arg_ref = arg_ref;
         }

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -406,11 +406,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut arg_ref = Ref::NONE;
         if !opts.is_typescript_declare {
-            // The closure argument is not a member of the namespace scope: a
-            // reference to the name inside the namespace resolves to a merged
-            // sibling's export of that name first. It is in `generated` so the
-            // renamer sees it; `rename_namespace_arg_to_avoid_collisions` (visit
-            // pass) renames it if a binding inside the body has the same name.
+            // The closure argument. Not a scope member: inside the namespace, a
+            // merged sibling's export of the same name wins. The visit pass
+            // renames it if a binding in the body shadows it.
             arg_ref = p.new_symbol(SymbolKind::Hoisted, name_text);
             VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             ts_namespace.arg_ref = arg_ref;
@@ -638,25 +636,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.fn_or_arrow_data_parse = old_fn_or_arrow_data;
 
         if !opts.is_typescript_declare {
-            // The enum's name inside the body resolves to the closure argument:
-            //
-            //   enum foo { bar = foo as any }
-            //
-            // unless a value has that name, which then wins, as in tsc:
-            //
-            //   enum foo { foo = 123, bar = foo }
-            //
-            // SAFETY: current_scope is an arena-owned Scope pointer valid for 'a.
+            // The closure argument. `enum foo { bar = foo }` resolves `foo` to it,
+            // unless a value is named `foo` (the visit pass then renames it).
             arg_ref = if p.current_scope().members.contains_key(name_text) {
                 p.new_symbol(SymbolKind::Hoisted, name_text)
             } else {
                 p.declare_symbol(SymbolKind::Hoisted, name_loc, name_text)
                     .expect("unreachable")
             };
-            // Listed in `generated` either way, like the namespace closure
-            // argument, so that `rename_namespace_arg_to_avoid_collisions`
-            // finds it by its current name. That pass renames it to `_foo` in
-            // the second case above.
+            // In `generated` so the visit pass finds it by its current name.
             VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             p.ref_to_ts_namespace_member
                 .insert(arg_ref, TSNamespaceMemberData::Namespace(exported_members));

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -16,7 +16,6 @@ use bun_ast::{
     self as js_ast, B, E, EnumValue, Expr, ExprNodeIndex, ExprNodeList, G, LocRef, S, Stmt,
     StmtData, TSNamespaceMember, TSNamespaceMemberMap,
 };
-use bun_core::strings;
 
 // `ts::Data` carries only Copy payloads but lacks a `derive(Clone)` upstream;
 // local helper so we can re-insert values fetched from `ref_to_ts_namespace_member`.
@@ -639,50 +638,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.fn_or_arrow_data_parse = old_fn_or_arrow_data;
 
         if !opts.is_typescript_declare {
-            // Avoid a collision with the enum closure argument variable if the
-            // enum exports a symbol with the same name as the enum itself:
+            // The enum's name inside the body resolves to the closure argument:
             //
-            //   enum foo {
-            //     foo = 123,
-            //     bar = foo,
-            //   }
+            //   enum foo { bar = foo as any }
             //
-            // TypeScript generates the following code in this case:
+            // unless a value has that name, which then wins, as in tsc:
             //
-            //   var foo;
-            //   (function (foo) {
-            //     foo[foo["foo"] = 123] = "foo";
-            //     foo[foo["bar"] = 123] = "bar";
-            //   })(foo || (foo = {}));
+            //   enum foo { foo = 123, bar = foo }
             //
-            // Whereas in this case:
-            //
-            //   enum foo {
-            //     bar = foo as any,
-            //   }
-            //
-            // TypeScript generates the following code:
-            //
-            //   var foo;
-            //   (function (foo) {
-            //     foo[foo["bar"] = foo] = "bar";
-            //   })(foo || (foo = {}));
             // SAFETY: current_scope is an arena-owned Scope pointer valid for 'a.
-            if p.current_scope().members.contains_key(name_text) {
-                // Add a "_" to make tests easier to read, since non-bundler tests don't
-                // run the renamer. For external-facing things the renamer will avoid
-                // collisions automatically so this isn't important for correctness.
-                // PERF: strings::cat heap-allocates — could allocate into p.arena.
-                let prefixed = strings::cat(b"_", name_text).expect("unreachable");
-                let prefixed: &'a [u8] = p.arena.alloc_slice_copy(&prefixed);
-                arg_ref = p.new_symbol(SymbolKind::Hoisted, prefixed);
-                // SAFETY: see above.
-                VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
+            arg_ref = if p.current_scope().members.contains_key(name_text) {
+                p.new_symbol(SymbolKind::Hoisted, name_text)
             } else {
-                arg_ref = p
-                    .declare_symbol(SymbolKind::Hoisted, name_loc, name_text)
-                    .expect("unreachable");
-            }
+                p.declare_symbol(SymbolKind::Hoisted, name_loc, name_text)
+                    .expect("unreachable")
+            };
+            // Listed in `generated` either way, like the namespace closure
+            // argument, so that `rename_namespace_arg_to_avoid_collisions`
+            // finds it by its current name. That pass renames it to `_foo` in
+            // the second case above.
+            VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             p.ref_to_ts_namespace_member
                 .insert(arg_ref, TSNamespaceMemberData::Namespace(exported_members));
             ts_namespace.arg_ref = arg_ref;

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -406,9 +406,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut arg_ref = Ref::NONE;
         if !opts.is_typescript_declare {
-            // The closure argument. Not a scope member: inside the namespace, a
-            // merged sibling's export of the same name wins. The visit pass
-            // renames it if a binding in the body shadows it.
+            // The closure argument; not a scope member so that a merged sibling's export of the name wins.
             arg_ref = p.new_symbol(SymbolKind::Hoisted, name_text);
             VecExt::append(&mut p.current_scope_mut().generated, arg_ref);
             ts_namespace.arg_ref = arg_ref;
@@ -636,8 +634,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.fn_or_arrow_data_parse = old_fn_or_arrow_data;
 
         if !opts.is_typescript_declare {
-            // The closure argument. `enum foo { bar = foo }` resolves `foo` to it,
-            // unless a value is named `foo` (the visit pass then renames it).
+            // The closure argument; `enum foo { bar = foo }` binds `foo` to it unless a value has that name.
             arg_ref = if p.current_scope().members.contains_key(name_text) {
                 p.new_symbol(SymbolKind::Hoisted, name_text)
             } else {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2363,6 +2363,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        p.rename_namespace_arg_to_avoid_collisions(data.arg, p.current_scope_ref());
         p.pop_scope();
         p.should_fold_typescript_constant_expressions =
             old_should_fold_typescript_constant_expressions;
@@ -2425,6 +2426,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .expect("unreachable");
         p.record_declared_symbol(data.arg);
         p.visit_stmts_and_prepend_temp_refs(&mut prepend_list, &mut prepend_temp_refs)?;
+        p.rename_namespace_arg_to_avoid_collisions(data.arg, p.current_scope_ref());
         p.pop_scope();
         p.enclosing_namespace_arg_ref = old_enclosing_namespace_arg_ref;
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: the TS namespace/enum closure argument is renamed when a nested binding shadows it.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2146,6 +2146,33 @@ export default class {
 })(E ||= {})`,
       );
 
+      // A value named like the enum (tsc keeps `foo` here, esbuild prints `_foo`).
+      ts.expectPrinted_(
+        `enum foo { foo = 123, bar = foo }`,
+        `var foo;
+((_foo) => {
+  _foo[_foo["foo"] = 123] = "foo";
+  _foo[_foo["bar"] = 123] = "bar";
+})(foo ||= {})`,
+      );
+
+      // A renamed inner argument takes `_E`, so the outer one takes `__E`.
+      ts.expectPrinted_(
+        `namespace E {
+  export let v = a;
+  export enum E { A = v, B = ((E) => E + 4)(1) }
+}`,
+        `var E;
+((__E) => {
+  __E.v = a;
+  let E;
+  ((_E) => {
+    _E[_E["A"] = __E.v] = "A";
+    _E[_E["B"] = ((E) => E + 4)(1)] = "B";
+  })(E = __E.E ||= {});
+})(E ||= {})`,
+      );
+
       // No shadowing binding: the argument keeps the namespace's name.
       ts.expectPrinted_(
         `namespace N {
@@ -2178,7 +2205,8 @@ export default class {
             export const arrow = (N: any) => v;
           }
           enum E { A = one(), B = ((E: any) => A + 1)({ A: 100 }) }
-          console.log(JSON.stringify([N.param({ v: 9 }), N.local(), N.caught(), N.klass(), N.arrow({ v: 6 }), E.B]));`,
+          namespace O { export let v = one(); export enum O { A = v, B = ((O: any) => O + 4)(1) } }
+          console.log(JSON.stringify([N.param({ v: 9 }), N.local(), N.caught(), N.klass(), N.arrow({ v: 6 }), E.B, O.O.A, O.O.B]));`,
         ],
         env: bunEnv,
         stdout: "pipe",
@@ -2188,7 +2216,7 @@ export default class {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
-      expect(stdout).toBe("[1,1,1,1,1,2]\n");
+      expect(stdout).toBe("[1,1,1,1,1,2,1,5]\n");
       expect(exitCode).toBe(0);
     });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2215,9 +2215,8 @@ export default class {
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(stderr).toBe("");
-      expect(stdout).toBe("[1,1,1,1,1,2,1,5]\n");
-      expect(exitCode).toBe(0);
+      expect({ stdout, exitCode }).toEqual({ stdout: "[1,1,1,1,1,2,1,5]\n", exitCode: 0 });
+      void stderr;
     });
 
     // The runtime transpiler does not run a renamer, so the generated closure

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2106,6 +2106,92 @@ export default class {
       ts.expectPrinted_(input6, output6);
     });
 
+    it("namespace argument renamed when a binding in a nested scope shadows it", () => {
+      // `v` inside `f` prints as a property access on the closure argument,
+      // which the parameter `N` would otherwise capture (tsc emits `N_1`).
+      ts.expectPrinted_(
+        `namespace N {
+  export let v = 1;
+  export function f(N) { return v }
+}`,
+        `var N;
+((_N) => {
+  _N.v = 1;
+  function f(N) {
+    return _N.v;
+  }
+  _N.f = f;
+})(N ||= {})`,
+      );
+
+      // The new name must not capture a reference made inside the body.
+      ts.expectPrinted_(
+        `namespace N {
+  export let v = 1;
+  export const f = (N) => v + _N;
+}`,
+        `var N;
+((__N) => {
+  __N.v = 1;
+  __N.f = (N) => __N.v + _N;
+})(N ||= {})`,
+      );
+
+      ts.expectPrinted_(
+        `enum E { A = a, B = ((E) => A)(0) }`,
+        `var E;
+((_E) => {
+  _E[_E["A"] = a] = "A";
+  _E[_E["B"] = ((E) => _E.A)(0)] = "B";
+})(E ||= {})`,
+      );
+
+      // No shadowing binding: the argument keeps the namespace's name.
+      ts.expectPrinted_(
+        `namespace N {
+  export let v = 1;
+  export function f(M) { return v + N.v }
+}`,
+        `var N;
+((N) => {
+  N.v = 1;
+  function f(M) {
+    return N.v + N.v;
+  }
+  N.f = f;
+})(N ||= {})`,
+      );
+    });
+
+    it("namespace closure argument is not captured by a nested binding at runtime", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `function one() { return 1; }
+          namespace N {
+            export let v = one();
+            export function param(N: any) { return v; }
+            export function local() { let N: any = { v: 9 }; return v; }
+            export function caught() { try { throw { v: 8 }; } catch (N) { return v; } }
+            export function klass() { class N { static v = 7; } return v; }
+            export const arrow = (N: any) => v;
+          }
+          enum E { A = one(), B = ((E: any) => A + 1)({ A: 100 }) }
+          console.log(JSON.stringify([N.param({ v: 9 }), N.local(), N.caught(), N.klass(), N.arrow({ v: 6 }), E.B]));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[1,1,1,1,1,2]\n");
+      expect(exitCode).toBe(0);
+    });
+
     // The runtime transpiler does not run a renamer, so the generated closure
     // argument must not shadow declarations inside the namespace body.
     it("namespace closure argument does not redeclare members at runtime", async () => {


### PR DESCRIPTION
### Problem
- `bun build --no-bundle`, `Bun.Transpiler` and `bun run` lower `namespace N { export let v = 1; export function f(N) { return v } }` to `function f(N) { return N.v; }`. The parameter captures the read, so `N.f(undefined)` throws `TypeError: undefined is not an object (evaluating 'N.v')`. Same for a `let`, `catch` binding or class, and in enum initializers.
- Cause: `parse_type_script_namespace_stmt` (`src/js_parser/parse/parse_typescript.rs:408`) named the closure argument at parse time and checked only the namespace scope's own members (#31261), not nested scopes. These paths print names verbatim. tsc prints `N_1` here.

### Fix
- `rename_namespace_arg_to_avoid_collisions` (`src/js_parser/p.rs`) runs after the namespace or enum body is visited and walks every scope in it. If one declares the argument's name, the argument becomes `_N` (`__N`, ...).
- Correct because no scope inside or around the body declares the new name, and every reference in the body is resolved by then, so the new name captures nothing. The enum argument is now in `generated` too, so an enclosing namespace sees its new name.
- Existing `_ns`, `__m2` and enum `_foo` outputs are unchanged. The runtime transpiler cache version is bumped.
- Verified: `test/bundler/transpiler/transpiler.test.js` (two new tests fail on 1.4.3), plus the esbuild `ts`, `bundler_minify`, `bundler_edgecase` and decorator suites. Self-reviewed: 1 concern raised, 1 addressed.

### Background
- `namespace N {}` lowers to `var N; ((N) => { ... })(N ||= {})`. Reads of exported variables in the body become `N.v` on the closure argument.
- The bundler's renamer renames a nested binding that would capture that argument. The non-bundle printer has no renamer, so the parser must pick a safe name. tsc does the same scope walk.

<details><summary>Notes</summary>

- Provenance: found by an internal transpiler fuzzer as a follow-up to #31261. There is no user report. The enum half goes beyond tsc (tsc does not rename the enum argument for a shadowing binding in an initializer) and matches what esbuild and `bun build` produce through their renamer.
- `bun x.ts` looked correct in the original repro only because `export const v = 1` is const-inlined on the Bun target (`return 1`). With `export let v = one()` the runtime path returned the wrong value too.
- The closure argument is a parser-generated symbol in the scope's `generated` list, which is where the bundler's `NumberRenamer` sees it. `print_ast` uses `NoOpRenamer`, which prints `symbol.original_name`.
- Unbound references inside the body are module scope members by the time the check runs, so a global `_N` used inside the body makes the argument `__N`.
- The rename also applies when bundling, so `bun build` now prints `((_N) => { ... function f(N) ... })` instead of renaming the user's parameter to `N2`. Both are correct.
- The self-review found that a renamed enum argument stayed keyed by its source name in the member table, so `namespace E { export let v = one(); export enum E { A = v, B = ((E) => E + 4)(1) } }` picked `_E` for both arguments. Listing the enum argument in `generated` fixes that. The case is in both new tests.
- The self-reference inside an enum (`enum Foo { Z = Foo }`) still binds to the closure argument, as in esbuild, so `ts/MinifyEnumExported` keeps its single-letter minified form.
- tsc reference: `isUniqueLocalName` in the TS transformer walks the containers inside the module declaration, then `makeUniqueName` picks a file-unique `N_1`.
- Other suites run: esbuild `extra`, `importstar`, `dce` (enum/namespace subset), `bundler_regressions`, `runtime-transpiler`, `ts-enum-redecl-panic`, `bundler_dynamic_import_dce`.
- A separate, pre-existing collision class (decorator temporaries such as `_init` next to a user `const _init`) is not addressed here.

</details>
