### PR TITLE
glob: validate continuation bytes when stepping over directory entry names

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -40,8 +40,8 @@ pub use unicode_draft::{
     copy_latin1_into_ascii, copy_latin1_into_utf8_stop_on_non_ascii, copy_latin1_into_utf16,
     copy_u8_into_u16, copy_u16_into_u8, copy_utf16_into_utf8_impl,
     element_length_cp1252_into_utf16, element_length_utf8_into_utf16, to_utf8_list_with_type_bun,
-    to_utf16_alloc_maybe_buffered, u16_is_lead, u16_is_trail, utf16_codepoint,
-    utf16_codepoint_with_fffd, wtf8_sequence,
+    to_utf16_alloc_maybe_buffered, u16_is_lead, u16_is_trail, utf8_codepoint_with_fffd,
+    utf16_codepoint, utf16_codepoint_with_fffd, wtf8_sequence,
 };
 
 /// `bun.strings.visible` — terminal-visible-width helpers. The implementation
@@ -2773,5 +2773,43 @@ mod tests {
         assert_eq!(out, &[0xD800][..]);
         let out = super::convert_utf8_to_utf16_in_buffer(&mut buf, b"\xC3\xA9\xF0\x9F\x98\x80");
         assert_eq!(out, &[0x00E9, 0xD83D, 0xDE00][..]);
+    }
+
+    #[test]
+    fn utf8_codepoint_with_fffd_steps_by_maximal_subpart() {
+        // (input, code_point, len, fail)
+        let cases: &[(&[u8], u32, u8, bool)] = &[
+            (b"a\x80", 0x61, 1, false),
+            (b"\xC3\xA9x", 0xE9, 2, false),
+            (b"\xE4\xB8\xAD", 0x4E2D, 3, false),
+            (b"\xF0\x9F\x98\x80js", 0x1F600, 4, false),
+            (b"\xEF\xBF\xBD", 0xFFFD, 3, false),
+            // stray continuation byte, invalid leads
+            (b"\x80x", 0xFFFD, 1, true),
+            (b"\xC0\xB8", 0xFFFD, 1, true),
+            (b"\xF5\x80\x80\x80", 0xFFFD, 1, true),
+            // lead followed by a non-continuation byte: the lead alone
+            (b"\xC3x", 0xFFFD, 1, true),
+            // second byte outside the narrowed range for E0 / ED / F0 / F4
+            (b"\xE0\x80\x80", 0xFFFD, 1, true),
+            (b"\xED\xA0\x80", 0xFFFD, 1, true),
+            (b"\xF0\x80\x80\x80", 0xFFFD, 1, true),
+            (b"\xF4\x90\x80\x80", 0xFFFD, 1, true),
+            // truncated sequences: the whole valid prefix is one replacement
+            (b"\xE4\xB8.js", 0xFFFD, 2, true),
+            (b"\xE4\xB8", 0xFFFD, 2, true),
+            (b"\xF0\x9F\x98js", 0xFFFD, 3, true),
+            (b"\xF0\x9F", 0xFFFD, 2, true),
+            (b"\xC3", 0xFFFD, 1, true),
+        ];
+        for &(input, code_point, len, fail) in cases {
+            let r = super::utf8_codepoint_with_fffd(input);
+            assert_eq!(
+                (r.code_point, r.len, r.fail),
+                (code_point, len, fail),
+                "input {:x?}",
+                input
+            );
+        }
     }
 }

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -409,6 +409,26 @@ pub(super) fn convert_utf8_bytes_into_utf16(bytes: &[u8]) -> UTF16Replacement {
     convert_utf8_bytes_into_utf16_with_length(sequence, sequence_length, bytes.len())
 }
 
+/// Decodes the codepoint at the front of `bytes` (non-empty). `len` is always
+/// in `1..=bytes.len()`. An ill-formed sequence yields U+FFFD with `fail` set
+/// over its maximal subpart, the same units `to_utf16_alloc` produces when the
+/// bytes become a JS string.
+pub fn utf8_codepoint_with_fffd(bytes: &[u8]) -> UTF16Replacement {
+    let lead = bytes[0];
+    if lead < 0x80 {
+        return UTF16Replacement {
+            code_point: u32::from(lead),
+            len: 1,
+            ..Default::default()
+        };
+    }
+    let r = convert_utf8_bytes_into_utf16(bytes);
+    UTF16Replacement {
+        len: r.len.max(1),
+        ..r
+    }
+}
+
 // SWAR body moved down into `crate::strings_impl` (T0) so the canonical
 // `copy_latin1_into_utf8` is the spec-faithful fast path. Re-export here so
 // `pub use unicode_draft::copy_latin1_into_utf8_stop_on_non_ascii` in

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -288,7 +288,7 @@ fn glob_match_impl(
                                 let mut is_match = false;
 
                                 // source unicode char to match against the target + its byte length in `path`
-                                let (c, len) = decode_wtf8_rune_at(path, state.path_index as usize);
+                                let (c, len) = decode_rune_at(path, state.path_index as usize);
 
                                 while (state.glob_index as usize) < glob.len()
                                     && (first || glob[state.glob_index as usize] != b']')
@@ -615,48 +615,20 @@ fn unescape(c: &mut u8, glob: &[u8], glob_index: &mut u32) -> bool {
     true
 }
 
-const REPLACEMENT_CHAR: u32 = 0xFFFD;
-
-/// Byte length of the codepoint at `bytes[idx]`; see [`decode_wtf8_rune_at`].
+/// Byte length of the codepoint at `bytes[idx]`; see [`decode_rune_at`].
 #[inline(always)]
 fn rune_len_at(bytes: &[u8], idx: usize) -> u8 {
-    decode_wtf8_rune_at(bytes, idx).1
+    decode_rune_at(bytes, idx).1
 }
 
-/// Decodes the WTF-8 codepoint at `bytes[idx]`, returning `(codepoint, byte_len)`.
-/// `bytes` can be a directory entry that is not valid UTF-8: an ill-formed
-/// sequence is U+FFFD over its maximal subpart, as `readdir` decodes it, so
-/// `byte_len` never reaches into the next character or past the end.
-#[inline]
-fn decode_wtf8_rune_at(bytes: &[u8], idx: usize) -> (u32, u8) {
-    let lead = bytes[idx];
-    if lead < 0x80 {
-        return (u32::from(lead), 1);
-    }
-    // (length, second-byte range): the ranges exclude overlong forms and
-    // codepoints above U+10FFFF, but keep surrogates (ED A0..BF) for WTF-8.
-    let (len, lo, hi): (u8, u8, u8) = match lead {
-        0xC2..=0xDF => (2, 0x80, 0xBF),
-        0xE0 => (3, 0xA0, 0xBF),
-        0xE1..=0xEF => (3, 0x80, 0xBF),
-        0xF0 => (4, 0x90, 0xBF),
-        0xF1..=0xF3 => (4, 0x80, 0xBF),
-        0xF4 => (4, 0x80, 0x8F),
-        _ => return (REPLACEMENT_CHAR, 1),
-    };
-    let tail = &bytes[idx + 1..];
-    match tail.first() {
-        Some(&b) if lo <= b && b <= hi => {}
-        _ => return (REPLACEMENT_CHAR, 1),
-    }
-    let mut cp = ((u32::from(lead) & (0x7F >> len)) << 6) | u32::from(tail[0] & 0x3F);
-    for i in 1..usize::from(len) - 1 {
-        match tail.get(i) {
-            Some(&b) if b & 0xC0 == 0x80 => cp = (cp << 6) | u32::from(b & 0x3F),
-            _ => return (REPLACEMENT_CHAR, (i + 1) as u8),
-        }
-    }
-    (cp, len)
+/// Decodes the codepoint at `bytes[idx]`, returning `(codepoint, byte_len)`.
+/// A directory entry need not be valid UTF-8, so this decodes the way the
+/// entry's name is decoded for JS: an ill-formed sequence is one U+FFFD over
+/// its maximal subpart, and `byte_len` never passes the end of `bytes`.
+#[inline(always)]
+fn decode_rune_at(bytes: &[u8], idx: usize) -> (u32, u8) {
+    let r = strings::utf8_codepoint_with_fffd(&bytes[idx..]);
+    (r.code_point, r.len)
 }
 
 /// Unescapes the character if needed
@@ -687,7 +659,7 @@ fn get_unicode(c: &mut u32, clen: &mut u8, glob: &[u8], glob_index: &mut u32) ->
                 b'r' => b'\r' as u32,
                 b't' => b'\t' as u32,
                 _ => 'brk: {
-                    let (cp, len) = decode_wtf8_rune_at(glob, *glob_index as usize);
+                    let (cp, len) = decode_rune_at(glob, *glob_index as usize);
                     *clen = len;
                     break 'brk cp;
                 }
@@ -695,7 +667,7 @@ fn get_unicode(c: &mut u32, clen: &mut u8, glob: &[u8], glob_index: &mut u32) ->
         }
         // multi-byte sequences
         _ => {
-            let (cp, len) = decode_wtf8_rune_at(glob, *glob_index as usize);
+            let (cp, len) = decode_rune_at(glob, *glob_index as usize);
             *clen = len;
             *c = cp;
         }

--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -208,9 +208,7 @@ fn glob_match_impl(
                             state.wildcard.glob_index = state.glob_index;
                             state.wildcard.path_index = state.path_index
                                 + if (state.path_index as usize) < path.len() {
-                                    u32::from(strings::wtf8_byte_sequence_length(
-                                        path[state.path_index as usize],
-                                    ))
+                                    u32::from(rune_len_at(path, state.path_index as usize))
                                 } else {
                                     1
                                 };
@@ -265,9 +263,7 @@ fn glob_match_impl(
                                 if !is_separator(path[state.path_index as usize]) {
                                     state.glob_index += 1;
                                     state.path_index +=
-                                        u32::from(strings::wtf8_byte_sequence_length(
-                                            path[state.path_index as usize],
-                                        ));
+                                        u32::from(rune_len_at(path, state.path_index as usize));
                                     continue 'main_loop;
                                 }
                                 break 'fallthrough;
@@ -619,14 +615,47 @@ fn unescape(c: &mut u8, glob: &[u8], glob_index: &mut u32) -> bool {
     true
 }
 
-/// Decodes the WTF-8 codepoint at `bytes[idx]`, returning `(codepoint, byte_len)`.
+const REPLACEMENT_CHAR: u32 = 0xFFFD;
+
+/// Byte length of the codepoint at `bytes[idx]`; see [`decode_wtf8_rune_at`].
 #[inline(always)]
+fn rune_len_at(bytes: &[u8], idx: usize) -> u8 {
+    decode_wtf8_rune_at(bytes, idx).1
+}
+
+/// Decodes the WTF-8 codepoint at `bytes[idx]`, returning `(codepoint, byte_len)`.
+/// `bytes` can be a directory entry that is not valid UTF-8: an ill-formed
+/// sequence is U+FFFD over its maximal subpart, as `readdir` decodes it, so
+/// `byte_len` never reaches into the next character or past the end.
+#[inline]
 fn decode_wtf8_rune_at(bytes: &[u8], idx: usize) -> (u32, u8) {
-    let len = strings::wtf8_byte_sequence_length(bytes[idx]);
-    let mut buf = [0u8; 4];
-    let n = (bytes.len() - idx).min(4);
-    buf[..n].copy_from_slice(&bytes[idx..idx + n]);
-    let cp = strings::decode_wtf8_rune_t::<u32>(buf, len, 0xFFFD);
+    let lead = bytes[idx];
+    if lead < 0x80 {
+        return (u32::from(lead), 1);
+    }
+    // (length, second-byte range): the ranges exclude overlong forms and
+    // codepoints above U+10FFFF, but keep surrogates (ED A0..BF) for WTF-8.
+    let (len, lo, hi): (u8, u8, u8) = match lead {
+        0xC2..=0xDF => (2, 0x80, 0xBF),
+        0xE0 => (3, 0xA0, 0xBF),
+        0xE1..=0xEF => (3, 0x80, 0xBF),
+        0xF0 => (4, 0x90, 0xBF),
+        0xF1..=0xF3 => (4, 0x80, 0xBF),
+        0xF4 => (4, 0x80, 0x8F),
+        _ => return (REPLACEMENT_CHAR, 1),
+    };
+    let tail = &bytes[idx + 1..];
+    match tail.first() {
+        Some(&b) if lo <= b && b <= hi => {}
+        _ => return (REPLACEMENT_CHAR, 1),
+    }
+    let mut cp = ((u32::from(lead) & (0x7F >> len)) << 6) | u32::from(tail[0] & 0x3F);
+    for i in 1..usize::from(len) - 1 {
+        match tail.get(i) {
+            Some(&b) if b & 0xC0 == 0x80 => cp = (cp << 6) | u32::from(b & 0x3F),
+            _ => return (REPLACEMENT_CHAR, (i + 1) as u8),
+        }
+    }
     (cp, len)
 }
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -990,16 +990,15 @@ describe("explicit dotfile segments match without dot:true", () => {
 });
 
 // Directory entries on Linux are bytes that need not be valid UTF-8. The
-// matcher has to check continuation bytes instead of trusting the lead byte,
-// or `?` and `*` step into the next character or past the end of the name.
-// An ill-formed sequence counts as one U+FFFD over its maximal subpart, the
-// way readdir (and so the names scan() returns) decodes it.
+// matcher must step over them in the same units the returned names use (one
+// U+FFFD per maximal ill-formed subpart), not by the lead byte's nominal
+// length, or `?` and `*` step into the next character or past the end.
 describe.skipIf(!isLinux)("scan over entry names that are not valid UTF-8", () => {
   let dir: string;
   beforeAll(() => {
     dir = String(tempDir("glob-scan-invalid-utf8", {}));
-    // Bytes after "t": `\xc3 x`, `\xe4\xb8 .js`, `é \xc3`, `😀 js`, `x \x80`.
-    for (const hex of ["c378", "e4b82e6a73", "c3a9c3", "f09f98806a73", "7880"]) {
+    // Bytes after "t": `\xc3 x`, `\xe4\xb8 .js`, `é \xc3`, `😀 js`, `x \x80`, `\xed\xa0\x80` (a WTF-8 surrogate).
+    for (const hex of ["c378", "e4b82e6a73", "c3a9c3", "f09f98806a73", "7880", "eda080"]) {
       fs.writeFileSync(Buffer.concat([Buffer.from(dir + "/t"), Buffer.from(hex, "hex")]), "");
     }
   });
@@ -1007,21 +1006,25 @@ describe.skipIf(!isLinux)("scan over entry names that are not valid UTF-8", () =
     fs.rmSync(dir, { recursive: true, force: true });
   });
   const scan = (pattern: string) => [...new Glob(pattern).scanSync({ cwd: dir })].sort();
+  const all = ["t\uFFFDx", "t\uFFFD.js", "té\uFFFD", "t😀js", "tx\uFFFD", "t\uFFFD\uFFFD\uFFFD"];
 
   test.each([
-    ["*", ["t\uFFFDx", "t\uFFFD.js", "té\uFFFD", "t😀js", "tx\uFFFD"]],
-    ["t*", ["t\uFFFDx", "t\uFFFD.js", "té\uFFFD", "t😀js", "tx\uFFFD"]],
+    ["*", all],
+    ["t*", all],
     ["t?", []],
     ["t??", ["t\uFFFDx", "té\uFFFD", "tx\uFFFD"]],
-    ["t???", ["t😀js"]],
+    ["t???", ["t😀js", "t\uFFFD\uFFFD\uFFFD"]],
     ["t????", ["t\uFFFD.js"]],
     ["t*.js", ["t\uFFFD.js"]],
     ["t?.js", ["t\uFFFD.js"]],
     ["t*s", ["t\uFFFD.js", "t😀js"]],
     ["t[!a-z]x", ["t\uFFFDx"]],
+    ["t[\uFFFD]*", ["t\uFFFDx", "t\uFFFD.js", "t\uFFFD\uFFFD\uFFFD"]],
   ] as [string, string[]][])("%j", (pattern, expected) => {
     expect(scan(pattern)).toEqual([...expected].sort());
-    // scan() over the raw bytes agrees with match() over the decoded names.
+    // Wildcards and classes see the raw bytes the way match() sees the decoded
+    // name. (A literal U+FFFD in a pattern still compares bytes, since the
+    // decode is lossy.)
     expect(scan(pattern)).toEqual(scan("*").filter(name => new Glob(pattern).match(name)));
   });
 });

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -24,7 +24,7 @@ import { Glob, GlobScanOptions } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { execSync } from "child_process";
 import fg from "fast-glob";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import * as fs from "node:fs";
 import * as path from "path";
 import { createTempDirectoryWithBrokenSymlinks, prepareEntries, tempFixturesDir } from "./util";
@@ -986,6 +986,43 @@ describe("explicit dotfile segments match without dot:true", () => {
     using dir = tempDir("glob-scan-explicit-dot-async", files);
     const result = await Array.fromAsync(new Glob(".dotdir/inner.txt").scan({ cwd: String(dir) }));
     expect(norm(result)).toEqual([".dotdir/inner.txt"]);
+  });
+});
+
+// Directory entries on Linux are bytes that need not be valid UTF-8. The
+// matcher has to check continuation bytes instead of trusting the lead byte,
+// or `?` and `*` step into the next character or past the end of the name.
+// An ill-formed sequence counts as one U+FFFD over its maximal subpart, the
+// way readdir (and so the names scan() returns) decodes it.
+describe.skipIf(!isLinux)("scan over entry names that are not valid UTF-8", () => {
+  let dir: string;
+  beforeAll(() => {
+    dir = String(tempDir("glob-scan-invalid-utf8", {}));
+    // Bytes after "t": `\xc3 x`, `\xe4\xb8 .js`, `é \xc3`, `😀 js`, `x \x80`.
+    for (const hex of ["c378", "e4b82e6a73", "c3a9c3", "f09f98806a73", "7880"]) {
+      fs.writeFileSync(Buffer.concat([Buffer.from(dir + "/t"), Buffer.from(hex, "hex")]), "");
+    }
+  });
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  const scan = (pattern: string) => [...new Glob(pattern).scanSync({ cwd: dir })].sort();
+
+  test.each([
+    ["*", ["t\uFFFDx", "t\uFFFD.js", "té\uFFFD", "t😀js", "tx\uFFFD"]],
+    ["t*", ["t\uFFFDx", "t\uFFFD.js", "té\uFFFD", "t😀js", "tx\uFFFD"]],
+    ["t?", []],
+    ["t??", ["t\uFFFDx", "té\uFFFD", "tx\uFFFD"]],
+    ["t???", ["t😀js"]],
+    ["t????", ["t\uFFFD.js"]],
+    ["t*.js", ["t\uFFFD.js"]],
+    ["t?.js", ["t\uFFFD.js"]],
+    ["t*s", ["t\uFFFD.js", "t😀js"]],
+    ["t[!a-z]x", ["t\uFFFDx"]],
+  ] as [string, string[]][])("%j", (pattern, expected) => {
+    expect(scan(pattern)).toEqual([...expected].sort());
+    // scan() over the raw bytes agrees with match() over the decoded names.
+    expect(scan(pattern)).toEqual(scan("*").filter(name => new Glob(pattern).match(name)));
   });
 });
 


### PR DESCRIPTION
### Problem
- `Bun.Glob.scan` matches raw directory-entry bytes, and on Linux those need not be valid UTF-8. The matcher (`src/glob/matcher.rs`) advanced `?`, the `*` backtrack position, and `[...]` by the nominal length of the UTF-8 lead byte and never checked the bytes that follow.
- So a stray lead byte swallowed the next ASCII character (`t?` matched `t\xc3x`), a truncated sequence ate a following `.` (`t*.js` missed `t\xe4\xb8.js`), and a lead byte at the end of a name stepped past the end, so `t*` missed `t\xc3\xa9\xc3` while `*` found it. Same results on 1.3.14, 1.4.2 and canary.

### Fix
- `bun_core::strings::utf8_codepoint_with_fffd(bytes)` exposes the existing WebKit-matching step decoder (`convert_utf8_bytes_into_utf16`, until now `pub(super)`) with an ASCII fast path and `len >= 1`. The matcher's `decode_rune_at` / `rune_len_at` are thin consumers at the three stepping sites.
- An ill-formed sequence is one U+FFFD over its maximal subpart. That is how the names `scan()` returns (and `readdir`, `TextDecoder`) are decoded, so for wildcards and classes `scan(p)` now equals `scan("*").filter(n => new Glob(p).match(n))`. The test asserts this, including a raw `ED A0 80` name (three replacements in both).
- Valid UTF-8 decodes to the same `(codepoint, len)` as before. The literal arm compares pattern bytes to path bytes and was already safe.
- Verified: `test/js/bun/glob/scan.test.ts` (`scan over entry names that are not valid UTF-8`, 11 cases, stock bun fails 9). `match.test.ts` passes (29). The `braces` throughput case runs 3.9 s with the change and 4.7 s without (debug+ASAN).

### Background
- A Linux file name is any byte string without `/` or NUL. Latin-1 archives and mojibake produce names that are not UTF-8. `readdir` shows them with U+FFFD, and `scan("*")` lists them, so other patterns must see them the same way.
- "Maximal subpart" (Unicode §3.9, WHATWG UTF-8 decode): a truncated but otherwise valid prefix such as `E4 B8` is one replacement character, a byte that can never start a sequence (`80`, `C0`, `F5`) is one each.
- Patterns and `Glob.match()` inputs come from JS strings, so they are always valid UTF-8 (a lone surrogate arrives as `EF BF BD`). Windows entry names are transcoded from UTF-16 with the same replacement. Only raw POSIX names reach the matcher ill-formed.

<details><summary>Notes</summary>

Self-reviewed: the first revision carried a private Unicode Table 3-7 transcription in the glob crate that kept WTF-8 surrogates (`ED A0..BF`) as one 3-byte unit. The review raised that `bun_core` already has the strict decoder and that the surrogate row disagreed with how the returned names decode, which made the scan/match invariant false for such names. Both addressed: the helper now lives in `bun_core::strings` over the existing decoder, and the test pins the `ED A0 80` row.

A literal U+FFFD in a pattern still compares bytes (`EF BF BD`), so it does not match an ill-formed sequence on disk. The decode is lossy, and the walker's literal fast paths open paths by their bytes, so that cannot be made consistent in the matcher alone.

`cargo test -p bun_core` does not link standalone in this tree (pre-existing: missing C++ symbols), so the new `#[test]` table for `utf8_codepoint_with_fffd` is compile-checked (`cargo check -p bun_core --tests`) and its rows are exercised through the scan test.

Six `glob.match > ... recursive search` cases in `scan.test.ts` scan the whole repository with a hardcoded 30 s timeout. They time out in this container under debug+ASAN with and without this diff.

Expected counts for the ledger repro after the fix: `*` 5, `t*` 5, `t?` 0, `t??` 3, `t???` 1 (`t😀js`), `t*.js` 1, `t*s` 2. `fs.globSync` differs only on `t???` (0) because its `?` matches one UTF-16 code unit and the emoji is two.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->