### PR TITLE
bundler: run each HTML <script src> as its own import site

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -928,21 +928,11 @@ impl<'a> LinkerContext<'a> {
         // Size the per-file part-liveness bitsets now that `scan_imports_and_exports`
         // has finished pushing wrapper / entry-point parts.
         {
-            let loaders = self.parse_graph().input_files.items_loader();
             let parts_col = self.graph.ast.items_parts();
             let mut parts_live: Vec<bun_collections::AutoBitSet> =
                 Vec::with_capacity(parts_col.len());
-            for (i, parts) in parts_col.iter().enumerate() {
-                let mut bits = bun_collections::AutoBitSet::init_empty(parts.len())?;
-                // The HTML loader's `ParseTask` builds its synthetic part 1 already
-                // live (so the JS-chunk visitor follows every embedded import record).
-                // `mark_file_live_for_tree_shaking` short-circuits for HTML and never
-                // walks its parts, so seed the bit here to preserve the old
-                // `Part::is_live = true` initializer.
-                if loaders.get(i).is_some_and(|l| *l == Loader::Html) && parts.len() > 1 {
-                    bits.set(1);
-                }
-                parts_live.push(bits);
+            for parts in parts_col.iter() {
+                parts_live.push(bun_collections::AutoBitSet::init_empty(parts.len())?);
             }
             self.graph.parts_live = parts_live;
         }
@@ -2185,6 +2175,7 @@ impl<'a> LinkerContext<'a> {
         loc: Loc,
         namespace_ref: Ref,
         import_record_index: u32,
+        source_index: u32,
         alloc: &Bump,
         ast: &JSAst<'_>,
     ) -> Result<bool, BunError> {
@@ -2193,8 +2184,14 @@ impl<'a> LinkerContext<'a> {
         if record.flags.contains(bun_ast::ImportRecordFlags::IS_UNUSED) {
             return Ok(true);
         }
+        let is_html_script =
+            self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html;
         // Is this an external import?
         if !record.source_index.is_valid() {
+            // An external `<script src>` stays a tag in the HTML file.
+            if is_html_script {
+                return Ok(true);
+            }
             // Keep the "import" statement if import statements are supported
             if self.options.output_format.keep_es6_import_export_syntax() {
                 return Ok(false);
@@ -2298,7 +2295,10 @@ impl<'a> LinkerContext<'a> {
                     loc,
                 );
 
-                if other_flags.is_async_or_has_async_dependency {
+                // An HTML file starts an async script where its tag was and lets the
+                // scripts after it run meanwhile, like the browser does for separate
+                // module scripts. `generate_entry_point_tail_js` awaits it at the end.
+                if other_flags.is_async_or_has_async_dependency && !is_html_script {
                     stmts
                         .inside_wrapper_prefix
                         .append_async_dependency(init_call, self.promise_all_runtime_ref)?;
@@ -3092,9 +3092,12 @@ impl<'a> LinkerContext<'a> {
             return;
         }
 
-        // HTML files can reference non-JS/CSS assets (favicons, images, etc.)
-        // via .url kind import records. Follow all import records for HTML files
-        // so these assets are marked live and included in the manifest.
+        // Everything an HTML file references is live: every script runs, and
+        // non-JS/CSS assets (favicons, images, etc.) referenced via .url kind
+        // import records must be included in the manifest. Its parts (one
+        // `import` per `<script src>`) are all live too, so that the wrapper
+        // and runtime dependencies `scan_imports_and_exports` attached to them
+        // are followed.
         if self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html {
             for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
@@ -3102,6 +3105,15 @@ impl<'a> LinkerContext<'a> {
                     if !self.graph.files_live.is_set(other as usize) {
                         ctx.worklist.push(TreeShakeWork::File(other));
                     }
+                }
+            }
+            let parts_len = ctx.parts[source_index as usize].len();
+            for part_index in (bun_ast::NAMESPACE_EXPORT_PART_INDEX as usize + 1)..parts_len {
+                if !ctx.parts_live[source_index as usize].is_set(part_index) {
+                    ctx.worklist.push(TreeShakeWork::Part {
+                        part_index: u32::try_from(part_index).expect("int cast"),
+                        source_index,
+                    });
                 }
             }
             return;

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2241,6 +2241,19 @@ impl<'a> LinkerContext<'a> {
         let other_flags = self.graph.meta.items_flags()[record.source_index.get() as usize];
         match other_flags.wrap {
             WrapKind::None => {}
+            // A `<script src>` only runs the module, in document order with the
+            // page's other scripts: "require_foo();"
+            WrapKind::Cjs if is_html_script => {
+                stmts
+                    .inside_wrapper_prefix
+                    .append_sync_dependency(Expr::init(
+                        E::RequireString {
+                            import_record_index,
+                            ..Default::default()
+                        },
+                        loc,
+                    ))?;
+            }
             WrapKind::Cjs => {
                 // Replace the statement with a call to "require()" since the other module is CJS-wrapped
                 stmts

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -203,6 +203,96 @@ pub enum Step {
     Resolve,
 }
 
+/// Builds the parts of an HTML file's JavaScript module: every `<script src>`
+/// becomes `import "./script"` in a part of its own, in document order. The
+/// linker then treats the tag like an import statement: it orders the script
+/// after the files before it, and it calls the script's wrapper where the tag
+/// was when the script is wrapped (CommonJS, lazily initialized ESM, or a
+/// script with a top-level await that must not hold back the scripts after
+/// it). The other records (stylesheets, images) join the part of the next
+/// script, so `find_imported_css_files_in_js_order` still sees document order.
+fn html_module_parts(
+    ast: &mut ast::Ast<'static>,
+    import_records: &mut [ImportRecord],
+    bump: &'static Bump,
+    source: &Source,
+) -> core::result::Result<(), bun_alloc::AllocError> {
+    use bun_ast::base::{RefInt, RefTag};
+    use bun_ast::{DeclaredSymbol, DeclaredSymbolList, ImportKind, ImportRecordFlags, Ref, S};
+
+    // Keep the namespace export part, drop the lazy export statement.
+    ast.parts.truncate(1);
+    let mut record_indices = ast::PartImportRecordIndices::new_in(bun_alloc::AstAlloc);
+    for (import_record_index, record) in import_records.iter_mut().enumerate() {
+        let import_record_index = u32::try_from(import_record_index).expect("int cast");
+        record_indices.push(import_record_index);
+        if record.kind != ImportKind::Stmt {
+            continue;
+        }
+        record
+            .flags
+            .insert(ImportRecordFlags::WAS_ORIGINALLY_BARE_IMPORT);
+
+        let name: &'static [u8] = bun_alloc::arena_format!(
+            in bump,
+            "import_{}",
+            bun_core::fmt::fmt_identifier(
+                bun_paths::fs::PathName::init(record.path.text).non_unique_name_string_base()
+            )
+        )
+        .into_bump_str()
+        .as_bytes();
+        let namespace_ref = Ref::new(
+            RefInt::try_from(ast.symbols.len()).expect("int cast"),
+            source.index.0,
+            RefTag::Symbol,
+        );
+        ast.symbols.push(ast::Symbol {
+            kind: ast::symbol::Kind::Other,
+            original_name: ast::StoreStr::new(name),
+            ..Default::default()
+        });
+        ast.module_scope.generated.push(namespace_ref);
+        let part_index = u32::try_from(ast.parts.len()).expect("int cast");
+        ast.top_level_symbols_to_parts
+            .entry(namespace_ref)
+            .or_insert_with(bun_alloc::AstAlloc::vec)
+            .push(part_index);
+
+        let stmts: &mut [ast::Stmt] = bump.alloc_slice_copy(&[ast::Stmt::alloc(
+            S::Import {
+                namespace_ref,
+                import_record_index,
+                is_single_line: true,
+                ..Default::default()
+            },
+            Loc::EMPTY,
+        )]);
+        ast.parts.push(Part {
+            stmts: ast::StoreSlice::new_mut(stmts),
+            declared_symbols: DeclaredSymbolList::from_slice(&[DeclaredSymbol {
+                ref_: namespace_ref,
+                is_top_level: true,
+            }])?,
+            import_record_indices: core::mem::replace(
+                &mut record_indices,
+                ast::PartImportRecordIndices::new_in(bun_alloc::AstAlloc),
+            ),
+            ..Default::default()
+        });
+    }
+    if ast.parts.len() == 1 {
+        ast.parts.push(Part {
+            import_record_indices: record_indices,
+            ..Default::default()
+        });
+    } else if let Some(last) = ast.parts.last_mut() {
+        last.import_record_indices
+            .extend(record_indices.iter().copied());
+    }
+    Ok(())
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // init
 // ───────────────────────────────────────────────────────────────────────────
@@ -1198,7 +1288,7 @@ pub mod parse_worker {
             Loader::Html => {
                 // scope the scanner so its `&mut log` / `&source`
                 // borrows release before `new_lazy_export_ast` re-borrows them.
-                let import_records = {
+                let mut import_records = {
                     let mut scanner = HTMLScanner::init(log, source);
                     scanner.scan(&source.contents)?;
                     scanner.import_records
@@ -1207,7 +1297,6 @@ pub mod parse_worker {
                 // Reuse existing code for creating the AST
                 // because it handles the various Ref and other structs we
                 // need in order to print code later.
-                let import_records_len = import_records.len();
                 let output_format = opts.output_format;
                 let mut ast = js_parser::new_lazy_export_ast(
                     bump,
@@ -1219,7 +1308,6 @@ pub mod parse_worker {
                     b"",
                 )?
                 .ok_or(AnyError::ParserError)?;
-                ast.import_records = bun_alloc::vec_from_iter_in(import_records, bump);
 
                 // We're banning import default of html loader files for now.
                 //
@@ -1231,23 +1319,8 @@ pub mod parse_worker {
                 // gave up on figuring out how to fix it so that
                 // this feature could ship.
                 ast.has_lazy_export = false;
-                // Liveness for this synthetic part is seeded in
-                // `tree_shaking_and_code_splitting` (the per-part bitset
-                // does not exist at parse time).
-                ast.parts.as_mut_slice()[1] = Part {
-                    stmts: ast::StoreSlice::EMPTY,
-                    import_record_indices: {
-                        // Generate a single part that depends on all the import records.
-                        // This is to ensure that we generate a JavaScript bundle containing all the user's code.
-                        let mut import_record_indices = ast::PartImportRecordIndices::init_capacity(
-                            import_records_len as usize,
-                        );
-                        import_record_indices
-                            .extend(0..u32::try_from(import_records_len).expect("int cast"));
-                        import_record_indices
-                    },
-                    ..Default::default()
-                };
+                html_module_parts(&mut ast, &mut import_records, bump, source)?;
+                ast.import_records = bun_alloc::vec_from_iter_in(import_records, bump);
 
                 // Try to avoid generating unnecessary ESM <> CJS wrapper code.
                 if output_format == js_parser::options::Format::Esm

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -102,6 +102,7 @@ pub(crate) fn convert_stmts_for_chunk(
                         stmt.loc,
                         s.namespace_ref,
                         s.import_record_index,
+                        source_index,
                         bump,
                         ast,
                     )? {
@@ -122,6 +123,7 @@ pub(crate) fn convert_stmts_for_chunk(
                             stmt.loc,
                             s.namespace_ref,
                             s.import_record_index,
+                            source_index,
                             bump,
                             ast,
                         )? {
@@ -405,6 +407,7 @@ pub(crate) fn convert_stmts_for_chunk(
                         stmt.loc,
                         s.namespace_ref,
                         s.import_record_index,
+                        source_index,
                         bump,
                         ast,
                     )? {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -909,6 +909,54 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                         }
                     }
 
+                    // An HTML file starts its async scripts where their tags were, without
+                    // awaiting them (`should_remove_import_export_stmt`). The chunk still
+                    // finishes evaluating only once they settle: "await init_foo();"
+                    if c.parse_graph().input_files.items_loader()[source_index as usize]
+                        == options::Loader::Html
+                    {
+                        let meta_flags = c.graph.meta.items_flags();
+                        let wrapper_refs = c.graph.ast.items_wrapper_ref();
+                        for record in ast.import_records.as_slice() {
+                            if record.kind != bun_ast::ImportKind::Stmt
+                                || !record.source_index.is_valid()
+                            {
+                                continue;
+                            }
+                            let other = record.source_index.get() as usize;
+                            let other_flags = meta_flags[other];
+                            let wrapper_ref = wrapper_refs[other];
+                            if other_flags.wrap != crate::WrapKind::Esm
+                                || !other_flags.is_async_or_has_async_dependency
+                                || !c.graph.files_live.is_set(other)
+                                || wrapper_ref.is_empty()
+                            {
+                                continue;
+                            }
+                            stmts.push(Stmt::alloc(
+                                S::SExpr {
+                                    value: Expr::init(
+                                        E::Await {
+                                            value: Expr::init(
+                                                E::Call {
+                                                    target: Expr::init_identifier(
+                                                        wrapper_ref,
+                                                        bun_ast::Loc::EMPTY,
+                                                    ),
+                                                    ..Default::default()
+                                                },
+                                                bun_ast::Loc::EMPTY,
+                                            ),
+                                        },
+                                        bun_ast::Loc::EMPTY,
+                                    ),
+                                    ..Default::default()
+                                },
+                                bun_ast::Loc::EMPTY,
+                            ));
+                        }
+                    }
+
                     let sorted_and_filtered_export_aliases =
                         &c.graph.meta.items_sorted_and_filtered_export_aliases()
                             [source_index as usize];

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -757,6 +757,7 @@ pub(crate) fn scan_imports_and_exports(
             let id = source_index as usize;
 
             let is_entry_point = col_ref!(entry_point_kinds)[id].is_entry_point();
+            let is_html = col_ref!(loaders)[id] == Loader::Html;
             let aliases = &col_ref!(sorted_aliases)[id];
             let flag = col_ref!(flags)[id];
             let wrap = flag.wrap;
@@ -1241,6 +1242,7 @@ pub(crate) fn scan_imports_and_exports(
                         // "__toESM" wrapper as long as it's not a bare "require()".
                         // A same-chunk `import()` of a lifted CommonJS module needs it
                         // too, so that `default` is `module.exports` (the namespace).
+                        // An HTML `<script src>` only runs the module: "require_foo();"
                         if kind != ImportKind::Require
                             && (other_export_kind == ExportsKind::Cjs
                                 || (kind == ImportKind::Dynamic
@@ -1248,6 +1250,7 @@ pub(crate) fn scan_imports_and_exports(
                                     && col_ref!(ast_flags_list)[other_id]
                                         .contains(AstFlags::COMMONJS_LIFTED_TO_ESM)))
                             && output_format != Format::InternalBakeDev
+                            && !is_html
                         {
                             col!(import_records_list)[id].as_mut_slice()
                                 [import_record_index as usize]

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -208,6 +208,28 @@ pub(crate) fn scan_imports_and_exports(
                 }
             }
 
+            // The scripts of an HTML file run like sibling `<script type="module">`
+            // tags: one that suspends on a top-level await does not hold back the
+            // scripts after it. Inlined into the chunk, its `await` would. So such a
+            // script gets an async `__esm` wrapper instead, which the HTML module
+            // starts in place without awaiting (`should_remove_import_export_stmt`)
+            // and awaits at the end of the chunk (`generate_entry_point_tail_js`).
+            // The last script holds nothing back and stays inline.
+            let html_last_script_record: usize = if col_ref!(loaders)[id] == Loader::Html {
+                col_ref!(import_records_list)[id]
+                    .as_slice()
+                    .iter()
+                    .rposition(|record| {
+                        record.kind == ImportKind::Stmt
+                            && record.source_index.is_valid()
+                            && (record.source_index.get() as usize) < col_ref!(exports_kind).len()
+                            && col_ref!(css_asts)[record.source_index.get() as usize].is_none()
+                    })
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+
             for (import_record_index, record) in col_ref!(import_records_list)[id]
                 .as_slice()
                 .iter()
@@ -224,6 +246,14 @@ pub(crate) fn scan_imports_and_exports(
                     continue;
                 }
                 let other_kind = col_ref!(exports_kind)[other_file];
+
+                if import_record_index < html_last_script_record
+                    && record.kind == ImportKind::Stmt
+                    && other_kind == ExportsKind::Esm
+                    && col_ref!(flags)[other_file].is_async_or_has_async_dependency
+                {
+                    col!(flags)[other_file].wrap = WrapKind::Esm;
+                }
 
                 // Union, per importee, of the export names its importers can
                 // observe: named static imports contribute their aliases, a

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -338,7 +338,8 @@ console.log("app: ready");`,
   });
 
   // A classic script that uses CommonJS features (here a UMD wrapper) is
-  // wrapped in a closure by the bundler. The page still runs it in its place.
+  // wrapped in a closure by the bundler. The page still runs it in its place,
+  // also relative to a wrapped module script next to it.
   itBundled("html/commonjs-script-runs-in-place", {
     outdir: "out/",
     files: {
@@ -348,6 +349,7 @@ console.log("app: ready");`,
   <body>
     <script src="./first.js"></script>
     <script src="./umd-badge.js"></script>
+    <script type="module" src="./widget.js"></script>
     <script src="./last.js"></script>
   </body>
 </html>`,
@@ -360,11 +362,18 @@ console.log("app: ready");`,
   console.log("umd badge");
   return {};
 });`,
+      "/widget.js": `
+console.log("widget: start");
+await 0;
+console.log("widget: ready");`,
       "/last.js": `console.log("last");`,
     },
     entryPoints: ["/index.html"],
-    onAfterBundle: writePageRunner,
-    run: { file: "out/run.mjs", stdout: "first\numd badge\nlast" },
+    onAfterBundle(api) {
+      expect(api.readFile("out/" + pageScript(api))).not.toContain("__toESM");
+      writePageRunner(api, `console.log("chunk settled");`);
+    },
+    run: { file: "out/run.mjs", stdout: "first\numd badge\nwidget: start\nlast\nwidget: ready\nchunk settled" },
   });
 
   // A script that another module also loads with import() is lazily

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect } from "bun:test";
-import { itBundled } from "./expectBundled";
+import { type BundlerTestBundleAPI, itBundled } from "./expectBundled";
+
+/** The script chunk `out/index.html` loads, relative to `out/`. */
+function pageScript(api: BundlerTestBundleAPI): string {
+  const src = api.readFile("out/index.html").match(/<script type="module" crossorigin src="([^"]+\.js)">/);
+  expect(src).not.toBeNull();
+  return "./" + src![1].replace(/^\.\//, "");
+}
+
+/** Writes `out/run.mjs`, which evaluates the page's script chunk like the browser's module loader would. */
+function writePageRunner(api: BundlerTestBundleAPI, after = "") {
+  api.writeFile("out/run.mjs", `await import(${JSON.stringify(pageScript(api))});\n${after}`);
+}
 
 describe("bundler", () => {
   // Basic test for bundling HTML with JS and CSS
@@ -247,6 +259,139 @@ export const padZero = (num) => String(num).padStart(2, '0');`,
       expect(api.readFile("out/" + jsMatch![1])).toMatch(/"first"[\s\S]*"second"/);
       api.expectFile("out/second.js").toContain('console.log("second")');
     },
+  });
+
+  // The scripts of a page behave like separate <script type="module"> tags:
+  // a script that suspends on a top-level await does not hold back the
+  // scripts after it, and the chunk settles once every script has.
+  for (const minify of [false, true]) {
+    itBundled("html/top-level-await-does-not-block-later-scripts" + (minify ? "-minified" : ""), {
+      outdir: "out/",
+      minifySyntax: minify,
+      minifyIdentifiers: minify,
+      minifyWhitespace: minify,
+      files: {
+        "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="./app.js"></script>
+  </head>
+  <body>
+    <main id="m">catalogue</main>
+    <script src="./legacy-badge.js"></script>
+    <script type="module" src="./widget.js"></script>
+  </body>
+</html>`,
+        "/app.js": `
+import { currencies } from "./currencies.js";
+console.log("app: start");
+const cfg = await new Promise(resolve => setTimeout(() => resolve({ currency: currencies[0] }), 0));
+console.log("app: loaded " + cfg.currency);`,
+        "/currencies.js": `export const currencies = ["EUR"];`,
+        "/legacy-badge.js": `console.log("legacy badge");`,
+        "/widget.js": `
+console.log("widget: start");
+await 0;
+console.log("widget: ready");`,
+      },
+      entryPoints: ["/index.html"],
+      onAfterBundle: api => writePageRunner(api, `console.log("chunk settled");`),
+      run: {
+        file: "out/run.mjs",
+        stdout: "app: start\nlegacy badge\nwidget: start\nwidget: ready\napp: loaded EUR\nchunk settled",
+      },
+    });
+  }
+
+  // A single script has nothing after it to hold back, so its top-level
+  // await stays inline instead of costing a wrapper.
+  itBundled("html/single-top-level-await-script-stays-inline", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./styles.css">
+    <script type="module" src="./app.js"></script>
+  </head>
+  <body>
+    <img src="./logo.png">
+  </body>
+</html>`,
+      "/styles.css": `body { color: red; }`,
+      "/logo.png": `not really a png`,
+      "/app.js": `
+console.log("app: start");
+await 0;
+console.log("app: ready");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/" + pageScript(api));
+      expect(js).not.toContain("__esm");
+      expect(js).toContain("await 0");
+      writePageRunner(api, `console.log("chunk settled");`);
+    },
+    run: { file: "out/run.mjs", stdout: "app: start\napp: ready\nchunk settled" },
+  });
+
+  // A classic script that uses CommonJS features (here a UMD wrapper) is
+  // wrapped in a closure by the bundler. The page still runs it in its place.
+  itBundled("html/commonjs-script-runs-in-place", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="./first.js"></script>
+    <script src="./umd-badge.js"></script>
+    <script src="./last.js"></script>
+  </body>
+</html>`,
+      "/first.js": `console.log("first");`,
+      "/umd-badge.js": `
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) module.exports = factory();
+  else root.Badge = factory();
+})(globalThis, function () {
+  console.log("umd badge");
+  return {};
+});`,
+      "/last.js": `console.log("last");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle: writePageRunner,
+    run: { file: "out/run.mjs", stdout: "first\numd badge\nlast" },
+  });
+
+  // A script that another module also loads with import() is lazily
+  // initialized by the bundler. The page still runs it in its place.
+  itBundled("html/script-also-imported-dynamically-runs-in-place", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="./first.js"></script>
+    <script type="module" src="./shared.js"></script>
+    <script type="module" src="./last.js"></script>
+  </body>
+</html>`,
+      "/first.js": `console.log("first");`,
+      "/shared.js": `
+export const value = 42;
+console.log("shared");`,
+      "/last.js": `
+console.log("last");
+import("./shared.js").then(m => console.log("value " + m.value));`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle: writePageRunner,
+    run: { file: "out/run.mjs", stdout: "first\nshared\nlast\nvalue 42" },
   });
 
   // Test CSS imports

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -141,11 +141,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-qjznw47b.js",
+                "path": "./client-17qwkagd.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "l5IfNVyE54s",
+                  "etag": "wUd3HJPK0E0",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -155,7 +155,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "xh1kdn7wbmI",
+                  "etag": "7cWfVx3iGHs",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
@@ -325,17 +325,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "Dl7kT6q7eY4",
+                  "etag": "ahXYAS2wHVA",
                 },
                 "input": "home.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./home-ey4favse.js",
+                "path": "./home-anr1dgxg.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "IhvRaM9jGDU",
+                  "etag": "wQCXUa45sTM",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -360,17 +360,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "RCRrF1EbBvo",
+                  "etag": "GmKAEu8UC_0",
                 },
                 "input": "about.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./about-44bqhv6t.js",
+                "path": "./about-t20jfmbx.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "2OGqRD6vx54",
+                  "etag": "uzXGsZwjhWg",
                 },
                 "input": "about.html",
                 "isEntry": true,

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -224,7 +224,7 @@ console.log("How...dashing?");
   "content-length": "316",
   "content-type": "text/javascript;charset=utf-8",
   "date": "<date>",
-  "etag": ""f862dbeedf9b72bc"",
+  "etag": ""a755ade5da9c0156"",
   "sourcemap": "/chunk-HASH.js.map",
 }
 `);


### PR DESCRIPTION
### Problem
- `bun build ./index.html` and `Bun.serve({ development: false })` flatten a page's `<script src>` tags into one module, so a script with a top-level `await` holds back every later script. A classic `document.write` snippet then runs after load and erases the page. The dev server is fine.
- Same cause: a classic script that parses as CommonJS (a UMD library) gets a `__commonJS` wrapper that nothing calls, so it never runs. A script that is also `import()`ed runs at the `import()`, not at its tag.
- Cause: the HTML loader (`ParseTask.rs`, `Loader::Html`) gave the page module import records but no import statements, so the linker had no import sites to order or call wrappers from.

### Fix
- Each `<script src>` becomes a bare `import` in its own part, in document order. A wrapped script's wrapper is now called where its tag was.
- An async script with a later sibling gets an async `__esm` wrapper. The page module starts it in place, unawaited, and awaits it at the end of the chunk, as browsers and the dev server run separate module scripts.
- Other pages keep the same JS bytes. Only their chunk hash moves (three snapshot updates).
- Verified: `test/bundler/bundler_html.test.ts` (5 new cases, 4 fail on 1.4.3). Also the HTML serve, manifest, splitting and dev server suites.

### Background
- An HTML entry is bundled as a JS module that imports the page's scripts, and the page loads that one chunk. The linker hoists modules into one flat chunk. A module it cannot hoist (CommonJS, an `import()` target without splitting) gets a wrapper, `require_x` or `init_x`, that each import site calls, with `await` when it is async.
- In the browser, a module script's pending top-level await does not delay the next `<script>` element.

<details><summary>Notes</summary>

- Related: #42026 is the part of this change that needs no semantics decision: one part per tag and the wrapper call at the tag, but it prints `await init_x()` in place, so a top-level await still holds back the later scripts (the reported case). If it lands first, this PR rebases onto it and keeps only the top-level-await rule, the tail await and their tests.
- Related: #41982 (draft, pending a direction call) wraps every script of a multi-script page in a `__script(() => {})` error boundary and also covers the top-level await case. It emits the wrapper calls next to the wrapper definitions, which the chunk prints ahead of all flat code, so with tags `[first, umd, tla, last]` that branch runs `umd, tla, first, last`. This PR keeps document order by emitting the calls from the HTML module's own parts, adds no runtime helper, and an error-boundary layer could sit on top of it.
- The chunk hash covers the part ranges of the chunk. The HTML file used to add one empty range and now adds none when all scripts are flat, so hashes and the etags derived from them move while the bytes stay equal.
- Wrapping an async script wraps its dependencies too (the existing `import()`-without-splitting machinery), so only pages that combine a top-level await with a later script pay for closures. The last script of a page never needs one.
- The tail `await init_x()` keeps two properties of today's output: the chunk's evaluation finishes after every script has, and a rejected top-level await surfaces as the module script's error.
- `document.write` from a module script is ignored while the script runs synchronously, but it reopens (erases) the document once the parser is done, which is what the delayed classic script hit.
- A page's CommonJS script is called as `require_x();` with no namespace object, so `__toESM` is not pulled in.
- Asset records (stylesheets, images) join the part of the next script so `find_imported_css_files_in_js_order` still walks them in document order.
- External `<script src="https://...">` tags stay in the HTML as before; their import statements are dropped from the chunk.
- With `--splitting`, a top-level-await script shared by two pages lands in a shared chunk that exports `init_x`; each page chunk starts and awaits it. Checked by hand along with `--compile --target=browser`, `--format=iife`, a server build that imports the page, and the esbuild and cjs2esm suites.
- Found on the way and handed off separately: an unwrapped file that imports two async wrapped modules references `__promiseAll` without bundling it; `init_x()` calls are hoisted above earlier `require_y()` imports in the same file.

</details>
