### PR TITLE
css: keep font/transition sub-properties on the side of the shorthand they were written on

### DIFF
--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -1606,6 +1606,21 @@ impl CustomPropertyName {
         unsafe { crate::arena_str(self.as_ptr()) }
     }
 
+    /// Whether this is an unknown (non-dashed) property whose name, with any
+    /// vendor prefix removed, starts with `prefix` (ASCII case-insensitive),
+    /// e.g. `font-kerning` / `-webkit-font-feature-settings` for `b"font-"`.
+    /// Shorthand handlers use this to recognize longhands of their group that
+    /// the parser has no typed representation for.
+    pub(crate) fn is_unknown_with_prefix(&self, prefix: &[u8]) -> bool {
+        match self {
+            CustomPropertyName::Unknown(_) => {
+                let (_, name) = crate::VendorPrefix::strip_from(self.as_str());
+                strings::starts_with_case_insensitive_ascii(name, prefix)
+            }
+            CustomPropertyName::Custom(_) => false,
+        }
+    }
+
     // deep_clone / eql — provided by `#[derive(DeepClone, CssEql)]`.
 }
 

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -1607,15 +1607,14 @@ impl CustomPropertyName {
     }
 
     /// Whether this is an unknown (non-dashed) property whose name, with any
-    /// vendor prefix removed, starts with `prefix` (ASCII case-insensitive),
-    /// e.g. `font-kerning` / `-webkit-font-feature-settings` for `b"font-"`.
-    /// Shorthand handlers use this to recognize longhands of their group that
-    /// the parser has no typed representation for.
-    pub(crate) fn is_unknown_with_prefix(&self, prefix: &[u8]) -> bool {
+    /// vendor prefix removed, is one of `names` (ASCII case-insensitive), e.g.
+    /// `font-kerning` or `-webkit-font-feature-settings`. Shorthand handlers use
+    /// this to recognize longhands of their group that have no typed `Property`.
+    pub(crate) fn is_unknown_any_of(&self, names: &[&[u8]]) -> bool {
         match self {
             CustomPropertyName::Unknown(_) => {
                 let (_, name) = crate::VendorPrefix::strip_from(self.as_str());
-                strings::starts_with_case_insensitive_ascii(name, prefix)
+                strings::eql_any_case_insensitive_ascii(name, names)
             }
             CustomPropertyName::Custom(_) => false,
         }

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -940,6 +940,16 @@ impl FontHandler {
                     return false;
                 }
             }
+            Property::Custom(val) => {
+                // The `font` shorthand also resets longhands it cannot set and that
+                // have no typed `Property` variant (font-kerning, font-feature-settings,
+                // font-variant-*, font-optical-sizing, ...). Emit anything buffered
+                // before such a longhand so it stays after the shorthand, as written.
+                if val.name.is_unknown_with_prefix(b"font-") {
+                    self.flush(dest, context);
+                }
+                return false;
+            }
             _ => return false,
         }
 

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -941,11 +941,9 @@ impl FontHandler {
                 }
             }
             Property::Custom(val) => {
-                // The `font` shorthand also resets longhands it cannot set and that
-                // have no typed `Property` variant (font-kerning, font-feature-settings,
-                // font-variant-*, font-optical-sizing, ...). Emit anything buffered
-                // before such a longhand so it stays after the shorthand, as written.
-                if val.name.is_unknown_with_prefix(b"font-") {
+                // Emit anything buffered before a sub-property that `font` resets, so
+                // it stays after a shorthand it was written after.
+                if val.name.is_unknown_any_of(UNTYPED_FONT_SUBPROPERTIES) {
                     self.flush(dest, context);
                 }
                 return false;
@@ -1154,3 +1152,26 @@ fn is_font_property(property_id: &crate::properties::PropertyId) -> bool {
             | PropertyId::Font
     )
 }
+
+/// Sub-properties that the `font` shorthand resets but that have no typed
+/// `Property` variant, so they reach the handler as `Property::Custom`.
+/// https://drafts.csswg.org/css-fonts-4/#font-prop
+/// `font-synthesis-*` and `-webkit-font-smoothing` are not sub-properties of
+/// `font` and are deliberately absent.
+const UNTYPED_FONT_SUBPROPERTIES: &[&[u8]] = &[
+    b"font-variant",
+    b"font-variant-ligatures",
+    b"font-variant-alternates",
+    b"font-variant-numeric",
+    b"font-variant-east-asian",
+    b"font-variant-position",
+    b"font-variant-emoji",
+    b"font-width",
+    b"font-size-adjust",
+    b"font-kerning",
+    b"font-feature-settings",
+    b"font-language-override",
+    b"font-optical-sizing",
+    b"font-variation-settings",
+    b"font-palette",
+];

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -337,10 +337,11 @@ mod transition_handler_body {
                     }
                 }
                 Property::Custom(x) => {
-                    // `transition-behavior` has no typed `Property` variant but is
-                    // reset by the `transition` shorthand, so anything buffered must
-                    // be emitted before it to keep it after the shorthand, as written.
-                    if x.name.is_unknown_with_prefix(b"transition-") {
+                    // `transition-behavior` (css-transitions-2) has no typed `Property`
+                    // variant but is reset by the `transition` shorthand, so anything
+                    // buffered must be emitted before it to keep it after a shorthand
+                    // it was written after.
+                    if x.name.is_unknown_any_of(&[b"transition-behavior"]) {
                         self.flush(dest, context);
                     }
                     return false;

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -336,6 +336,15 @@ mod transition_handler_body {
                         return false;
                     }
                 }
+                Property::Custom(x) => {
+                    // `transition-behavior` has no typed `Property` variant but is
+                    // reset by the `transition` shorthand, so anything buffered must
+                    // be emitted before it to keep it after the shorthand, as written.
+                    if x.name.is_unknown_with_prefix(b"transition-") {
+                        self.flush(dest, context);
+                    }
+                    return false;
+                }
                 _ => return false,
             }
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -4995,7 +4995,7 @@ describe("css tests", () => {
     minify_test(".foo { font-family: 'revert', foo, sans-serif; }", '.foo{font-family:"revert",foo,sans-serif}');
     minify_test(".foo { font-family: ''; }", '.foo{font-family:""}');
 
-    // `font` resets longhands it cannot set (font-kerning, font-feature-settings,
+    // `font` resets sub-properties it cannot set (font-kerning, font-feature-settings,
     // font-variant-*, ...). They have no typed Property, but must stay on the side
     // of the shorthand they were written on.
     minify_test(".foo { font: 12px serif; font-kerning: none; }", ".foo{font:12px serif;font-kerning:none}");
@@ -5005,14 +5005,24 @@ describe("css tests", () => {
       ".foo{font-kerning:none;font:12px serif;font-kerning:normal}",
     );
     minify_test(
-      `.foo { font: 12px serif; font-size-adjust: .5; font-optical-sizing: none; font-variation-settings: "wght" 700; font-feature-settings: "liga" 0; font-variant-ligatures: none; font-variant: small-caps; font-language-override: "TRK"; font-palette: --x; }`,
-      `.foo{font:12px serif;font-size-adjust:.5;font-optical-sizing:none;font-variation-settings:"wght" 700;font-feature-settings:"liga" 0;font-variant-ligatures:none;font-variant:small-caps;font-language-override:"TRK";font-palette:--x}`,
+      `.foo { font: 12px serif; font-size-adjust: .5; font-optical-sizing: none; font-variation-settings: "wght" 700; font-feature-settings: "liga" 0; font-language-override: "TRK"; font-palette: --x; }`,
+      `.foo{font:12px serif;font-size-adjust:.5;font-optical-sizing:none;font-variation-settings:"wght" 700;font-feature-settings:"liga" 0;font-language-override:"TRK";font-palette:--x}`,
+    );
+    minify_test(
+      `.foo { font: 12px serif; font-variant-ligatures: none; font-variant-alternates: historical-forms; font-variant-numeric: tabular-nums; font-variant-east-asian: jis78; font-variant-position: sub; font-variant-emoji: text; font-variant: small-caps; }`,
+      `.foo{font:12px serif;font-variant-ligatures:none;font-variant-alternates:historical-forms;font-variant-numeric:tabular-nums;font-variant-east-asian:jis78;font-variant-position:sub;font-variant-emoji:text;font-variant:small-caps}`,
     );
     minify_test(".foo { FONT: 12px serif; Font-Kerning: none; }", ".foo{font:12px serif;Font-Kerning:none}");
     minify_test(
-      ".foo { font: 12px serif; -webkit-font-feature-settings: 'liga' 0; }",
-      '.foo{font:12px serif;-webkit-font-feature-settings:"liga" 0}',
+      ".foo { font: 12px serif; -webkit-font-feature-settings: 'liga' 0; -moz-font-feature-settings: 'liga' 0; }",
+      '.foo{font:12px serif;-webkit-font-feature-settings:"liga" 0;-moz-font-feature-settings:"liga" 0}',
     );
+    // `font-variant` and `font-width` also override typed longhands written before them.
+    minify_test(
+      ".foo { font-variant-caps: small-caps; font-variant: normal; }",
+      ".foo{font-variant-caps:small-caps;font-variant:normal}",
+    );
+    minify_test(".foo { font-stretch: condensed; font-width: normal; }", ".foo{font-stretch:75%;font-width:normal}");
     // A longhand the handler does absorb still folds into the shorthand across the unknown one.
     minify_test(
       ".foo { font: 12px serif; font-kerning: none; font-weight: bold; }",
@@ -5030,10 +5040,19 @@ describe("css tests", () => {
       ".foo { font: 12px serif !important; font-kerning: none !important; }",
       ".foo{font:12px serif!important;font-kerning:none!important}",
     );
-    // Custom properties and unrelated unknown properties do not flush the handler.
+    // Properties that `font` does not reset keep folding across them: custom
+    // properties, unrelated unknown names, `font-synthesis-*`, `-webkit-font-smoothing`.
     minify_test(
       ".foo { font-family: serif; --font-x: 1; fonts: 2; font-size: 12px; font-style: normal; font-weight: normal; font-stretch: normal; line-height: normal; font-variant-caps: normal; }",
       ".foo{--font-x:1;fonts:2;font:12px serif}",
+    );
+    minify_test(
+      ".foo { font: 14px Arial; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; line-height: 1.4; }",
+      ".foo{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font:14px/1.4 Arial}",
+    );
+    minify_test(
+      ".foo { font: 12px serif; font-synthesis: none; font-synthesis-weight: none; font-weight: bold; }",
+      ".foo{font-synthesis:none;font-synthesis-weight:none;font:700 12px serif}",
     );
 
     // fonTfamily in @font-face
@@ -6633,6 +6652,16 @@ describe("css tests", () => {
     minify_test(
       ".foo { -webkit-transition: all 1s; transition: all 1s; transition-behavior: allow-discrete }",
       ".foo{-webkit-transition:all 1s;transition:all 1s;transition-behavior:allow-discrete}",
+    );
+    minify_test(
+      ".foo { transition: all 1s !important; Transition-Behavior: allow-discrete !important }",
+      ".foo{transition:all 1s!important;Transition-Behavior:allow-discrete!important}",
+    );
+    // Unknown `-o-` prefixed longhands (Bootstrap 3) are not reset by `transition`
+    // and do not stop the typed longhands from folding.
+    minify_test(
+      ".foo { -webkit-transition-property: opacity; -o-transition-property: opacity; transition-property: opacity; -webkit-transition-duration: 1s; -o-transition-duration: 1s; transition-duration: 1s; -webkit-transition-timing-function: linear; -o-transition-timing-function: linear; transition-timing-function: linear; -webkit-transition-delay: 0s; -o-transition-delay: 0s; transition-delay: 0s; }",
+      ".foo{-o-transition-property:opacity;-o-transition-duration:1s;-o-transition-timing-function:linear;-o-transition-delay:0s;-webkit-transition:opacity 1s linear;transition:opacity 1s linear}",
     );
     cssTest(
       `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -4995,6 +4995,47 @@ describe("css tests", () => {
     minify_test(".foo { font-family: 'revert', foo, sans-serif; }", '.foo{font-family:"revert",foo,sans-serif}');
     minify_test(".foo { font-family: ''; }", '.foo{font-family:""}');
 
+    // `font` resets longhands it cannot set (font-kerning, font-feature-settings,
+    // font-variant-*, ...). They have no typed Property, but must stay on the side
+    // of the shorthand they were written on.
+    minify_test(".foo { font: 12px serif; font-kerning: none; }", ".foo{font:12px serif;font-kerning:none}");
+    minify_test(".foo { font-kerning: none; font: 12px serif; }", ".foo{font-kerning:none;font:12px serif}");
+    minify_test(
+      ".foo { font-kerning: none; font: 12px serif; font-kerning: normal; }",
+      ".foo{font-kerning:none;font:12px serif;font-kerning:normal}",
+    );
+    minify_test(
+      `.foo { font: 12px serif; font-size-adjust: .5; font-optical-sizing: none; font-variation-settings: "wght" 700; font-feature-settings: "liga" 0; font-variant-ligatures: none; font-variant: small-caps; font-language-override: "TRK"; font-palette: --x; }`,
+      `.foo{font:12px serif;font-size-adjust:.5;font-optical-sizing:none;font-variation-settings:"wght" 700;font-feature-settings:"liga" 0;font-variant-ligatures:none;font-variant:small-caps;font-language-override:"TRK";font-palette:--x}`,
+    );
+    minify_test(".foo { FONT: 12px serif; Font-Kerning: none; }", ".foo{font:12px serif;Font-Kerning:none}");
+    minify_test(
+      ".foo { font: 12px serif; -webkit-font-feature-settings: 'liga' 0; }",
+      '.foo{font:12px serif;-webkit-font-feature-settings:"liga" 0}',
+    );
+    // A longhand the handler does absorb still folds into the shorthand across the unknown one.
+    minify_test(
+      ".foo { font: 12px serif; font-kerning: none; font-weight: bold; }",
+      ".foo{font:12px serif;font-kerning:none;font-weight:700}",
+    );
+    minify_test(
+      ".foo { font: 12px serif; font-weight: bold; font-kerning: none; }",
+      ".foo{font:700 12px serif;font-kerning:none}",
+    );
+    minify_test(
+      ".foo { font-family: serif; line-height: 1.5; font-feature-settings: 'liga' 0; font-size: 12px; }",
+      '.foo{font-family:serif;line-height:1.5;font-feature-settings:"liga" 0;font-size:12px}',
+    );
+    minify_test(
+      ".foo { font: 12px serif !important; font-kerning: none !important; }",
+      ".foo{font:12px serif!important;font-kerning:none!important}",
+    );
+    // Custom properties and unrelated unknown properties do not flush the handler.
+    minify_test(
+      ".foo { font-family: serif; --font-x: 1; fonts: 2; font-size: 12px; font-style: normal; font-weight: normal; font-stretch: normal; line-height: normal; font-variant-caps: normal; }",
+      ".foo{--font-x:1;fonts:2;font:12px serif}",
+    );
+
     // fonTfamily in @font-face
     minify_test("@font-face { font-family: 'revert'; }", '@font-face{font-family:"revert"}');
     minify_test("@font-face { font-family: 'revert-layer'; }", '@font-face{font-family:"revert-layer"}');
@@ -6575,6 +6616,24 @@ describe("css tests", () => {
     minify_test(".foo { transition: width 2s ease 1s }", ".foo{transition:width 2s 1s}");
     minify_test(".foo { transition: ease-in 1s width 4s }", ".foo{transition:width 1s ease-in 4s}");
     minify_test(".foo { transition: opacity 0s .6s }", ".foo{transition:opacity 0s .6s}");
+    // `transition-behavior` has no typed Property but is reset by the shorthand,
+    // so it must stay on the side of the shorthand it was written on.
+    minify_test(
+      ".foo { transition: all 1s; transition-behavior: allow-discrete }",
+      ".foo{transition:all 1s;transition-behavior:allow-discrete}",
+    );
+    minify_test(
+      ".foo { transition-behavior: allow-discrete; transition: all 1s }",
+      ".foo{transition-behavior:allow-discrete;transition:all 1s}",
+    );
+    minify_test(
+      ".foo { transition-property: opacity; transition-behavior: allow-discrete; transition-duration: 1s }",
+      ".foo{transition-property:opacity;transition-behavior:allow-discrete;transition-duration:1s}",
+    );
+    minify_test(
+      ".foo { -webkit-transition: all 1s; transition: all 1s; transition-behavior: allow-discrete }",
+      ".foo{-webkit-transition:all 1s;transition:all 1s;transition-behavior:allow-discrete}",
+    );
     cssTest(
       `
       .foo {


### PR DESCRIPTION
### Problem
- `bun build` moves reset-only longhands written after their shorthand to before it. `.b { font: 12px serif; font-kerning: none }` becomes `font-kerning: none; font: 12px serif`. `.c { transition: all 1s; transition-behavior: allow-discrete }` becomes `transition-behavior: allow-discrete; transition: all 1s`. The browser then resets the longhand again (font-kerning `none` -> `auto` in Chromium 148).
- Cause: `FontHandler::handle_property` (`src/css/properties/font.rs:906`) and `TransitionHandler::handle_property` (`src/css/properties/transition.rs:200`) buffer their group until `finalize()`. `font-kerning`, `transition-behavior` and the rest have no typed `Property` variant. They parse as `Property::Custom` with an `Unknown` name, no handler claims them, and they go to the output at once, ahead of the buffered shorthand.

### Fix
- Both handlers get a `Property::Custom` arm. When the name (vendor prefix stripped, case-insensitive) is a sub-property the shorthand resets, the handler flushes its buffer and returns `false`, so the property lands right after it. The `Property::Unparsed` arm already does this for `var()` values.
- The names are the spec lists (`UNTYPED_FONT_SUBPROPERTIES` in `font.rs`, and `transition-behavior`). Names the shorthands do not reset (`-webkit-font-smoothing`, `font-synthesis-*`, Bootstrap 3's `-o-transition-*`) still let the typed longhands around them fold.
- Verified: `test/js/bun/css/css.test.ts` (22 new cases, 16 fail on stock bun). Also all of `test/js/bun/css/`, `test/bundler/esbuild/css.test.ts`, and a byte compare of 17 real-world stylesheets (no change).

### Background
- `DeclarationBlock::minify` (`src/css/declaration.rs`) runs each declaration through a chain of per-shorthand handlers. A handler that claims a property buffers it. Unclaimed properties go straight to the output. `finalize()` flushes the handlers last. So a handler must own every property its shorthand interacts with.
- CSS Fonts 4 section 4.7: `font` first resets all its sub-properties, also the ones it cannot set. CSS Transitions 2 makes `transition` reset `transition-behavior`.

<details><summary>Notes</summary>

- The `font` list: `font-variant`, `font-variant-ligatures`, `-alternates`, `-numeric`, `-east-asian`, `-position`, `-emoji`, `font-width`, `font-size-adjust`, `font-kerning`, `font-feature-settings`, `font-language-override`, `font-optical-sizing`, `font-variation-settings`, `font-palette`. The typed members of the group (`font-family`, `font-size`, `font-style`, `font-weight`, `font-stretch`, `line-height`, `font-variant-caps`) never reach this arm.
- The 17 stylesheets compared byte for byte between stock bun and this branch: the 15 in `test/js/bun/css/files/` (bootstrap 4, bulma, foundation, tailwind, uikit, ...) plus Bootstrap 3.3.5 and 3.4.1.
- Same bug in lightningcss 1.30.2. Upstream prior art: parcel-bundler/lightningcss#1209 (open, unmerged) flushes on any `font-*` name. A first revision here did the same. A `font-*` / `transition-*` prefix also fires on `-webkit-font-smoothing`, `font-synthesis` and `-o-transition-*`, which are not reset by the shorthands, and it stopped `font: 14px Arial; -webkit-font-smoothing: antialiased; line-height: 1.4` from folding to `font:14px/1.4 Arial` and Bootstrap 3's prefixed transition longhands from folding to `transition:opacity 1s linear`. The explicit list avoids that.
- Chromium 148 computed styles for the original repro, source vs. bundled: font-kerning `none` -> `auto`, font-size-adjust `0.5` -> `none`, font-optical-sizing `none` -> `auto`, font-variation-settings `"wght" 700` -> `normal`, font-feature-settings `"liga" 0` -> `normal`, transition-behavior `allow-discrete` -> `normal`.
- `font-variant: normal` after `font-variant-caps: small-caps`, and `font-width: normal` after `font-stretch: condensed`, were reordered the same way and are covered by the same arm.
- The vendor prefix is stripped so that `-webkit-font-feature-settings` / `-moz-font-feature-settings`, which those engines alias to the unprefixed property, also stay after `font`.
- `Property::Unparsed` is a known property whose value did not parse (usually `var()`). `Property::Custom` with `CustomPropertyName::Unknown` is a name the crate has no variant for.
- A flush marks `font-family` as emitted for the block, so a later `font: ... system-ui` in the same rule does not get the system-ui fallback list again. That is the existing behaviour of the `Property::Unparsed` path (`font-family: x; font-size: var(--s); font: 16px system-ui` does the same on stock bun).
- `animation-composition` / `animation-timeline` after `animation` were already kept in order: bun has no animation handler, so nothing is buffered there.
- Not changed here: `all: initial` written after handler-owned properties (`font`, `margin`, ...) is emitted before them, because lightningcss's `DeclarationHandler::handle_all` was never ported. That is a separate change of about 40 lines confined to `src/css/declaration.rs` and does not interact with these arms. It is being handled on its own.
- Not changed here: when all seven `font` longhands appear in one rule they are folded into a `font` shorthand, even if a reset-only longhand precedes them or another rule sets one. That is a pre-existing lightningcss trade-off of synthesizing the shorthand at all.
- Self-reviewed: 4 concerns raised (prefix over-match on `-webkit-font-smoothing`, `font-synthesis`, `-o-transition-*`; vague wording about the `all` follow-up), 4 addressed.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static
... (truncated)

release without fix: 16 failed, 67 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.16ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.02ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.42ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.08ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.07ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     626ae24956
  features     baseline

23 deps, 131 codegen, 1172 objects in 732ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [15.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [8.00ms]
[5/1243] gen bindgenv2
[6/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [17.00ms]
[7/1243] fetch zlib
[zlib] up to date
[8/1243] gen .bind.ts → GeneratedBindings.cpp
[9/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[10/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1243] fetch libjpeg-turbo
[libjpe
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/custom.rs     | 14 +++++++
 src/css/properties/font.rs       | 31 ++++++++++++++
 src/css/properties/transition.rs | 10 +++++
 test/js/bun/css/css.test.ts      | 88 ++++++++++++++++++++++++++++++++++++++++
 4 files changed, 143 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/css/properties/custom.rs          2      2     11
src/css/properties/font.rs            3      3     11
src/css/properties/transition.rs      2      2     11
test/js/bun/css/css.test.ts           5      5     11
```

</details>

<!-- robobun:evidence:end -->