### PR TITLE
node:fs: hand fs.watch and fs.watchFile paths to the OS as given on POSIX

### DIFF
--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -15,13 +15,13 @@ use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSValue, JsCell, JsRef, JsResult, WorkPool,
     WorkPoolTask,
 };
-use bun_paths::resolve_path::{self as Path, platform};
 use bun_ptr::{BackRef, ParentRef, RefPtr, ThreadSafeRefCount};
 use bun_resolver::fs;
-use bun_sys::{self, PosixStat};
+use bun_sys::{self, E, PosixStat};
 use bun_threading::{Guarded, UnboundedQueue};
 
 use crate::generated_classes::js_StatWatcher as js;
+use crate::node::node_fs_watcher::absolute_watch_path_z;
 use crate::node::stat::{StatsBig, StatsSmall};
 use crate::node::types::PathLikeExt;
 use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
@@ -828,15 +828,13 @@ impl StatWatcher {
             slice = &slice[b"file://".len()..];
         }
 
-        // SAFETY: `FileSystem::instance()` is initialized at process start
-        // (`FileSystem::init` runs before any JS module loads).
         let top_level_dir = fs::FileSystem::get().top_level_dir;
-        let parts: [&[u8]; 1] = [slice];
-        let file_path =
-            Path::join_abs_string_buf::<platform::Auto>(top_level_dir, &mut buf[..], &parts);
+        let Some(file_path) = absolute_watch_path_z(top_level_dir, slice, &mut buf) else {
+            return Err(bun_sys::Error::from_code(E::ENAMETOOLONG, bun_sys::Tag::watch).into());
+        };
 
         // allocSentinel + memcpy → owned NUL-terminated copy (ZBox)
-        let alloc_file_path = ZBox::from_bytes(file_path);
+        let alloc_file_path = ZBox::from_bytes(file_path.as_bytes());
         // errdefer free → Drop handles it
 
         // `args.global_this` is a `BackRef` (JSC_BORROW); safe Deref.

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -32,14 +32,9 @@ use super::path_watcher;
 #[cfg(windows)]
 use super::win_watcher as path_watcher;
 
-/// The absolute, NUL-terminated form of a `fs.watch()` / `fs.watchFile()`
-/// path for the OS watcher, or `None` when it does not fit `buf`.
-///
-/// On POSIX the caller's bytes are kept as given: an absolute path verbatim,
-/// a relative one appended to `cwd`. The kernel resolves `.` and `..`
-/// through symlinks and `\` is an ordinary filename byte there, and a
-/// lexical join would rewrite both. Win32 resolves paths lexically itself,
-/// so Windows keeps the normalizing join.
+/// `cwd`-absolute, NUL-terminated copy of a `fs.watch()` / `fs.watchFile()`
+/// path, or `None` if it does not fit `buf`. POSIX keeps the caller's bytes
+/// (no `..` folding, `\` is a filename byte); Win32 is lexical anyway.
 pub(crate) fn absolute_watch_path_z<'a>(
     cwd: &[u8],
     path: &[u8],

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -32,9 +32,7 @@ use super::path_watcher;
 #[cfg(windows)]
 use super::win_watcher as path_watcher;
 
-/// `cwd`-absolute, NUL-terminated copy of a `fs.watch()` / `fs.watchFile()`
-/// path, or `None` if it does not fit `buf`. POSIX keeps the caller's bytes
-/// (no `..` folding, `\` is a filename byte); Win32 is lexical anyway.
+/// Absolute watch path; POSIX keeps the caller's bytes unnormalized. `None` if it does not fit.
 pub(crate) fn absolute_watch_path_z<'a>(
     cwd: &[u8],
     path: &[u8],

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -19,7 +19,6 @@ use bun_jsc::{
     VirtualMachineRef as VirtualMachine,
 };
 use bun_jsc::{JsCell, JsCellRefExt as _};
-use bun_paths::resolve_path::{self as Path, platform};
 use bun_sys::{self, SystemErrno};
 use bun_threading::Mutex;
 
@@ -32,6 +31,49 @@ bun_output::declare_scope!(fs_watch, hidden);
 use super::path_watcher;
 #[cfg(windows)]
 use super::win_watcher as path_watcher;
+
+/// The absolute, NUL-terminated form of a `fs.watch()` / `fs.watchFile()`
+/// path for the OS watcher, or `None` when it does not fit `buf`.
+///
+/// On POSIX the caller's bytes are kept as given: an absolute path verbatim,
+/// a relative one appended to `cwd`. The kernel resolves `.` and `..`
+/// through symlinks and `\` is an ordinary filename byte there, and a
+/// lexical join would rewrite both. Win32 resolves paths lexically itself,
+/// so Windows keeps the normalizing join.
+pub(crate) fn absolute_watch_path_z<'a>(
+    cwd: &[u8],
+    path: &[u8],
+    buf: &'a mut bun_paths::PathBuffer,
+) -> Option<&'a bun_core::ZStr> {
+    let cap = buf.len() - 1;
+    #[cfg(windows)]
+    let len = bun_paths::resolve_path::join_abs_string_buf_checked::<
+        bun_paths::resolve_path::platform::Windows,
+    >(cwd, &mut buf[..cap], &[path])?
+    .len();
+    #[cfg(not(windows))]
+    let len = {
+        let mut len = 0;
+        if !bun_paths::is_absolute(path) {
+            if cwd.len() + 1 > cap {
+                return None;
+            }
+            buf[..cwd.len()].copy_from_slice(cwd);
+            len = cwd.len();
+            if len > 0 && buf[len - 1] != b'/' {
+                buf[len] = b'/';
+                len += 1;
+            }
+        }
+        if len + path.len() > cap {
+            return None;
+        }
+        buf[len..len + path.len()].copy_from_slice(path);
+        len + path.len()
+    };
+    buf[len] = 0;
+    Some(bun_core::ZStr::from_buf(&buf[..], len))
+}
 
 // TODO: make this a top-level struct
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
@@ -1115,15 +1157,8 @@ impl FSWatcher {
             }
             s
         };
-        // SAFETY: `FileSystem::instance()` returns the process-global singleton
-        // initialized at startup; never null once init has run.
         let cwd = bun_resolver::fs::FileSystem::get().top_level_dir;
-        let joined_buf_len = joined_buf.len();
-        let Some(joined) = Path::join_abs_string_buf_checked::<platform::Auto>(
-            cwd,
-            &mut joined_buf[..joined_buf_len - 1],
-            &[slice],
-        ) else {
+        let Some(file_path) = absolute_watch_path_z(cwd, slice, &mut joined_buf) else {
             return Err(bun_sys::Error {
                 errno: SystemErrno::ENAMETOOLONG as _,
                 syscall: bun_sys::Tag::watch,
@@ -1131,9 +1166,6 @@ impl FSWatcher {
                 ..Default::default()
             });
         };
-        let joined_len = joined.len();
-        joined_buf[joined_len] = 0;
-        let file_path: &bun_core::ZStr = bun_core::ZStr::from_buf(&joined_buf[..], joined_len);
 
         let vm = args.global_this.bun_vm_ptr();
         // `bun_vm()` is the audited safe `&'static VirtualMachine` accessor —

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -227,6 +227,49 @@ describe("fs.watch", () => {
     });
   });
 
+  // On POSIX `a\b` is one filename, not `a/b`.
+  test.skipIf(isWindows)("a backslash in the path is not a separator", async () => {
+    const dir = tempDirWithFiles("watch-backslash", { "a/other.txt": "unrelated" });
+    const literal = path.join(dir, "a\\b");
+    fs.writeFileSync(literal, "literal");
+
+    // `a/b` does not exist, so a watcher that split on `\` throws ENOENT here.
+    const watcher = fs.watch(literal);
+    try {
+      const { promise, resolve } = Promise.withResolvers<[string, string | Buffer | null]>();
+      watcher.once("change", (event, filename) => resolve([event, filename]));
+      const interval = repeat(() => fs.writeFileSync(literal, "changed"));
+      const [event, filename] = await promise.finally(() => clearInterval(interval));
+      expect([event, filename]).toEqual(["change", "a\\b"]);
+    } finally {
+      watcher.close();
+    }
+  });
+
+  // The kernel resolves `link/..` to the parent of the link target. A lexical
+  // join folds it to the directory that holds the link instead.
+  test.skipIf(isWindows)("`symlink/..` in the path resolves through the symlink", async () => {
+    const dir = tempDirWithFiles("watch-dotdot", { "d/keep.txt": "", "other/sub/keep.txt": "" });
+    fs.symlinkSync(path.join(dir, "other", "sub"), path.join(dir, "d", "link"));
+
+    // d/link/.. is other/, not d/. (path.join would fold the `..` away.)
+    const watcher = fs.watch(`${dir}/d/link/..`);
+    try {
+      const { promise, resolve } = Promise.withResolvers<string | Buffer | null>();
+      watcher.on("change", (event, filename) => {
+        if (filename === "in-other.txt" || filename === "in-d.txt") resolve(filename);
+      });
+      const interval = repeat(() => {
+        fs.writeFileSync(path.join(dir, "other", "in-other.txt"), "x");
+        fs.writeFileSync(path.join(dir, "d", "in-d.txt"), "x");
+      });
+      const filename = await promise.finally(() => clearInterval(interval));
+      expect(filename).toBe("in-other.txt");
+    } finally {
+      watcher.close();
+    }
+  });
+
   test("should emit 'change' event when file is modified", done => {
     const filepath = path.join(testDir, "watch.txt");
 

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -236,7 +236,8 @@ describe("fs.watch", () => {
     // `a/b` does not exist, so a watcher that split on `\` throws ENOENT here.
     const watcher = fs.watch(literal);
     try {
-      const { promise, resolve } = Promise.withResolvers<[string, string | Buffer | null]>();
+      const { promise, resolve, reject } = Promise.withResolvers<[string, string | Buffer | null]>();
+      watcher.once("error", reject);
       watcher.once("change", (event, filename) => resolve([event, filename]));
       const interval = repeat(() => fs.writeFileSync(literal, "changed"));
       const [event, filename] = await promise.finally(() => clearInterval(interval));
@@ -255,7 +256,8 @@ describe("fs.watch", () => {
     // d/link/.. is other/, not d/. (path.join would fold the `..` away.)
     const watcher = fs.watch(`${dir}/d/link/..`);
     try {
-      const { promise, resolve } = Promise.withResolvers<string | Buffer | null>();
+      const { promise, resolve, reject } = Promise.withResolvers<string | Buffer | null>();
+      watcher.once("error", reject);
       watcher.on("change", (event, filename) => {
         if (filename === "in-other.txt" || filename === "in-d.txt") resolve(filename);
       });

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -101,6 +101,34 @@ describe("fs.watchFile", () => {
     expect(entries[0][0].mtimeMs).toBeGreaterThan(entries[0][1].mtimeMs);
   });
 
+  // On POSIX `a\b` is one filename, not `a/b`.
+  test.skipIf(isWindows)("a backslash in the filename is not a separator", async () => {
+    const literal = path.join(testDir, "a\\b");
+    const nested = path.join(testDir, "a", "b");
+    fs.mkdirSync(path.join(testDir, "a"));
+    fs.writeFileSync(literal, "literal");
+    fs.writeFileSync(nested, "n");
+
+    let { promise, resolve } = Promise.withResolvers<[fs.Stats, fs.Stats]>();
+    fs.watchFile(literal, { interval: 50 }, (curr, prev) => resolve([curr, prev]));
+    let increment = 0;
+    // Touch both files so the listener fires whichever one the watcher stats.
+    const interval = repeat(() => {
+      increment++;
+      updateFile(literal, "literal" + increment);
+      updateFile(nested, "n" + (increment % 10));
+    });
+    const [curr, prev] = await promise;
+    clearInterval(interval);
+    fs.unwatchFile(literal);
+
+    // `a\b` holds "literal..." (7+ bytes), `a/b` holds "n." (1-2 bytes). The
+    // first update can land before the watcher's initial stat, so `prev` may
+    // already be past 7.
+    expect(prev.size).toBeGreaterThanOrEqual("literal".length);
+    expect(curr.size).toBeGreaterThanOrEqual("literal1".length);
+  });
+
   test("bigint stats", async () => {
     let entries: any = [];
     let { promise, resolve } = Promise.withResolvers<void>();


### PR DESCRIPTION
### Problem
- On POSIX `fs.watch("a\\b")` and `fs.watchFile("a\\b")` watched `a/b`: `fs.watch` threw `ENOENT: no such file or directory, watch 'a\b'` when only the literal file existed, and `fs.watchFile` reported the other file's stats. `fs.watch("d/link/..")` watched `d/`, not the parent of the link target. Node hands the string to inotify / kqueue / `stat` unchanged.
- Cause: `FSWatcher::init` (`src/runtime/node/node_fs_watcher.rs`) and `StatWatcher::init` (`node_fs_stat_watcher.rs`) built the absolute path with `join_abs_string_buf`. Its `Platform::Posix` normalizer splits on `\` and folds `..` lexically. Same root cause as #33410.

### Fix
- One helper, `absolute_watch_path_z`, for both watchers. On POSIX an absolute path is copied verbatim and a relative one is appended to the cwd, unnormalized. Windows keeps the normalizing join: Win32 resolves `..` lexically itself.
- Correct because the POSIX backend only `open()`s this string and then keys, stores, and reports the `get_fd_path()` realpath, and `fs.watchFile` only `stat()`s it.
- Verified: new tests in `test/js/node/watch/fs.watch.test.ts` (backslash, `symlink/..`) and `fs.watchFile.test.ts` (backslash) fail on 1.4.3-canary and pass here. All `test/js/node/watch/*.test.ts` files and 45 vendored `test-fs-watch*` node tests pass.
- Self-reviewed as part of a larger diff; the review asked for this split (both watchers, one helper, both tests).

### Background
- On POSIX `\` is an ordinary filename byte, and the kernel resolves `..` in the directory a symlink points to. A lexical normalizer does neither.
- `fs.watchFile` already `path.resolve()`s its argument in JS (node too). `fs.watch` passes the caller's string through.
- #33410 found that a strict `Platform::Posix` normalizer breaks npm lockfile migration (`packages\pkg1`), so this change avoids the normalizer rather than changing it.

<details><summary>Notes</summary>

- Found by a differential run of bun 1.4.2 / canary against node v26.3.0: `fs.watchFile('a\\b')` stat'ed `<cwd>/a/b` (append to the literal `a\b`: no event; append to `a/b`: event), node the literal name. `fs.watch` had been recorded earlier with the same backslash behavior.
- `path_watcher::watch` (POSIX) flow: `open(path, O_PATH|O_DIRECTORY)` (retried without `O_DIRECTORY` for files), `get_fd_path(fd)` for the canonical path, dedup map keyed by that realpath plus the recursive flag, inotify wd owners tracked per wd in `wd_map: HashMap<i32, Vec<WdOwner>>`, so two spellings of one directory were already handled. Only if `get_fd_path` fails does the caller's string become the key, as before.
- `top_level_dir` tracks `process.chdir()` (`node_process.rs`), so a relative `fs.watch` path still resolves against the cwd at call time, as before.
- `StatWatcher::init` used the unchecked join; an over-long path now returns `ENAMETOOLONG` through the existing "Failed to watch file" error instead of indexing past the buffer.
- Companion PR: #41975 (recursive readdir `parentPath`), split from the same report.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/watch/fs.watchFile.test.ts, test/js/node/watch/fs.watch.test.ts

<!-- robobun:evidence:end -->