### PR TITLE
docs: CSS selector-list splitting and :dir() fallback limits, cookie browser limits, fake timer controls

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -410,7 +410,7 @@ For browsers that don't fully support logical properties, Bun's CSS bundler comp
 
 If the `:dir()` selector isn't supported, Bun generates additional fallbacks.
 
-Block-axis properties (`inset-block`, `margin-block`, `padding-block`, `border-block-*`) compile to the physical `top` and `bottom` properties. That is only equivalent in a horizontal writing mode, so content set in `writing-mode: vertical-rl` or `vertical-lr` needs targets that support logical properties natively.
+Block-axis properties (`inset-block`, `margin-block`, `padding-block`, `border-block-*`) compile to their physical top and bottom counterparts (`top`/`bottom`, `margin-top`/`margin-bottom`, and so on) with no per-direction rule. That is only equivalent in a horizontal writing mode, so content set in `writing-mode: vertical-rl` or `vertical-lr` needs targets that support logical properties natively.
 
 ### :dir() selector
 
@@ -465,7 +465,8 @@ The fallback infers direction from the element's language alone: the value `:lan
 nearest `lang` attribute on the element or an ancestor (or from the document). A `dir` attribute is invisible to
 `:lang()`, so `<div dir="rtl">` inside a page with `lang="en"` does not match the fallback for `:dir(rtl)`, and an
 Arabic page that sets `dir="ltr"` on an element still matches it. If your markup sets direction with `dir`, select on
-the attribute instead (`[dir="rtl"]`) or target browsers that support `:dir()`.
+the attribute instead (`.nav-arrow[dir="rtl"]` when the element carries it, `[dir="rtl"] .nav-arrow` when an ancestor
+does) or target browsers that support `:dir()`.
 
 </Warning>
 

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -28,6 +28,31 @@ By default, Bun's CSS bundler targets the following browsers:
 - Safari 14+
 - Opera 67+
 
+Lowering is decided per rule and per selector. When one selector in a selector list needs a fallback that the others do not, or is a selector Bun does not recognize (a vendor-specific pseudo-class, for example), Bun splits the rule into one rule per selector (or, when the targets and the selectors allow it, wraps the list in `:is()`), so that the other selectors keep working everywhere. A rule that counted on one unrecognized selector to make other browsers drop the whole rule, a common form of browser hack, no longer does that after bundling:
+
+<CodeGroup>
+
+```css title="input.css" icon="file-code"
+/* Only Safari understands the second selector, so other browsers drop the rule */
+.callout,
+_::-webkit-full-page-media .never-matches {
+  padding: 1px;
+}
+```
+
+```css title="output.css" icon="file-code"
+/* After bundling, .callout applies in every browser */
+.callout {
+  padding: 1px;
+}
+
+_::-webkit-full-page-media .never-matches {
+  padding: 1px;
+}
+```
+
+</CodeGroup>
+
 ## Syntax Lowering
 
 ### Nesting
@@ -385,6 +410,8 @@ For browsers that don't fully support logical properties, Bun's CSS bundler comp
 
 If the `:dir()` selector isn't supported, Bun generates additional fallbacks.
 
+Block-axis properties (`inset-block`, `margin-block`, `padding-block`, `border-block-*`) compile to the physical `top` and `bottom` properties. That is only equivalent in a horizontal writing mode, so content set in `writing-mode: vertical-rl` or `vertical-lr` needs targets that support logical properties natively.
+
 ### :dir() selector
 
 The `:dir()` pseudo-class styles elements based on their text direction (RTL or LTR), as determined by the document or explicit direction attributes. Use it to write direction-aware styles without JavaScript.
@@ -409,28 +436,35 @@ The `:dir()` pseudo-class styles elements based on their text direction (RTL or 
 }
 ```
 
-For browsers that don't support the `:dir()` selector, Bun's CSS bundler converts it to the more widely supported `:lang()` selector with appropriate language mappings:
+For browsers that don't support the `:dir()` selector, Bun's CSS bundler converts it to the more widely supported `:lang()` selector. `:dir(rtl)` becomes a match on the languages that are written right to left, and `:dir(ltr)` becomes every other language:
 
 ```css title="styles.css" icon="file-code"
-/* Converted to use language-based selectors as fallback */
-.nav-arrow:lang(en, fr, de, es, it, pt, nl) {
+/* Converted to use language-based selectors as fallback (language list shortened here) */
+.nav-arrow:not(:lang(ar, dv, fa, he, ku, ps, sd, ug, ur, yi)) {
   transform: rotate(0deg);
 }
 
-.nav-arrow:lang(ar, he, fa, ur) {
+.nav-arrow:lang(ar, dv, fa, he, ku, ps, sd, ug, ur, yi) {
   transform: rotate(180deg);
 }
 
-.sidebar:lang(en, fr, de, es, it, pt, nl) {
+.sidebar:not(:lang(ar, dv, fa, he, ku, ps, sd, ug, ur, yi)) {
   border-right: 1px solid #ddd;
 }
 
-.sidebar:lang(ar, he, fa, ur) {
+.sidebar:lang(ar, dv, fa, he, ku, ps, sd, ug, ur, yi) {
   border-left: 1px solid #ddd;
 }
 ```
 
 If multiple arguments to `:lang()` aren't supported, Bun generates further fallbacks.
+
+<Warning>
+  The fallback infers direction from the `lang` attribute alone. A `dir` attribute is invisible to `:lang()`, so
+  `<div dir="rtl">` inside a page with `lang="en"` does not match the fallback for `:dir(rtl)`, and an Arabic page that
+  sets `dir="ltr"` on an element still matches it. If your markup sets direction with `dir`, select on the attribute
+  instead (`[dir="rtl"]`) or target browsers that support `:dir()`.
+</Warning>
 
 ### :lang() selector
 

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -460,10 +460,13 @@ For browsers that don't support the `:dir()` selector, Bun's CSS bundler convert
 If multiple arguments to `:lang()` aren't supported, Bun generates further fallbacks.
 
 <Warning>
-  The fallback infers direction from the `lang` attribute alone. A `dir` attribute is invisible to `:lang()`, so
-  `<div dir="rtl">` inside a page with `lang="en"` does not match the fallback for `:dir(rtl)`, and an Arabic page that
-  sets `dir="ltr"` on an element still matches it. If your markup sets direction with `dir`, select on the attribute
-  instead (`[dir="rtl"]`) or target browsers that support `:dir()`.
+
+The fallback infers direction from the element's language alone: the value `:lang()` matches, which comes from the
+nearest `lang` attribute on the element or an ancestor (or from the document). A `dir` attribute is invisible to
+`:lang()`, so `<div dir="rtl">` inside a page with `lang="en"` does not match the fallback for `:dir(rtl)`, and an
+Arabic page that sets `dir="ltr"` on an element still matches it. If your markup sets direction with `dir`, select on
+the attribute instead (`[dir="rtl"]`) or target browsers that support `:dir()`.
+
 </Warning>
 
 ### :lang() selector

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -28,7 +28,7 @@ By default, Bun's CSS bundler targets the following browsers:
 - Safari 14+
 - Opera 67+
 
-Lowering is decided per rule and per selector. When one selector in a selector list needs a fallback that the others do not, or is a selector Bun does not recognize (a vendor-specific pseudo-class, for example), Bun splits the rule into one rule per selector (or, when the targets and the selectors allow it, wraps the list in `:is()`), so that the other selectors keep working everywhere. A rule that counted on one unrecognized selector to make other browsers drop the whole rule, a common form of browser hack, no longer does that after bundling:
+Lowering is decided per rule and per selector. When one selector in a selector list needs a fallback that the others do not, or is a selector Bun does not recognize (a vendor-specific pseudo-class or pseudo-element, for example), Bun splits the rule into one rule per selector (or, when the targets and the selectors allow it, wraps the list in `:is()`), so that the other selectors keep working everywhere. A rule that counted on one unrecognized selector to make other browsers drop the whole rule, a common form of browser hack, no longer does that after bundling:
 
 <CodeGroup>
 

--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -62,6 +62,8 @@ const server = Bun.serve({
 console.log("Server listening at: " + server.url);
 ```
 
+`req.cookies` is parsed from the request's `Cookie` header. HTTP header values are byte strings, so each byte becomes one character. `cookies.set()` percent-encodes values and `CookieMap` percent-decodes them as UTF-8, so any string you set through this API round-trips. A value that reached the browser some other way as raw UTF-8 (for example `document.cookie = "name=café"` in page JavaScript) arrives as Latin-1 characters (`"cafÃ©"`). Decode such a value with `Buffer.from(value, "latin1").toString("utf8")`.
+
 ### Methods
 
 #### `get(name: string): string | null`
@@ -376,6 +378,16 @@ const cookie = Bun.Cookie.from("session", "abc123", {
   maxAge: 3600,
 });
 ```
+
+## Browser limits
+
+`Bun.Cookie` builds the `Set-Cookie` line you ask for. The browser then applies its own rules ([RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265) and the [6265bis draft](https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/)) when it stores the cookie and decides which requests get it back. The ones that most often surprise:
+
+- A cookie whose name plus value is longer than 4096 bytes is not stored at all. The value counts after percent-encoding.
+- An attribute value longer than 1024 bytes is ignored and the cookie is stored with that attribute's default. For `Path` the default is the directory of the request URL. For `Domain` it is the exact request host. Either way the cookie's scope is not the one you wrote.
+- `Path` is matched against the path of later request URLs by whole segments. That path is percent-encoded and never has a query string, a fragment, or `.` and `..` segments, so a `Path` that contains a space, `?`, `#`, `/./` or `/../` never matches and the cookie is never sent.
+- `Max-Age` is a whole number of seconds. Browsers ignore a `Max-Age` attribute with a decimal point in it, which leaves a session cookie, and cap long lifetimes (400 days in Chromium).
+- Every matching cookie comes back on every request in one `Cookie` header. `Bun.serve` rejects a request whose headers exceed `--max-http-header-size` (16 KB by default) with `431 Request Header Fields Too Large`, and the browser keeps sending the same cookies until they expire or the user clears them. Keep the total size of the cookies you set for one site well under that limit.
 
 ## Types
 

--- a/docs/test/dates-times.mdx
+++ b/docs/test/dates-times.mdx
@@ -122,17 +122,17 @@ test("retries after one second", () => {
 });
 ```
 
-| Function                          | What it does                                                                                                                                                                                  |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `jest.useFakeTimers({ now? })`    | Turns fake timers on. `now` (a number or a `Date`) sets what `Date.now()` returns and defaults to the real current time. `performance.now()` starts again from 0.                             |
-| `jest.useRealTimers()`            | Turns fake timers off and discards every pending fake timer without running it.                                                                                                               |
-| `jest.advanceTimersByTime(ms)`    | Moves the clock forward by `ms` milliseconds and runs each timer that comes due, in order. `advanceTimersByTime(0)` runs timers that were scheduled with a 0 ms delay.                        |
-| `jest.advanceTimersToNextTimer()` | Moves the clock to the earliest pending timer and runs it.                                                                                                                                    |
-| `jest.runOnlyPendingTimers()`     | Runs the timers that are pending at the time of the call. Timers that those callbacks schedule stay pending.                                                                                  |
-| `jest.runAllTimers()`             | Runs timers until none are pending, including timers scheduled along the way. An active `setInterval` always schedules another one, so clear intervals first or use `runOnlyPendingTimers()`. |
-| `jest.clearAllTimers()`           | Discards every pending fake timer without running it.                                                                                                                                         |
-| `jest.getTimerCount()`            | Returns the number of pending fake timers.                                                                                                                                                    |
-| `jest.isFakeTimers()`             | Returns `true` while fake timers are on.                                                                                                                                                      |
+| Function                          | What it does                                                                                                                                                                                                |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jest.useFakeTimers({ now? })`    | Turns fake timers on. `now` (a number or a `Date`) sets what `Date.now()` returns and defaults to the real current time. `performance.now()` starts again from 0.                                           |
+| `jest.useRealTimers()`            | Turns fake timers off and discards every pending fake timer without running it.                                                                                                                             |
+| `jest.advanceTimersByTime(ms)`    | Moves the clock forward by `ms` milliseconds and runs each timer that comes due, in order. `advanceTimersByTime(0)` runs timers that were scheduled with a 0 ms delay.                                      |
+| `jest.advanceTimersToNextTimer()` | Moves the clock to the earliest pending timer and runs it.                                                                                                                                                  |
+| `jest.runOnlyPendingTimers()`     | Moves the clock to the latest timer pending at the time of the call and runs every timer due by then. A timer that a callback schedules runs too if it comes due by that time; one due later stays pending. |
+| `jest.runAllTimers()`             | Runs timers until none are pending, including timers scheduled along the way. An active `setInterval` always schedules another one, so clear intervals first or use `runOnlyPendingTimers()`.               |
+| `jest.clearAllTimers()`           | Discards every pending fake timer without running it.                                                                                                                                                       |
+| `jest.getTimerCount()`            | Returns the number of pending fake timers.                                                                                                                                                                  |
+| `jest.isFakeTimers()`             | Returns `true` while fake timers are on.                                                                                                                                                                    |
 
 The functions that do not return a value return the `jest` object, so calls chain: `jest.useFakeTimers().advanceTimersByTime(100)`.
 

--- a/docs/test/dates-times.mdx
+++ b/docs/test/dates-times.mdx
@@ -98,7 +98,13 @@ Use it to read the mocked time without creating a new `Date` object.
 `jest.useFakeTimers()` also puts `setTimeout`, `setInterval`, and `AbortSignal.timeout()` on a fake clock that only moves when the test moves it. `Date.now()`, `new Date()`, and `performance.now()` follow the same clock. `setImmediate`, `process.nextTick`, `queueMicrotask`, and I/O keep running in real time. The same functions exist on `vi` for tests written against Vitest.
 
 ```ts title="test.ts" icon="/icons/typescript.svg"
-import { test, expect, jest } from "bun:test";
+import { afterEach, test, expect, jest } from "bun:test";
+
+// Fake timers stay on until useRealTimers() is called, also when a test fails,
+// so turn them off in afterEach rather than at the end of each test.
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 test("retries after one second", () => {
   jest.useFakeTimers();
@@ -113,8 +119,6 @@ test("retries after one second", () => {
 
   jest.advanceTimersByTime(1);
   expect(retried).toBe(true);
-
-  jest.useRealTimers();
 });
 ```
 

--- a/docs/test/dates-times.mdx
+++ b/docs/test/dates-times.mdx
@@ -93,6 +93,47 @@ test("get the current mocked time", () => {
 
 Use it to read the mocked time without creating a new `Date` object.
 
+## Fake timers
+
+`jest.useFakeTimers()` also puts `setTimeout`, `setInterval`, and `AbortSignal.timeout()` on a fake clock that only moves when the test moves it. `Date.now()`, `new Date()`, and `performance.now()` follow the same clock. `setImmediate`, `process.nextTick`, `queueMicrotask`, and I/O keep running in real time. The same functions exist on `vi` for tests written against Vitest.
+
+```ts title="test.ts" icon="/icons/typescript.svg"
+import { test, expect, jest } from "bun:test";
+
+test("retries after one second", () => {
+  jest.useFakeTimers();
+
+  let retried = false;
+  setTimeout(() => {
+    retried = true;
+  }, 1000);
+
+  jest.advanceTimersByTime(999);
+  expect(retried).toBe(false);
+
+  jest.advanceTimersByTime(1);
+  expect(retried).toBe(true);
+
+  jest.useRealTimers();
+});
+```
+
+| Function                          | What it does                                                                                                                                                                                  |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `jest.useFakeTimers({ now? })`    | Turns fake timers on. `now` (a number or a `Date`) sets what `Date.now()` returns and defaults to the real current time. `performance.now()` starts again from 0.                             |
+| `jest.useRealTimers()`            | Turns fake timers off and discards every pending fake timer without running it.                                                                                                               |
+| `jest.advanceTimersByTime(ms)`    | Moves the clock forward by `ms` milliseconds and runs each timer that comes due, in order. `advanceTimersByTime(0)` runs timers that were scheduled with a 0 ms delay.                        |
+| `jest.advanceTimersToNextTimer()` | Moves the clock to the earliest pending timer and runs it.                                                                                                                                    |
+| `jest.runOnlyPendingTimers()`     | Runs the timers that are pending at the time of the call. Timers that those callbacks schedule stay pending.                                                                                  |
+| `jest.runAllTimers()`             | Runs timers until none are pending, including timers scheduled along the way. An active `setInterval` always schedules another one, so clear intervals first or use `runOnlyPendingTimers()`. |
+| `jest.clearAllTimers()`           | Discards every pending fake timer without running it.                                                                                                                                         |
+| `jest.getTimerCount()`            | Returns the number of pending fake timers.                                                                                                                                                    |
+| `jest.isFakeTimers()`             | Returns `true` while fake timers are on.                                                                                                                                                      |
+
+The functions that do not return a value return the `jest` object, so calls chain: `jest.useFakeTimers().advanceTimersByTime(100)`.
+
+Only timers created after `useFakeTimers()` are fake. A `setTimeout` that was already scheduled when fake timers were turned on still fires in real time, and `getTimerCount()` does not count it.
+
 ## Set the time zone
 
 By default, `bun test` runs in UTC (`Etc/UTC`). To change the time zone, either pass the `TZ` environment variable to `bun test`:


### PR DESCRIPTION
### Problem
- Three documented features have behavior a reader cannot predict from the page. `docs/bundler/css.mdx` does not say that a selector list with one unsupported selector is split into separate rules, so a whole-rule browser hack (`.a, _::-webkit-full-page-media .b {}`) starts applying everywhere after `bun build`. Its `:dir()` fallback example shows a shape Bun does not emit and does not say the fallback ignores `dir` attributes.
- `docs/runtime/cookies.mdx` has no word on the limits browsers apply to what `Bun.Cookie` serializes (4096-byte name+value, 1024-byte attributes, `Path` matching, integer `Max-Age`, total `Cookie` header size against `--max-http-header-size`), or on request cookie values being byte strings.
- No docs page mentions `advanceTimersByTime`, `runOnlyPendingTimers`, `runAllTimers`, `advanceTimersToNextTimer`, `clearAllTimers`, `getTimerCount` or `isFakeTimers`. They exist only as bare declarations in `packages/bun-types/test.d.ts`.

### Fix
- `css.mdx`: a paragraph plus input/output example on selector-list splitting under Browser Compatibility, one paragraph on block-axis logical properties lowering to `top`/`bottom`, a corrected `:dir()` fallback example (`:not(:lang(<rtl list>))` for `ltr`), and a warning that the fallback reads `lang`, not `dir`.
- `cookies.mdx`: a paragraph under "In HTTP servers" on byte-string values and percent-encoding round-trips, and a "Browser limits" section before Types.
- `dates-times.mdx`: a "Fake timers" section with an example, a table of the control functions, what `useFakeTimers` fakes (`setTimeout`, `setInterval`, `AbortSignal.timeout()`, `Date`, `performance.now()`) and what stays real.
- Verified: every statement was checked against bun 1.4.3 output and the source on main (`src/css/rules/mod.rs:665`, `src/css/selectors/selector.rs:187`, `src/css/properties/margin_padding.rs:836`, `src/jsc/bindings/CookieMap.cpp:94`, `src/runtime/test_runner/timers/FakeTimers.rs`, `src/event_loop/EventLoopTimer.rs:221`). The example test in `dates-times.mdx` passes as written. `prettier --check` passes.

### Background
- Bun's CSS pipeline is a port of LightningCSS. With the default targets (Chrome 80, Firefox 78, Safari 14) it lowers selectors per rule: `src/css/rules/mod.rs` partitions a style rule's selector list into compatible and incompatible selectors and emits the incompatible ones as their own rules.
- `:dir()` lowering (`src/css/selectors/selector.rs`) maps `rtl` to a fixed list of right-to-left language codes under `:lang()` and `ltr` to `:not()` of that list.
- `req.cookies` is a `CookieMap` built from the `Cookie` header, which the server stores as Latin-1 (one character per byte). `CookieMap` percent-decodes values as UTF-8 when a `%` is present. `Bun.Cookie` percent-encodes on serialize.

<details><summary>Notes</summary>

- Docs only. No runtime or type changes.
- Does not touch `css.mdx` lines 533-536 and 589 (the `:is()`/`:not()` prefixing claims). Those are tied to a code change in the `:not()` lowering path and are handled separately.
- Does not overlap with the open docs PRs #41918, #41937, #41943, #41971, #41813, #41728, or with #41964 (cookie attribute limits in code), #41959, #41982.
- Probes used (bun 1.4.3): `bun build ./hack.css` for the split example (output is byte-identical to the doc), `bun build ./dir.css` for the `:dir()` and `inset-block` shapes, `new Bun.CookieMap("raw=caf\xC3\xA9")` for the Latin-1 note, and a `bun test` file exercising every function in the fake-timer table (including `setImmediate`/`nextTick`/`queueMicrotask` staying real, pre-existing timers staying real, and chaining).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->