### PR TITLE
Report a late rejection of the HTML entry point or a runMain override once

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2938,6 +2938,8 @@ impl VirtualMachine {
                         JSC__JSInternalPromise__resolvedPromise(global_ref, ret)
                     })
                     .map_err(|_| crate::CrateError::JSError)?;
+                    // This VM reports the entry promise itself; the loader's promises come handled too.
+                    crate::JSPromise::opaque_mut(resolved).set_handled();
                     self.pending_internal_promise = Some(resolved);
                     self.pending_internal_promise_is_protected = false;
                     return Ok(resolved);

--- a/src/jsc/bindings/HTMLEntryPoint.cpp
+++ b/src/jsc/bindings/HTMLEntryPoint.cpp
@@ -37,6 +37,8 @@ extern "C" JSPromise* Bun__loadHTMLEntryPoint(Zig::GlobalObject* globalObject)
     if (!promise) [[unlikely]] {
         BUN_PANIC("Failed to load HTML entry point");
     }
+    // The VM reports a rejected entry point promise itself, as with the handled promise from JSC::loadAndEvaluateModule().
+    promise->markAsHandled();
     return promise;
 }
 

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -675,6 +675,54 @@ test("importing bun:main from HTML entry preload does not crash", async () => {
   await proc.exited;
 });
 
+// The bad port makes Bun.serve() throw in internal/html's start() after its first await: the entry point fails, reported once.
+test.concurrent("bun ./index.html prints a late start() failure once", async () => {
+  using dir = tempDir("html-entry-late-rejection", {
+    "index.html": `<!DOCTYPE html><html><body><h1>Hello</h1></body></html>`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./index.html", "--port=99999", "--hostname=127.0.0.1"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({
+    stdout,
+    rangeErrorsPrinted: stderr.match(/^RangeError: /gm)?.length ?? 0,
+    exitCode,
+  }).toEqual({ stdout: "", rangeErrorsPrinted: 1, exitCode: 1 });
+  expect(stderr).toContain(`"options.port"`);
+});
+
+test.concurrent("bun ./index.html reports a late start() failure to process listeners once", async () => {
+  using dir = tempDir("html-entry-late-rejection-listeners", {
+    "index.html": `<!DOCTYPE html><html><body><h1>Hello</h1></body></html>`,
+    "listeners.cjs": `
+      process.on("unhandledRejection", err => console.log("unhandledRejection:", err.code));
+      process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.code, origin));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./listeners.cjs", "./index.html", "--port=99999", "--hostname=127.0.0.1"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "uncaughtException: ERR_OUT_OF_RANGE unhandledRejection\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/24031
 test.concurrent("subdirectory routes use forward slashes on Windows", async () => {
   await using dir = tempDir("html-subdir-routes", {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -890,6 +890,92 @@ console.log("survived", require("./late.js"));`,
     expect(stdout.trim()).toBe("pass");
     expect(await proc.exited).toBe(0);
   });
+
+  // bun adopts the override's return value as the entry point promise: a rejection is the entry point failing, reported once.
+  const rejectingRunMainOverrides = [
+    ["an already rejected promise", `async () => { throw new Error("run-main-boom"); }`],
+    ["a promise that rejects later", `async () => { await 0; throw new Error("run-main-boom"); }`],
+    ["a thenable that rejects", `() => ({ then(_, reject) { reject(new Error("run-main-boom")); } })`],
+  ];
+  test.each(rejectingRunMainOverrides)(
+    "Module.runMain override returning %s prints the error once",
+    async (_, runMain) => {
+      using dir = tempDir("run-main-rejection", {
+        "preload.cjs": `require("module").runMain = ${runMain};`,
+        "main.cjs": `console.log("main ran");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--require", "./preload.cjs", "./main.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, errorsPrinted: stderr.split("error: run-main-boom").length - 1, exitCode }).toEqual({
+        stdout: "",
+        errorsPrinted: 1,
+        exitCode: 1,
+      });
+    },
+  );
+  const listenersThenOverride = runMain => `
+    process.on("unhandledRejection", err => console.log("unhandledRejection:", err.message));
+    process.on("uncaughtException", (err, origin) => console.log("uncaughtException:", err.message, origin));
+    require("module").runMain = ${runMain};
+  `;
+  test.each(rejectingRunMainOverrides)(
+    "Module.runMain override returning %s reports the error to process once, as the entry point failing",
+    async (_, runMain) => {
+      using dir = tempDir("run-main-rejection-listeners", {
+        "preload.cjs": listenersThenOverride(runMain),
+        "main.cjs": `console.log("main ran");`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--require", "./preload.cjs", "./main.cjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "uncaughtException: run-main-boom unhandledRejection\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
+  // A worker's preload can override runMain too, and the worker checks its entry point promise the same way.
+  test("Module.runMain override in a worker preload reports a late rejection to the worker's process once", async () => {
+    const [, lateRejection] = rejectingRunMainOverrides[1];
+    using dir = tempDir("run-main-rejection-worker", {
+      "preload.cjs": listenersThenOverride(lateRejection),
+      "body.cjs": `console.log("worker body ran");`,
+      "main.cjs": `
+        const { Worker } = require("worker_threads");
+        const path = require("path");
+        const worker = new Worker(path.join(__dirname, "body.cjs"), { preload: [path.join(__dirname, "preload.cjs")] });
+        worker.on("exit", code => { process.exitCode = code; });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "./main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "uncaughtException: run-main-boom unhandledRejection\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],


### PR DESCRIPTION
### Problem
- `bun ./index.html --port=99999` prints `RangeError: The value of "options.port" is out of range ... at start (internal:html)` twice and exits 1. So does any throw in `internal/html`'s `start()` after its first `await`, or a `Module.runMain` override whose promise rejects later.
- Cause: the VM reports a rejected entry point promise itself (`src/runtime/cli/run_command.rs:1428`). Two producers store it without the handled flag, so a late rejection reaches the rejection tracker too: `Bun__loadHTMLEntryPoint` (`src/jsc/bindings/HTMLEntryPoint.cpp:40`) and the adopted override result (`src/jsc/VirtualMachine.rs:2941`).

### Fix
- Mark both promises as handled where they are produced, so the entry point reporter is the only one (also under `--hot` and in a worker).
- Correct because every other producer is the JSC module loader, which sets the flag for the same reason. Both paths now match a module entry that throws after a top-level `await`: printed once, exit 1, one `uncaughtException` event.
- Excluded: the macro runner has the same shape. #40059 rewrites it and sets the flag there.
- Verified: `bun-serve-html-entry.test.ts` (2 new), `node-module-module.test.js` (7 new, 5 fail on 1.4.3 canary). Self-reviewed: 8 concerns, all packaging, addressed by folding #38160 in.

### Background
- `pending_internal_promise` holds the entry point promise. `Run::start` waits for it and reports a rejection as an uncaught exception.
- `Bun__loadHTMLEntryPoint` runs `internal/html`'s async `start()`, not the module loader. When a preload overrides `Module.runMain`, bun adopts the override's return value as that promise.
- Rejection tracker: JSC tells Bun when a promise with no handler rejects. Bun reports it at the end of the tick unless it is handled by then.

<details><summary>Notes</summary>

This PR supersedes #38160, which fixed only the `Module.runMain` site. Its tests are carried over here unchanged apart from shortened comments.

Probes on 1.4.3-canary.1+f42e98025 (before) and the debug build of this branch (after).

HTML entry, `bun ./index.html --port=99999 --hostname=127.0.0.1` in a directory with one `index.html`:

```
no listeners                         before: printed twice, exit 1      after: printed once, exit 1
--hot                                before: printed twice              after: printed once
unhandledRejection + uncaughtException listeners (preload)
                                     before: both fire                  after: only uncaughtException (origin unhandledRejection), exit 0
unhandledRejection listener only     before: fires, then printed, exit 1
                                     after: printed, exit 1 (same as a module entry, and as Node for a rejected main module promise)
bun './*.html' with no match         before and after: printed once, exit 1
```

`Module.runMain` override installed by `--require`, entry `main.cjs`:

```
async () => { await 0; throw }                    before: printed twice, exit 1   after: once
() => ({ then(_, reject) { reject(err) } })       before: printed twice, exit 1   after: once
async () => { throw }  (already rejected)         before and after: once
late override + both listeners                    before: both fire               after: only uncaughtException (origin unhandledRejection)
worker with { preload } installing the override   before: both listeners fire in the worker   after: only uncaughtException
```

A rejection before the first `await` printed once already: `Run::start` reports and marks an already rejected promise before the tracker drains. The two early-return paths in `Bun__loadHTMLEntryPoint` (`rejectedPromiseWithCaughtException`) are that case and are left as they were.

The other stores into `pending_internal_promise` all hold module loader promises: `load_preloads` (`JSC::importModule`), the main entry and the test runner entry (`JSC::loadAndEvaluateModule`), and an override that calls the original `runMain` (`JSC::loadAndEvaluateModule` via `NodeModuleModule.cpp`). JSC marks each of those handled on creation (`Completion.cpp`, `JSModuleLoader.cpp` in oven-sh/WebKit at 2e2aa229).

Under `--hot` the second reporter was `report_exception_in_hot_reloaded_module_if_needed`. In a worker it was the worker's entry check in `web_worker.rs`. The handled flag covers both the same way.

Also ran: the rest of both test files, `bun-serve-html.test.ts`, `bun-serve-html-405.test.ts`, `bun-serve-html-manifest.test.ts`, `test-module-run-main-monkey-patch.js`, `test/cli/run/preload-test.test.js`, `test/js/bun/resolve/bun-main-entry-point.test.ts`.

The error output for the HTML case still shows a source snippet from `internal:html`. That is how the error printer treats any top frame in an internal module (for example `Readable.from(42)` shows `internal:streams/from`), so it is not specific to this path and not changed here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->