### PR TITLE
build: honor --format=cjs with --no-bundle, reject --format=iife

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2999,8 +2999,8 @@ pub mod bv2_impl {
             this.transpiler.log_mut().clone_line_text = true;
 
             // Bake forbids tree-shaking since every export must always exist in
-            // case a future module starts depending on it. The override comes
-            // from `Bun.build({ treeShaking })` or `--no-bundle --format=cjs`.
+            // case a future module starts depending on it. The override is only
+            // set by `Bun.build({ treeShaking })` and `bun build --no-bundle --format=cjs`.
             let tree_shaking = this.transpiler.options.tree_shaking_override.unwrap_or(
                 this.transpiler.options.output_format != options::Format::InternalBakeDev,
             );

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2999,9 +2999,8 @@ pub mod bv2_impl {
             this.transpiler.log_mut().clone_line_text = true;
 
             // Bake forbids tree-shaking since every export must always exist in
-            // case a future module starts depending on it. The override is set
-            // by `Bun.build({ treeShaking })` and by `bun build --no-bundle
-            // --format=cjs`, which must keep every statement of the file.
+            // case a future module starts depending on it. The override comes
+            // from `Bun.build({ treeShaking })` or `--no-bundle --format=cjs`.
             let tree_shaking = this.transpiler.options.tree_shaking_override.unwrap_or(
                 this.transpiler.options.output_format != options::Format::InternalBakeDev,
             );

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2999,8 +2999,9 @@ pub mod bv2_impl {
             this.transpiler.log_mut().clone_line_text = true;
 
             // Bake forbids tree-shaking since every export must always exist in
-            // case a future module starts depending on it. The override is only
-            // set by `Bun.build({ treeShaking })` for tests/debugging.
+            // case a future module starts depending on it. The override is set
+            // by `Bun.build({ treeShaking })` and by `bun build --no-bundle
+            // --format=cjs`, which must keep every statement of the file.
             let tree_shaking = this.transpiler.options.tree_shaking_override.unwrap_or(
                 this.transpiler.options.output_format != options::Format::InternalBakeDev,
             );

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -82,6 +82,24 @@ impl BuildCommand {
             ctx.bundler_options.compile = false;
         }
 
+        // The single-file transpiler behind --no-bundle can only print ESM. For
+        // cjs (also implied by --bytecode), convert each entry point with the
+        // linker instead and mark every import external: one output per input,
+        // nothing inlined, every statement kept. esbuild converts the format of
+        // unbundled files the same way.
+        let no_bundle = ctx.bundler_options.transform_only;
+        let convert_format_only =
+            no_bundle && ctx.bundler_options.output_format == options::Format::Cjs;
+        if convert_format_only {
+            ctx.bundler_options.transform_only = false;
+            ctx.args.external.push(Box::from(b"*".as_slice()));
+        } else if no_bundle && ctx.bundler_options.output_format == options::Format::Iife {
+            bun_core::pretty_errorln!(
+                "<r><red>error<r><d>:<r> --format=iife does not support --no-bundle"
+            );
+            Global::exit(1);
+        }
+
         let compile_target = &ctx.bundler_options.compile_target;
 
         if ctx.bundler_options.compile {
@@ -252,13 +270,16 @@ impl BuildCommand {
         if ctx.bundler_options.output_format == options::OutputFormat::InternalBakeDev {
             this_transpiler.options.tree_shaking = false;
         }
+        if convert_format_only {
+            this_transpiler.options.tree_shaking_override = Some(false);
+        }
 
         this_transpiler.options.bytecode = ctx.bundler_options.bytecode;
         this_transpiler.options.bytecode_depth = ctx.bundler_options.bytecode_depth;
         let mut was_renamed_from_index = false;
 
         if ctx.bundler_options.compile {
-            if ctx.bundler_options.transform_only {
+            if no_bundle {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r><d>:<r> --compile does not support --no-bundle"
                 );
@@ -364,7 +385,7 @@ impl BuildCommand {
             }
         }
 
-        if ctx.bundler_options.transform_only {
+        if no_bundle {
             // Check if any entry point is an HTML file
             for entry_point in this_transpiler.options.entry_points.iter() {
                 if strings::has_suffix_comptime(entry_point, b".html") {
@@ -616,7 +637,6 @@ impl BuildCommand {
         let opt_public_path: Box<[u8]> = this_transpiler.options.public_path.clone();
         let opt_output_format = this_transpiler.options.output_format;
         let opt_source_map = this_transpiler.options.source_map;
-        let opt_transform_only = this_transpiler.options.transform_only;
         let env_ptr = this_transpiler.env;
 
         let mut output_files: Vec<options::OutputFile> = 'brk: {
@@ -1056,7 +1076,7 @@ impl BuildCommand {
             }
 
             if log_ref.errors == 0 {
-                if opt_transform_only {
+                if no_bundle {
                     bun_core::prettyln!(
                         "<green>Transpiled file in {}ms<r>",
                         (bun_core::time::nano_timestamp() - cli_start_time())

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -82,9 +82,7 @@ impl BuildCommand {
             ctx.bundler_options.compile = false;
         }
 
-        // The --no-bundle transpiler only prints ESM. For cjs (and --bytecode),
-        // convert each file with the linker instead: every import external,
-        // tree shaking off.
+        // The --no-bundle printer is ESM-only: convert cjs per file with the linker instead.
         let no_bundle = ctx.bundler_options.transform_only;
         let convert_format_only =
             no_bundle && ctx.bundler_options.output_format == options::Format::Cjs;

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -82,11 +82,9 @@ impl BuildCommand {
             ctx.bundler_options.compile = false;
         }
 
-        // The single-file transpiler behind --no-bundle can only print ESM. For
-        // cjs (also implied by --bytecode), convert each entry point with the
-        // linker instead and mark every import external: one output per input,
-        // nothing inlined, every statement kept. esbuild converts the format of
-        // unbundled files the same way.
+        // The --no-bundle transpiler only prints ESM. For cjs (and --bytecode),
+        // convert each file with the linker instead: every import external,
+        // tree shaking off.
         let no_bundle = ctx.bundler_options.transform_only;
         let convert_format_only =
             no_bundle && ctx.bundler_options.output_format == options::Format::Cjs;

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -799,6 +799,126 @@ describe.concurrent("--no-bundle with --outdir", () => {
   });
 });
 
+// https://github.com/oven-sh/bun/issues/29187
+describe.concurrent("--no-bundle with --format", () => {
+  test("cjs converts each file on its own and keeps every import external", async () => {
+    using dir = tempDir("no-bundle-format-cjs", {
+      "entry.ts": [
+        `import { dep } from "./dep";`,
+        `import { basename } from "node:path";`,
+        `function unused(): number { return 1; }`,
+        `export const x: string = dep + "!";`,
+        `export default function base(p: string) { return basename(p); }`,
+        ``,
+      ].join("\n"),
+      "dep.ts": `export const dep: string = "from-dep-module";\n`,
+      "check.cjs": [
+        `const m = require("./out/entry.js");`,
+        `console.log(JSON.stringify({ x: m.x, base: m.default("/a/b.txt"), esm: m.__esModule }));`,
+        ``,
+      ].join("\n"),
+    });
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--format=cjs", "./entry.ts", "./dep.ts", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    expect(buildStderr).toBe("");
+    expect(buildStdout).toContain("entry.js");
+    expect(buildStdout).toContain("dep.js");
+    expect(buildExitCode).toBe(0);
+
+    const out = await Bun.file(path.join(String(dir), "out", "entry.js")).text();
+    expect(out).toContain('require("./dep")');
+    expect(out).toContain('require("node:path")');
+    expect(out).toContain("module.exports");
+    expect(out).toContain("function unused()");
+    // dep.ts is a separate output, not inlined into entry.js
+    expect(out).not.toContain("from-dep-module");
+    expect(out).not.toMatch(/^\s*(import|export)\b/m);
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "check.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ x: "from-dep-module!", base: "b.txt", esm: true });
+    expect(exitCode).toBe(0);
+  });
+
+  test("--bytecode writes a cjs module and a bytecode cache per entry point", async () => {
+    using dir = tempDir("no-bundle-format-bytecode", {
+      "entry.ts": `import { dep } from "./dep";\nexport const x: string = dep + "!";\nconsole.log(x);\n`,
+      "dep.ts": `export const dep: string = "from-dep-module";\n`,
+    });
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--bytecode", "./entry.ts", "./dep.ts", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).toBe("");
+    expect(buildExitCode).toBe(0);
+
+    expect(fs.readdirSync(path.join(String(dir), "out")).sort()).toEqual([
+      "dep.js",
+      "dep.js.jsc",
+      "entry.js",
+      "entry.js.jsc",
+    ]);
+    const out = await Bun.file(path.join(String(dir), "out", "entry.js")).text();
+    expect(out).toStartWith("// @bun @bytecode @bun-cjs");
+    expect(out).toContain('require("./dep")');
+    expect(out).not.toContain("from-dep-module");
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "./out/entry.js"],
+      env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(stdout).toBe("from-dep-module!\n");
+    expect(stderr).toMatch(/\[Disk Cache\].*Cache hit/i);
+    expect(exitCode).toBe(0);
+  });
+
+  test("iife is rejected instead of printing esm", async () => {
+    using dir = tempDir("no-bundle-format-iife", {
+      "entry.ts": `export const x: number = 1;\n`,
+    });
+
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--format=iife", "./entry.ts", "--outfile=out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(stderr).toContain("error: --format=iife does not support --no-bundle");
+    expect(stdout).toBe("");
+    expect(fs.existsSync(path.join(String(dir), "out.js"))).toBe(false);
+    expect(exitCode).toBe(1);
+  });
+});
+
 test.concurrent("bun build names every input that maps to a shared output path", async () => {
   using dir = tempDir("bundle-outdir-collision", {
     "a.ts": `export const a = 1;\n`,

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2064,7 +2064,6 @@ describe.concurrent("bundler", () => {
         })()
       `,
     },
-    format: "iife",
     minifyIdentifiers: true,
     bundling: false,
     run: {
@@ -2652,7 +2651,6 @@ describe.concurrent("bundler", () => {
         b
       `,
     },
-    format: "iife",
     minifySyntax: true,
     minifyWhitespace: true,
     bundling: false,


### PR DESCRIPTION
### Problem
- `bun build --no-bundle --format=cjs entry.ts` exits 0 and prints plain ESM: `export const x = 1;`. Node then fails with `SyntaxError: Unexpected token 'export'`. `--format=iife` and `--bytecode` are dropped the same way. Reported in #29187.
- The cause: the `--no-bundle` path (`build_with_resolve_result_eager`, `src/bundler/transpiler.rs:3019`) always prints with `js_printer::Format::Esm`. The single-file printer has no ESM-to-CJS lowering, so it never reads `output_format`.

### Fix
- For `--no-bundle` with `--format=cjs` (also what `--bytecode` implies), `build_command.rs` sends the entry points through the linker instead, with `*` added to the externals and tree shaking off.
- The result is still a per-file transpile: one output per input, every `import` becomes `require()` of the same specifier, nothing is inlined, unused top-level code is kept. `--bytecode` also writes a `.jsc` per file. `--no-bundle` with no format or `--format=esm` takes the old path unchanged.
- `--no-bundle --format=iife` becomes an error. The linker's iife output never calls a CommonJS entry point (#37843), so routing it would turn a `.cjs` input into dead code.
- Verified: `test/bundler/cli.test.ts` (`--no-bundle with --format`, all three fail on bun 1.4.2), plus every other `--no-bundle` test file.

### Background
- `bun build --no-bundle` does not use `BundleV2`. It uses the older `Transpiler::transform` loop, which prints each entry point alone and only knows ESM.
- The ESM-to-CJS conversion (`__export`, `__toCommonJS`, `__toESM(require(...))`) lives in the linker. An external import prints there as `require("<specifier>")`. esbuild implements `--format` without `--bundle` the same way: its linker runs on the one file and leaves imports unresolved.
- With tree shaking off, the linker keeps every part of an entry point (`LinkerContext.rs:3189`).

Fixes #29187

<details><summary>Notes</summary>

- The #29187 example now matches esbuild's `--format=cjs` output apart from helper names. The output is byte-identical to `Bun.build({ format: "cjs", external: ["*"], treeShaking: false })`, so no new output shape is introduced.
- Alternative considered: reject `--format=cjs` too. That also fixes the silent wrong output, but it leaves #29187 unsolved, and it breaks anyone who runs `--no-bundle --format=cjs` on input that is already CommonJS (that works today by accident). The conversion path handles CJS input too (`module.exports` passes through).
- iife can take the cjs route once #37843 (call the wrapped entry point in iife output) lands. ESM input already converts fine; CommonJS input is the case that breaks.
- Differences a `--no-bundle --format=cjs` user sees compared to the ESM path: the runtime helpers are inlined at the top of each file, a `// entry.ts` comment precedes the module body, and `import.meta.url`/`dir`/`path` are inlined as strings (existing `--format=cjs` behaviour in `fold.rs`). Top-level `await` is an error, as it is for any cjs build.
- `--target=bun` keeps its `// @bun @bun-cjs` wrapper, same as a bundled cjs build. `--no-bundle --bytecode` output loads from the bytecode cache (`BUN_JSC_verboseDiskCache=1` reports a hit), which the test asserts.
- `--compile --no-bundle` and HTML entry points with `--no-bundle` still error as before.
- Two esbuild ports (`default/WithStatementTaintingNoBundle`, `default/UseStrictDirectiveMinifyNoBundle`) passed `format: "iife"` with `bundling: false`. The esbuild originals set no output format (pass-through), and `--no-bundle` ignored the flag, so the ports now drop it.
- The `*` external is pushed into `ctx.args.external` before `Transpiler::init`, so it goes through the same `init_external_modules` parsing as `--external '*'`. Tree shaking is turned off through the existing `tree_shaking_override` that `Bun.build({ treeShaking })` uses.
- Self-reviewed: 4 concerns raised, 4 addressed (iife dropped to an error because of #37843, `--bytecode` stated and tested, stale `tree_shaking_override` comment updated, no visibility change on `BundleOptions.external`).
- Other suites run: `test/bundler/cli.test.ts` in full, `test/js/bun/toml/toml.test.ts`, `test/bundler/transpiler/transpiler-stack-overflow.test.ts`, `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`, `test/regression/issue/{23569,29242,31401}.test.ts`.
- Moving all of `--no-bundle` (including esm) onto the linker would also fix the other flags the old path ignores (`--sourcemap`, `--banner`, ...), but it changes output for invocations that work today, so it is not part of this PR.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->