### PR TITLE
bundler: treat a file with no extension as tsx, like the runtime does

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1197,7 +1197,7 @@ A map of global identifiers to be replaced at build time. Keys of this object ar
 
 ### loader
 
-A map of file extensions to built-in loader names. Use this to customize how certain files are loaded.
+A map of file extensions to built-in loader names. Use this to customize how certain files are loaded. The empty extension `""` maps files that have none, which use the `tsx` loader by default.
 
 <Tabs>
   <Tab title="JavaScript">

--- a/docs/bundler/loaders.mdx
+++ b/docs/bundler/loaders.mdx
@@ -9,7 +9,7 @@ The Bun bundler has a set of built-in loaders.
 
 `.js` `.cjs` `.mjs` `.mts` `.cts` `.ts` `.tsx` `.jsx` `.css` `.json` `.jsonc` `.json5` `.toml` `.yaml` `.yml` `.xml` `.txt` `.text` `.md` `.markdown` `.wasm` `.node` `.html` `.sh`
 
-Bun uses the file extension to choose which built-in loader parses the file. Every loader has a name, such as `js`, `tsx`, or `json`. Plugins that extend Bun with custom loaders refer to these names.
+Bun uses the file extension to choose which built-in loader parses the file. Every loader has a name, such as `js`, `tsx`, or `json`. Plugins that extend Bun with custom loaders refer to these names. A file with no extension, such as a `bin/cli` script, uses the `tsx` loader. To change that, map the empty extension: `--loader :js` on the command line, `loader: { "": "js" }` in `Bun.build`, or `"" = "js"` under `[loader]` in `bunfig.toml`.
 
 To specify a loader explicitly, use the `'type'` import attribute.
 
@@ -53,7 +53,7 @@ Strips out all TypeScript syntax, then behaves identically to the `js` loader. B
 
 ### `tsx`
 
-**TypeScript + JSX loader.** Default for `.tsx`.
+**TypeScript + JSX loader.** Default for `.tsx` and for files with no extension.
 
 Transpiles both TypeScript and JSX to vanilla JavaScript.
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -87,6 +87,8 @@ Configure how Bun maps file extensions to [loaders](/bundler/loaders). Use this 
 [loader]
 # when a .bagel file is imported, treat it like a tsx file
 ".bagel" = "tsx"
+# the empty extension maps files that have none (default: tsx)
+"" = "js"
 ```
 
 Bun supports the following loaders:

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -214,10 +214,10 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--loader" type="string">
-  Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. An empty extension maps files
-  that have none, e.g. <code>--loader :js</code> (the default for them is <code>tsx</code>). Valid loaders:{" "}
-  <code>js</code>, <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>,{" "}
-  <code>text</code>, <code>file</code>, <code>wasm</code>, <code>napi</code>. Alias: <code>-l</code>
+  Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. An empty extension maps files that have
+  none, e.g. <code>--loader :js</code> (the default for them is <code>tsx</code>). Valid loaders: <code>js</code>,{" "}
+  <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>, <code>text</code>,{" "}
+  <code>file</code>, <code>wasm</code>, <code>napi</code>. Alias: <code>-l</code>
 </ParamField>
 
 <ParamField path="--no-macros" type="boolean">

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -214,9 +214,10 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--loader" type="string">
-  Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. Valid loaders: <code>js</code>,{" "}
-  <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>, <code>text</code>,{" "}
-  <code>file</code>, <code>wasm</code>, <code>napi</code>. Alias: <code>-l</code>
+  Parse files with <code>.ext:loader</code>, e.g. <code>--loader .js:jsx</code>. An empty extension maps files
+  that have none, e.g. <code>--loader :js</code> (the default for them is <code>tsx</code>). Valid loaders:{" "}
+  <code>js</code>, <code>jsx</code>, <code>ts</code>, <code>tsx</code>, <code>json</code>, <code>toml</code>,{" "}
+  <code>text</code>, <code>file</code>, <code>wasm</code>, <code>napi</code>. Alias: <code>-l</code>
 </ParamField>
 
 <ParamField path="--no-macros" type="boolean">

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3285,6 +3285,17 @@ declare module "bun" {
     publicPath?: string;
     define?: Record<string, string>;
     // origin?: string; // e.g. http://mydomain.com
+    /**
+     * Map file extensions to built-in loaders, e.g. `{ ".png": "dataurl" }`.
+     *
+     * The empty extension `""` maps files that have none. They use the
+     * `"tsx"` loader by default.
+     *
+     * @example
+     * ```ts
+     * loader: { ".txt": "file", "": "js" }
+     * ```
+     */
     loader?: { [k in string]: Loader };
     /**
      * Specifies if and how to generate source maps.

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1071,9 +1071,7 @@ pub fn loaders_from_transform_options(
         }
     }
 
-    // A file with no extension (`bin/cli`, `./tool`) is source code, at runtime
-    // and in `bun build` alike. `PathName::ext` is `""` for such a file, so the
-    // empty key is its entry. `--loader :<name>` overrides it.
+    // Files with no extension (`bin/cli`): `PathName::ext` is `""` for them.
     if !loaders.contains(b"") {
         loaders.insert(b"", Loader::Tsx);
     }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1053,7 +1053,8 @@ pub fn loaders_from_transform_options(
         } else {
             0
         }
-        + DEFAULT_LOADER_EXT.len();
+        + DEFAULT_LOADER_EXT.len()
+        + 1;
 
     let mut loaders = StringArrayHashMap::<Loader>::default();
     loaders.reserve(u32::try_from(total_capacity).expect("int cast") as usize);
@@ -1068,6 +1069,13 @@ pub fn loaders_from_transform_options(
         if !loaders.contains(*ext) {
             loaders.insert(*ext, *DEFAULT_LOADERS.get(*ext).unwrap());
         }
+    }
+
+    // A file with no extension (`bin/cli`, `./tool`) is source code, at runtime
+    // and in `bun build` alike. `PathName::ext` is `""` for such a file, so the
+    // empty key is its entry. `--loader :<name>` overrides it.
+    if !loaders.contains(b"") {
+        loaders.insert(b"", Loader::Tsx);
     }
 
     if target.is_bun() {

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1060,10 +1060,8 @@ impl<'a> Parser<'a> {
                 let key = key_expr
                     .as_string(self.bump)
                     .expect("infallible: type checked");
-                if key.is_empty() {
-                    continue;
-                }
-                if key[0] != b'.' {
+                // An empty key maps files with no extension, as `--loader :tsx` does.
+                if !key.is_empty() && key[0] != b'.' {
                     self.add_error(
                         key_expr.loc,
                         b"file extension for loader must start with a '.'",

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1137,17 +1137,17 @@ pub mod js_bundler {
                     global_this,
                     loaders_ref,
                     jsc::JSPropertyIteratorOptions {
-                        skip_empty_name: true,
+                        // `""` maps files with no extension, as `--loader :tsx` does.
+                        skip_empty_name: false,
                         include_value: true,
                         ..Default::default()
                     },
                 )?;
 
                 // `loader_iter.i` is the property position, not a dense index of yielded
-                // entries. With `skip_empty_name = true` (or a skipped property getter),
-                // writing at `loader_iter.i` would leave earlier slots uninitialized and
-                // later freed as garbage. Use ArrayLists so the stored slice is always
-                // exactly what was appended.
+                // entries. With a skipped property getter, writing at `loader_iter.i`
+                // would leave earlier slots uninitialized and later freed as garbage.
+                // Use Vecs so the stored slice is always exactly what was appended.
                 let mut loader_names: Vec<Box<[u8]>> = Vec::new();
                 // errdefer: Vec<Box<[u8]>> drops automatically
                 let mut loader_values: Vec<api::Loader> = Vec::new();
@@ -1157,9 +1157,11 @@ pub mod js_bundler {
 
                 while let Some((prop, value)) = loader_iter.next()? {
                     let prop_slice = prop.to_utf8();
-                    if !prop_slice.slice().starts_with(b".") || prop.length() < 2 {
+                    if !prop_slice.slice().is_empty()
+                        && (!prop_slice.slice().starts_with(b".") || prop.length() < 2)
+                    {
                         return Err(global_this.throw_invalid_arguments(format_args!(
-                            "loader property names must be file extensions, such as '.txt'"
+                            "loader property names must be file extensions, such as '.txt', or '' for files with no extension"
                         )));
                     }
                     drop(prop_slice);

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1144,12 +1144,8 @@ pub mod js_bundler {
                     },
                 )?;
 
-                // `loader_iter.i` is the property position, not a dense index of yielded
-                // entries. With a skipped property getter, writing at `loader_iter.i`
-                // would leave earlier slots uninitialized and later freed as garbage.
-                // Use Vecs so the stored slice is always exactly what was appended.
+                // Push, do not index by `loader_iter.i`: the iterator can skip properties.
                 let mut loader_names: Vec<Box<[u8]>> = Vec::new();
-                // errdefer: Vec<Box<[u8]>> drops automatically
                 let mut loader_values: Vec<api::Loader> = Vec::new();
 
                 loader_names.reserve_exact(loader_iter.len);

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -120,7 +120,7 @@ const TRANSPILER_PARAMS_: &[ParamType] = &[
         "--feature <STR>...               Enable a feature flag for dead-code elimination, e.g. --feature=SUPER_SECRET"
     ),
     parse_param!(
-        "-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi"
+        "-l, --loader <STR>...             Parse files with .ext:loader, e.g. --loader .js:jsx, or :js for files with no extension. Valid loaders: js, jsx, ts, tsx, json, toml, text, file, wasm, napi"
     ),
     parse_param!(
         "--no-macros                       Disable macros from being executed in the bundler, transpiler and runtime"

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3650,11 +3650,11 @@ impl RunCommand {
                         // resolver dir-cache for the process lifetime.
                         let value = unsafe { &**entry.1 };
                         let name = value.base();
+                        let ext = paths::extension(name);
+                        // `Makefile`, `LICENSE`: runnable as tsx, but not worth completing.
                         if name[0] != b'.'
-                            && this_transpiler
-                                .options
-                                .loader(paths::extension(name))
-                                .can_be_run_by_bun()
+                            && !ext.is_empty()
+                            && this_transpiler.options.loader(ext).can_be_run_by_bun()
                             && !strings::contains(name, b".config")
                             && !strings::contains(name, b".d.ts")
                             && !strings::contains(name, b".d.mts")

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4354,10 +4354,6 @@ pub unsafe extern "C" fn Bun__transpileFile(
         let (has_loaded, is_in_preload) =
             unsafe { ((*jsc_vm).has_loaded, (*jsc_vm).is_in_preload) };
         if has_loaded || is_in_preload {
-            // Extensionless files in this context are treated as the JS loader.
-            if lr.path.name().ext.is_empty() {
-                break 'loader Loader::Tsx;
-            }
             // Unknown extensions are to be treated as file loader.
             if is_commonjs_require {
                 use bun_jsc::node_module_module::{

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -22,6 +22,21 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!", stderr: "" },
   });
+  // A `bin/cli` script with no extension is source code (tsx), as it is for
+  // `bun run`. It used to go through the file loader, so the executable ran an
+  // empty program.
+  itBundled("compile/ExtensionlessEntryPoint", {
+    compile: true,
+    files: {
+      "/bin/mycli": [
+        `#!/usr/bin/env bun`,
+        `const args: string[] = process.argv.slice(2);`,
+        `console.log("cli ran", args.join(","));`,
+      ].join("\n"),
+    },
+    entryPoints: ["/bin/mycli"],
+    run: { args: ["a", "b"], stdout: "cli ran a,b", stderr: "" },
+  });
   // --footer/--banner are concatenated verbatim (UTF-8). Guard against the
   // standalone module graph treating those bytes as Latin-1, which would
   // print "rÃ©sumÃ©" / "ã\x81\x93ã\x82\x93..." (one Latin-1 char per UTF-8

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -595,19 +595,22 @@ describe("bundler", async () => {
       run: { stdout: "cjs" },
     });
 
-    // `--loader :<name>` maps the empty extension, which overrides the default.
-    itBundled("bun/loader-extensionless-override", {
-      backend: "cli",
-      loader: { "": "text" },
-      files: {
-        "/entry.ts": /* ts */ `
-          import license from "./LICENSE";
-          console.log(JSON.stringify(license));
-        `,
-        "/LICENSE": `not (valid) typescript: at all`,
-      },
-      run: { stdout: `"not (valid) typescript: at all"` },
-    });
+    // The empty extension maps files that have none, which overrides the default:
+    // `--loader :<name>` on the CLI, `loader: { "": <name> }` in Bun.build.
+    for (const backend of ["cli", "api"] as const) {
+      itBundled(`bun/loader-extensionless-override-${backend}`, {
+        backend,
+        loader: { "": "text" },
+        files: {
+          "/entry.ts": /* ts */ `
+            import license from "./LICENSE";
+            console.log(JSON.stringify(license));
+          `,
+          "/LICENSE": `not (valid) typescript: at all`,
+        },
+        run: { stdout: `"not (valid) typescript: at all"` },
+      });
+    }
   });
 
   // Lazy-export modules (JSON, TOML, CSS modules, ...) used to crash the

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -544,6 +544,72 @@ describe("bundler", async () => {
     }
   });
 
+  // A file with no extension is source code (tsx), the same as `bun run` treats
+  // it. It used to go through the file loader: an entry point lost its program
+  // body and an import resolved to an asset path string.
+  describe("files without an extension", () => {
+    for (const target of ["bun", "node", "browser"] as const) {
+      itBundled(`${target}/loader-extensionless-entry-point`, {
+        target,
+        files: {
+          "/bin/mycli": [
+            `#!/usr/bin/env bun`,
+            `const args: string[] = process.argv.slice(2);`,
+            `console.log("cli ran", args.join(","));`,
+          ].join("\n"),
+        },
+        entryPoints: ["/bin/mycli"],
+        onAfterBundle(api) {
+          const out = api.readFile("/out.js");
+          expect(out).toStartWith("#!/usr/bin/env bun\n");
+          expect(out).toContain(`console.log("cli ran", args.join(","));`);
+        },
+        run: { args: ["a", "b"], stdout: "cli ran a,b" },
+      });
+    }
+
+    itBundled("bun/loader-extensionless-import", {
+      files: {
+        "/entry.ts": /* ts */ `
+          import tool, { kind } from "./tool";
+          console.log(JSON.stringify(tool), kind);
+        `,
+        "/tool": /* ts */ `
+          export const kind: string = "named";
+          export default "i-am-js" as string;
+        `,
+      },
+      run: { stdout: `"i-am-js" named` },
+    });
+
+    itBundled("bun/loader-extensionless-require", {
+      files: {
+        "/entry.cjs": /* js */ `
+          const tool = require("./tool");
+          console.log(tool.kind);
+        `,
+        "/tool": /* ts */ `
+          module.exports = { kind: "cjs" as string };
+        `,
+      },
+      run: { stdout: "cjs" },
+    });
+
+    // `--loader :<name>` maps the empty extension, which overrides the default.
+    itBundled("bun/loader-extensionless-override", {
+      backend: "cli",
+      loader: { "": "text" },
+      files: {
+        "/entry.ts": /* ts */ `
+          import license from "./LICENSE";
+          console.log(JSON.stringify(license));
+        `,
+        "/LICENSE": `not (valid) typescript: at all`,
+      },
+      run: { stdout: `"not (valid) typescript: at all"` },
+    });
+  });
+
   // Lazy-export modules (JSON, TOML, CSS modules, ...) used to crash the
   // printer when bundled with the dev server's module format.
   // https://github.com/oven-sh/bun/issues/31943

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -247,7 +247,8 @@ export interface BundlerTestInput {
   publicPath?: string;
   keepNames?: boolean;
   legalComments?: "none" | "inline" | "eof" | "linked" | "external";
-  loader?: Record<`.${string}`, Loader>;
+  /** `""` maps files with no extension. */
+  loader?: { [ext: `.${string}`]: Loader; ""?: Loader };
   mangleProps?: RegExp;
   mangleQuoted?: boolean;
   mainFields?: string[];

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -241,6 +241,27 @@ describe("bun", () => {
         expect(exitCode).toBe(0);
       }
     });
+
+    // Extensionless files run as tsx, but `Makefile`/`LICENSE` are not useful
+    // `bun run <TAB>` suggestions, so the file scan only offers known extensions.
+    test("getcompletes j lists runnable source files, not extensionless ones", () => {
+      using dir = tempDir("getcompletes-files", {
+        "package.json": JSON.stringify({ name: "test", scripts: {} }),
+        "index.ts": "export {}",
+        "script.mjs": "export {}",
+        "Makefile": "all:\n\ttrue\n",
+        "LICENSE": "MIT",
+        "notes.txt": "hi",
+      });
+      const { stdout, exitCode } = spawnSync({
+        cmd: [bunExe(), "getcompletes", "j"],
+        env: bunEnv,
+        cwd: String(dir),
+      });
+      const lines = stdout.toString().split("\n").filter(Boolean).sort();
+      expect(lines).toEqual(["index.ts", "script.mjs"]);
+      expect(exitCode).toBe(0);
+    });
   });
   // On Windows `bun completions` installs bunx as a hardlink (or a .cmd shim) instead of a symlink.
   describe.skipIf(isWindows)("completions", () => {

--- a/test/cli/run/run-extensionless.test.ts
+++ b/test/cli/run/run-extensionless.test.ts
@@ -59,22 +59,30 @@ describe.concurrent("run-extensionless", () => {
     }
   });
 
-  // `--loader :<name>` maps the empty extension, which overrides the tsx default.
-  test("--loader : overrides the loader for extensionless files", async () => {
-    using dir = tempDir("run-extensionless-override", {
-      "LICENSE": `not (valid) typescript: at all`,
-      "entry.ts": `import text from "./LICENSE"; console.log(JSON.stringify(text));`,
+  // The empty extension maps files that have none, which overrides the tsx
+  // default: `--loader :<name>` on the CLI, `"" = "<name>"` under `[loader]`
+  // in bunfig.toml.
+  for (const [via, files, args] of [
+    ["--loader :", {}, ["--loader", ":text"]],
+    ["bunfig [loader]", { "bunfig.toml": `[loader]\n"" = "text"\n` }, []],
+  ] as const) {
+    test(`${via} overrides the loader for extensionless files`, async () => {
+      using dir = tempDir("run-extensionless-override", {
+        ...files,
+        "LICENSE": `not (valid) typescript: at all`,
+        "entry.ts": `import text from "./LICENSE"; console.log(JSON.stringify(text));`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args, "entry.ts"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(`"not (valid) typescript: at all"\n`);
+      expect(exitCode).toBe(0);
     });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--loader", ":text", "entry.ts"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe(`"not (valid) typescript: at all"\n`);
-    expect(exitCode).toBe(0);
-  });
+  }
 });

--- a/test/cli/run/run-extensionless.test.ts
+++ b/test/cli/run/run-extensionless.test.ts
@@ -85,4 +85,30 @@ describe.concurrent("run-extensionless", () => {
       expect(exitCode).toBe(0);
     });
   }
+
+  // The override also reaches an extensionless entry point. `<T>(x: T) => x` is
+  // a generic arrow to the ts loader and an unclosed tag to the tsx loader, so
+  // it parses only when the mapping took effect.
+  for (const [via, files, args] of [
+    ["--loader :", {}, ["--loader=:ts"]],
+    ["bunfig [loader]", { "bunfig.toml": `[loader]\n"" = "ts"\n` }, []],
+  ] as const) {
+    test(`${via} overrides the loader for an extensionless entry point`, async () => {
+      using dir = tempDir("run-extensionless-entry-override", {
+        ...files,
+        "cool": `const id = <T>(x: T) => x; console.log(id("hello world"));`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...args, "./cool"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("hello world\n");
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/cli/run/run-extensionless.test.ts
+++ b/test/cli/run/run-extensionless.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 describe.concurrent("run-extensionless", () => {
@@ -31,5 +31,50 @@ describe.concurrent("run-extensionless", () => {
     });
     const stdout = await proc.stdout.text();
     expect(stdout).toEqual("hello world\n");
+  });
+
+  test("importing an extensionless file treats it as tsx", async () => {
+    using dir = tempDir("run-extensionless-import", {
+      "dep": `export const kind: string = "dep"; export default (<T,>(x: T) => x)("default");`,
+      "static.ts": `import def, { kind } from "./dep"; console.log("static", def, kind);`,
+      "dynamic.ts": `const m = await import("./dep"); console.log("dynamic", m.default, m.kind);`,
+      "require.cjs": `const m = require("./dep"); console.log("require", m.default, m.kind);`,
+    });
+    for (const [file, expected] of [
+      ["static.ts", "static default dep\n"],
+      ["dynamic.ts", "dynamic default dep\n"],
+      ["require.cjs", "require default dep\n"],
+    ] as const) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), file],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(expected);
+      expect(exitCode).toBe(0);
+    }
+  });
+
+  // `--loader :<name>` maps the empty extension, which overrides the tsx default.
+  test("--loader : overrides the loader for extensionless files", async () => {
+    using dir = tempDir("run-extensionless-override", {
+      "LICENSE": `not (valid) typescript: at all`,
+      "entry.ts": `import text from "./LICENSE"; console.log(JSON.stringify(text));`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--loader", ":text", "entry.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`"not (valid) typescript: at all"\n`);
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `bun build`, `bun build --compile`, and `Bun.build` sent a file with no extension through the file loader. An entry point such as `bin/mycli` lost its program body (`var mycli_default = "./mycli-rdmxxyva.";`) and the executable ran nothing. `import t from "./tool"` gave an asset path string.
- The cause is `loaders_from_transform_options` (`src/bundler/options.rs:1031`). Its extension-to-loader map has no entry for the empty extension, so the bundler fell to `Loader::File`. The runtime had its own `ext.is_empty()` branch that picked `tsx` (#5711), so `bun ./bin/mycli` worked.

### Fix
- Behavior change: `bun build` and `Bun.build` parse a file with no extension as `tsx`, like `bun run` does. `--loader :file`, `loader: { "": "file" }`, `"" = "file"` under `[loader]`, or `with { type: "file" }` restores the old result. No issue asked for it. Precedent: #5711, and esbuild's default `"" => js`.
- The map gets `"" => tsx` as a default. A user entry wins over it. The runtime branch goes away, so one rule covers `bun run`, `bun build`, `--no-bundle`, and `Bun.build`.
- `Bun.build({ loader })` and bunfig `[loader]` now accept the `""` key. Both dropped it silently before. This supersedes #36904 by @elibarzilay: its bunfig hunk, `--help` and docs lines, and entry-point tests are carried here with co-author credit on those commits.
- Verified: `bundler_loader.test.ts` (7 new cases, 6 fail on 1.4.3), `compile/ExtensionlessEntryPoint`, `run-extensionless.test.ts`, and the plugin, import-attributes, and edgecase suites.

### Background
- The map key is the extension with its dot. `PathName::init` reports `""` only for a basename with no dot (`mycli`, `LICENSE`). A dotfile such as `.env` reports `.env` and is not affected.
- The bundler asks `Path::loader(&loaders)` for each entry point and import. `None` falls to the file loader: copy the file, export its path. The CLI already parsed `--loader :tsx` as the empty key.

<details><summary>Notes</summary>

Other readers of the same map, audited:

- Runtime module loader: an extensionless import now gets `Some(tsx)` from the map instead of `None` plus a later fallback. Same loader. A non-main extensionless ESM import now qualifies for the concurrent transpiler path, like a `.ts` file does.
- `Bun__getDefaultLoader` (runtime plugin `onLoad` default) and the bundler's `Load::init` default: a virtual module whose specifier has no extension and whose plugin returns no `loader` now defaults to `tsx` instead of `js`.
- `bun build --no-bundle ./noext` now transpiles the file. Before, it printed an empty chunk.
- The `--hot` directory-event filter now counts an extensionless changed file as source.
- `bun test` discovery is unchanged: the scanner rejects an empty extension before it asks the map.
- `bun run <TAB>` completion (`bun getcompletes j`) asked the map whether a top-level file is runnable, so `Makefile` and `LICENSE` started to qualify. The scan now skips the empty extension, with a test in `test/cli/bun.test.ts`.
- `DEFAULT_LOADERS` (the static table that `bun <file>` and `Module._extensions` use) is unchanged.
- #36904 also patched `Arguments.zig` and `bunfig.zig`, which #32621 removed. The Rust bunfig parser pushes to a `Vec`, so it never had the uninitialized-slot bug that PR fixed on the Zig side. Its three tests pass on this branch, and the bunfig one fails on 1.4.3. #36904 is closed as superseded.
- Separate, pre-existing: forcing the file loader on an extensionless file names the asset `NAME-HASH.` with a trailing dot (esbuild: `NAME-HASH`). Tracked separately.
- Self-reviewed: 3 concerns raised (override only reachable from the CLI, overlap with #36904, missing behavior-change note), 3 addressed.

Repro from the report, after the fix:

```
$ bun build ./bin/mycli --outdir dist && bun dist/mycli.js a b
cli ran a,b
$ bun build ./dep.mjs --outdir d2 && bun d2/dep.js
"i-am-js"
$ bun build ./bin/mycli --compile --outfile mycli-exe && ./mycli-exe a b
cli ran a,b
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-extensionless.test.ts, test/cli/bun.test.ts, test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->
