### PR TITLE
pm view, pm diff: report an unknown dist-tag instead of resolving it to latest

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1527,6 +1527,11 @@ impl PackageManifest {
         self.pkg.releases.keys.get(&self.versions)
     }
 
+    /// Published prerelease versions, oldest first, as sorted at serialization time.
+    pub fn prerelease_versions(&self) -> &[Semver::Version] {
+        self.pkg.prereleases.keys.get(&self.versions)
+    }
+
     /// `(tag, version)` pairs of the dist-tags.
     pub fn dist_tags(&self) -> impl Iterator<Item = (&[u8], Semver::Version)> + '_ {
         let versions = self.pkg.dist_tags.versions.get(&self.versions);
@@ -1554,6 +1559,22 @@ impl PackageManifest {
             }
         }
         None
+    }
+
+    /// Resolves the `spec` of a user-typed `name@spec`: the dist-tag with that
+    /// name if there is one, else the best match for `spec` as a semver range.
+    /// A spec the range parser cannot read (an unknown dist-tag, a git or file
+    /// spec) parses to an empty group, which would satisfy every version, so it
+    /// finds nothing.
+    pub fn find_by_spec(&self, spec: &[u8]) -> Result<Option<FindResult<'_>>, AllocError> {
+        if let Some(result) = self.find_by_dist_tag(spec) {
+            return Ok(Some(result));
+        }
+        let range = Semver::query::parse(spec, SlicedString::init(spec, spec))?;
+        if range.is_empty() {
+            return Ok(None);
+        }
+        Ok(self.find_best_version(&range, spec))
     }
 
     pub(crate) fn should_exclude_from_age_filter(&self, exclusions: Option<&[&[u8]]>) -> bool {

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -762,16 +762,7 @@ fn fetch_registry_tree(
     } else {
         version
     };
-    let found = 'found: {
-        if let Some(r) = manifest.find_by_dist_tag(version) {
-            break 'found r;
-        }
-        let sliced = Semver::SlicedString::init(version, version);
-        if let Ok(query) = Semver::query::parse(version, sliced) {
-            if let Some(r) = manifest.find_best_version(&query, version) {
-                break 'found r;
-            }
-        }
+    let Some(found) = manifest.find_by_spec(version)? else {
         Status::clear();
         Output::err_generic(
             "no version of {} matches {}",

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -197,19 +197,9 @@ pub(crate) fn view(
                 let versions = versions_e_obj.properties.slice();
                 versions_len = versions.len();
 
-                let wanted_version: Semver::Version = 'brk2: {
-                    // First try dist-tag lookup (like "latest", "beta", etc.)
-                    if let Some(result) = parsed_manifest.find_by_dist_tag(version) {
-                        break 'brk2 result.version;
-                    } else {
-                        // Parse as semver query and find best version
-                        let sliced_literal = Semver::SlicedString::init(version, version);
-                        let query = Semver::query::parse(version, sliced_literal)?;
-                        if let Some(result) = parsed_manifest.find_best_version(&query, version) {
-                            break 'brk2 result.version;
-                        }
-                    }
-
+                let Some(wanted_version) =
+                    parsed_manifest.find_by_spec(version)?.map(|r| r.version)
+                else {
                     break 'from_versions;
                 };
 
@@ -248,13 +238,12 @@ pub(crate) fn view(
 
             let max_versions_to_display: usize = 5;
 
-            let start_index = parsed_manifest
-                .versions
-                .len()
-                .saturating_sub(max_versions_to_display);
-            let mut versions_to_display = &parsed_manifest.versions[start_index..];
-            versions_to_display =
-                &versions_to_display[..versions_to_display.len().min(max_versions_to_display)];
+            let published = match parsed_manifest.release_versions() {
+                [] => parsed_manifest.prerelease_versions(),
+                releases => releases,
+            };
+            let start_index = published.len().saturating_sub(max_versions_to_display);
+            let versions_to_display = &published[start_index..];
             if !versions_to_display.is_empty() {
                 bun_core::pretty_errorln!("\nRecent versions:<r>");
                 for v in versions_to_display {

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { describe, expect, it, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 
@@ -224,7 +224,6 @@ describe.concurrent("bun info", () => {
       expect(output).toBe("");
     });
 
-    // TODO: Version validation needs to be fixed - currently falls back to first version instead of failing
     it("should handle non-existent version", async () => {
       const testDir = await setupTest();
       const { output, error, code } = await runCommand([bunExe(), "pm", "view", "is-number@999.0.0"], testDir, false);
@@ -233,12 +232,12 @@ describe.concurrent("bun info", () => {
         "error: No version of "is-number" satisfying "999.0.0" found
 
         Recent versions:
+        - 3.0.0
         - 4.0.0
         - 5.0.0
         - 6.0.0
         - 7.0.0
-        - 7.0.0
-          ... and 11 more
+          ... and 10 more
         "
       `);
       expect(code).toBe(1);
@@ -369,6 +368,112 @@ describe.concurrent("bun info", () => {
         "
       `);
     });
+  });
+});
+
+describe.concurrent("bun info with a spec that is neither a dist-tag nor a range", () => {
+  // `taggy` has the dist-tags `latest` and `next`. `beta` is not one of them, and it is
+  // not a semver range either, so nothing matches it (npm: E404 "No match found for version beta").
+  // `preonly` has prereleases only, for the "Recent versions" hint.
+  function packument(name: string, versionList: string[], distTags: Record<string, string>) {
+    const versions: Record<string, object> = {};
+    for (const v of versionList) {
+      versions[v] = { name, version: v, dist: { tarball: `http://localhost/${name}-${v}.tgz` } };
+    }
+    return JSON.stringify({ name, "dist-tags": distTags, versions });
+  }
+  const packuments: Record<string, string> = {
+    "/taggy": packument("taggy", ["1.0.0", "1.1.0", "2.0.0-rc.1"], { latest: "1.1.0", next: "2.0.0-rc.1" }),
+    "/preonly": packument("preonly", ["0.1.0-alpha.1", "0.1.0-alpha.2"], { latest: "0.1.0-alpha.2" }),
+  };
+  let server: ReturnType<typeof Bun.serve>;
+  let dir: string;
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const body = packuments[new URL(req.url).pathname];
+        if (body === undefined) return new Response("Not Found", { status: 404 });
+        return new Response(body, { headers: { "content-type": "application/json" } });
+      },
+    });
+    dir = tempDirWithFiles("view-dist-tag", {
+      "package.json": JSON.stringify({ name: "proj", version: "1.0.0" }),
+      "bunfig.toml": `[install]\nregistry = "${server.url.origin}/"\n`,
+    });
+  });
+  afterAll(() => server?.stop(true));
+
+  async function run(...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.each(["info", "pm view"])("bun %s: an unknown dist-tag is an error, not latest", async cmd => {
+    const { stdout, stderr, exitCode } = await run(...cmd.split(" "), "taggy@beta", "version");
+    expect(stdout).toBe("");
+    // The hint lists each release once: no prereleases, no dist-tag targets.
+    expect(stderr).toMatchInlineSnapshot(`
+      "error: No version of "taggy" satisfying "beta" found
+
+      Recent versions:
+      - 1.0.0
+      - 1.1.0
+      "
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("--json: an unknown dist-tag is an error, not latest", async () => {
+    const { stdout, stderr, exitCode } = await run("info", "taggy@beta", "version", "--json");
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ error: "No matching version found", version: "taggy@beta" });
+    expect(exitCode).toBe(1);
+  });
+
+  test("a git or file spec does not fall back to latest either", async () => {
+    // `pm view` does not support these spec kinds. The exact wording of the error is not
+    // pinned here, only that they are an error and print no version.
+    for (const spec of ["taggy@github:user/taggy", "taggy@file:./taggy"]) {
+      const { stdout, stderr, exitCode } = await run("info", spec, "version");
+      expect(stdout).toBe("");
+      expect(stderr).toStartWith("error: ");
+      expect(exitCode).toBe(1);
+    }
+  });
+
+  test("a package with prereleases only lists those in the hint", async () => {
+    const { stdout, stderr, exitCode } = await run("info", "preonly@beta", "version");
+    expect(stdout).toBe("");
+    expect(stderr).toMatchInlineSnapshot(`
+      "error: No version of "preonly" satisfying "beta" found
+
+      Recent versions:
+      - 0.1.0-alpha.1
+      - 0.1.0-alpha.2
+      "
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("known dist-tags and ranges still resolve", async () => {
+    const results = await Promise.all([
+      run("info", "taggy", "version"),
+      run("info", "taggy@next", "version"),
+      run("info", "taggy@^1.0.0", "version"),
+      run("info", "taggy@*", "version"),
+    ]);
+    expect(results.map(r => r.stdout.trim())).toEqual(["1.1.0", "2.0.0-rc.1", "1.1.0", "1.1.0"]);
+    expect(results.map(r => r.stderr)).toEqual(["", "", "", ""]);
+    expect(results.map(r => r.exitCode)).toEqual([0, 0, 0, 0]);
   });
 });
 

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -478,6 +478,11 @@ diffme@1.0.0 → diffme@2.0.0
     // …and what exists instead, newest first, plus the tags.
     expect(nover.stderr).toContain("recent versions: 2.0.0, 1.0.0");
     expect(nover.stderr).toMatch(/tags: .*latest: 2\.0\.0/);
+    // A word that is not one of the dist-tags is not a range either. It must not resolve to latest.
+    const notag = await diff(["diffme@beta", "1.0.0"]);
+    expect(notag.stdout).toBe("");
+    expect(notag.stderr).toContain("no version of diffme matches beta");
+    expect(notag.exitCode).toBe(1);
     const many = await diff(["diffme@1", "diffme@2", "diffme@3"]);
     expect(many.stderr).toContain("no file in either side matches diffme@3");
     expect(many.exitCode).toBe(1);


### PR DESCRIPTION
### Problem
- With a dist-tag the registry does not have, `bun info pkg@<tag>` and `bun pm diff pkg@<tag> <v>` print the data for `latest` and exit 0: `bun info is-number@nonexistenttag version` prints `7.0.0`. npm exits 1 with `E404 No match found for version`.
- Cause: both commands try the spec as a dist-tag, then as a semver range (`pm_view_command.rs:200`, `pm_diff_command.rs:765`). `Semver::query::parse` skips words it cannot read, so the tag parses to an empty `Group`. An empty `Group` satisfies every version, and `find_best_version` returns `latest`.

### Fix
- Add `PackageManifest::find_by_spec`: the dist-tag if there is one, else the range, but only when the parser found a comparator. Both commands call it and take their existing not-found exit, plain and `--json`.
- The "Recent versions" hint on that exit sliced the tail of `PackageManifest::versions`, which ends with the dist-tag targets, so it repeated versions. It now lists the newest five releases (prereleases if there is no release).
- Verified: `test/cli/install/bun-info.test.ts` (new block, 5 of 6 fail on 1.4.3) and `bun-pm-diff.test.ts` (new case, fails on 1.4.3). Both files pass.
- Self-reviewed: 3 concerns, 1 addressed (the `github:`/`file:` test no longer pins the error wording), 2 answered under Notes.

### Background
- A packument's `dist-tags` maps names like `latest` or `next` to versions. npm's `view` swaps a known tag for its version, then filters with `semver.satisfies`, false for an invalid range.
- The range parser is lenient on purpose: `1.0.0 || boop` ignores `boop`. `Group::is_empty()` reports a parse that found no comparator.
- `PackageManifest::versions` holds releases, then prereleases, then the dist-tag targets.

<details><summary>Notes</summary>

- A typo'd tag (`bun info react@nxt`) was the motivating case: it showed `latest` with no hint that the tag does not exist.
- `Group::is_empty()` is the same check `add_catalog.rs` and `audit_fix.rs` use to reject an unparseable range.
- `bun install` is not affected: it classifies a spec with `Tag::infer` before it parses a range, and `find_best_version` itself is unchanged. `find_best_version` had two callers outside `npm.rs`, the two fixed here.
- Behavior change on one edge: `bun info pkg` against a packument whose `latest` tag is missing, or points at a version that is not in `versions`, now reports `No version of "pkg" satisfying "latest" found` with the recent versions. Before, it printed the highest release through the same accidental path. `bun install pkg@latest` already fails in that case (`DistTagNotFound`). #36671 proposes a fallback for install and leaves `pm view` out on purpose. If that fallback lands and a maintainer wants `pm view` to follow, `find_by_spec` is the one place to add it.
- Specs such as `github:user/repo`, `file:./x` and `npm:other@1` also went down the `latest` path. They now exit 1 through the same not-found message. `pm view` never supported them, and the test only asserts the exit code and an `error:` line, so a later dedicated "unsupported spec" message does not break it.
- Review concern, not changed: the `is-number@999.0.0` snapshot in the pre-existing real-registry block now reads `3.0.0 .. 7.0.0, ... and 10 more` instead of `7.0.0` twice and `11 more`. That test already depended on registry.npmjs.org data (as do its neighbours, e.g. `versions: 15`). is-number last published in 2018.
- Review concern, not changed: #38671 rewrites the same lines in `pm_view_command.rs` for a different bug (range buffer). Whichever lands second needs a small rebase. With this PR the range is parsed and matched inside `find_by_spec` against `spec`, which is also what #38671 wants.
- The other npm-parity gaps in `pm view` (several property arguments, array-pluck paths, the two `--json` error shapes, the package.json requirement in #20673 / #38151) are separate and not touched here.
- `redacted-config-logs.test.ts` (which runs `pm view`) also passes.
- Repro on 1.4.3, in any directory with a package.json:
  ```
  $ bun info is-number@nonexistenttag version; echo $?
  7.0.0
  0
  $ bun pm diff is-number@nonexistenttag is-number@7.0.0
  is-number@7.0.0 → is-number@7.0.0
  No differences (4 files)
  ```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-pm-diff.test.ts

<!-- robobun:evidence:end -->