### PR TITLE
require(esm): do not run an import() started by the required module inside the require()

### DIFF
--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -282,6 +282,13 @@ public:
     // after every swap.
     WTF::UncheckedKeyHashMap<WTF::String, RefPtr<JSC::SourceProvider>> isolationSourceProviderCache;
 
+    // The frame a dynamic import() request pushed onto vm.m_synchronousModuleQueue
+    // because require(esm) was loading a graph when the import() was called
+    // (Zig::DynamicImportQueueScope in ZigGlobalObject.cpp). While it is the
+    // head of that chain the loader is serving the import(), not the require(),
+    // so moduleLoaderFetch must not switch to its synchronous path.
+    JSC::VM::SynchronousModuleQueue* dynamicImportModuleQueue { nullptr };
+
     JSC::DecoderStringTable* decoderStringTable() final { return m_decoderStringTable.get(); }
     void setDecoderStringTable(std::span<const uint8_t>);
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -37,6 +37,7 @@
 #include "JavaScriptCore/JSMap.h"
 #include "JavaScriptCore/JSMicrotask.h"
 #include "JavaScriptCore/MicrotaskQueue.h"
+#include "JavaScriptCore/MicrotaskQueueInlines.h"
 #include "JavaScriptCore/JSModuleLoader.h"
 #include "JavaScriptCore/CyclicModuleRecord.h"
 #include "JavaScriptCore/ModuleRegistryEntry.h"
@@ -3528,6 +3529,62 @@ JSC::Identifier StandaloneGlobalObject::moduleLoaderResolve(JSGlobalObject* glob
     return GlobalObject::moduleLoaderResolve(globalObject, loader, key, referrer, WTF::move(fetcher), b);
 }
 
+namespace {
+
+// require(esm) loads a module graph without yielding: it points
+// vm.m_synchronousModuleQueue at a stack frame, the loader's internal promise
+// reactions are appended to that frame instead of the microtask queue, and the
+// frame is drained in a loop (JSModuleLoader::loadModuleSync,
+// Bun::fetchCommonJSModule). A dynamic import() that a module in that graph
+// calls while it evaluates is a new asynchronous load, not part of the graph.
+// For the duration of the import() request this scope pushes a frame of its
+// own, so nothing the request queues reaches the frame require() is draining,
+// and publishes it as JSVMClientData::dynamicImportModuleQueue so
+// moduleLoaderFetch keeps fetching asynchronously. On exit it hands every
+// reaction the request queued to the microtask queue, which is where they go
+// when no require() is on the stack. The frame stays linked through `prev`
+// while it is installed, so VM::visitAggregate keeps marking the tasks of the
+// frames under it.
+class DynamicImportQueueScope {
+    WTF_MAKE_NONCOPYABLE(DynamicImportQueueScope);
+    WTF_FORBID_HEAP_ALLOCATION;
+
+public:
+    DynamicImportQueueScope(JSC::JSGlobalObject* globalObject, JSC::VM& vm)
+        : m_globalObject(globalObject)
+        , m_vm(vm)
+    {
+        if (!vm.m_synchronousModuleQueue)
+            return;
+        m_clientData = WebCore::clientData(vm);
+        m_queue.prev = vm.m_synchronousModuleQueue;
+        vm.m_synchronousModuleQueue = &m_queue;
+        m_outerDynamicImportQueue = std::exchange(m_clientData->dynamicImportModuleQueue, &m_queue);
+    }
+
+    ~DynamicImportQueueScope()
+    {
+        if (!m_clientData)
+            return;
+        ASSERT(m_vm.m_synchronousModuleQueue == &m_queue);
+        // Queue before unlinking: queueMicrotask can allocate, and the tasks not
+        // yet moved are only reachable through the frame chain.
+        for (auto& task : m_queue.tasks)
+            m_globalObject->queueMicrotask(m_vm, task.task, task.payload, task.arg0, task.arg1, task.arg2, task.arg3);
+        m_clientData->dynamicImportModuleQueue = m_outerDynamicImportQueue;
+        m_vm.m_synchronousModuleQueue = m_queue.prev;
+    }
+
+private:
+    JSC::JSGlobalObject* m_globalObject;
+    JSC::VM& m_vm;
+    WebCore::JSVMClientData* m_clientData { nullptr };
+    JSC::VM::SynchronousModuleQueue* m_outerDynamicImportQueue { nullptr };
+    JSC::VM::SynchronousModuleQueue m_queue;
+};
+
+}
+
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,
     JSModuleLoader*,
     JSString* moduleNameValue,
@@ -3539,6 +3596,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     auto* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
 
     VM& vm = JSC::getVM(globalObject);
+    DynamicImportQueueScope dynamicImportQueueScope(globalObject, vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     {
@@ -3684,8 +3742,10 @@ JSC::JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
     // to microtasks. The async fetch path goes through the transpiler thread
     // pool; route to the synchronous fetch instead so the returned promise is
     // already fulfilled and the loader keeps draining its private queue (see
-    // JSModuleLoader::loadModuleSync / VM::m_synchronousModuleQueue).
-    if (vm.m_synchronousModuleQueue) {
+    // JSModuleLoader::loadModuleSync / VM::m_synchronousModuleQueue). A frame
+    // pushed by DynamicImportQueueScope is the exception: that fetch is for an
+    // import() call, which loads asynchronously like any other.
+    if (vm.m_synchronousModuleQueue && vm.m_synchronousModuleQueue != WebCore::clientData(vm)->dynamicImportModuleQueue) {
         JSValue result = Bun::fetchESMSourceCodeSync(
             static_cast<Zig::GlobalObject*>(globalObject),
             moduleKeyJS,

--- a/test/js/bun/resolve/require-esm-microtask-order.test.ts
+++ b/test/js/bun/resolve/require-esm-microtask-order.test.ts
@@ -2,11 +2,173 @@
 // queue so the loader's own pipeline reactions don't yield to user microtasks.
 // That diversion must NOT capture user-visible continuations: an `await`
 // inside an evaluated module body (AsyncFunctionResume) is a normal microtask
-// and has to interleave with one queued *before* the require() in FIFO order.
-import { expect, test } from "bun:test";
+// and has to interleave with one queued *before* the require() in FIFO order,
+// and a dynamic import() a module in that graph issues is a separate
+// asynchronous load whose modules must not evaluate inside the require().
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test("require(esm) does not run user `await` continuations ahead of earlier microtasks", async () => {
+// Shared by the dynamic import() tests below: `t` records evaluation order and
+// is printed once the process has nothing left to do.
+const trace = `globalThis.t = []; process.on("exit", () => console.log(JSON.stringify(t)));`;
+
+// The import()ed file is transpiled on the thread pool by default, so its fetch
+// is still pending when the require() returns. With the thread pool off the
+// fetch has already settled inside the require(), which is the case where the
+// loader used to carry straight on into evaluation.
+describe.each([
+  ["async transpiler", {}],
+  ["sync transpiler", { BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" }],
+])("%s", (_, extraEnv) => {
+  async function run(dir: string, entry: string): Promise<string[]> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), entry],
+      env: { ...bunEnv, ...extraEnv },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout.trim());
+  }
+
+  test.concurrent("require(esm) does not evaluate an import() the required module starts", async () => {
+    using dir = tempDir("require-esm-dynamic-import", {
+      "package.json": `{"name": "r"}`,
+      "entry.cjs": `
+        ${trace}
+        t.push("before-require");
+        require("./a.mjs");
+        t.push("after-require");
+        require("./z.cjs");
+        t.push("end");
+      `,
+      "a.mjs": `
+        t.push("a");
+        import("./x.mjs").then(() => t.push("x-resolved"));
+        export const a = 1;
+      `,
+      "x.mjs": `import "./y.cjs"; t.push("x"); export const x = 1;`,
+      "y.cjs": `t.push("y"); module.exports = {};`,
+      "z.cjs": `t.push("z"); module.exports = {};`,
+    });
+
+    // Node: before-require a after-require z end y x x-resolved
+    expect(await run(String(dir), "entry.cjs")).toEqual([
+      "before-require",
+      "a",
+      "after-require",
+      "z",
+      "end",
+      "y",
+      "x",
+      "x-resolved",
+    ]);
+  });
+
+  test.concurrent(
+    "require(esm): import() of a throwing or top-level-await module does not run inside the require()",
+    async () => {
+      using dir = tempDir("require-esm-dynamic-import-tla", {
+        "package.json": `{"name": "r"}`,
+        "entry.cjs": `
+          ${trace}
+          t.push("before-require");
+          require("./a.mjs");
+          t.push("after-require");
+        `,
+        "a.mjs": `
+          t.push("a");
+          import("./tla.mjs").then(() => t.push("tla-resolved"));
+          import("./throws.mjs").catch(e => t.push("throws-rejected:" + e.message));
+          export const a = 1;
+        `,
+        "tla.mjs": `t.push("tla-before-await"); await 1; t.push("tla-after-await"); export const v = 1;`,
+        "throws.mjs": `t.push("throws"); throw new Error("boom");`,
+      });
+
+      const t = await run(String(dir), "entry.cjs");
+      // Nothing from either import() target runs before require() returns. The
+      // two targets are fetched concurrently, so only assert each one's own order.
+      expect(t.slice(0, 3)).toEqual(["before-require", "a", "after-require"]);
+      expect(t.filter(e => e.startsWith("tla"))).toEqual(["tla-before-await", "tla-after-await", "tla-resolved"]);
+      expect(t.filter(e => e.startsWith("throws"))).toEqual(["throws", "throws-rejected:boom"]);
+      expect(t.length).toBe(8);
+    },
+  );
+
+  test.concurrent(
+    "require(esm) reached from an ESM entry does not evaluate an import() the required module starts",
+    async () => {
+      using dir = tempDir("require-esm-dynamic-import-esm-entry", {
+        "package.json": `{"name": "r"}`,
+        "entry.mjs": `
+          import "./c1.cjs";
+          import "./b.mjs";
+          t.push("entry");
+        `,
+        "c1.cjs": `
+          ${trace}
+          t.push("c1");
+          require("./a.mjs");
+          t.push("c1-after-require");
+        `,
+        "a.mjs": `
+          t.push("a");
+          import("./x.mjs").then(() => t.push("x-resolved"));
+          export const a = 1;
+        `,
+        "b.mjs": `t.push("b"); export const b = 1;`,
+        "x.mjs": `import "./y.cjs"; t.push("x"); export const x = 1;`,
+        "y.cjs": `t.push("y"); module.exports = {};`,
+      });
+
+      const t = await run(String(dir), "entry.mjs");
+      // Node: c1 a c1-after-require b entry y x x-resolved. The import()'s graph
+      // loads concurrently with the rest of the entry's graph, so only pin down
+      // that none of it runs inside the require() and that each graph keeps its
+      // own order.
+      expect(t.slice(0, 3)).toEqual(["c1", "a", "c1-after-require"]);
+      expect(t.filter(e => e === "b" || e === "entry")).toEqual(["b", "entry"]);
+      expect(t.filter(e => e.startsWith("x") || e === "y")).toEqual(["y", "x", "x-resolved"]);
+      expect(t.length).toBe(8);
+    },
+  );
+
+  test.concurrent("require(esm): a module can import() and then require() the same file", async () => {
+    using dir = tempDir("require-esm-dynamic-import-then-require", {
+      "package.json": `{"name": "r"}`,
+      "entry.cjs": `
+        ${trace}
+        t.push("before-require");
+        const { viaRequire } = require("./a.mjs");
+        t.push("after-require:" + viaRequire);
+      `,
+      "a.mjs": `
+        import { createRequire } from "node:module";
+        t.push("a");
+        const viaImport = import("./x.mjs");
+        export const viaRequire = createRequire(import.meta.url)("./x.mjs").x;
+        viaImport.then(ns => t.push("x-resolved:" + ns.x + ":" + (ns.bump === createRequire(import.meta.url)("./x.mjs").bump)));
+      `,
+      "x.mjs": `t.push("x"); export const x = 1; export function bump() {}`,
+    });
+
+    // x.mjs evaluates once, synchronously, because it is require()d; the earlier
+    // import() resolves afterwards with the same namespace.
+    expect(await run(String(dir), "entry.cjs")).toEqual([
+      "before-require",
+      "a",
+      "x",
+      "after-require:1",
+      "x-resolved:1:true",
+    ]);
+  });
+});
+
+test.concurrent("require(esm) does not run user `await` continuations ahead of earlier microtasks", async () => {
   using dir = tempDir("require-esm-microtask-order", {
     "esm.mjs": `
       globalThis.__order ??= [];


### PR DESCRIPTION
### Problem
- An `import()` called from an ES module that a synchronous `require()` is loading ran inside that `require()`: the target and its whole static graph evaluated before `require()` returned. With `entry.cjs` → `require("./a.mjs")` → `import("./x.mjs")`, bun prints `a y x after-require` where Node prints `a after-require … y x`.
- Cause: `GlobalObject::moduleLoaderImportModule` (`src/jsc/bindings/ZigGlobalObject.cpp`) runs while `vm.m_synchronousModuleQueue` is set. So `moduleLoaderFetch` transpiled the target on the spot, and the new graph's loader reactions joined the queue the `require()` was draining.

### Fix
- `moduleLoaderImportModule` installs a `DynamicImportQueueScope`. When a synchronous load is active it pushes its own queue frame for the request, then moves what landed there to the microtask queue, as when no `require()` is on the stack.
- The frame is recorded in `JSVMClientData::dynamicImportModuleQueue`. `moduleLoaderFetch` stays asynchronous while it is the head. A nested `require()` pushes a newer frame and still loads synchronously.
- The frame stays linked through `prev`, so `VM::visitAggregate` still marks the outer frames' tasks.
- Verified: `test/js/bun/resolve/require-esm-microtask-order.test.ts` (4 new tests, each with the async and sync transpiler; 6 of 8 fail on 1.4.2). Also `test/js/bun/resolve/`, `test/js/node/{module,vm}`, `test/js/bun/plugin`.

### Background
- `require(esm)` must load and evaluate a graph without yielding. While `VM::m_synchronousModuleQueue` (JSC, `BUN_JSC_ADDITIONS`) points at a stack frame, `JSPromise` appends the module loader's internal microtasks to that frame, and `JSModuleLoader::drainSynchronousModuleQueue` runs them in a loop.
- The diversion keys on the task type only. It cannot tell the `require()` graph's reactions from an `import()`'s.
- `import()` enters Bun through the `moduleLoaderImportModule` hook, which resolves, calls `moduleLoaderFetch`, and chains the first loader reaction on the fetch promise.

<details><summary>Notes</summary>

- A throwing or top-level-await `import()` target also ran its body inside the `require()` before this change; the rejection still went to the promise. Covered by the second test.
- With the thread-pool transpiler (the default once the entry point has loaded) the fetch promise is still pending when the request returns, so the isolation frame is usually empty and the fix reduces to "fetch asynchronously". With `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1`, builtins, JSON/text modules, or an already-registered module, the fetch promise is already settled, the first reaction lands in the isolation frame, and the flush is what keeps it out of the `require()`. The tests run both modes.
- Clearing `vm.m_synchronousModuleQueue` for the request instead of pushing a frame would hide the outer frames' queued JSValues from `VM::visitAggregate` during any GC the request triggers.
- Flushing uses `JSGlobalObject::queueMicrotask(vm, task, payload, args…)`, the same call `drainSynchronousModuleQueue` already uses to hand diverted tasks back on its exception path.
- Tasks are queued before the frame is unlinked because `queueMicrotask` can allocate and the not-yet-moved tasks are only reachable through the frame chain.
- Scope of this PR: it closes one door, the `import()` request issued while a synchronous load is on the stack. A second door stays open and this PR does not change it: when a registry entry is shared between an asynchronous load (an earlier `import()`, or the entry graph still fetching a sibling) and a later synchronous load, `hostLoadImportedModule` force-settles the shared fetch promise (`JSModuleLoader.cpp`, the `vm.m_synchronousModuleQueue && status == Fetching` branch) and the settle-time capture in `JSPromise.cpp` (`settleInlineInternalMicrotask`, `triggerPromiseReactions`) diverts the asynchronous load's reactions into that `require()` too. No scope on the Bun side can reach that, because the capture decision is made where the promise settles. Please do not add more per-door scopes like this one for it.
- The retirement path for both `JSVMClientData::dynamicImportModuleQueue` and the pointer compare in `moduleLoaderFetch` is a fork change: give `VM::SynchronousModuleQueue` an owner/kind, expose one `VM` predicate that the five `JSPromise.cpp` divert sites, the `hostLoadImportedModule` branch and `moduleLoaderFetch` all consult, and push the `import()` boundary once in `JSModuleLoader::importModule` so nothing is diverted in the first place. This PR is the Bun-side step that fixes the reported ordering now without a WebKit bump.
- `NodeVMGlobalObject::moduleLoaderImportModule` is untouched. Its default-loader case delegates to the `Zig::GlobalObject` hook, which is covered (checked with `vm.Script` + `USE_MAIN_CONTEXT_DEFAULT_LOADER`). ShadowRealm globals use the same hook; `ShadowRealm.prototype.importValue` from a required module now evaluates the target in the shadow realm after the `require()` returns (before, the drain ran it inside the `require()` against the incubating realm).
- Also checked by hand: `import()` of `node:fs`, a missing file, `.json`, `type: "text"`, a CJS target, the requiring module itself, inside a Worker, under `BUN_JSC_collectContinuously=1`, and a `require(esm)` issued after startup from a timer. A module-graph ordering fuzz pass (about 250 generated graphs, CJS and ESM entries, both transpiler modes) found no case where this branch moves away from Node relative to 1.4.2.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/require-esm-microtask-order.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/usr/local/bun/bin/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Creloc
... (truncated)

release without fix: 6 FAILED
bun test v1.4.2 (744846f84)

test/js/bun/resolve/require-esm-microtask-order.test.ts:
54 |       "y.cjs": `t.push("y"); module.exports = {};`,
55 |       "z.cjs": `t.push("z"); module.exports = {};`,
56 |     });
57 | 
58 |     // Node: before-require a after-require z end y x x-resolved
59 |     expect(await run(String(dir), "entry.cjs")).toEqual([
                                                     ^
error: expect(received).toEqual(expected)

  [
    "before-require",
    "a",
+   "y",
+   "x",
    "after-require",
    "z",
    "end",
-   "y",
-   "x",
    "x-resolved",
  ]

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/resolve/require-esm-microtask-order.test.ts:59:49)
90 |       });
91 | 
92 |       const t = await run(String(dir), "entry.cjs");
93 |       // Nothing from either import() target runs before require() returns. The
94 |       // two targets are fetched concurrently, so only assert each one's own order.
95 |       expect(t.slice(0, 3)).toEqual(["before-require", "a", "after-require"]);
                                 ^
error: expect(received).toEqual(expected)

  [
    "before-require",
    "a",
-   "after-requi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/require-esm-microtask-order.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/resolve/require-esm-microtask-order.test.ts:
(pass) async transpiler > require(esm): import() of a throwing or top-level-await module does not run inside the require() [324.97ms]
(pass) sync transpiler > require(esm) does not evaluate an import() the required module starts [297.49ms]
(pass) async transpiler > require(esm): a module can import() and then require() the same file [328.57ms]
(pass) async transpiler > require(esm) does not evaluate an import() the required module starts [461.29ms]
(pass) async transpiler > require(esm) reached from an ESM entry does not evaluate an import() the required module starts [389.54ms]
(pass) sync transpiler > require(esm): a module can import() and then require() the same file [288.88ms]
(pass) require(esm) does not run user `await` continuations ahead of earlier microtasks [302.10ms]
(pass) sync transpiler > require(esm): import() of a throwing or top-level-await module does not run inside the require(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4c63e318ca
  features     baseline

23 deps, 131 codegen, 1172 objects in 804ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] mkdir stamps
[2/1248] mkdir codegen
[3/1248] mkdir obj
[4/1248] mkdir pch
[5/1248] gen ErrorCode+*.h
[6/1248] install /workspace/bun
bun install v1.4.2 (744846f84)

Checked 22 installs across 61 packages (no changes) [21.00ms]
[7/1248] install /workspace/bun/packages/bun-error
bun install v1.4.2 (744846f84)

Checked 1 install across 2 packages (no changes) [1.00ms]
[8/1248] gen bindgenv2
[9/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.2 (744846f84)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[10/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1248] fetch tinycc
[tinycc] up to date
[12/1248] gen node-fallbacks/react-refresh.js
Bundled 1 module in 13ms

  react-refresh.js  4.81 KB  (entry point)

[13/1248] fetch zlib
[zlib] up to date
[14/1248] fetch picohttpparser
[picohttpparser] up to date
[15
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunClientData.h                   |   7 +
 src/jsc/bindings/ZigGlobalObject.cpp               |  64 +++++++-
 .../resolve/require-esm-microtask-order.test.ts    | 168 ++++++++++++++++++++-
 3 files changed, 234 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/BunClientData.h                             2      2     11
src/jsc/bindings/ZigGlobalObject.cpp                         4      4     11
test/js/bun/resolve/require-esm-microtask-order.test.ts      2      5     11
```

</details>

<!-- robobun:evidence:end -->