### PR TITLE
Request: take a method from RequestInit only when it has one

### DIFF
--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1077,13 +1077,17 @@ impl Request {
         let values_to_try = &values_to_try_[0..((!is_first_argument_a_url) as usize
             + (arguments.len() > 1 && arguments[1].is_object()) as usize)];
 
-        for &value in values_to_try {
+        for (i, &value) in values_to_try.iter().enumerate() {
             let value_type = value.js_type();
-            let explicit_check = values_to_try.len() == 2
-                && value_type == bun_jsc::JSType::FinalObject
-                && values_to_try[1].js_type() == bun_jsc::JSType::DOMWrapper;
+            // The last candidate is `input` (unless that was a URL); anything before it is the
+            // `RequestInit` dictionary, which only contributes members it actually has.
+            let is_input = !is_first_argument_a_url && i == values_to_try.len() - 1;
+            // A pristine Request/Response has its headers and method copied from internal state
+            // below, so the `headers`/`method` getters are not consulted again for it.
+            let mut copied_internal_fields = false;
             if value_type == bun_jsc::JSType::DOMWrapper {
                 if let Some(request) = value.as_direct::<Request>() {
+                    copied_internal_fields = true;
                     // SAFETY: as_direct returns a live *mut Request payload (m_ctx)
                     let request = unsafe { &*request };
                     if values_to_try.len() == 1 {
@@ -1149,9 +1153,11 @@ impl Request {
                 }
 
                 if let Some(response) = value.as_direct::<Response>() {
+                    copied_internal_fields = true;
                     // SAFETY: `as_direct` returned a live `*mut Response` owned by the JS wrapper.
                     let response = unsafe { &mut *response };
-                    if !fields.contains(Fields::Method) {
+                    // A Response has no `method` property, so as `init` it cannot set one.
+                    if is_input && !fields.contains(Fields::Method) {
                         req.method = response.get_method();
                         fields.insert(Fields::Method);
                     }
@@ -1297,39 +1303,31 @@ impl Request {
                 }
             }
 
-            if !fields.contains(Fields::Method) || !fields.contains(Fields::Headers) {
-                match crate::webcore::response::Init::init(global_this, value) {
-                    Ok(Some(response_init)) => {
-                        let header_check = !explicit_check
-                            || (explicit_check
-                                && match value.fast_get(global_this, bun_jsc::BuiltinName::Headers)
-                                {
-                                    Ok(v) => v.is_some(),
-                                    Err(e) => bail!(Err(e)),
-                                });
-                        if header_check {
-                            if let Some(headers) = response_init.headers {
-                                if !fields.contains(Fields::Headers) {
-                                    req.headers.set(Some(headers));
-                                    fields.insert(Fields::Headers);
-                                } else {
-                                    drop(headers); // headers.deref()
-                                }
+            if !copied_internal_fields && !fields.contains(Fields::Headers) {
+                match value.fast_get(global_this, bun_jsc::BuiltinName::Headers) {
+                    Ok(Some(headers_)) => {
+                        match HeadersRef::from_init_value(global_this, headers_) {
+                            Ok(Some(headers)) => {
+                                req.headers.set(Some(headers));
+                                fields.insert(Fields::Headers);
                             }
+                            Ok(None) => {}
+                            Err(e) => bail!(Err(e)),
                         }
+                    }
+                    Ok(None) => {}
+                    Err(e) => bail!(Err(e)),
+                }
+            }
 
-                        let method_check = !explicit_check
-                            || (explicit_check
-                                && match value.fast_get(global_this, bun_jsc::BuiltinName::Method) {
-                                    Ok(v) => v.is_some(),
-                                    Err(e) => bail!(Err(e)),
-                                });
-                        if method_check {
-                            if !fields.contains(Fields::Method) {
-                                req.method = response_init.method;
-                                fields.insert(Fields::Method);
-                            }
+            if !copied_internal_fields && !fields.contains(Fields::Method) {
+                match value.fast_get(global_this, bun_jsc::BuiltinName::Method) {
+                    Ok(Some(method_)) => {
+                        match bun_http_jsc::method_jsc::from_js(global_this, method_) {
+                            Ok(method) => req.method = method.unwrap_or(Method::GET),
+                            Err(e) => bail!(Err(e)),
                         }
+                        fields.insert(Fields::Method);
                     }
                     Ok(None) => {}
                     Err(e) => bail!(Err(e)),

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -76,6 +76,27 @@ impl HeadersRef {
         Ok(FetchHeaders::create_from_js(global, value)?.map(|p| unsafe { Self::adopt(p) }))
     }
 
+    /// The `headers` member of a `RequestInit`/`ResponseInit` dictionary: a
+    /// `Headers` object is deep-copied without going through the iterator
+    /// protocol, anything else takes the `HeadersInit` conversion. Empty → `None`.
+    pub(crate) fn from_init_value(
+        global: &JSGlobalObject,
+        value: JSValue,
+    ) -> JsResult<Option<Self>> {
+        // `JSValue::as_::<FetchHeaders>()` requires `JsClass`; FetchHeaders is a
+        // hand-bound opaque, so use its dedicated `cast()`.
+        if let Some(orig) = FetchHeaders::cast(value) {
+            // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
+            let orig = bun_opaque::opaque_deref_mut(orig.as_ptr());
+            if orig.is_empty() {
+                return Ok(None);
+            }
+            // SAFETY: `clone_this` returns a fresh +1 ref or null.
+            return Ok(orig.clone_this(global)?.map(|p| unsafe { Self::adopt(p) }));
+        }
+        Self::create_from_js(global, value)
+    }
+
     /// `FetchHeaders.cloneThis(global)` — deep copy on the C++ side.
     #[inline]
     pub(crate) fn clone_this(&self, global: &JSGlobalObject) -> JsResult<Option<Self>> {
@@ -1190,8 +1211,7 @@ impl Response {
 
 // We deliberately do NOT `impl Drop for Init` so struct-update
 // syntax (`Init { status_code: x, ..Default::default() }`) and partial moves
-// (e.g. Request::construct_into reading `response_init.headers`) keep working;
-// the fields' own drop glue releases `headers` and `status_text`.
+// keep working; the fields' own drop glue releases `headers` and `status_text`.
 pub struct Init {
     pub(crate) headers: Option<HeadersRef>,
     pub(crate) status_code: u16,
@@ -1272,23 +1292,7 @@ impl Init {
         }
 
         if let Some(headers) = response_init.fast_get(global_this, BuiltinName::headers)? {
-            // `JSValue::as_::<FetchHeaders>()` requires `JsClass`;
-            // FetchHeaders is a hand-bound opaque, so use its dedicated
-            // `cast()` (wraps `WebCore__FetchHeaders__cast_`).
-            if let Some(orig) = FetchHeaders::cast(headers) {
-                // `orig` is a live `WebCore::FetchHeaders*` borrowed from JS;
-                // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
-                let orig = bun_opaque::opaque_deref_mut(orig.as_ptr());
-                if !orig.is_empty() {
-                    result.headers = orig.clone_this(global_this)?.map(|p| {
-                        // SAFETY: `clone_this` returns a fresh +1-ref'd `FetchHeaders*`;
-                        // ownership of that ref is transferred into the `HeadersRef`.
-                        unsafe { HeadersRef::adopt(p) }
-                    });
-                }
-            } else {
-                result.headers = HeadersRef::create_from_js(global_this, headers)?;
-            }
+            result.headers = HeadersRef::from_init_value(global_this, headers)?;
         }
 
         if let Some(status_value) = response_init.fast_get(global_this, BuiltinName::status)? {

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -76,6 +76,118 @@ test("clone() does not lock original body when body was accessed before clone", 
   expect(clonedText).toBe("Hello, world!");
 });
 
+// `RequestInit` is a WebIDL dictionary: a member is present only when the init object has that
+// property (and it is not undefined). An init without a `method` keeps the input Request's method.
+describe("RequestInit method presence", () => {
+  const put = () =>
+    new Request("http://h.example/x", { method: "PUT", body: "a", headers: { "x-k": "1" }, redirect: "manual" });
+  // Only the custom headers: a Content-Type derived from the body is not the subject here.
+  const xHeaders = (r: Request) => Object.fromEntries([...r.headers].filter(([name]) => name.startsWith("x-")));
+
+  test("a Response passed as init contributes headers and body, not a method", async () => {
+    // @ts-expect-error a Response is not a RequestInit, but it is an object with `headers`/`body`.
+    const r = new Request(put(), new Response("b", { headers: { "x-r": "2" } }));
+    expect(r.method).toBe("PUT");
+    expect(r.url).toBe("http://h.example/x");
+    expect(r.redirect).toBe("manual");
+    expect(xHeaders(r)).toEqual({ "x-r": "2" });
+    expect(await r.text()).toBe("b");
+  });
+
+  test("a Response with a null body passed as init keeps the input Request's method", () => {
+    // @ts-expect-error
+    const r = new Request(put(), new Response(null, { status: 204 }));
+    expect(r.method).toBe("PUT");
+    expect(r.url).toBe("http://h.example/x");
+    // Bun lets ResponseInit carry a `method` (HTMLRewriter uses it). It is internal state, not a
+    // property, so it must not leak into a Request either.
+    // @ts-expect-error
+    expect(new Request(put(), new Response(null, { method: "DELETE" })).method).toBe("PUT");
+    // @ts-expect-error
+    expect(new Request("http://h.example/y", new Response(null, { method: "DELETE" })).method).toBe("GET");
+  });
+
+  // The kind of object does not matter, only which properties it has.
+  test.each([
+    ["Proxy", () => new Proxy({ headers: { "x-o": "3" } }, {})],
+    ["array", () => Object.assign([], { headers: { "x-o": "3" } })],
+    ["function", () => Object.assign(function init() {}, { headers: { "x-o": "3" } })],
+    [
+      "class instance",
+      () =>
+        new (class Init {
+          headers = { "x-o": "3" };
+        })(),
+    ],
+    ["null-prototype object", () => Object.assign(Object.create(null), { headers: { "x-o": "3" } })],
+  ])("%s init without a method keeps the input Request's method", async (_, makeInit) => {
+    const r = new Request(put(), makeInit() as RequestInit);
+    expect(r.method).toBe("PUT");
+    expect(r.redirect).toBe("manual");
+    expect(xHeaders(r)).toEqual({ "x-o": "3" });
+    expect(await r.text()).toBe("a");
+  });
+
+  test.each([
+    ["Headers", () => new Headers({ "x-o": "3" })],
+    ["URL", () => new URL("http://other.example/")],
+    ["Blob", () => new Blob(["zz"])],
+    ["Map", () => new Map([["method", "DELETE"]])],
+  ])("%s as init has no RequestInit members at all", async (_, makeInit) => {
+    const r = new Request(put(), makeInit() as unknown as RequestInit);
+    expect(r.method).toBe("PUT");
+    expect(r.url).toBe("http://h.example/x");
+    expect(xHeaders(r)).toEqual({ "x-k": "1" });
+    expect(await r.text()).toBe("a");
+  });
+
+  test("a method on a non-plain init object is still honoured", () => {
+    expect(new Request(put(), new Proxy({ method: "POST" }, {})).method).toBe("POST");
+    expect(new Request(put(), Object.assign([], { method: "DELETE" })).method).toBe("DELETE");
+    class WithMethod extends Response {
+      get method() {
+        return "PATCH";
+      }
+    }
+    // @ts-expect-error
+    expect(new Request(put(), new WithMethod()).method).toBe("PATCH");
+    let reads = 0;
+    const init = {
+      get method() {
+        reads++;
+        return "OPTIONS";
+      },
+    };
+    expect(new Request(put(), init).method).toBe("OPTIONS");
+    expect(reads).toBe(1);
+  });
+
+  test("an object input keeps its method when init has none", () => {
+    // A plain object with a `url` as input is a Bun extension.
+    // @ts-expect-error
+    const r = new Request({ url: "http://h.example/x", method: "PUT" }, { headers: { "x-o": "3" } });
+    expect(r.method).toBe("PUT");
+    expect(r.url).toBe("http://h.example/x");
+    expect(xHeaders(r)).toEqual({ "x-o": "3" });
+  });
+
+  test("ResponseInit-only members on a RequestInit are not read", () => {
+    const init = {
+      method: "POST",
+      get status() {
+        throw new Error("status must not be read");
+      },
+      get statusText() {
+        throw new Error("statusText must not be read");
+      },
+    };
+    expect(new Request("http://h.example/x", init).method).toBe("POST");
+    expect(new Request(put(), init).method).toBe("POST");
+    // @ts-expect-error
+    expect(new Request("http://h.example/x", { status: 0 }).method).toBe("GET");
+  });
+});
+
 describe("RequestInit signal presence", () => {
   // Fetch spec step 27: "If init['signal'] exists, then set signal to it."
   // A present `signal: null` must replace (detach from) the input Request's signal.


### PR DESCRIPTION
Fixes #42759

### Problem
- `new Request(input, init)` returns a GET when `init` has no `method`, unless `init` is a plain object and `input` is a native Request. `new Request({ url, method: "POST", body }, {})` is a GET that keeps the body (#42759). So is `new Request(put, new Response("b"))` (undici keeps PUT), or a Proxy, an array, a `Headers` or a `URL` as `init`.
- The cause is `Request::construct_into` (`src/runtime/webcore/Request.rs:1301`). It parsed `init` with `response::Init::init`, the `ResponseInit` parser, which yields GET when `method` is absent. The `explicit_check` guard from #6154 covers only that one pair. The `Response` direct-copy branch (`Request.rs:1151`) also copied the Response's internal method in the `init` position.

### Fix
- Read the `headers` and `method` members of each candidate with `fast_get`. Set a method only when the member is present. `explicit_check` and the `Init::init` call go away, so `init` is not probed for `status`/`statusText` either.
- The `Response` direct-copy branch sets a method only when the Response is the `input`.
- The `Headers`-or-`HeadersInit` conversion moves into `HeadersRef::from_init_value`, shared with `Init::init`. Header semantics do not change.
- Verified: `test/js/web/request/request.test.ts` (13 cases fail on main, two came from #42761 for #42759). Self-reviewed: 1 concern (order against open PRs on this loop), addressed in Notes.

### Background
- `RequestInit` is a WebIDL dictionary: one `Get` per member, and `undefined` means absent. A `Response` as `init` contributes `headers` and `body` (its getters), nothing else.
- `construct_into` visits `[init?, input?]` in that order and takes each field from the first candidate that has it. A default out of `init` shadows the real value on `input`.
- A pristine `Request`/`Response` wrapper (`as_direct`) is copied from internal state without getters. Any other object has its members read as properties, also as `input` (a Bun extension, test "#874").

<details><summary>Notes</summary>

Repro (bun 1.4.3 vs node v26.3.0/undici):

```js
const put = new Request("http://h.example/x", { method: "PUT", body: "a", headers: { "x-k": "1" } });
const r = new Request(put, new Response("b", { headers: { "x-r": "2" } }));
console.log(r.method, r.url, await r.text());
// bun before: GET http://h.example/x b
// bun after:  PUT http://h.example/x b
// undici: TypeError (duplex option is required when sending a body). It reads init.body and
// init.headers through the Response's getters; with duplex it keeps PUT.
```

Repro from #42759. A Request look-alike is an object that is not a native Request, but whose prototype chain reaches `Request.prototype`. srvx hands Node.js requests to fetch handlers in this form. Node 26 throws a TypeError for all three lines, because the object fails the Request brand check.

```js
function requestLike() {
  const backing = new Request("http://localhost/a", { method: "POST", body: "{}" });
  class RequestLike {}
  for (const [key, desc] of Object.entries(Object.getOwnPropertyDescriptors(Request.prototype))) {
    if (key === "constructor") continue;
    Object.defineProperty(RequestLike.prototype, key, desc.get
      ? { get() { return backing[key]; } }
      : { value: (...args) => backing[key](...args) });
  }
  Object.setPrototypeOf(RequestLike.prototype, Request.prototype);
  return new RequestLike();
}
console.log(new Request(requestLike()).method);
console.log(new Request(requestLike(), {}).method);
console.log(new Request(requestLike(), { headers: { "x-a": "1" } }).method);
// main (7e56b402b0): POST GET GET
// this branch:       POST POST POST
```

Relation to #42761: that PR fixed the #42759 face alone. It made `explicit_check` apply to `init` for every kind of `input`. It is closed in favor of this PR. Its two tests are now `RequestInit method presence > a non-native input` in `request.test.ts`, and the original two tests of #42761 also pass on this branch as written. On the code of #42761, 4 of the cases in this file still fail: the two `Response`-as-`init` cases, the double read of an `init.method` getter, and `status` read from a `RequestInit`.

Other faces of the same cause, all fixed here (method was GET before, stays PUT now, as in undici): `new Request(put, new Response(null))`, `new Request(put, new Proxy({}, {}))`, `new Request(put, [])`, `new Request(put, function(){})`, `new Request(put, new Headers({a: "1"}))`, `new Request(put, new Blob([]))`, `new Request(put, new URL("http://z/"))`, `new Request({ url, method: "PUT" }, { headers })`. On 1.4.3 `fetch(put, init)` already sends PUT for all of these (`fetch.rs` reads `method` by presence), while `fetch(new Request(put, init))` failed with `fetch() request with GET/HEAD method cannot have body`.

Also changed as a consequence:
- A `method` getter on `init` is read once (it was read twice when `explicit_check` applied).
- `new Request(url, { status: 0 })` no longer throws `RangeError: The status provided (0) must be 101 or in the range of [200, 599]`. `status` and `statusText` are not `RequestInit` members and are not read anymore.
- `new Request(url, new Response(null, { method: "DELETE" })).method` is GET, not DELETE. The `method` a `ResponseInit` can carry in Bun is internal Response state (HTMLRewriter uses it), not a property.

Deliberately not changed here:
- `init.url` and a Response's url in the `init` position: #41902. That PR computes the same `is_input` flag; whichever lands second drops the duplicate line.
- `init.body: null` dropping the input body: #41901.
- An empty `headers` (`{}`, `[]`, `new Headers()`, a Response without headers) still counts as absent and keeps the input's headers. undici empties the header list in that case. Separate behaviour change.
- An unrecognized or empty method token still falls back to GET (`{ method: "FOO" }`, `{ method: null }`), as before: #33469.
- `Init::init` keeps its Request/Response fast paths for `new Response(body, requestOrResponse)`.
- An `input` that is not a native Request is still accepted (test "#874"). A Node-style brand check that throws is a separate decision.

Sequencing: #41841 (`Init::init_without_status`) and #33469 (`Init::init_for_request`) each add a Request-specific variant of `Init::init` for this call site. With this change the call site is gone, so those hunks become unnecessary. #40411 rewrites the same block mechanically (`bail!` to `?`); the conflict is textual.

Suites run on the debug build: `test/js/web/request/` (all four files), `test/js/web/fetch/{fetch -t "Request|Response|Headers",body,body-clone,body-mixin-errors,body-stream,fetch-args,response,headers,headers-case,client-fetch,request-cyclic-reference}`, `test/js/web/html/FormData`, `test/js/workerd/html-rewriter`, `test/js/deno/fetch/{request,body}`, `test/js/bun/globals`, `test/js/bun/util/filesystem_router`, `test/regression/issue/{02368,2993}`. Pre-existing under the debug ASAN build with or without this change: the `utf16 ... (with gc)` cases in `fetch.test.ts` and the loops in `request-clone-leak.test.ts` / `request-method-getter.test.ts` exceed the 5 s default timeout; their assertions pass with a longer timeout.

Run again on the debug build after the merge of main (7e56b402b0): `test/js/web/request/{request,request-subclass}`, `test/js/web/fetch/{fetch-args,body,body-clone,body-mixin-errors,request-cyclic-reference,headers,headers-case,response}`, `test/js/workerd/html-rewriter`, `test/js/deno/fetch/request`. All pass, except that `response.test.ts` "handle stack overflow" (no init involved) takes 7.5 s under the debug ASAN build and exceeds the 5 s default timeout.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/request/request.test.ts
bun test v1.4.3 (09bb54630)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [3.61ms]
(pass) request can receive undefined signal [29.23ms]
(pass) request can receive null signal [9.32ms]
(pass) clone() does not lock original body when body was accessed before clone [14.98ms]
85 |   const xHeaders = (r: Request) => Object.fromEntries([...r.headers].filter(([name]) => name.startsWith("x-")));
86 | 
87 |   test("a Response passed as init contributes headers and body, not a method", async () => {
88 |     // A Response is not a RequestInit, but it is an object with `headers` and `body`.
89 |     const r = new Request(put(), new Response("b", { headers: { "x-r": "2" } }));
90 |     expect(r.method).toBe("PUT");
                          ^
error: expect(received).toBe(expected)

Expected: "PUT"
Received: "GET"

      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:90:22)
      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:87:80)
(fail) RequestI
... (truncated)

release without fix: 13 FAILED
bun test v1.4.3-canary.1 (09bb54630)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [0.08ms]
(pass) request can receive undefined signal [0.23ms]
(pass) request can receive null signal [0.12ms]
(pass) clone() does not lock original body when body was accessed before clone [0.39ms]
85 |   const xHeaders = (r: Request) => Object.fromEntries([...r.headers].filter(([name]) => name.startsWith("x-")));
86 | 
87 |   test("a Response passed as init contributes headers and body, not a method", async () => {
88 |     // A Response is not a RequestInit, but it is an object with `headers` and `body`.
89 |     const r = new Request(put(), new Response("b", { headers: { "x-r": "2" } }));
90 |     expect(r.method).toBe("PUT");
                          ^
error: expect(received).toBe(expected)

Expected: "PUT"
Received: "GET"

      at <anonymous> (/workspace/bun/test/js/web/request/request.test.ts:90:22)
(fail) RequestInit method presence > a Response passed as init contributes headers and body, not a method [0.35ms]
94 |     expect(await r.text()).toBe("b");
95 |   });
96 | 
97 |   test("a Response with a null body passed as init keeps the input Request's
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/request/request.test.ts
bun test v1.4.3 (09bb54630)

test/js/web/request/request.test.ts:
(pass) undefined args don't throw [6.62ms]
(pass) request can receive undefined signal [39.64ms]
(pass) request can receive null signal [12.51ms]
(pass) clone() does not lock original body when body was accessed before clone [23.34ms]
(pass) RequestInit method presence > a Response passed as init contributes headers and body, not a method [28.51ms]
(pass) RequestInit method presence > a Response with a null body passed as init keeps the input Request's method [8.19ms]
(pass) RequestInit method presence > Proxy init without a method keeps the input Request's method [14.90ms]
(pass) RequestInit method presence > array init without a method keeps the input Request's method [6.94ms]
(pass) RequestInit method presence > function init without a method keeps the input Request's method [5.84ms]
(pass) RequestInit method presence > class instance init without a method keeps the input Request's method [9.01ms]
(pass) RequestInit method presence >
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 772ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m std v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
[1m[92m   Compiling[0m proc_macro v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/proc_macro)
[1m[92m   Compiling[0m memchr v2.8.0
[1m[92m   Compiling[0m libc v0.2.186
[1m[92m   Compiling[0m allocator-api2 v0.2.21
[1m[92m   Compiling[0m bun_opaque v0.0.0 (/workspace/bun/src/opaque)
[1m[92m   Compiling[0m itoa v1.0.18
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m konst_macro_rules v0.2.19
[1m[92m   Compiling[0m thiserror v2.0.18
[1m[92m   Compiling[0m konst v0.2.20
[1m[92m   Compiling[0m strum v0.26.3
[1m[92m   Compiling[0m bun_out
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Request.rs      |  64 +++++++-------
 src/runtime/webcore/Response.rs     |  38 ++++-----
 test/js/web/request/request.test.ts | 161 ++++++++++++++++++++++++++++++++++++
 3 files changed, 210 insertions(+), 53 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/webcore/Request.rs           4      8     16
src/runtime/webcore/Response.rs          5      5     16
test/js/web/request/request.test.ts      3      3     16
```

</details>

<!-- robobun:evidence:end -->
