### PR TITLE
fetch: do not reuse a pooled connection the origin already wrote to

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -901,6 +901,29 @@ ssize_t bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags) {
     }
 }
 
+int bsd_queued_input(LIBUS_SOCKET_DESCRIPTOR fd) {
+    /* Windows has no MSG_DONTWAIT. Every socket uSockets owns there is already
+     * non-blocking, which is what bsd_recv relies on too. */
+#ifdef _WIN32
+    const int peek_flags = MSG_PEEK;
+#else
+    const int peek_flags = MSG_PEEK | MSG_DONTWAIT;
+#endif
+    char byte;
+    ssize_t ret;
+    do {
+        ret = recv(fd, &byte, 1, peek_flags);
+    } while (UNLIKELY(IS_EINTR(ret)));
+
+    if (ret > 0) {
+        return LIBUS_QUEUED_INPUT_DATA;
+    }
+    if (ret == 0) {
+        return LIBUS_QUEUED_INPUT_EOF;
+    }
+    return bsd_would_block() ? LIBUS_QUEUED_INPUT_NONE : LIBUS_QUEUED_INPUT_ERROR;
+}
+
 #if !defined(_WIN32)
 ssize_t bsd_recvmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct msghdr *msg, int flags) {
     ssize_t injected = 0; int unused = 0;

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -214,6 +214,9 @@ int bsd_addr_get_port(struct bsd_addr_t *addr);
 LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr);
 
 ssize_t bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags);
+/* One of the LIBUS_QUEUED_INPUT_* codes. Peeks, so it consumes nothing and the
+ * next readable event still reports whatever it found. */
+int bsd_queued_input(LIBUS_SOCKET_DESCRIPTOR fd);
 #if !defined(_WIN32)
 ssize_t bsd_recvmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct msghdr *msg, int flags);
 #endif

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -677,6 +677,19 @@ void us_socket_shutdown(us_socket_r s) nonnull_fn_decl;
 void us_socket_shutdown_read(us_socket_r s) nonnull_fn_decl;
 int us_socket_is_shut_down(us_socket_r s) nonnull_fn_decl;
 int us_socket_is_closed(us_socket_r s) nonnull_fn_decl;
+
+/* Return codes of us_socket_queued_input. */
+#define LIBUS_QUEUED_INPUT_NONE 0  /* a read would block: nothing is queued */
+#define LIBUS_QUEUED_INPUT_DATA 1  /* at least one byte is readable */
+#define LIBUS_QUEUED_INPUT_EOF 2   /* the peer sent a FIN */
+#define LIBUS_QUEUED_INPUT_ERROR 3 /* the read side failed, e.g. a reset */
+/* What the read side of the socket holds right now, without a trip through
+ * the event loop. The peek consumes nothing, so the poll still reports the
+ * same input later and the normal read path still handles it. Callers that
+ * own a socket between loop iterations use this to tell an idle connection
+ * from one the peer has already written to or closed. */
+int us_socket_queued_input(us_socket_r s) nonnull_fn_decl;
+
 int us_socket_is_ssl_handshake_finished(us_socket_r s) nonnull_fn_decl;
 int us_socket_ssl_handshake_callback_has_fired(us_socket_r s) nonnull_fn_decl;
 /* TLS ciphertext bytes already sealed for this socket and reported as

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -169,6 +169,13 @@ __attribute__((always_inline)) int us_socket_is_established(struct us_socket_t *
     return us_internal_poll_type((struct us_poll_t *) s) != POLL_TYPE_SEMI_SOCKET;
 }
 
+int us_socket_queued_input(struct us_socket_t *s) {
+    if (s->flags.is_closed || !us_socket_is_established(s)) {
+        return LIBUS_QUEUED_INPUT_NONE;
+    }
+    return bsd_queued_input(us_poll_fd(&s->p));
+}
+
 /* Detach c from its group + drop the borrowed SSL_CTX ref, but leave c
  * allocated. After this, c->group is NULL and the embedding owner may safely
  * deinit; the only remaining link is into a loop-owned list. */

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -876,20 +876,13 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     continue;
                 }
 
-                // The pool hands sockets out from `HTTPThread::drain_events`,
-                // which runs before the loop polls. So input the origin already
-                // wrote on this idle connection is still in the kernel, and
-                // none of the checks above can see it: an unsolicited response,
-                // a `408 Request Timeout` that retires the connection, a FIN.
-                // Writing the next request onto such a socket attributes those
-                // bytes to it. The peek below reaches the same verdict the
-                // idle-socket handlers reach once the loop does poll
-                // (`Handler::on_data` terminates, `Handler::on_end` closes),
-                // only before the request goes out instead of after.
-                //
-                // An HTTP/2 session is exempt: idle frames (PING, SETTINGS,
-                // WINDOW_UPDATE) are part of a healthy connection, so
-                // `on_idle_data` decides for those.
+                // `HTTPThread::drain_events` hands a socket out before the loop
+                // polls it, so input the origin already wrote is unread in the
+                // kernel and invisible to the checks above; reuse answers this
+                // request with it. Same verdicts the idle handlers reach after
+                // a poll: `Handler::on_data` terminates, `Handler::on_end`
+                // closes. HTTP/2 idle frames are healthy, so `on_idle_data`
+                // keeps deciding for those.
                 if socket.h2_session.is_none() {
                     match http_socket.queued_input() {
                         uws::QueuedInput::None => {}

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -876,6 +876,34 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     continue;
                 }
 
+                // The pool hands sockets out from `HTTPThread::drain_events`,
+                // which runs before the loop polls. So input the origin already
+                // wrote on this idle connection is still in the kernel, and
+                // none of the checks above can see it: an unsolicited response,
+                // a `408 Request Timeout` that retires the connection, a FIN.
+                // Writing the next request onto such a socket attributes those
+                // bytes to it. The peek below reaches the same verdict the
+                // idle-socket handlers reach once the loop does poll
+                // (`Handler::on_data` terminates, `Handler::on_end` closes),
+                // only before the request goes out instead of after.
+                //
+                // An HTTP/2 session is exempt: idle frames (PING, SETTINGS,
+                // WINDOW_UPDATE) are part of a healthy connection, so
+                // `on_idle_data` decides for those.
+                if socket.h2_session.is_none() {
+                    match http_socket.queued_input() {
+                        uws::QueuedInput::None => {}
+                        uws::QueuedInput::Eof => {
+                            Self::close_socket(http_socket);
+                            continue;
+                        }
+                        uws::QueuedInput::Data | uws::QueuedInput::Error => {
+                            Self::terminate_socket(http_socket);
+                            continue;
+                        }
+                    }
+                }
+
                 // Transfer tunnel ownership (the parked strong ref) to the caller.
                 let tunnel: Option<RefPtr<ProxyTunnel>> = socket.proxy_tunnel.take();
                 socket.target_hostname = Box::default();

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1367,6 +1367,7 @@ pub use bun_uws_sys::SocketKind;
 pub type DispatchKind = SocketKind;
 
 pub use bun_uws_sys::CloseCode;
+pub use bun_uws_sys::QueuedInput;
 /// Legacy alias — `bun_uws_sys::CloseCode` is the one canonical `#[repr(i32)]`
 /// enum (`normal`/`failure`/`fast_shutdown`, with `Normal`/`Failure`/
 /// `FastShutdown` associated-const aliases).

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -492,7 +492,7 @@ pub use response::{AnyResponse, SocketAddress, WebSocketUpgradeContext};
 pub use socket_context::BunSocketContextOptions;
 pub use socket_group::ConnectResult;
 pub use socket_group::SocketGroup;
-pub use us_socket::{CloseCode, UsIoVec, us_socket_stream_buffer_t, us_socket_t};
+pub use us_socket::{CloseCode, QueuedInput, UsIoVec, us_socket_stream_buffer_t, us_socket_t};
 pub use web_socket::{AnyWebSocket, RawWebSocket, WebSocketBehavior};
 
 /// Legacy aliases for `App<SSL>` / `Response<SSL>`.

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -302,8 +302,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
     }
 
     /// What the read side holds right now, without waiting for the loop to
-    /// poll. Transports that the loop does not read with `recv()` (an upgraded
-    /// duplex, a Windows named pipe) report [`QueuedInput::None`].
+    /// poll. Transports the loop does not `recv()` report nothing queued.
     pub fn queued_input(&self) -> QueuedInput {
         on_socket!(self.socket;
             connected s => s.queued_input(),

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -21,7 +21,7 @@ use bun_core::{Fd, ZStr};
 use crate::WindowsNamedPipe;
 use crate::{
     CloseCode, ConnectResult, ConnectingSocket, LIBUS_SOCKET_ALLOW_HALF_OPEN,
-    LIBUS_SOCKET_DESCRIPTOR, SocketGroup, SocketKind, SslCtx, UpgradedDuplex,
+    LIBUS_SOCKET_DESCRIPTOR, QueuedInput, SocketGroup, SocketKind, SslCtx, UpgradedDuplex,
     us_bun_verify_error_t, us_socket_t,
 };
 
@@ -299,6 +299,18 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
     #[inline]
     pub fn is_closed_or_has_error(&self) -> bool {
         self.is_closed() || self.is_shutdown() || self.get_error() != 0
+    }
+
+    /// What the read side holds right now, without waiting for the loop to
+    /// poll. Transports that the loop does not read with `recv()` (an upgraded
+    /// duplex, a Windows named pipe) report [`QueuedInput::None`].
+    pub fn queued_input(&self) -> QueuedInput {
+        on_socket!(self.socket;
+            connected s => s.queued_input(),
+            duplex _d => QueuedInput::None,
+            pipe _p => QueuedInput::None,
+            else => QueuedInput::None,
+        )
     }
 
     pub fn get_verify_error(&self) -> us_bun_verify_error_t {

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -44,21 +44,29 @@ pub enum CloseCode {
     fast_shutdown = 2,
 }
 
+/// `us_socket_queued_input` return codes, mirroring the `LIBUS_QUEUED_INPUT_*`
+/// defines in libusockets.h by name.
+pub const LIBUS_QUEUED_INPUT_NONE: c_int = 0;
+pub const LIBUS_QUEUED_INPUT_DATA: c_int = 1;
+pub const LIBUS_QUEUED_INPUT_EOF: c_int = 2;
+pub const LIBUS_QUEUED_INPUT_ERROR: c_int = 3;
+
 /// What the read side of a socket holds right now, read with a peek instead of
-/// a trip through the event loop. Mirrors the `LIBUS_QUEUED_INPUT_*` codes.
+/// a trip through the event loop.
 ///
 /// The peek consumes nothing, so a socket that reports `Data` still delivers
 /// the same bytes to the normal read path on the next poll.
+#[repr(i32)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum QueuedInput {
     /// A read would block: the peer has written nothing since the last read.
-    None,
+    None = LIBUS_QUEUED_INPUT_NONE,
     /// At least one byte is readable.
-    Data,
+    Data = LIBUS_QUEUED_INPUT_DATA,
     /// The peer sent a FIN.
-    Eof,
+    Eof = LIBUS_QUEUED_INPUT_EOF,
     /// The read side failed, for example a reset.
-    Error,
+    Error = LIBUS_QUEUED_INPUT_ERROR,
 }
 
 /// Layout-compatible with `struct us_iovec_t` in libusockets.h (== POSIX iovec).
@@ -484,9 +492,9 @@ impl us_socket_t {
 
     pub(crate) fn queued_input(&self) -> QueuedInput {
         match c::us_socket_queued_input(self) {
-            1 => QueuedInput::Data,
-            2 => QueuedInput::Eof,
-            3 => QueuedInput::Error,
+            LIBUS_QUEUED_INPUT_DATA => QueuedInput::Data,
+            LIBUS_QUEUED_INPUT_EOF => QueuedInput::Eof,
+            LIBUS_QUEUED_INPUT_ERROR => QueuedInput::Error,
             _ => QueuedInput::None,
         }
     }

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -44,18 +44,14 @@ pub enum CloseCode {
     fast_shutdown = 2,
 }
 
-/// `us_socket_queued_input` return codes, mirroring the `LIBUS_QUEUED_INPUT_*`
-/// defines in libusockets.h by name.
+/// `LIBUS_QUEUED_INPUT_*` in libusockets.h, mirrored by name.
 pub const LIBUS_QUEUED_INPUT_NONE: c_int = 0;
 pub const LIBUS_QUEUED_INPUT_DATA: c_int = 1;
 pub const LIBUS_QUEUED_INPUT_EOF: c_int = 2;
 pub const LIBUS_QUEUED_INPUT_ERROR: c_int = 3;
 
-/// What the read side of a socket holds right now, read with a peek instead of
-/// a trip through the event loop.
-///
-/// The peek consumes nothing, so a socket that reports `Data` still delivers
-/// the same bytes to the normal read path on the next poll.
+/// What a socket's read side holds right now. The peek behind it consumes
+/// nothing, so the normal read path still gets the same bytes.
 #[repr(i32)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum QueuedInput {

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -44,6 +44,23 @@ pub enum CloseCode {
     fast_shutdown = 2,
 }
 
+/// What the read side of a socket holds right now, read with a peek instead of
+/// a trip through the event loop. Mirrors the `LIBUS_QUEUED_INPUT_*` codes.
+///
+/// The peek consumes nothing, so a socket that reports `Data` still delivers
+/// the same bytes to the normal read path on the next poll.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum QueuedInput {
+    /// A read would block: the peer has written nothing since the last read.
+    None,
+    /// At least one byte is readable.
+    Data,
+    /// The peer sent a FIN.
+    Eof,
+    /// The read side failed, for example a reset.
+    Error,
+}
+
 /// Layout-compatible with `struct us_iovec_t` in libusockets.h (== POSIX iovec).
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -464,6 +481,15 @@ impl us_socket_t {
     pub(crate) fn is_established(&self) -> bool {
         c::us_socket_is_established(self) > 0
     }
+
+    pub(crate) fn queued_input(&self) -> QueuedInput {
+        match c::us_socket_queued_input(self) {
+            1 => QueuedInput::Data,
+            2 => QueuedInput::Eof,
+            3 => QueuedInput::Error,
+            _ => QueuedInput::None,
+        }
+    }
 }
 
 /// Raw externs. Private — every operation has a typed method on `us_socket_t`.
@@ -576,6 +602,7 @@ mod c {
         pub(super) safe fn us_socket_verify_error(s: &us_socket_t) -> us_bun_verify_error_t;
         pub(super) safe fn us_socket_get_error(s: &us_socket_t) -> c_int;
         pub(super) safe fn us_socket_is_established(s: &us_socket_t) -> i32;
+        pub(super) safe fn us_socket_queued_input(s: &us_socket_t) -> c_int;
 
         /// ssl_ctx is required (the whole point); sni may be null.
         pub(super) fn us_socket_adopt_tls(

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -711,7 +711,7 @@ for (const [label, earlyReply, body, first, onWindows] of earlyReplyCases) {
 // never processed, yet `fetch()` resolves with 408 and the origin's timeout
 // body.
 //
-// Every round below writes the injected event BEFORE it queues request 2, so
+// Every round writes the injected event BEFORE it queues request 2, so
 // the bytes are in bun's kernel buffer before bun can write that request
 // anywhere. Two ballast requests to an origin that never answers are queued
 // first, which takes the HTTP thread out of `poll()`: without them the loop
@@ -730,27 +730,28 @@ const idleInjections: [label: string, bytes: string][] = [
   ["a FIN", ""],
 ];
 
-test("a pooled connection the origin already wrote to is not reused", async () => {
-  const rounds = 12;
-  // Subprocess so the keep-alive pool starts empty and so the origin shares a
-  // thread with the client: the injected write and the next fetch() are then
-  // ordered by the JS thread, not by a timer.
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      const injections = ${JSON.stringify(idleInjections)};
-      const misattributed = [];
+test.concurrent.each(idleInjections)(
+  "a pooled connection the origin answered with %s is not reused",
+  async (_label, bytes) => {
+    const rounds = 12;
+    // Subprocess so the keep-alive pool starts empty and so the origin shares a
+    // thread with the client: the injected write and the next fetch() are then
+    // ordered by the JS thread, not by a timer.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const bytes = ${JSON.stringify(bytes)};
+        const misattributed = [];
 
-      // Accepts connections and never answers them.
-      using sink = Bun.listen({
-        hostname: "127.0.0.1",
-        port: 0,
-        socket: { open() {}, data() {}, close() {}, error() {}, drain() {} },
-      });
+        // Accepts connections and never answers them.
+        using sink = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: { open() {}, data() {}, close() {}, error() {}, drain() {} },
+        });
 
-      for (const [label, bytes] of injections) {
         let accepted = 0;
         let idle = null;
         using server = Bun.listen({
@@ -804,22 +805,22 @@ test("a pooled connection the origin already wrote to is not reused", async () =
           // accepted later. Anything else means bun read the injected bytes as
           // the answer.
           const honest = /^200:c\\d+$/.test(got) && got !== "200:" + warmConn;
-          if (!honest) misattributed.push(label + " round " + round + " -> " + got);
+          if (!honest) misattributed.push("round " + round + " -> " + got);
         }
-      }
-      console.log(JSON.stringify({ misattributed }));
-      process.exit(0);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+        console.log(JSON.stringify({ misattributed }));
+        process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-  expect({ result, exitCode }).toEqual({ result: { misattributed: [] }, exitCode: 0 });
-});
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ result, exitCode }).toEqual({ result: { misattributed: [] }, exitCode: 0 });
+  },
+);
 
 test.skipIf(isWindows)("a full keep-alive pool evicts the longest-idle connection", async () => {
   function makeServer() {

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tls } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tls } from "harness";
 import { once } from "node:events";
 import { createServer } from "node:net";
+import { join } from "node:path";
 
 test("keepalive", async () => {
   using server = Bun.serve({
@@ -711,11 +712,11 @@ for (const [label, earlyReply, body, first, onWindows] of earlyReplyCases) {
 // never processed, yet `fetch()` resolves with 408 and the origin's timeout
 // body.
 //
-// Every round writes the injected event BEFORE it queues request 2, so
-// the bytes are in bun's kernel buffer before bun can write that request
-// anywhere. Two ballast requests to an origin that never answers are queued
-// first, which takes the HTTP thread out of `poll()`: without them the loop
-// reads the injected bytes on the idle connection and retires it through
+// Every round writes the injected event BEFORE it queues request 2, so the
+// bytes are in bun's kernel buffer before bun can write that request anywhere.
+// Two ballast requests to an origin that never answers are queued first, which
+// takes the HTTP thread out of `poll()`: without them the loop reads the
+// injected bytes on the idle connection and retires it through
 // `Handler::on_data`, which is the behaviour this check extends to the checkout
 // window. Whichever of the two gets there first, request 2 must be answered on
 // a connection the origin accepted later.
@@ -729,20 +730,30 @@ const idleInjections: [label: string, bytes: string][] = [
   ["64 bytes of garbage", Buffer.alloc(64, "!").toString()],
   ["a FIN", ""],
 ];
+// "Before" only holds when write() returns with the bytes already in the
+// peer's receive buffer. An AF_UNIX stream does that everywhere, and TCP
+// loopback does it on Linux and Windows. macOS hands a loopback segment to
+// the dlil input thread first, so it can land after the checkout, which no
+// client can tell from an answer: there only the unix-socket pool is checked.
+// fetch() does not pool unix sockets on Windows. Both pools check a socket
+// out through the same code.
+const idleTransports = [...(isMacOS ? [] : ["tcp"]), ...(isWindows ? [] : ["unix"])];
 
-test.concurrent.each(idleInjections)(
-  "a pooled connection the origin answered with %s is not reused",
-  async (_label, bytes) => {
-    const rounds = 12;
-    // Subprocess so the keep-alive pool starts empty and so the origin shares a
-    // thread with the client: the injected write and the next fetch() are then
-    // ordered by the JS thread, not by a timer.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+test.concurrent.each(
+  idleTransports.flatMap(transport => idleInjections.map(([label, bytes]) => [transport, label, bytes])),
+)("%s: a pooled connection the origin answered with %s is not reused", async (transport, _label, bytes) => {
+  const rounds = 12;
+  using dir = tempDir("fetch-ka-idle", {});
+  // Subprocess so the keep-alive pool starts empty and so the origin shares a
+  // thread with the client: the injected write and the next fetch() are then
+  // ordered by the JS thread, not by a timer.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
         const bytes = ${JSON.stringify(bytes)};
+        const unix = ${JSON.stringify(transport === "unix" ? join(String(dir), "o.sock") : null)};
         const misattributed = [];
 
         // Accepts connections and never answers them.
@@ -755,8 +766,7 @@ test.concurrent.each(idleInjections)(
         let accepted = 0;
         let idle = null;
         using server = Bun.listen({
-          hostname: "127.0.0.1",
-          port: 0,
+          ...(unix ? { unix } : { hostname: "127.0.0.1", port: 0 }),
           socket: {
             open(socket) {
               socket.data = { id: ++accepted, buf: "" };
@@ -775,10 +785,11 @@ test.concurrent.each(idleInjections)(
             close() {}, error() {}, drain() {},
           },
         });
-        const origin = "http://127.0.0.1:" + server.port;
+        const origin = unix ? "http://localhost" : "http://127.0.0.1:" + server.port;
+        const init = unix ? { unix } : {};
 
         for (let round = 0; round < ${rounds}; round++) {
-          const warm = await fetch(origin + "/warm");
+          const warm = await fetch(origin + "/warm", init);
           const warmConn = warm.headers.get("x-conn");
           if ((await warm.text()) !== warmConn) throw new Error("warm body " + warmConn);
 
@@ -788,7 +799,7 @@ test.concurrent.each(idleInjections)(
           );
           if (bytes.length === 0) idle.end();
           else idle.write(bytes);
-          const pending = fetch(origin + "/next");
+          const pending = fetch(origin + "/next", init);
 
           let got;
           try {
@@ -810,17 +821,16 @@ test.concurrent.each(idleInjections)(
         console.log(JSON.stringify({ misattributed }));
         process.exit(0);
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-    expect({ result, exitCode }).toEqual({ result: { misattributed: [] }, exitCode: 0 });
-  },
-);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({ result: { misattributed: [] }, exitCode: 0 });
+});
 
 test.skipIf(isWindows)("a full keep-alive pool evicts the longest-idle connection", async () => {
   function makeServer() {

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -700,6 +700,126 @@ for (const [label, earlyReply, body, first, onWindows] of earlyReplyCases) {
   });
 }
 
+// A connection parked in the keep-alive pool is handed to the next request by
+// `HTTPThread::drain_events`, which runs before the loop polls. So input the
+// origin wrote after its last response can still be sitting unread in the
+// kernel at that moment, and `is_closed`/`is_shutdown`/`get_error` cannot see
+// it. Writing the next request onto such a connection makes bun answer that
+// request with bytes that were already on the wire before it: an unsolicited
+// response, or the `HTTP/1.1 408 Request Timeout` + `Connection: close` that
+// many servers and load balancers use to retire an idle keep-alive connection.
+// The request was never processed, yet `fetch()` resolved with 408 and the
+// origin's timeout body.
+//
+// The origin below answers `/warm`, waits long enough for bun to read that
+// response and park the connection, then writes one unsolicited event on it.
+// bun must never answer `/next` on that connection: each round's second
+// response has to come from a connection the origin accepted later.
+const idleInjections: [label: string, bytes: string][] = [
+  [
+    "408 Request Timeout and Connection: close",
+    "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nContent-Length: 5\r\n\r\nT-OUT",
+  ],
+  ["a complete unsolicited response", "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nPWNED"],
+  ["one stray CRLF", "\r\n"],
+  ["64 bytes of garbage", "!".repeat(64)],
+  ["a FIN", ""],
+];
+
+test("a pooled connection the origin already wrote to is not reused", async () => {
+  const rounds = 12;
+  // How long the origin waits between its response and the injected event. It
+  // has to outlast one read on the client (microseconds on loopback) and stay
+  // well inside one fetch() round trip through the JS thread, which is where
+  // the checkout happens.
+  const gapNs = 50_000;
+
+  const origins: { stop: () => void; port: number; label: string }[] = [];
+  for (const [label, bytes] of idleInjections) {
+    let accepted = 0;
+    const server = Bun.listen<{ id: number; buf: string }>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = { id: ++accepted, buf: "" };
+        },
+        data(socket, chunk) {
+          socket.data.buf += chunk.toString("latin1");
+          let end: number;
+          while ((end = socket.data.buf.indexOf("\r\n\r\n")) >= 0) {
+            const path = socket.data.buf.slice(0, end).split(" ")[1];
+            socket.data.buf = socket.data.buf.slice(end + 4);
+            const body = `c${socket.data.id}`;
+            socket.write(`HTTP/1.1 200 OK\r\nX-Conn: ${body}\r\nContent-Length: ${body.length}\r\n\r\n${body}`);
+            if (path !== "/warm") continue;
+            const until = Bun.nanoseconds() + gapNs;
+            while (Bun.nanoseconds() < until) {}
+            if (bytes.length === 0) socket.end();
+            else socket.write(bytes);
+          }
+        },
+        close() {},
+        error() {},
+        drain() {},
+      },
+    });
+    origins.push({ stop: () => server.stop(true), port: server.port, label });
+  }
+
+  try {
+    // Subprocess so the keep-alive pool starts empty.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const ports = ${JSON.stringify(origins.map(o => o.port))};
+        const labels = ${JSON.stringify(origins.map(o => o.label))};
+        const misattributed = [];
+        for (let i = 0; i < ports.length; i++) {
+          const origin = "http://127.0.0.1:" + ports[i];
+          for (let round = 0; round < ${rounds}; round++) {
+            const warm = await fetch(origin + "/warm");
+            const warmConn = warm.headers.get("x-conn");
+            if ((await warm.text()) !== warmConn) throw new Error("warm body " + warmConn);
+            let got;
+            try {
+              const next = await fetch(origin + "/next");
+              got = next.status + ":" + (await next.text());
+            } catch (e) {
+              got = "ERR:" + (e.code ?? e.name);
+            }
+            // The parked connection was written to, so the answer to /next has
+            // to be an honest 200 from a connection the origin accepted after
+            // it. Anything else means bun read the injected bytes as the
+            // answer, or reused the connection they arrived on.
+            const honest = /^200:c\\d+$/.test(got) && got !== "200:" + warmConn;
+            if (!honest) misattributed.push(labels[i] + " round " + round + " -> " + got);
+          }
+        }
+        console.log(JSON.stringify({ misattributed }));
+        process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    // The injected event can also land after bun has already written /next,
+    // which no client can tell from an answer, and the origin's own wait can
+    // be preempted into that window. One such round out of 60 is allowed.
+    // Without the checkout check nearly every round is misattributed.
+    expect(result.misattributed.length, result.misattributed.join("\n")).toBeLessThanOrEqual(1);
+  } finally {
+    for (const o of origins) o.stop();
+  }
+});
+
 test.skipIf(isWindows)("a full keep-alive pool evicts the longest-idle connection", async () => {
   function makeServer() {
     let connections = 0;

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -701,20 +701,24 @@ for (const [label, earlyReply, body, first, onWindows] of earlyReplyCases) {
 }
 
 // A connection parked in the keep-alive pool is handed to the next request by
-// `HTTPThread::drain_events`, which runs before the loop polls. So input the
-// origin wrote after its last response can still be sitting unread in the
-// kernel at that moment, and `is_closed`/`is_shutdown`/`get_error` cannot see
-// it. Writing the next request onto such a connection makes bun answer that
-// request with bytes that were already on the wire before it: an unsolicited
-// response, or the `HTTP/1.1 408 Request Timeout` + `Connection: close` that
-// many servers and load balancers use to retire an idle keep-alive connection.
-// The request was never processed, yet `fetch()` resolved with 408 and the
-// origin's timeout body.
+// `HTTPThread::drain_events`, which runs before the event loop polls. So input
+// the origin wrote after its last response can still be unread in the kernel at
+// that moment, and `is_closed`/`is_shutdown`/`get_error` cannot see it. Writing
+// the next request onto that connection makes bun answer the request with bytes
+// that were already on the wire before it: an unsolicited response, or the
+// `HTTP/1.1 408 Request Timeout` plus `Connection: close` that many servers and
+// load balancers use to retire an idle keep-alive connection. The request was
+// never processed, yet `fetch()` resolves with 408 and the origin's timeout
+// body.
 //
-// The origin below answers `/warm`, waits long enough for bun to read that
-// response and park the connection, then writes one unsolicited event on it.
-// bun must never answer `/next` on that connection: each round's second
-// response has to come from a connection the origin accepted later.
+// Every round below writes the injected event BEFORE it queues request 2, so
+// the bytes are in bun's kernel buffer before bun can write that request
+// anywhere. Two ballast requests to an origin that never answers are queued
+// first, which takes the HTTP thread out of `poll()`: without them the loop
+// reads the injected bytes on the idle connection and retires it through
+// `Handler::on_data`, which is the behaviour this check extends to the checkout
+// window. Whichever of the two gets there first, request 2 must be answered on
+// a connection the origin accepted later.
 const idleInjections: [label: string, bytes: string][] = [
   [
     "408 Request Timeout and Connection: close",
@@ -722,102 +726,99 @@ const idleInjections: [label: string, bytes: string][] = [
   ],
   ["a complete unsolicited response", "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nPWNED"],
   ["one stray CRLF", "\r\n"],
-  ["64 bytes of garbage", "!".repeat(64)],
+  ["64 bytes of garbage", Buffer.alloc(64, "!").toString()],
   ["a FIN", ""],
 ];
 
 test("a pooled connection the origin already wrote to is not reused", async () => {
   const rounds = 12;
-  // How long the origin waits between its response and the injected event. It
-  // has to outlast one read on the client (microseconds on loopback) and stay
-  // well inside one fetch() round trip through the JS thread, which is where
-  // the checkout happens.
-  const gapNs = 50_000;
+  // Subprocess so the keep-alive pool starts empty and so the origin shares a
+  // thread with the client: the injected write and the next fetch() are then
+  // ordered by the JS thread, not by a timer.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const injections = ${JSON.stringify(idleInjections)};
+      const misattributed = [];
 
-  const origins: { stop: () => void; port: number; label: string }[] = [];
-  for (const [label, bytes] of idleInjections) {
-    let accepted = 0;
-    const server = Bun.listen<{ id: number; buf: string }>({
-      hostname: "127.0.0.1",
-      port: 0,
-      socket: {
-        open(socket) {
-          socket.data = { id: ++accepted, buf: "" };
-        },
-        data(socket, chunk) {
-          socket.data.buf += chunk.toString("latin1");
-          let end: number;
-          while ((end = socket.data.buf.indexOf("\r\n\r\n")) >= 0) {
-            const path = socket.data.buf.slice(0, end).split(" ")[1];
-            socket.data.buf = socket.data.buf.slice(end + 4);
-            const body = `c${socket.data.id}`;
-            socket.write(`HTTP/1.1 200 OK\r\nX-Conn: ${body}\r\nContent-Length: ${body.length}\r\n\r\n${body}`);
-            if (path !== "/warm") continue;
-            const until = Bun.nanoseconds() + gapNs;
-            while (Bun.nanoseconds() < until) {}
-            if (bytes.length === 0) socket.end();
-            else socket.write(bytes);
-          }
-        },
-        close() {},
-        error() {},
-        drain() {},
-      },
-    });
-    origins.push({ stop: () => server.stop(true), port: server.port, label });
-  }
+      // Accepts connections and never answers them.
+      using sink = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: { open() {}, data() {}, close() {}, error() {}, drain() {} },
+      });
 
-  try {
-    // Subprocess so the keep-alive pool starts empty.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const ports = ${JSON.stringify(origins.map(o => o.port))};
-        const labels = ${JSON.stringify(origins.map(o => o.label))};
-        const misattributed = [];
-        for (let i = 0; i < ports.length; i++) {
-          const origin = "http://127.0.0.1:" + ports[i];
-          for (let round = 0; round < ${rounds}; round++) {
-            const warm = await fetch(origin + "/warm");
-            const warmConn = warm.headers.get("x-conn");
-            if ((await warm.text()) !== warmConn) throw new Error("warm body " + warmConn);
-            let got;
-            try {
-              const next = await fetch(origin + "/next");
-              got = next.status + ":" + (await next.text());
-            } catch (e) {
-              got = "ERR:" + (e.code ?? e.name);
-            }
-            // The parked connection was written to, so the answer to /next has
-            // to be an honest 200 from a connection the origin accepted after
-            // it. Anything else means bun read the injected bytes as the
-            // answer, or reused the connection they arrived on.
-            const honest = /^200:c\\d+$/.test(got) && got !== "200:" + warmConn;
-            if (!honest) misattributed.push(labels[i] + " round " + round + " -> " + got);
+      for (const [label, bytes] of injections) {
+        let accepted = 0;
+        let idle = null;
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open(socket) {
+              socket.data = { id: ++accepted, buf: "" };
+            },
+            data(socket, chunk) {
+              socket.data.buf += chunk.toString("latin1");
+              let end;
+              while ((end = socket.data.buf.indexOf("\\r\\n\\r\\n")) >= 0) {
+                const path = socket.data.buf.slice(0, end).split(" ")[1];
+                socket.data.buf = socket.data.buf.slice(end + 4);
+                const body = "c" + socket.data.id;
+                socket.write("HTTP/1.1 200 OK\\r\\nX-Conn: " + body + "\\r\\nContent-Length: " + body.length + "\\r\\n\\r\\n" + body);
+                if (path === "/warm") idle = socket;
+              }
+            },
+            close() {}, error() {}, drain() {},
+          },
+        });
+        const origin = "http://127.0.0.1:" + server.port;
+
+        for (let round = 0; round < ${rounds}; round++) {
+          const warm = await fetch(origin + "/warm");
+          const warmConn = warm.headers.get("x-conn");
+          if ((await warm.text()) !== warmConn) throw new Error("warm body " + warmConn);
+
+          const ac = new AbortController();
+          const ballast = [0, 1].map(b =>
+            fetch("http://127.0.0.1:" + sink.port + "/" + round + "/" + b, { signal: ac.signal }).catch(() => {}),
+          );
+          if (bytes.length === 0) idle.end();
+          else idle.write(bytes);
+          const pending = fetch(origin + "/next");
+
+          let got;
+          try {
+            const next = await pending;
+            got = next.status + ":" + (await next.text());
+          } catch (e) {
+            got = "ERR:" + (e.code ?? e.name);
           }
+          ac.abort();
+          await Promise.all(ballast);
+
+          // The parked connection was written to before this request existed,
+          // so the answer has to be an honest 200 from a connection the origin
+          // accepted later. Anything else means bun read the injected bytes as
+          // the answer.
+          const honest = /^200:c\\d+$/.test(got) && got !== "200:" + warmConn;
+          if (!honest) misattributed.push(label + " round " + round + " -> " + got);
         }
-        console.log(JSON.stringify({ misattributed }));
-        process.exit(0);
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      }
+      console.log(JSON.stringify({ misattributed }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
-    // The injected event can also land after bun has already written /next,
-    // which no client can tell from an answer, and the origin's own wait can
-    // be preempted into that window. One such round out of 60 is allowed.
-    // Without the checkout check nearly every round is misattributed.
-    expect(result.misattributed.length, result.misattributed.join("\n")).toBeLessThanOrEqual(1);
-  } finally {
-    for (const o of origins) o.stop();
-  }
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({ result: { misattributed: [] }, exitCode: 0 });
 });
 
 test.skipIf(isWindows)("a full keep-alive pool evicts the longest-idle connection", async () => {


### PR DESCRIPTION
### Problem

- `fetch()` can resolve with bytes that were on the wire before its request. An origin that retires an idle keep-alive connection with `HTTP/1.1 408 Request Timeout` and `Connection: close`, or that sends an unsolicited response, has that answer attributed to the next request: 99 of 100 rounds here, GET and POST alike. undici, curl and Chromium dial a fresh connection instead.
- The cause is `HTTPContext::find_in` (`src/http/HTTPContext.rs:869`). The pool hands a parked socket out from `HTTPThread::drain_events`, which runs before `uws_loop.tick()` (`src/http/HTTPThread.rs:1272`). Input the origin already wrote is still unread in the kernel, and `is_closed`, `is_shutdown` and `get_error` cannot see it.

### Fix

- `find_in` peeks the read side before it hands a socket out. Queued data or a read error retires the connection with a reset. A FIN retires it with a FIN. An HTTP/2 session keeps its own idle-frame handling.
- Correct because the peek reaches the verdict the idle-socket handlers already reach once the loop polls (`Handler::on_data` terminates, `Handler::on_end` closes). A zero gap now behaves like a 5 ms gap.
- `us_socket_queued_input` is the new uSockets call. `recv(MSG_PEEK | MSG_DONTWAIT)` consumes nothing, so the normal read path still sees what it found.
- Verified: `test/js/web/fetch/fetch-keepalive.test.ts`, one case per injected event and pool (TCP, unix), 12 rounds each. Stock bun misattributes 12 of 12 rounds on each event that leaks. Also all of `test/js/web/fetch/`, `test/js/node/http/node-http.test.ts`, and keep-alive reuse over plain, TLS and unix (30 requests, 1 connection).

### Background

- The keep-alive pool parks a finished connection in `pending_sockets` and hands it to the next request for the same origin. `release_socket` parks it, `find_in` checks it out.
- bun runs HTTP on its own thread. Its loop body is `drain_events()` and then `uws_loop.tick()`, so the queue of new requests is drained before the loop polls the sockets. A checkout can happen with no poll since the socket was parked.
- A parked socket stays armed for readable events, so the idle handlers retire it as soon as the loop polls. That is why the fault shows only in the checkout window.
- `MSG_PEEK` reports what the kernel holds on a socket without removing it.

<details><summary>Notes</summary>

**Reproduction.** A raw origin answers request 1 with `200 ... REAL1`, waits, then writes one unsolicited event on the now idle connection. The client reads response 1 and issues request 2 at once.

| injected event | stock bun | this branch |
| --- | --- | --- |
| `HTTP/1.1 408 Request Timeout` + `Connection: close` | 99/100 answered with `408` / `T-OUT` | 1/100 |
| complete unsolicited `200` response | 49/50 answered with the injected body | 0/50 |
| one stray CRLF | 21/30 `Malformed_HTTP_Response` | 0/30 |
| 64 bytes of garbage | 17/30 `Malformed_HTTP_Response` | 0/30 |
| FIN | 0/30 (the existing stale-socket retry covers it) | 0/30 |

Node v26 answers 0/50 on the unsolicited-response origin. With the injected event at least 1 ms old, stock bun already retires the socket (0/100), because the loop has polled by then.

**Sweep of the origin's delay between response 1 and the injected event** (40 rounds each, `408` event):

| delay | stock bun | this branch |
| --- | --- | --- |
| 0 ms | 30/40 | 0/40 |
| 0.05 ms | 38/40 | 0/40 |
| 0.2 ms | 35/40 | 0/40 |
| 0.5 ms | 40/40 | 0/40 |
| 1 ms | 40/40 | 13/40 |
| 5 ms | 40/40 | 40/40 |

The residual from 1 ms on is the other half of the race: the injected bytes reach the client after it has already written request 2. No readability check can see those, and no client can tell them from an answer (node answers 7/100 there, curl 3/30). Browsers treat a `408` on a reused connection that answered no byte as a stale socket and replay an idempotent request. That is a separate behaviour change and is not in this PR. bun's existing stale-socket retry (`src/http/lib.rs:2141`) already covers the FIN and reset flavours the same way.

**The test does not race.** Each round writes the injected event before it queues request 2, so the bytes are in bun's kernel buffer before bun can write that request anywhere. Two requests to an origin that never answers are queued first, which takes the HTTP thread out of `poll()`: without them the loop reads the injected bytes on the idle connection and retires it through `Handler::on_data`, which is the behaviour this change extends to the checkout window. Whichever of the two wins, request 2 has to be answered on a later connection, so the test has no timing tolerance to spend.

That ordering only holds when `write()` returns with the bytes already in the peer's receive buffer. An AF_UNIX stream does that everywhere, and TCP loopback does it on Linux and Windows. macOS hands a loopback segment to the dlil input thread first: the darwin lane saw it land after the checkout in 4 of 60 rounds, which no client can tell from an answer. So the cases run over the unix-socket pool wherever fetch() has one (not Windows) and over TCP on Linux and Windows. Both pools check a socket out through `find_in`. An earlier version timed the origin's write against one fetch() round trip and was flaky everywhere.

**Keep-alive reuse is unchanged.** 30 sequential requests still ride one connection over plain HTTP, TLS and a unix socket. A TLS 1.3 `NewSessionTicket` was the main worry: a ticket queued at checkout time would retire a healthy connection. It never is, because the client consumes the ticket while it reads the first response. Checked against an OpenSSL origin that sends tickets: 30 requests, 1 connection.

**Conservative by design.** The peek reports that input is queued, not what it is, which is all a TLS socket can report without decrypting. So a pooled HTTP/1 socket carrying a trailing `0\r\n\r\n` (which `Handler::on_data` ignores by name) is retired when the race window hits it, instead of reused. That costs one connection, and only in the window.

**Cost.** One `recv(MSG_PEEK | MSG_DONTWAIT)` per pooled checkout, on a socket the kernel has cached. Transports the loop does not read with `recv()` (an upgraded duplex, a Windows named pipe) report nothing queued and behave as before.

**Related.** #35817 makes bun honour a server's `Keep-Alive: timeout=N` hint, which shortens how long bun holds a connection the origin is about to time out. This PR is the other side: what to do with a connection the origin has already written to.

</details>
