### PR TITLE
css: print align-items:center without a stray space when no safe/unsafe keyword is given

### DIFF
--- a/src/css_derive/lib.rs
+++ b/src/css_derive/lib.rs
@@ -865,38 +865,42 @@ fn has_css_flag(attrs: &[Attribute], flag: &str) -> bool {
 
 /// Emit the `__generateToCss` field-sequence body shared by the struct branch
 /// and named-field enum variants: each field is `to_css`'d in declaration
-/// order, `Option<_>` fields are unwrapped, and a single space is written
-/// between fields (unconditionally — the separator is not elided when an
-/// optional field is `None`).
+/// order, `Option<_>` fields are unwrapped, and a single space separates
+/// adjacent fields that printed something (a `None` optional prints nothing
+/// and takes no separator).
 ///
 /// `access` maps a field ident to the expression that reads it (`self.f` for
 /// a struct, the binding name for a destructured enum variant).
 fn gen_field_seq_to_css<'a>(
-    fields: impl ExactSizeIterator<Item = &'a syn::Field> + Clone,
+    fields: impl Iterator<Item = &'a syn::Field>,
     access: impl Fn(&syn::Ident) -> TokenStream2,
 ) -> TokenStream2 {
-    let len = fields.len();
-    let last = len.saturating_sub(1);
-    let stmts = fields.enumerate().map(|(j, f)| {
-        let fname = f.ident.as_ref().unwrap();
-        let slot = access(fname);
-        let body = if is_option_type(&f.ty) {
+    let sep = quote! {
+        if __needs_space {
+            __dest.write_char(b' ')?;
+        }
+    };
+    let stmts = fields.map(|f| {
+        let slot = access(f.ident.as_ref().unwrap());
+        if is_option_type(&f.ty) {
             quote! {
                 if let ::core::option::Option::Some(__v) = &#slot {
+                    #sep
                     __v.to_css(__dest)?;
+                    __needs_space = true;
                 }
             }
         } else {
-            quote! { #slot.to_css(__dest)?; }
-        };
-        let sep = if len > 1 && j != last {
-            quote! { __dest.write_char(b' ')?; }
-        } else {
-            quote! {}
-        };
-        quote! { #body #sep }
+            quote! {
+                #sep
+                #slot.to_css(__dest)?;
+                __needs_space = true;
+            }
+        }
     });
-    quote! { #(#stmts)* }
+    // The store after the last field is dead. rustc does not lint derive
+    // output, so it needs no `allow(unused_assignments)`.
+    quote! { let mut __needs_space = false; #(#stmts)* }
 }
 
 /// `true` when `ty` is spelled `Option<…>` (any path ending in `Option` with one
@@ -929,8 +933,8 @@ fn expand_derive_to_css(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let body = match &input.data {
         // ── Struct branch ──────────────────────────────────────────────────
         // Auto-serializer for a payload struct: the printer is the field
-        // sequence, space-separated, with optionals unwrapped (and the
-        // inter-field space emitted unconditionally).
+        // sequence, space-separated, with optionals unwrapped (a `None`
+        // optional prints nothing and takes no separator).
         //
         // Proc-macros cannot see through a type name, so `ToCss` is derived
         // directly on the payload struct; the enum arm's

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -3768,6 +3768,20 @@ describe("css tests", () => {
        `,
     );
 
+    // No separator space is printed for an absent <overflow-position>.
+    minify_test(".foo { align-content: center }", ".foo{align-content:center}");
+    minify_test(".foo { align-content: unsafe start }", ".foo{align-content:unsafe start}");
+    minify_test(".foo { align-self: center }", ".foo{align-self:center}");
+    minify_test(".foo { align-self: safe end }", ".foo{align-self:safe end}");
+    minify_test(".foo { align-items: center }", ".foo{align-items:center}");
+    minify_test(".foo { align-items: unsafe flex-start }", ".foo{align-items:unsafe flex-start}");
+    minify_test(".foo { place-content: center start }", ".foo{place-content:center start}");
+    minify_test(".foo { place-content: safe center start }", ".foo{place-content:safe center start}");
+    minify_test(".foo { place-self: center }", ".foo{place-self:center}");
+    minify_test(".foo { place-self: center unsafe start }", ".foo{place-self:center unsafe start}");
+    minify_test(".foo { place-items: center start }", ".foo{place-items:center start}");
+    minify_test(".foo { place-items: safe center }", ".foo{place-items:safe center}");
+
     cssTest(
       `
          .foo {


### PR DESCRIPTION
### Problem
- The CSS printer writes a stray space before a position keyword when no `safe`/`unsafe` keyword precedes it. `.a{align-items:center}` minifies to `.a{align-items: center}`. The same happens for `align-self`, `align-content`, `place-items`, `place-self` and `place-content`.
- The cause is `gen_field_seq_to_css` in `src/css_derive/lib.rs:874`. It generates the printer for `#[derive(css::ToCss)]` structs such as `AlignItemsSelfPosition { overflow: Option<OverflowPosition>, value: SelfPosition }` (`src/css/properties/align.rs:392`). It wrote the space between fields unconditionally, also when the leading `Option` field was `None` and printed nothing.

### Fix
- Write the separator before a field only when an earlier field printed something. The generated body tracks this in a `__needs_space` flag. This matches the lightningcss `ToCss` derive.
- Only the three `*Position` structs in `align.rs` use this code path, so no other output changes.
- Verified: `test/js/bun/css/css.test.ts` (12 new `minify_test` cases, 7 fail on stock bun). Also ran all of `test/js/bun/css/` and `test/bundler/css/`.
- Self-reviewed: 3 concerns raised, 0 needed a change here. A stricter compare in the `cssTest` helper, a missing `try_parse` in `PlaceContent::parse`, and the `place-self` `auto` collapse are separate changes (see Notes).

### Background
- `css_derive` is the proc-macro crate behind `#[derive(css::Parse, css::ToCss)]` in `src/css/`. For a named-field struct, `ToCss` prints the fields in declaration order, separated by one space, and unwraps `Option` fields.
- The `justify-*` properties were not affected: their `to_css` is hand-written and skips the space when `overflow` is `None`.
- The existing `cssTest` cases compare with `toEqualIgnoringWhitespace`, so they did not catch the extra space. `minify_test` compares exactly.

<details><summary>Notes</summary>

- Repro on bun 1.4.3:
  ```
  printf '.a{align-items:center}\n.b{align-items:safe center}\n.d{place-self:center}' > d.css
  bun build --minify d.css
  # .a{align-items: center}.b{align-items:safe center}.d{place-self: center}
  ```
- The removed Zig `DeriveToCss.__generateToCss` had the same unconditional separator, so this predates the Rust port.
- Generated body for `AlignItemsSelfPosition` after the change:
  ```rust
  let mut __needs_space = false;
  if let Some(__v) = &self.overflow {
      if __needs_space { __dest.write_char(b' ')?; }
      __v.to_css(__dest)?;
      __needs_space = true;
  }
  if __needs_space { __dest.write_char(b' ')?; }
  self.value.to_css(__dest)?;
  __needs_space = true;
  ```
  The dead store after the last field raises no warning because rustc does not lint derive output.
- Review follow-ups, not in this PR:
  - `cssTest`/`prefix_test` in `test/js/bun/css/util.ts` compare with `toEqualIgnoringWhitespace`. A per-line trimmed exact compare would have caught this bug. It only becomes possible after this fix, because several existing flex expectations carry the stray space on stock bun.
  - `PlaceContent::parse` (`align.rs:803`) calls `JustifyContent::parse` without `input.try_parse`, unlike `PlaceItems`/`PlaceSelf` and upstream.
  - `PlaceSelf::to_css` treats `JustifySelf::Auto` as equal to any `align` value (`align.rs:733`), so `place-self: center auto` prints as `center`. Upstream has the same line.
- The failures in a local debug run of `test/js/bun/css/` are the `!isCI` fuzz loops and the nesting-bound tests that hit their fixed 5 s and 10 s timeouts under the ASAN build. They pass with a longer timeout and do not touch this code.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static
... (truncated)

release without fix: 7 failed, 67 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.17ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.04ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.05ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.48ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.35ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.20ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 762ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_css_derive v0.0.0 (/workspace/bun/src/css_derive)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css_derive/lib.rs       | 46 ++++++++++++++++++++++++---------------------
 test/js/bun/css/css.test.ts | 14 ++++++++++++++
 2 files changed, 39 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/css_derive/lib.rs            5      7      6
test/js/bun/css/css.test.ts      3      1      6
```

</details>

<!-- robobun:evidence:end -->