### PR TITLE
Worker: build the worker's native env map from its env option, not the parent's launch environment

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1424,7 +1424,7 @@ impl Map {
     }
 
     #[inline]
-    pub(crate) fn init() -> Map {
+    pub fn init() -> Map {
         Map {
             map: HashTable::default(),
         }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,14 +595,22 @@ impl Loader {
         }
     }
 
-    /// A `Worker`'s loader: the map, with the explicit entries marked loaded so a pipe is not read twice.
-    pub fn clone_for_worker(&self) -> Result<Loader, AllocError> {
+    /// A `Worker`'s loader. `snapshot` is the environment the worker starts
+    /// with (its `env` option, or a copy of the parent's `process.env`); `None`
+    /// copies this loader's map. Everything this loader already read (`environ`,
+    /// `.env` files, `--env-file` pipes) counts as read, so the worker neither
+    /// merges the launch environment over the snapshot nor reads a file twice.
+    pub fn for_worker(&self, snapshot: Option<Map>) -> Result<Loader, AllocError> {
+        let did_load_process = snapshot.is_some() || self.did_load_process;
         Ok(Loader {
-            map: self.map.clone_with_allocator()?,
-            default_files_loaded: EnumSet::empty(),
+            map: match snapshot {
+                Some(map) => map,
+                None => self.map.clone_with_allocator()?,
+            },
+            default_files_loaded: self.default_files_loaded,
             custom_files_loaded: self.custom_files_loaded.clone()?,
             quiet: false,
-            did_load_process: false,
+            did_load_process,
             reject_unauthorized: Cell::new(None),
             aws_credentials: None,
         })

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -597,9 +597,10 @@ impl Loader {
 
     /// A `Worker`'s loader. `snapshot` is the environment the worker starts
     /// with (its `env` option, or a copy of the parent's `process.env`); `None`
-    /// copies this loader's map. Everything this loader already read (`environ`,
-    /// `.env` files, `--env-file` pipes) counts as read, so the worker neither
-    /// merges the launch environment over the snapshot nor reads a file twice.
+    /// copies this loader's map. Either one already holds what this loader
+    /// read from `environ` and from env files, so the worker's loader counts
+    /// all of them as read: it neither merges the launch environment over the
+    /// snapshot nor reads a `.env` file (or an `--env-file` pipe) again.
     pub fn for_worker(&self, snapshot: Option<Map>) -> Result<Loader, AllocError> {
         let did_load_process = snapshot.is_some() || self.did_load_process;
         Ok(Loader {
@@ -607,7 +608,7 @@ impl Loader {
                 Some(map) => map,
                 None => self.map.clone_with_allocator()?,
             },
-            default_files_loaded: self.default_files_loaded,
+            default_files_loaded: EnumSet::all(),
             custom_files_loaded: self.custom_files_loaded.clone()?,
             quiet: false,
             did_load_process,

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -563,8 +563,9 @@ static ALWAYS_INLINE void syncWindowsEnv(SharedEnvStore* store, const String& ke
 // `process.env` object that is a thin write-through view over the tree's
 // SharedEnvStore (lock-guarded, strings isolatedCopy()'d both ways).
 //
-// Only the JS-visible `process.env` is shared; Bun's Zig-side env map (Bun.env,
-// fetch proxy resolution) is still snapshotted per worker.
+// Only the JS-visible `process.env` is shared. The worker VM's native env map
+// (Bun.spawn's default env, Bun.which, fetch proxy and TLS defaults) is a
+// snapshot of the store taken when the worker starts (WorkerMessagingProxy).
 
 // The store for the tree this global belongs to, or null if it's in none. The
 // context can be gone during teardown, when a surviving process.env is read.

--- a/src/jsc/bindings/SharedEnvStore.h
+++ b/src/jsc/bindings/SharedEnvStore.h
@@ -62,6 +62,17 @@ public:
         return out;
     }
 
+    // Every (name, value) as it is now, e.g. to seed a joining worker's native env map.
+    Vector<std::pair<String, String>> entries()
+    {
+        Locker locker { m_lock };
+        Vector<std::pair<String, String>> out;
+        out.reserveInitialCapacity(m_map.size());
+        for (const auto& entry : m_map.values())
+            out.append({ entry.name.isolatedCopy(), entry.value.isolatedCopy() });
+        return out;
+    }
+
     // Windows env keys are case-insensitive. This follows bun's own Windows env
     // object, not node: node only folds case for a main-rooted tree (RealEnvStore),
     // and is case-sensitive for one rooted at a snapshot worker (MapKVStore).

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -68,7 +68,13 @@ void* WebWorker__create(
     StringImpl** execArgvPtr,
     size_t execArgvLen,
     BunString* preloadModulesPtr,
-    size_t preloadModulesLen);
+    size_t preloadModulesLen,
+    // The env snapshot (WorkerOptions::env) the worker's process.env is built from, so the worker
+    // VM's native env map starts from the same entries. hasEnvSnapshot=false: copy the parent's map.
+    bool hasEnvSnapshot,
+    const BunString* envKeysPtr,
+    const BunString* envValuesPtr,
+    size_t envLen);
 // Raise a TerminationException in the worker VM at its next safepoint and wake its loop. Any thread.
 void WebWorker__requestTermination(void*);
 // Toggle the keep-alive this worker holds on the parent event loop. Parent thread.
@@ -140,6 +146,19 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
                                                })
                                                .value_or(std::span<WTF::StringImpl*> {});
 
+    // Borrowed views; m_options.env keeps the strings alive until the worker thread consumes it.
+    Vector<BunString> envKeys;
+    Vector<BunString> envValues;
+    const bool hasEnvSnapshot = m_options.env.has_value();
+    if (hasEnvSnapshot) {
+        envKeys.reserveInitialCapacity(m_options.env->size());
+        envValues.reserveInitialCapacity(m_options.env->size());
+        for (const auto& entry : *m_options.env) {
+            envKeys.append(Bun::toString(entry.key));
+            envValues.append(Bun::toString(entry.value));
+        }
+    }
+
     // The thread holds a ref on the proxy until releaseWorkerThread().
     ref();
     BunString errorMessage = BunStringEmpty;
@@ -163,7 +182,11 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
         execArgv.data(),
         execArgv.size(),
         preloadModules.begin(),
-        preloadModules.size());
+        preloadModules.size(),
+        hasEnvSnapshot,
+        envKeys.begin(),
+        envValues.begin(),
+        envKeys.size());
     m_options.preloadModules.clear();
 
     if (!m_workerThread) {

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -69,8 +69,9 @@ void* WebWorker__create(
     size_t execArgvLen,
     BunString* preloadModulesPtr,
     size_t preloadModulesLen,
-    // The env snapshot (WorkerOptions::env) the worker's process.env is built from, so the worker
-    // VM's native env map starts from the same entries. hasEnvSnapshot=false: copy the parent's map.
+    // The entries the worker's process.env starts with (WorkerOptions::env, or the SHARE_ENV store
+    // as it is now), so the worker VM's native env map starts from the same environment.
+    // hasEnvSnapshot=false: copy the parent VM's map.
     bool hasEnvSnapshot,
     const BunString* envKeysPtr,
     const BunString* envValuesPtr,
@@ -146,16 +147,26 @@ ExceptionOr<void> WorkerMessagingProxy::startWorkerGlobalScope(const String& scr
                                                })
                                                .value_or(std::span<WTF::StringImpl*> {});
 
-    // Borrowed views; m_options.env keeps the strings alive until the worker thread consumes it.
+    // The environment the worker's process.env starts with, as borrowed views: m_options.env keeps
+    // its strings alive until the worker thread consumes it, sharedEnv until this call returns.
     Vector<BunString> envKeys;
     Vector<BunString> envValues;
-    const bool hasEnvSnapshot = m_options.env.has_value();
-    if (hasEnvSnapshot) {
+    Vector<std::pair<String, String>> sharedEnv;
+    const bool hasEnvSnapshot = m_options.env.has_value() || m_options.sharedEnvStore;
+    if (m_options.env.has_value()) {
         envKeys.reserveInitialCapacity(m_options.env->size());
         envValues.reserveInitialCapacity(m_options.env->size());
         for (const auto& entry : *m_options.env) {
             envKeys.append(Bun::toString(entry.key));
             envValues.append(Bun::toString(entry.value));
+        }
+    } else if (m_options.sharedEnvStore) {
+        sharedEnv = m_options.sharedEnvStore->entries();
+        envKeys.reserveInitialCapacity(sharedEnv.size());
+        envValues.reserveInitialCapacity(sharedEnv.size());
+        for (const auto& entry : sharedEnv) {
+            envKeys.append(Bun::toString(entry.first));
+            envValues.append(Bun::toString(entry.second));
         }
     }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -377,13 +377,14 @@ impl WebWorker {
         // The worker VM's env map must hold what the worker's `process.env`
         // starts with, because native readers (`Bun.spawn` without `env`,
         // `Bun.which`, the TLS and proxy defaults) read the map, not the JS
-        // object. With an `env` option (or once the parent's `process.env`
-        // exists) that is the snapshot C++ took for the JS object; otherwise
-        // the parent's map, which its untouched `process.env` would mirror.
+        // object. That is the snapshot C++ builds the JS object from (the `env`
+        // option, the parent's current `process.env`, or the SHARE_ENV store);
+        // with none of those, the parent's map, which its untouched
+        // `process.env` would mirror.
         let mut proxy_env_slots = jsc::rare_data::ProxyEnvSlots::default();
         let env_loader = if has_env_snapshot {
             // SAFETY: caller passed valid (ptr,len) pairs (or `(null,0)`)
-            // borrowed from the C++ WorkerOptions for the duration of this call.
+            // that stay alive for the duration of this call.
             let (keys, values) = unsafe {
                 (
                     bun_core::ffi::slice(env_keys_ptr, env_len),
@@ -1282,10 +1283,9 @@ fn on_unhandled_rejection(
     vm.handle_ref().request_termination();
 }
 
-/// Builds the worker's env map from the `process.env` snapshot C++ took for
-/// it (`WorkerOptions::env`). An entry with a NUL byte could not reach a child
-/// process intact (`Bun.spawn` rejects one in an explicit `env`), so it is
-/// left out of the map as well.
+/// Builds the worker's env map from the entries its `process.env` starts
+/// with. An entry with a NUL byte could not reach a child process intact
+/// (`Bun.spawn` rejects one in an explicit `env`), so it is left out.
 fn env_map_from_snapshot(
     keys: &[BunString],
     values: &[BunString],

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -299,6 +299,10 @@ impl WebWorker {
         exec_argv_len: usize,
         preload_modules_ptr: *const BunString,
         preload_modules_len: usize,
+        has_env_snapshot: bool,
+        env_keys_ptr: *const BunString,
+        env_values_ptr: *const BunString,
+        env_len: usize,
     ) -> *mut WebWorker {
         jsc::mark_binding();
         log!("[{}] create", this_context_id);
@@ -370,23 +374,39 @@ impl WebWorker {
                 transform_options.allow_ffi_cc = Some(parent_allows_ffi_cc && flags.allow_ffi_cc);
             }
         }
-        // The worker's `process.env` starts as a copy of the parent's now (as in
-        // Node). Proxy-env values may be RefCountedEnvValue bytes owned by the
-        // parent's proxy_env_storage: snapshot slots + map under its lock so
-        // every slice copied is backed by a ref the snapshot holds.
+        // The worker VM's env map must hold what the worker's `process.env`
+        // starts with, because native readers (`Bun.spawn` without `env`,
+        // `Bun.which`, the TLS and proxy defaults) read the map, not the JS
+        // object. With an `env` option (or once the parent's `process.env`
+        // exists) that is the snapshot C++ took for the JS object; otherwise
+        // the parent's map, which its untouched `process.env` would mirror.
         let mut proxy_env_slots = jsc::rare_data::ProxyEnvSlots::default();
-        let mut env_loader = {
+        let env_loader = if has_env_snapshot {
+            // SAFETY: caller passed valid (ptr,len) pairs (or `(null,0)`)
+            // borrowed from the C++ WorkerOptions for the duration of this call.
+            let (keys, values) = unsafe {
+                (
+                    bun_core::ffi::slice(env_keys_ptr, env_len),
+                    bun_core::ffi::slice(env_values_ptr, env_len),
+                )
+            };
+            env_map_from_snapshot(keys, values)
+                .and_then(|map| parent_ref.env_loader().for_worker(Some(map)))
+        } else {
+            // Proxy-env values may be RefCountedEnvValue bytes owned by the
+            // parent's proxy_env_storage: copy slots + map under its lock so
+            // every slice copied is backed by a ref the copy holds.
             let parent_slots = parent_ref.proxy_env_storage.lock();
             proxy_env_slots.clone_from(&parent_slots);
-            match parent_ref.env_loader().clone_for_worker() {
-                Ok(loader) => loader,
-                Err(_) => {
-                    *error_message = BunString::static_("Out of memory");
-                    return core::ptr::null_mut();
-                }
-            }
+            parent_ref.env_loader().for_worker(None).map(|mut loader| {
+                proxy_env_slots.sync_into(&mut loader.map);
+                loader
+            })
         };
-        proxy_env_slots.sync_into(&mut env_loader.map);
+        let Ok(env_loader) = env_loader else {
+            *error_message = BunString::static_("Out of memory");
+            return core::ptr::null_mut();
+        };
         let init = WorkerVmInit {
             transform_options,
             env_loader,
@@ -1260,6 +1280,30 @@ fn on_unhandled_rejection(
     //
     // Instead, request the stop as `exit()` does and unwind to `spin()`'s `shutdown()`.
     vm.handle_ref().request_termination();
+}
+
+/// Builds the worker's env map from the `process.env` snapshot C++ took for
+/// it (`WorkerOptions::env`). An entry with a NUL byte could not reach a child
+/// process intact (`Bun.spawn` rejects one in an explicit `env`), so it is
+/// left out of the map as well.
+fn env_map_from_snapshot(
+    keys: &[BunString],
+    values: &[BunString],
+) -> Result<bun_dotenv::Map, bun_alloc::AllocError> {
+    let mut map = bun_dotenv::Map::init();
+    map.ensure_unused_capacity(keys.len())?;
+    for (key, value) in keys.iter().zip(values) {
+        let key = key.to_utf8();
+        let value = value.to_utf8();
+        if key.is_empty()
+            || bun_core::strings::contains_char(&key, 0)
+            || bun_core::strings::contains_char(&value, 0)
+        {
+            continue;
+        }
+        map.put(&key, &value)?;
+    }
+    Ok(map)
 }
 
 /// Resolve a worker entry-point specifier to a path the module loader can

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -245,6 +245,16 @@ describe("web worker", () => {
       worker.on("error", e => { console.error(e); process.exit(1); });
       worker.once("message", m => { console.log(JSON.stringify(m)); worker.terminate(); });
     `;
+    // Worker-side helpers to dump the environment a child receives: "env" on POSIX
+    // (a debug bun child is slow), bun itself on Windows.
+    const childEnvHelpers = `
+      const win32 = process.platform === "win32";
+      const dumpCmd = win32 ? [process.execPath, "-e", "process.stdout.write(JSON.stringify(process.env))"] : ["/usr/bin/env"];
+      const parseEnv = out =>
+        win32
+          ? JSON.parse(out)
+          : Object.fromEntries(out.split("\\n").filter(l => l.includes("=")).map(l => [l.slice(0, l.indexOf("=")), l.slice(l.indexOf("=") + 1)]));
+    `;
 
     test.concurrent("Bun.spawn, Bun.spawnSync, Bun.which and Bun.$ (worker_threads, env without PATH)", async () => {
       // The worker's whole environment. A Windows child needs SystemRoot to start.
@@ -259,21 +269,15 @@ describe("web worker", () => {
         "worker.cjs": `
           const { parentPort } = require("node:worker_threads");
           const { $ } = require("bun");
-          // Dump the child's environment: "env" on POSIX (a debug bun child is slow), bun on Windows.
-          const win32 = process.platform === "win32";
-          const cmd = win32 ? [process.execPath, "-e", "process.stdout.write(JSON.stringify(process.env))"] : ["/usr/bin/env"];
-          const parse = out =>
-            win32
-              ? JSON.parse(out)
-              : Object.fromEntries(out.split("\\n").filter(l => l.includes("=")).map(l => [l.slice(0, l.indexOf("=")), l.slice(l.indexOf("=") + 1)]));
+          ${childEnvHelpers}
           (async () => {
-            const proc = Bun.spawn({ cmd, stdout: "pipe", stderr: "inherit" });
-            const sync = Bun.spawnSync({ cmd, stdout: "pipe", stderr: "inherit" });
+            const proc = Bun.spawn({ cmd: dumpCmd, stdout: "pipe", stderr: "inherit" });
+            const sync = Bun.spawnSync({ cmd: dumpCmd, stdout: "pipe", stderr: "inherit" });
             const [asyncOut] = await Promise.all([proc.stdout.text(), proc.exited]);
             parentPort.postMessage({
               processEnv: { ...process.env },
-              spawnSyncChildEnv: parse(sync.stdout.toString()),
-              spawnChildEnv: parse(asyncOut),
+              spawnSyncChildEnv: parseEnv(sync.stdout.toString()),
+              spawnChildEnv: parseEnv(asyncOut),
               whichLaunchTool: Bun.which("launch-only-tool"),
               // No PATH in this worker's env: the shell must not fall back to the launch PATH.
               shellRanLaunchTool: win32 ? false : (await $\`launch-only-tool\`.quiet().nothrow()).exitCode === 0,
@@ -289,6 +293,34 @@ describe("web worker", () => {
         shellRanLaunchTool: false,
       });
     });
+
+    test.concurrent(
+      "a SHARE_ENV worker's children see the shared environment as it was when the worker started",
+      async () => {
+        const result = await run({
+          "main.mjs": `
+          import { SHARE_ENV, Worker } from "node:worker_threads";
+          delete process.env.LAUNCH_SECRET;
+          process.env.SET_AT_RUNTIME = "1";
+          const worker = new Worker("./worker.cjs", { env: SHARE_ENV });
+          ${report}
+        `,
+          "worker.cjs": `
+          const { parentPort } = require("node:worker_threads");
+          ${childEnvHelpers}
+          const pick = env => ({ LAUNCH_SECRET: env.LAUNCH_SECRET ?? null, SET_AT_RUNTIME: env.SET_AT_RUNTIME ?? null });
+          parentPort.postMessage({
+            own: pick(process.env),
+            child: pick(parseEnv(Bun.spawnSync({ cmd: dumpCmd, stdout: "pipe", stderr: "inherit" }).stdout.toString())),
+          });
+        `,
+        });
+        expect(result).toEqual({
+          own: { LAUNCH_SECRET: null, SET_AT_RUNTIME: "1" },
+          child: { LAUNCH_SECRET: null, SET_AT_RUNTIME: "1" },
+        });
+      },
+    );
 
     test.concurrent("Bun.which and Bun.spawnSync resolve argv[0] on the worker's PATH (Web Worker)", async () => {
       const result = await run({

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -259,18 +259,24 @@ describe("web worker", () => {
         "worker.cjs": `
           const { parentPort } = require("node:worker_threads");
           const { $ } = require("bun");
-          const cmd = [process.execPath, "-e", "process.stdout.write(JSON.stringify(process.env))"];
+          // Dump the child's environment: "env" on POSIX (a debug bun child is slow), bun on Windows.
+          const win32 = process.platform === "win32";
+          const cmd = win32 ? [process.execPath, "-e", "process.stdout.write(JSON.stringify(process.env))"] : ["/usr/bin/env"];
+          const parse = out =>
+            win32
+              ? JSON.parse(out)
+              : Object.fromEntries(out.split("\\n").filter(l => l.includes("=")).map(l => [l.slice(0, l.indexOf("=")), l.slice(l.indexOf("=") + 1)]));
           (async () => {
-            const sync = Bun.spawnSync({ cmd, stdout: "pipe", stderr: "inherit" });
             const proc = Bun.spawn({ cmd, stdout: "pipe", stderr: "inherit" });
+            const sync = Bun.spawnSync({ cmd, stdout: "pipe", stderr: "inherit" });
             const [asyncOut] = await Promise.all([proc.stdout.text(), proc.exited]);
             parentPort.postMessage({
               processEnv: { ...process.env },
-              spawnSyncChildEnv: JSON.parse(sync.stdout.toString()),
-              spawnChildEnv: JSON.parse(asyncOut),
+              spawnSyncChildEnv: parse(sync.stdout.toString()),
+              spawnChildEnv: parse(asyncOut),
               whichLaunchTool: Bun.which("launch-only-tool"),
               // No PATH in this worker's env: the shell must not fall back to the launch PATH.
-              shellRanLaunchTool: ${isWindows} ? false : (await $\`launch-only-tool\`.quiet().nothrow()).exitCode === 0,
+              shellRanLaunchTool: win32 ? false : (await $\`launch-only-tool\`.quiet().nothrow()).exitCode === 0,
             });
           })();
         `,
@@ -325,40 +331,45 @@ describe("web worker", () => {
       });
     });
 
-    const tlsMain = (workerOptions: string) => `
-      import { Worker } from "node:worker_threads";
-      const server = Bun.serve({
-        port: 0,
-        tls: ${JSON.stringify({ cert: tlsCert.cert, key: tlsCert.key })},
-        fetch: () => new Response("hello over tls"),
-      });
-      const url = "https://127.0.0.1:" + server.port + "/";
-      function probe(options) {
-        return new Promise((resolve, reject) => {
-          const worker = new Worker("./probe.cjs", { ...options, workerData: url });
-          worker.on("error", reject);
-          worker.once("message", m => { worker.terminate(); resolve(m); });
+    // Each worker in `probes` fetches a self-signed https origin and reports the
+    // body or the error code, next to its own process.env.NODE_TLS_REJECT_UNAUTHORIZED.
+    const tlsFiles = (probes: string) => ({
+      "main.mjs": `
+        import { Worker } from "node:worker_threads";
+        const server = Bun.serve({
+          port: 0,
+          tls: ${JSON.stringify({ cert: tlsCert.cert, key: tlsCert.key })},
+          fetch: () => new Response("hello over tls"),
         });
-      }
-      const results = {};
-      results.fromOption = await probe(${workerOptions});
-      // A runtime assignment in the parent is part of the env a default worker copies.
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-      results.fromParentRuntime = await probe({});
-      console.log(JSON.stringify(results));
-      server.stop(true);
-    `;
-    const probeWorker = `
-      const { parentPort, workerData } = require("node:worker_threads");
-      fetch(workerData).then(r => r.text()).then(
-        body => parentPort.postMessage({ env: process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? null, body }),
-        err => parentPort.postMessage({ env: process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? null, error: err.code }),
-      );
-    `;
+        const url = "https://127.0.0.1:" + server.port + "/";
+        function probe(options) {
+          return new Promise((resolve, reject) => {
+            const worker = new Worker("./probe.cjs", { ...options, workerData: url });
+            worker.on("error", reject);
+            worker.once("message", m => { worker.terminate(); resolve(m); });
+          });
+        }
+        const probes = ${probes};
+        const results = await Promise.all(Object.values(probes).map(probe));
+        console.log(JSON.stringify(Object.fromEntries(Object.keys(probes).map((name, i) => [name, results[i]]))));
+        server.stop(true);
+      `,
+      "probe.cjs": `
+        const { parentPort, workerData } = require("node:worker_threads");
+        fetch(workerData).then(r => r.text()).then(
+          body => parentPort.postMessage({ env: process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? null, body }),
+          err => parentPort.postMessage({ env: process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? null, error: err.code }),
+        );
+      `,
+    });
 
     test.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0 in the worker's env disables verification in that worker", async () => {
       const { result } = await run(
-        { "main.mjs": tlsMain(`{ env: { NODE_TLS_REJECT_UNAUTHORIZED: "0" } }`), "probe.cjs": probeWorker },
+        tlsFiles(`(() => {
+          // A runtime assignment in the parent is part of the env a default worker copies.
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+          return { fromOption: { env: { NODE_TLS_REJECT_UNAUTHORIZED: "0" } }, fromParentRuntime: {} };
+        })()`),
         { NODE_TLS_REJECT_UNAUTHORIZED: undefined },
       );
       expect(result).toEqual({
@@ -368,14 +379,10 @@ describe("web worker", () => {
     });
 
     test.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0 at launch does not reach a worker whose env omits it", async () => {
-      const { result } = await run(
-        { "main.mjs": tlsMain(`{ env: { PATH: process.env.PATH } }`), "probe.cjs": probeWorker },
-        { NODE_TLS_REJECT_UNAUTHORIZED: "0" },
-      );
-      expect(result).toEqual({
-        fromOption: { env: null, error: "DEPTH_ZERO_SELF_SIGNED_CERT" },
-        fromParentRuntime: { env: "0", body: "hello over tls" },
+      const { result } = await run(tlsFiles(`{ scrubbed: { env: { PATH: process.env.PATH } } }`), {
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
       });
+      expect(result).toEqual({ scrubbed: { env: null, error: "DEPTH_ZERO_SELF_SIGNED_CERT" } });
     });
   });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tls as tlsCert } from "harness";
+import { chmodSync } from "node:fs";
 import path from "path";
 import wt from "worker_threads";
 
@@ -201,6 +202,181 @@ describe("web worker", () => {
       nodeEnv: "production",
     });
     expect(exitCode).toBe(0);
+  });
+
+  // The `env` option must confine the worker's native env readers too, not only
+  // its `process.env` object: `Bun.spawn` without `env`, `Bun.which`, `Bun.$`'s
+  // command lookup and the TLS default all read the worker VM's env map.
+  describe("worker-env: native readers see the worker's env, not the launch environment", () => {
+    // A directory on the launching process's PATH with a tool that exists nowhere else.
+    function launchFiles() {
+      return isWindows
+        ? { "launch-bin/launch-only-tool.cmd": "@echo launch\r\n" }
+        : { "launch-bin/launch-only-tool": "#!/bin/sh\necho launch\n" };
+    }
+    async function run(files: Record<string, string>, env: Record<string, string | undefined> = {}) {
+      using dir = tempDir("worker-env-native", { ...launchFiles(), ...files });
+      if (!isWindows) chmodSync(path.join(String(dir), "launch-bin/launch-only-tool"), 0o755);
+      const launchEnv: Record<string, string | undefined> = {
+        ...bunEnv,
+        LAUNCH_SECRET: "s3cr3t",
+        PATH: path.join(String(dir), "launch-bin") + path.delimiter + bunEnv.PATH,
+        ...env,
+      };
+      for (const key in launchEnv) if (launchEnv[key] === undefined) delete launchEnv[key];
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.mjs"],
+        env: launchEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      let result: any;
+      try {
+        result = JSON.parse(stdout);
+      } catch {
+        throw new Error(`fixture printed no JSON (exit code ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
+      }
+      expect(exitCode).toBe(0);
+      return { result, dir: String(dir) };
+    }
+    const report = `
+      worker.on("error", e => { console.error(e); process.exit(1); });
+      worker.once("message", m => { console.log(JSON.stringify(m)); worker.terminate(); });
+    `;
+
+    test.concurrent("Bun.spawn, Bun.spawnSync, Bun.which and Bun.$ (worker_threads, env without PATH)", async () => {
+      // The worker's whole environment. A Windows child needs SystemRoot to start.
+      const only: Record<string, string> = { ONLY: "1", BUN_DEBUG_QUIET_LOGS: "1" };
+      if (isWindows) only.SystemRoot = process.env.SystemRoot!;
+      const { result } = await run({
+        "main.mjs": `
+          import { Worker } from "node:worker_threads";
+          const worker = new Worker("./worker.cjs", { env: ${JSON.stringify(only)} });
+          ${report}
+        `,
+        "worker.cjs": `
+          const { parentPort } = require("node:worker_threads");
+          const { $ } = require("bun");
+          const cmd = [process.execPath, "-e", "process.stdout.write(JSON.stringify(process.env))"];
+          (async () => {
+            const sync = Bun.spawnSync({ cmd, stdout: "pipe", stderr: "inherit" });
+            const proc = Bun.spawn({ cmd, stdout: "pipe", stderr: "inherit" });
+            const [asyncOut] = await Promise.all([proc.stdout.text(), proc.exited]);
+            parentPort.postMessage({
+              processEnv: { ...process.env },
+              spawnSyncChildEnv: JSON.parse(sync.stdout.toString()),
+              spawnChildEnv: JSON.parse(asyncOut),
+              whichLaunchTool: Bun.which("launch-only-tool"),
+              // No PATH in this worker's env: the shell must not fall back to the launch PATH.
+              shellRanLaunchTool: ${isWindows} ? false : (await $\`launch-only-tool\`.quiet().nothrow()).exitCode === 0,
+            });
+          })();
+        `,
+      });
+      expect(result).toEqual({
+        processEnv: only,
+        spawnSyncChildEnv: only,
+        spawnChildEnv: only,
+        whichLaunchTool: null,
+        shellRanLaunchTool: false,
+      });
+    });
+
+    test.concurrent("Bun.which and Bun.spawnSync resolve argv[0] on the worker's PATH (Web Worker)", async () => {
+      const { result, dir } = await run({
+        ...(isWindows
+          ? { "worker-bin/worker-only-tool.cmd": "@echo worker\r\n" }
+          : { "worker-bin/worker-only-tool": "#!/bin/sh\necho worker\n" }),
+        "main.mjs": `
+          import { chmodSync } from "node:fs";
+          import { join } from "node:path";
+          if (process.platform !== "win32") chmodSync("worker-bin/worker-only-tool", 0o755);
+          const worker = new Worker("./worker.mjs", {
+            env: { PATH: join(process.cwd(), "worker-bin"), BUN_DEBUG_QUIET_LOGS: "1" },
+          });
+          worker.onerror = e => { console.error(e.message); process.exit(1); };
+          worker.onmessage = e => { console.log(JSON.stringify(e.data)); worker.terminate(); };
+        `,
+        "worker.mjs": `
+          // stdout of the tool, or the error code when it cannot be spawned.
+          function trySpawn(tool) {
+            try {
+              return Bun.spawnSync({ cmd: [tool], stdout: "pipe" }).stdout.toString().trim();
+            } catch (e) {
+              return e.code ?? String(e);
+            }
+          }
+          postMessage({
+            whichWorkerTool: Bun.which("worker-only-tool"),
+            whichLaunchTool: Bun.which("launch-only-tool"),
+            // .cmd files do not spawn without a shell, so only the lookup is checked on Windows.
+            spawnWorkerTool: process.platform === "win32" ? "worker" : trySpawn("worker-only-tool"),
+            spawnLaunchTool: process.platform === "win32" ? "ENOENT" : trySpawn("launch-only-tool"),
+          });
+        `,
+      });
+      expect(result).toEqual({
+        whichWorkerTool: path.join(dir, "worker-bin", isWindows ? "worker-only-tool.cmd" : "worker-only-tool"),
+        whichLaunchTool: null,
+        spawnWorkerTool: "worker",
+        spawnLaunchTool: "ENOENT",
+      });
+    });
+
+    const tlsMain = (workerOptions: string) => `
+      import { Worker } from "node:worker_threads";
+      const server = Bun.serve({
+        port: 0,
+        tls: ${JSON.stringify({ cert: tlsCert.cert, key: tlsCert.key })},
+        fetch: () => new Response("hello over tls"),
+      });
+      const url = "https://127.0.0.1:" + server.port + "/";
+      function probe(options) {
+        return new Promise((resolve, reject) => {
+          const worker = new Worker("./probe.cjs", { ...options, workerData: url });
+          worker.on("error", reject);
+          worker.once("message", m => { worker.terminate(); resolve(m); });
+        });
+      }
+      const results = {};
+      results.fromOption = await probe(${workerOptions});
+      // A runtime assignment in the parent is part of the env a default worker copies.
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+      results.fromParentRuntime = await probe({});
+      console.log(JSON.stringify(results));
+      server.stop(true);
+    `;
+    const probeWorker = `
+      const { parentPort, workerData } = require("node:worker_threads");
+      fetch(workerData).then(r => r.text()).then(
+        body => parentPort.postMessage({ env: process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? null, body }),
+        err => parentPort.postMessage({ env: process.env.NODE_TLS_REJECT_UNAUTHORIZED ?? null, error: err.code }),
+      );
+    `;
+
+    test.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0 in the worker's env disables verification in that worker", async () => {
+      const { result } = await run(
+        { "main.mjs": tlsMain(`{ env: { NODE_TLS_REJECT_UNAUTHORIZED: "0" } }`), "probe.cjs": probeWorker },
+        { NODE_TLS_REJECT_UNAUTHORIZED: undefined },
+      );
+      expect(result).toEqual({
+        fromOption: { env: "0", body: "hello over tls" },
+        fromParentRuntime: { env: "0", body: "hello over tls" },
+      });
+    });
+
+    test.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0 at launch does not reach a worker whose env omits it", async () => {
+      const { result } = await run(
+        { "main.mjs": tlsMain(`{ env: { PATH: process.env.PATH } }`), "probe.cjs": probeWorker },
+        { NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+      );
+      expect(result).toEqual({
+        fromOption: { env: null, error: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+        fromParentRuntime: { env: "0", body: "hello over tls" },
+      });
+    });
   });
 
   test("worker-env with a lot of properties", done => {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -239,7 +239,7 @@ describe("web worker", () => {
         throw new Error(`fixture printed no JSON (exit code ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`);
       }
       expect(exitCode).toBe(0);
-      return { result, dir: String(dir) };
+      return result;
     }
     const report = `
       worker.on("error", e => { console.error(e); process.exit(1); });
@@ -250,7 +250,7 @@ describe("web worker", () => {
       // The worker's whole environment. A Windows child needs SystemRoot to start.
       const only: Record<string, string> = { ONLY: "1", BUN_DEBUG_QUIET_LOGS: "1" };
       if (isWindows) only.SystemRoot = process.env.SystemRoot!;
-      const { result } = await run({
+      const result = await run({
         "main.mjs": `
           import { Worker } from "node:worker_threads";
           const worker = new Worker("./worker.cjs", { env: ${JSON.stringify(only)} });
@@ -291,7 +291,7 @@ describe("web worker", () => {
     });
 
     test.concurrent("Bun.which and Bun.spawnSync resolve argv[0] on the worker's PATH (Web Worker)", async () => {
-      const { result, dir } = await run({
+      const result = await run({
         ...(isWindows
           ? { "worker-bin/worker-only-tool.cmd": "@echo worker\r\n" }
           : { "worker-bin/worker-only-tool": "#!/bin/sh\necho worker\n" }),
@@ -306,6 +306,9 @@ describe("web worker", () => {
           worker.onmessage = e => { console.log(JSON.stringify(e.data)); worker.terminate(); };
         `,
         "worker.mjs": `
+          import { basename, dirname } from "node:path";
+          // "<dir>/<file>" of a Bun.which() hit, so the assertion does not depend on temp path spelling.
+          const where = p => (p == null ? p : basename(dirname(p)) + "/" + basename(p));
           // stdout of the tool, or the error code when it cannot be spawned.
           function trySpawn(tool) {
             try {
@@ -315,8 +318,8 @@ describe("web worker", () => {
             }
           }
           postMessage({
-            whichWorkerTool: Bun.which("worker-only-tool"),
-            whichLaunchTool: Bun.which("launch-only-tool"),
+            whichWorkerTool: where(Bun.which("worker-only-tool")),
+            whichLaunchTool: where(Bun.which("launch-only-tool")),
             // .cmd files do not spawn without a shell, so only the lookup is checked on Windows.
             spawnWorkerTool: process.platform === "win32" ? "worker" : trySpawn("worker-only-tool"),
             spawnLaunchTool: process.platform === "win32" ? "ENOENT" : trySpawn("launch-only-tool"),
@@ -324,7 +327,7 @@ describe("web worker", () => {
         `,
       });
       expect(result).toEqual({
-        whichWorkerTool: path.join(dir, "worker-bin", isWindows ? "worker-only-tool.cmd" : "worker-only-tool"),
+        whichWorkerTool: isWindows ? "worker-bin/worker-only-tool.cmd" : "worker-bin/worker-only-tool",
         whichLaunchTool: null,
         spawnWorkerTool: "worker",
         spawnLaunchTool: "ENOENT",
@@ -363,23 +366,26 @@ describe("web worker", () => {
       `,
     });
 
-    test.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0 in the worker's env disables verification in that worker", async () => {
-      const { result } = await run(
-        tlsFiles(`(() => {
+    test.concurrent(
+      "NODE_TLS_REJECT_UNAUTHORIZED=0 in the worker's env disables verification in that worker",
+      async () => {
+        const result = await run(
+          tlsFiles(`(() => {
           // A runtime assignment in the parent is part of the env a default worker copies.
           process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
           return { fromOption: { env: { NODE_TLS_REJECT_UNAUTHORIZED: "0" } }, fromParentRuntime: {} };
         })()`),
-        { NODE_TLS_REJECT_UNAUTHORIZED: undefined },
-      );
-      expect(result).toEqual({
-        fromOption: { env: "0", body: "hello over tls" },
-        fromParentRuntime: { env: "0", body: "hello over tls" },
-      });
-    });
+          { NODE_TLS_REJECT_UNAUTHORIZED: undefined },
+        );
+        expect(result).toEqual({
+          fromOption: { env: "0", body: "hello over tls" },
+          fromParentRuntime: { env: "0", body: "hello over tls" },
+        });
+      },
+    );
 
     test.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0 at launch does not reach a worker whose env omits it", async () => {
-      const { result } = await run(tlsFiles(`{ scrubbed: { env: { PATH: process.env.PATH } } }`), {
+      const result = await run(tlsFiles(`{ scrubbed: { env: { PATH: process.env.PATH } } }`), {
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
       });
       expect(result).toEqual({ scrubbed: { env: null, error: "DEPTH_ZERO_SELF_SIGNED_CERT" } });


### PR DESCRIPTION
### Problem
- In a Worker created with `env: { ONLY: "1" }`, `process.env` and the `child_process` and `Bun.$` children see only `ONLY=1`, but a `Bun.spawn` child with no `env` option gets the parent's full launch environment. `Bun.which`, `Bun.$` command lookup and fetch's `NODE_TLS_REJECT_UNAUTHORIZED` default read it too, and `SHARE_ENV` workers leak the same way.
- Cause: the `env` option only seeds the worker's JS `process.env` (`initializeWorker`, `ZigGlobalObject.cpp`). The native env map was a copy of the parent's (`WebWorker::create`, `src/jsc/web_worker.rs`), with `environ` merged over it at startup.

### Fix
- `startWorkerGlobalScope` passes the entries the worker's `process.env` starts with (`WorkerOptions::env`, or the `SHARE_ENV` store) to `WebWorker__create`, which builds the worker's map from them (`Loader::for_worker`).
- `for_worker` counts `environ` and env files as read for every worker: none merges the launch environment over its map or reads a `.env` file again.
- Correct because the worker's `process.env` and its map now start from the same entries.
- Verified: five new tests in `test/js/web/workers/worker.test.ts` (all fail on 1.4.3), `worker_threads.test.ts`, the `env.test.ts` worker cells.

### Background
- A Bun VM holds the environment twice: the JS `process.env` object and a native `bun_dotenv::Loader` map. `Bun.spawn`'s default env, `Bun.which`, the shell's `PATH` fallback, the TLS default and fetch's proxy config read the map.
- `WorkerOptions::env` (`JSWorker.cpp`) is the parent-thread copy of the `env` option, or of the parent's current `process.env`. The worker builds its `process.env` from it. `new Worker(url)` with no options object has neither and still copies the parent's map.
- Found by a fuzzer, no user report. #34972, #40571 (main thread, #40846) and #39677 (no options object) are related but separate, see Notes.

<details><summary>Notes</summary>

- Cells covered by the new tests, each from inside an `env`-scoped worker: `Bun.spawn` and `Bun.spawnSync` child environment (exact), `Bun.which` and `Bun.spawnSync` argv[0] lookup on the worker's `PATH` in both directions, `Bun.$` with no `PATH` in the worker env, `NODE_TLS_REJECT_UNAUTHORIZED=0` given only to the worker (fetch to a self-signed origin succeeds), `=0` at launch with a worker env that omits it (`DEPTH_ZERO_SELF_SIGNED_CERT`), a main-thread runtime assignment inherited by a default `worker_threads` worker, and a `SHARE_ENV` worker whose parent deleted a launch variable and set another at runtime.
- Before this change `clone_for_worker` left `did_load_process: false` and no `.env` file marked loaded, so every worker's `configure_defines()` re-read `environ` (overwriting the copied map, including a proxy variable the parent set at runtime) and the default `.env` files. `for_worker` now marks both as done for every worker, with or without a snapshot. The values a worker needs are already in the snapshot or in the parent's map.
- `worker_threads.Worker` always passes an options object, so its workers always take the snapshot path. The snapshot reflects the parent's runtime `process.env` writes and deletes, which the old map copy did not.
- How this sits next to the other open env PRs: #34972 makes `Bun.spawn`'s default env and `Bun.which` read the calling global's live `process.env` object on any thread. That also fixes those two readers inside a worker, but not the TLS default, the shell `PATH` fallback, or fetch's proxy config, which read the map. #40571 writes main-thread `process.env` changes through to the map and `environ` (#40846). #39677 takes the `process.env` copy for `new Worker(url)` with no options object. This PR only changes where a worker's map comes from, so it composes with all three.
- The proxy-variable slots (`ProxyEnvSlots`) are only copied from the parent on the no-snapshot path. The map owns its values, so a snapshot needs no parent refs.
- Snapshot entries with an empty key or a NUL byte are left out of the map, because no real environment entry can carry them. `Bun.spawn` rejects such entries in an explicit `env` too. The worker's `process.env` still shows them, as in Node.
- A `SHARE_ENV` worker's map is a snapshot of the store at worker start. Later writes through the shared `process.env` reach every thread's JS view but not the maps, the same as a main-thread write today (#40846).
- Not in this PR: on the main thread, `delete process.env.PATH` still lets `Bun.$` find tools on the launch `PATH`, because the shell seeds its lookup `PATH` from the map (`SpawnArgs::default`, `src/runtime/shell/subproc.rs`). That is the #40846 root.

</details>
