### PR TITLE
bun test: keep running a file's tests after an unhandled error during collection

### DIFF
--- a/docs/test/runtime-behavior.mdx
+++ b/docs/test/runtime-behavior.mdx
@@ -87,7 +87,7 @@ test("test without timeout", async () => {
 
 ### Unhandled Errors
 
-`bun test` tracks unhandled promise rejections and errors that occur between tests. If any occur, `bun test` exits with a non-zero code even when no test failed. In both examples below the error happens while the file is being loaded, so the file's tests are not run at all.
+`bun test` tracks unhandled promise rejections and errors that occur between tests. If any occur, `bun test` exits with a non-zero code even when no test failed. In both examples below the error happens while the file is being loaded: it is reported as an unhandled error and the file's tests still run.
 
 This helps catch errors in asynchronous code that might otherwise go unnoticed:
 
@@ -107,8 +107,8 @@ test("test 2", () => {
   expect(true).toBe(true);
 });
 
-// bun test reports this as "Unhandled error between tests", does not run
-// this file's tests (0 pass, 1 error), and exits with code 1
+// bun test reports this as "Unhandled error between tests", still runs both
+// tests (2 pass, 1 error), and exits with code 1
 ```
 
 ### Promise Rejections
@@ -122,8 +122,8 @@ test("test 1", () => {
   expect(1).toBe(1);
 });
 
-// bun test reports this as "Unhandled error between tests", does not run
-// this file's tests, and exits with code 1
+// bun test reports this as "Unhandled error between tests", still runs
+// "test 1" (1 pass, 1 error), and exits with code 1
 Promise.reject(new Error("Unhandled rejection"));
 ```
 

--- a/src/runtime/test_runner/Collection.rs
+++ b/src/runtime/test_runner/Collection.rs
@@ -16,9 +16,10 @@ use crate::test_runner::jest::Jest;
 pub struct Collection {
     /// set to true after collection phase ends
     pub(crate) locked: bool,
-    /// Set while an async describe() callback's promise is outstanding. Only then can
-    /// an uncaught error be that callback's failure. At module or preload top level,
-    /// and while a describe() body runs synchronously, no callback is waiting.
+    /// Set while an async describe() callback's promise is outstanding. An uncaught
+    /// error that lands then is charged to that describe and completes it. At module
+    /// or preload top level, and while a describe() body runs synchronously, no
+    /// callback is waiting and an uncaught error fails nothing.
     pub(crate) describe_callback_pending: bool,
     pub(crate) describe_callback_queue: Vec<QueuedDescribe>,
     pub(crate) current_scope_callback_queue: Vec<QueuedDescribe>,

--- a/src/runtime/test_runner/Collection.rs
+++ b/src/runtime/test_runner/Collection.rs
@@ -16,6 +16,10 @@ use crate::test_runner::jest::Jest;
 pub struct Collection {
     /// set to true after collection phase ends
     pub(crate) locked: bool,
+    /// Set while an async describe() callback's promise is outstanding. Only then can
+    /// an uncaught error be that callback's failure. At module or preload top level,
+    /// and while a describe() body runs synchronously, no callback is waiting.
+    pub(crate) describe_callback_pending: bool,
     pub(crate) describe_callback_queue: Vec<QueuedDescribe>,
     pub(crate) current_scope_callback_queue: Vec<QueuedDescribe>,
     // The two queues above are self-referential — their `NonNull<DescribeScope>` fields point
@@ -79,6 +83,7 @@ impl Collection {
 
         Collection {
             locked: false,
+            describe_callback_pending: false,
             describe_callback_queue: Vec::new(),
             current_scope_callback_queue: Vec::new(),
             root_scope,
@@ -170,6 +175,7 @@ impl Collection {
             "collection:runOneCompleted reset scope back from {}",
             bstr::BStr::new(self.active_scope().base.name.as_deref().unwrap_or(b"undefined")),
         ));
+        self.describe_callback_pending = false;
         self.active_scope = prev_scope;
         group::log(format_args!(
             "collection:runOneCompleted reset scope back to {}",
@@ -234,17 +240,20 @@ impl Collection {
                 bstr::BStr::new(this.active_scope().base.name.as_deref().unwrap_or(b"undefined")),
             ));
 
-            if let Some(cfg_data) = BunTest::run_test_callback(
+            let sync_result = BunTest::run_test_callback(
                 buntest_strong,
                 global_this,
                 callback.get(),
                 false,
                 RefDataValue::Collection { active_scope: previous_scope },
                 &Timespec::EPOCH,
-            ) {
+            );
+            // Re-derive after re-entrant call per BunTestCell::get aliasing contract.
+            let buntest = buntest_strong.get();
+            match sync_result {
                 // the result is available immediately; queue
-                // Re-derive after re-entrant call per BunTestCell::get aliasing contract.
-                buntest_strong.get().add_result(cfg_data);
+                Some(cfg_data) => buntest.add_result(cfg_data),
+                None => buntest.collection.describe_callback_pending = true,
             }
 
             return Ok(StepResult::Waiting { timeout: Timespec::EPOCH });
@@ -254,9 +263,17 @@ impl Collection {
 
     pub(crate) fn handle_uncaught_exception(
         &mut self,
-        _: &RefDataValue,
+        data: &RefDataValue,
     ) -> HandleUncaughtExceptionResult {
         let _g = group::begin();
+
+        // Only a describe() callback's own throw or rejection fails its scope. Any other
+        // error seen during collection (module or preload top level, a `.each` table, a
+        // timer) has no scope to fail, and failing the active scope for it would drop
+        // tests that registered fine.
+        let RefDataValue::Collection { .. } = data else {
+            return HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests;
+        };
 
         self.active_scope_mut().failed = true;
 

--- a/src/runtime/test_runner/Collection.rs
+++ b/src/runtime/test_runner/Collection.rs
@@ -16,10 +16,7 @@ use crate::test_runner::jest::Jest;
 pub struct Collection {
     /// set to true after collection phase ends
     pub(crate) locked: bool,
-    /// Set while an async describe() callback's promise is outstanding. An uncaught
-    /// error that lands then is charged to that describe and completes it. At module
-    /// or preload top level, and while a describe() body runs synchronously, no
-    /// callback is waiting and an uncaught error fails nothing.
+    /// an async describe() callback's promise is outstanding; an uncaught error now is charged to it
     pub(crate) describe_callback_pending: bool,
     pub(crate) describe_callback_queue: Vec<QueuedDescribe>,
     pub(crate) current_scope_callback_queue: Vec<QueuedDescribe>,
@@ -268,10 +265,7 @@ impl Collection {
     ) -> HandleUncaughtExceptionResult {
         let _g = group::begin();
 
-        // Only a describe() callback's own throw or rejection fails its scope. Any other
-        // error seen during collection (module or preload top level, a `.each` table, a
-        // timer) has no scope to fail, and failing the active scope for it would drop
-        // tests that registered fine.
+        // An error that no describe() callback owns has no scope to fail.
         let RefDataValue::Collection { .. } = data else {
             return HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests;
         };

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -603,6 +603,16 @@ pub(crate) mod on_unhandled_rejection {
             // re-borrows. Const→mut projection is centralized in `buntest_as_mut`
             // pending the BunTestPtr interior-mut reshape (see bun_test.rs).
             let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
+            if buntest.phase == bun_test::Phase::Collection && !buntest.collection.describe_callback_pending {
+                // No describe() callback is waiting on a promise: the error came from
+                // module or preload top level, a `.each` table, or synchronously from a
+                // describe() body. There is no callback to complete, so report it and
+                // keep collecting. Stepping the collection here would run the queued
+                // describe() callbacks early and finish the run before the file has
+                // registered its tests.
+                buntest.on_uncaught_exception(global_object, Some(rejection), true, &RefDataValue::Start);
+                return;
+            }
             // mark unhandled errors as belonging to the currently active test. note that this can be misleading.
             let mut current_state_data = buntest.get_current_state_data();
             // split entry()/sequence() borrows via raw-ptr capture (per-use reborrow).

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -604,12 +604,7 @@ pub(crate) mod on_unhandled_rejection {
             // pending the BunTestPtr interior-mut reshape (see bun_test.rs).
             let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
             if buntest.phase == bun_test::Phase::Collection && !buntest.collection.describe_callback_pending {
-                // No describe() callback is waiting on a promise: the error came from
-                // module or preload top level, a `.each` table, or synchronously from a
-                // describe() body. There is no callback to complete, so report it and
-                // keep collecting. Stepping the collection here would run the queued
-                // describe() callbacks early and finish the run before the file has
-                // registered its tests.
+                // No callback owns this error: report it, fail no scope, and do not step collection.
                 buntest.on_uncaught_exception(global_object, Some(rejection), true, &RefDataValue::Start);
                 return;
             }

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -748,4 +748,198 @@ test("my-test", () => {
       expect(output).toContain("Ran 1 test across 1 file");
     });
   }
+});
+
+// An unhandled rejection or uncaught exception that lands while a file is still
+// registering its tests does not belong to any describe() callback. It is reported
+// as an unhandled error and the file's tests still run.
+describe.concurrent("unhandled error during collection does not drop the file's tests", () => {
+  test("from module top level, a .each table, and a describe body", async () => {
+    using dir = tempDir("unhandled-collection", {
+      "package.json": "{}",
+      // Flush left, no blank lines: the code frames below are part of the snapshot.
+      "stray.test.ts": [
+        `import { describe, expect, test } from "bun:test";`,
+        `Promise.reject(new Error("stray-top-level"));`,
+        `test.each([[Promise.reject(new Error("stray-each-row"))], [Promise.resolve(1)]])("row %#", value => {`,
+        `  expect(value).toBeInstanceOf(Promise);`,
+        `});`,
+        `describe("d", () => {`,
+        `  Promise.reject(new Error("stray-in-describe"));`,
+        `  test("t1", () => {});`,
+        `  describe("inner", () => {`,
+        `    test("t2", () => {});`,
+        `  });`,
+        `});`,
+        `test("failing", () => {`,
+        `  expect(1).toBe(2);`,
+        `});`,
+      ].join("\n"),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "./stray.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n`);
+    expect(normalizeBunSnapshot(stderr, dir)).toMatchInlineSnapshot(`
+      "stray.test.ts:
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | import { describe, expect, test } from "bun:test";
+      2 | Promise.reject(new Error("stray-top-level"));
+                             ^
+      error: stray-top-level
+            at <dir>/stray.test.ts:2:20
+      -------------------------------
+
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | import { describe, expect, test } from "bun:test";
+      2 | Promise.reject(new Error("stray-top-level"));
+      3 | test.each([[Promise.reject(new Error("stray-each-row"))], [Promise.resolve(1)]])("row %#", value => {
+                                         ^
+      error: stray-each-row
+            at <dir>/stray.test.ts:3:32
+      -------------------------------
+
+
+      # Unhandled error between tests
+      -------------------------------
+      2 | Promise.reject(new Error("stray-top-level"));
+      3 | test.each([[Promise.reject(new Error("stray-each-row"))], [Promise.resolve(1)]])("row %#", value => {
+      4 |   expect(value).toBeInstanceOf(Promise);
+      5 | });
+      6 | describe("d", () => {
+      7 |   Promise.reject(new Error("stray-in-describe"));
+                               ^
+      error: stray-in-describe
+          at <anonymous> (file:NN:NN)
+      -------------------------------
+
+      (pass) row 0
+      (pass) row 1
+      (pass) d > t1
+      (pass) d > inner > t2
+       9 |   describe("inner", () => {
+      10 |     test("t2", () => {});
+      11 |   });
+      12 | });
+      13 | test("failing", () => {
+      14 |   expect(1).toBe(2);
+                       ^
+      error: expect(received).toBe(expected)
+
+      Expected: 2
+      Received: 1
+          at <anonymous> (file:NN:NN)
+      (fail) failing
+
+       4 pass
+       1 fail
+       3 errors
+       3 expect() calls
+      Ran 5 tests across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("from a --preload module", async () => {
+    using dir = tempDir("unhandled-collection-preload", {
+      "package.json": "{}",
+      // Flush left, no blank lines: the code frames below are part of the snapshot.
+      "preload.ts": [
+        `Promise.reject(new Error("stray-preload-rejection"));`,
+        `queueMicrotask(() => {`,
+        `  throw new Error("stray-preload-exception");`,
+        `});`,
+      ].join("\n"),
+      "a.test.ts": [
+        `import { expect, test } from "bun:test";`,
+        `test("a1", () => {`,
+        `  expect(1).toBe(2);`,
+        `});`,
+        `test("a2", async () => {`,
+        `  await 0;`,
+        `});`,
+      ].join("\n"),
+      "b.test.ts": [
+        `import { describe, test } from "bun:test";`,
+        `describe("d", () => {`,
+        `  test("b1", () => {});`,
+        `});`,
+      ].join("\n"),
+    });
+
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "test",
+        "--preload",
+        "./preload.ts",
+        "--reporter=junit",
+        "--reporter-outfile=junit.xml",
+        "./a.test.ts",
+        "./b.test.ts",
+      ],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n`);
+    expect(normalizeBunSnapshot(stderr, dir)).toMatchInlineSnapshot(`
+      "a.test.ts:
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | Promise.reject(new Error("stray-preload-rejection"));
+      2 | queueMicrotask(() => {
+      3 |   throw new Error("stray-preload-exception");
+                                                     ^
+      error: stray-preload-exception
+          at <anonymous> (file:NN:NN)
+      -------------------------------
+
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | Promise.reject(new Error("stray-preload-rejection"));
+                             ^
+      error: stray-preload-rejection
+            at <dir>/preload.ts:1:20
+      -------------------------------
+
+      1 | import { expect, test } from "bun:test";
+      2 | test("a1", () => {
+      3 |   expect(1).toBe(2);
+                      ^
+      error: expect(received).toBe(expected)
+
+      Expected: 2
+      Received: 1
+          at <anonymous> (file:NN:NN)
+      (fail) a1
+      (pass) a2
+
+      b.test.ts:
+      (pass) d > b1
+
+       2 pass
+       1 fail
+       2 errors
+       1 expect() calls
+      Ran 3 tests across 2 files."
+    `);
+    const junit = await Bun.file(join(String(dir), "junit.xml")).text();
+    expect([...junit.matchAll(/<testcase name="([^"]+)"/g)].map(m => m[1]).sort()).toEqual(["a1", "a2", "b1"]);
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### Problem
- An unhandled error that lands while a file still registers its tests silently deletes every test in the active describe scope. A file with a top-level `Promise.reject(new Error("x"))` reports `Ran 0 tests`, `1 error`. Same for a rejected promise in a `.each` table, a stray rejection in a sync `describe()` body, and a `--preload` that rejects, where each `test()` also throws `Cannot call test() after the test run has completed` (knock-on 3 of #37968).
- Cause: `jest::on_unhandled_rejection` (`src/runtime/test_runner/jest.rs:594`) treats every unhandled error as the completion of the current callback. In Collection that failed the active scope (the root scope at top level) and stepped the state machine to Done before the module body ran.

### Fix
- `Collection::describe_callback_pending` records whether an async `describe()` callback's promise is outstanding. When an error lands in Collection and none is, report it as an unhandled error between tests (exit code 1) and return. No scope fails, nothing steps.
- `Collection::handle_uncaught_exception` fails the active scope only for `RefDataValue::Collection` data: the callback's own throw or rejection, or an error that lands while an async describe is pending. That last case keeps today's behaviour: the pending describe fails and its tests do not run. Node draws the same line.
- Correct because in the changed places no callback waits for a completion. Node `--test` (v26.3.0) and Vitest also run every test and report the stray error.
- Verified: `test/js/bun/test/test-test.test.ts` (two new tests, both fail on stock bun), plus `test/js/bun/test/**` and eight `test/cli/test` files. Self-reviewed: 3 concerns raised, 3 addressed (docs sweep, residual stated, doc comment).

### Background
- A file runs in phases: Collection (module body, then queued `describe()` callbacks), Execution, Done. In Collection a queued result means "a describe callback completed".
- In `bun test` every uncaught exception and unhandled rejection reaches `jest::on_unhandled_rejection`, which in Execution fails the running test.
- `--preload` modules run inside the first file's Collection phase. `docs/test/runtime-behavior.mdx` described the old output and is updated here.

<details><summary>Notes</summary>

- Smallest repro before this change:
  ```ts
  import { test } from "bun:test";
  Promise.reject(new Error("stray"));
  test("t", () => {});
  // bun test: "1 error, Ran 0 tests", exit 1. t never runs and nothing says so.
  ```
- With a `--preload` that rejects synchronously, the old code stepped Collection to Done during preload evaluation. The first file's `test()` calls then threw `Cannot call test() after the test run has completed`, the module failed to load, and the summary counted that as `1 fail` with no `(fail)` line. The JUnit report had no testcase for the file. #37968 reports the same symptom after an unrelated error during module load under `--isolate`; this change removes that knock-on, not the `epoll_ctl` error itself.
- Node parity, checked on v26.3.0 with `node --test`: a stray rejection at module top level, in a `--import` preload, in a `.each`-style table, and inside a synchronous `describe()` body all leave every test running and fail the run with the error's own stack. An error while an async `describe()` is still awaiting fails that suite in Node too.
- A describe callback that returns a promise which never settles, plus an uncaught error from a timer it started, still fails that describe and lets the rest of the file run (unchanged; this is what the pending flag preserves). Without the flag such a file would wait forever, as a never-settling describe without an error already does.
- Possible follow-up, not in this PR: give `RefDataValue::Collection` a generation token so a stale describe completion is rejected the way `Execution::get_current_and_valid_execution_sequence` rejects stale test completions. That would also cover a late settle of a describe promise whose scope an error already completed.
- The error is printed under the header of the file that is active when it lands. For a preload that is the first file (every file under `--isolate`); the code frame and stack name the preload module.
- Suites run locally on the debug build: `test/js/bun/test/**` (80 files), `test/cli/test/{bun-test,isolation,rerun-each,retry-flag,test-timeout-behavior,parallel,expectations,pass-with-no-tests}.test.ts`. Failures seen on both builds and unrelated: `stack.test.ts` "Async functions frame should be included in stack trace" when run after other files, two `--parallel` worker-count tests under load, `snapshot.test.ts` "error snapshots" (ANSI colour detection in this environment).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts

<!-- robobun:evidence:end -->