### PR TITLE
js_parser: fold references to const variables in enum initializers

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -734,7 +734,7 @@ impl Number {
         Self::to_string_from_f64(self.value(), bump)
     }
 
-    pub(crate) fn to_string_from_f64(value: f64, bump: &Bump) -> Option<Str> {
+    pub fn to_string_from_f64(value: f64, bump: &Bump) -> Option<Str> {
         if value == value.trunc() && (value < i32::MAX as f64 && value > i32::MIN as f64) {
             let int_value = value as i64;
             let abs = int_value.unsigned_abs();

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -213,6 +213,13 @@ pub struct RecentlyVisitedTSNamespace {
     pub(crate) map: Option<js_ast::StoreRef<js_ast::TSNamespaceMemberMap>>,
 }
 
+/// The value of a TypeScript constant expression. The string is never a rope.
+#[derive(Clone, Copy)]
+pub(crate) enum TSConstantValue {
+    Number(f64),
+    String(js_ast::StoreRef<E::EString>),
+}
+
 #[derive(Clone, Copy)]
 pub struct ReactRefreshImportClause<'a> {
     pub(crate) name: &'a [u8],
@@ -693,6 +700,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// node has metadata) and "tsNamespaceMemberData" will be set to the metadata.
     pub(crate) ts_namespace: RecentlyVisitedTSNamespace,
     pub(crate) top_level_enums: List<'a, Ref>,
+
+    /// Since TypeScript 5.0 an enum member initializer may reference a `const`
+    /// variable whose own initializer is a constant expression. Enums are
+    /// visited before the other statements of their list, so these values are
+    /// computed from the unvisited declarations (`record_ts_enum_constants`)
+    /// and substituted only while an enum member initializer is visited.
+    pub(crate) ts_enum_constants: HashMap<Ref, TSConstantValue>,
+    pub(crate) is_visiting_ts_enum_initializer: bool,
 
     // Value is a shared `&'a [ScopeOrder<'a>]`. The visit pass never writes
     // through these slices — it only reads
@@ -2270,6 +2285,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         if TYPESCRIPT {
+            if self.is_visiting_ts_enum_initializer
+                && let Some(&value) = self.ts_enum_constants.get(&ref_)
+            {
+                self.ignore_usage(ref_);
+                let name = self.symbols[ref_.inner_index() as usize]
+                    .original_name
+                    .slice();
+                let value = match value {
+                    TSConstantValue::Number(num) => Expr {
+                        loc,
+                        data: js_ast::ExprData::ENumber(E::Number::new(num)),
+                    },
+                    TSConstantValue::String(str_) => self.new_expr(&*str_, loc),
+                };
+                return self.wrap_inlined_enum(value, name);
+            }
+
             if let Some(member_data) = self.ref_to_ts_namespace_member.get(&ref_) {
                 match member_data {
                     js_ast::ts::Data::EnumNumber(num) => {
@@ -9827,6 +9859,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 map: None,
             },
             top_level_enums: BumpVec::new_in(arena),
+            ts_enum_constants: Default::default(),
+            is_visiting_ts_enum_initializer: false,
             scopes_in_order_for_enum: Default::default(),
             will_wrap_module_in_try_catch_for_using: false,
             nearest_stmt_list: None,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -701,11 +701,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub(crate) ts_namespace: RecentlyVisitedTSNamespace,
     pub(crate) top_level_enums: List<'a, Ref>,
 
-    /// Since TypeScript 5.0 an enum member initializer may reference a `const`
-    /// variable whose own initializer is a constant expression. Enums are
-    /// visited before the other statements of their list, so these values are
-    /// computed from the unvisited declarations (`record_ts_enum_constants`)
-    /// and substituted only while an enum member initializer is visited.
+    /// `const` values an enum initializer can fold (TS 5.0), see `record_ts_enum_constants`.
     pub(crate) ts_enum_constants: HashMap<Ref, TSConstantValue>,
     pub(crate) is_visiting_ts_enum_initializer: bool,
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -704,6 +704,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// `const` values an enum initializer can fold (TS 5.0), see `record_ts_enum_constants`.
     pub(crate) ts_enum_constants: HashMap<Ref, TSConstantValue>,
     pub(crate) is_visiting_ts_enum_initializer: bool,
+    /// `const x: T = ...`: tsc does not fold a const with a type annotation.
+    pub(crate) ts_annotated_constants: RefMap,
 
     // Value is a shared `&'a [ScopeOrder<'a>]`. The visit pass never writes
     // through these slices — it only reads
@@ -7273,6 +7275,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 }
 
+/// Drops the entries keyed by symbols at index `symbols_len` and above.
+fn forget_symbols_from<V>(map: &mut HashMap<Ref, V>, symbols_len: usize) {
+    let stale: Vec<Ref> = map
+        .keys()
+        .filter(|ref_| ref_.inner_index() as usize >= symbols_len)
+        .copied()
+        .collect();
+    for ref_ in stale {
+        map.remove(&ref_);
+    }
+}
+
 /// The unscoped npm package of a specifier (`react/x`) or path (`node_modules<sep>react<sep>x.js`).
 fn path_package_name<'a>(path: &fs::Path<'a>) -> Option<&'a [u8]> {
     let (name_to_use, separators): (&[u8], &[u8]) =
@@ -8357,15 +8371,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if TYPESCRIPT {
                 self.ts_use_counts.truncate(snapshot.symbols_len);
             }
-            let stale: Vec<Ref> = self
-                .ref_to_ts_namespace_member
-                .keys()
-                .filter(|ref_| ref_.inner_index() as usize >= snapshot.symbols_len)
-                .copied()
-                .collect();
-            for ref_ in stale {
-                self.ref_to_ts_namespace_member.remove(&ref_);
-            }
+            forget_symbols_from(&mut self.ref_to_ts_namespace_member, snapshot.symbols_len);
+            forget_symbols_from(&mut self.ts_annotated_constants, snapshot.symbols_len);
         }
         self.allocated_names.truncate(snapshot.allocated_names_len);
         self.import_records.truncate(snapshot.import_records_len);
@@ -9857,6 +9864,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             top_level_enums: BumpVec::new_in(arena),
             ts_enum_constants: Default::default(),
             is_visiting_ts_enum_initializer: false,
+            ts_annotated_constants: Default::default(),
             scopes_in_order_for_enum: Default::default(),
             will_wrap_module_in_try_catch_for_using: false,
             nearest_stmt_list: None,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1302,6 +1302,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if is_definite_assignment_assertion || p.lexer.token == T::TColon {
                     p.lexer.expect(T::TColon)?;
                     p.skip_type_script_type(Level::Lowest)?;
+                    if kind == js_ast::symbol::Kind::Constant
+                        && let js_ast::binding::Data::BIdentifier(id) = local.data
+                    {
+                        p.ts_annotated_constants.insert(id.r#ref, ());
+                    }
                 }
             }
 

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -991,24 +991,29 @@ impl<'a> Parser<'a> {
             let mut preprocessed_enum_i: usize = 0;
             if p.scopes_in_order_for_enum.count() > 0 {
                 for stmt in stmts.iter_mut() {
-                    if matches!(stmt.data, js_ast::StmtData::SEnum(_)) {
-                        let old_scopes_in_order = p.scope_order_to_visit;
-                        let idx = p
-                            .scopes_in_order_for_enum
-                            .keys()
-                            .iter()
-                            .position(|k| *k == stmt.loc)
-                            .expect("enum scope-order entry recorded during parse");
-                        // Map stores `&'a [ScopeOrder]`; shared borrow may freely alias the inner
-                        // re-lookup performed by `append_part → visit_stmts`.
-                        p.scope_order_to_visit = p.scopes_in_order_for_enum.values()[idx];
+                    match stmt.data {
+                        js_ast::StmtData::SEnum(_) => {
+                            let old_scopes_in_order = p.scope_order_to_visit;
+                            let idx = p
+                                .scopes_in_order_for_enum
+                                .keys()
+                                .iter()
+                                .position(|k| *k == stmt.loc)
+                                .expect("enum scope-order entry recorded during parse");
+                            // Map stores `&'a [ScopeOrder]`; shared borrow may freely alias the inner
+                            // re-lookup performed by `append_part → visit_stmts`.
+                            p.scope_order_to_visit = p.scopes_in_order_for_enum.values()[idx];
 
-                        let mut enum_parts = BumpVec::<js_ast::Part>::new_in(arena);
-                        let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(&mut enum_parts, sliced)?;
-                        preprocessed_enums.push(enum_parts);
+                            let mut enum_parts = BumpVec::<js_ast::Part>::new_in(arena);
+                            let sliced = arena.alloc_slice_copy(&[*stmt]);
+                            p.append_part(&mut enum_parts, sliced)?;
+                            preprocessed_enums.push(enum_parts);
 
-                        p.scope_order_to_visit = old_scopes_in_order;
+                            p.scope_order_to_visit = old_scopes_in_order;
+                        }
+                        // An enum above can only see the constants declared before it.
+                        js_ast::StmtData::SLocal(local) => p.record_ts_enum_constants(&local),
+                        _ => {}
                     }
                 }
             }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1000,8 +1000,7 @@ impl<'a> Parser<'a> {
                                 .iter()
                                 .position(|k| *k == stmt.loc)
                                 .expect("enum scope-order entry recorded during parse");
-                            // Map stores `&'a [ScopeOrder]`; shared borrow may freely alias the inner
-                            // re-lookup performed by `append_part → visit_stmts`.
+                            // A shared `&'a [ScopeOrder]`: `append_part -> visit_stmts` may re-read it.
                             p.scope_order_to_visit = p.scopes_in_order_for_enum.values()[idx];
 
                             let mut enum_parts = BumpVec::<js_ast::Part>::new_in(arena);

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1978,8 +1978,7 @@ pub(crate) fn float_to_int32(f: f64) -> i32 {
     if f < 0.0 { 0i32.wrapping_sub(int) } else { int }
 }
 
-/// The arithmetic and bitwise binary operators applied to two numbers with
-/// JavaScript semantics. `None` for any other operator.
+/// A JavaScript arithmetic or bitwise binary operator on two numbers, `None` for other operators.
 pub(crate) fn fold_numeric_binary_operator(
     op: js_ast::OpCode,
     left: f64,
@@ -1991,9 +1990,7 @@ pub(crate) fn fold_numeric_binary_operator(
         Op::BinSub => left - right,
         Op::BinMul => left * right,
         Op::BinDiv => left / right,
-        // Rust `%` on f64 has libc fmod semantics (LLVM frem),
-        // which matches what JavaScriptCore does:
-        // https://github.com/oven-sh/WebKit/blob/7a0b13626e5db69aa5a32d037431d381df5dfb61/Source/JavaScriptCore/runtime/MathCommon.cpp#L574-L597
+        // f64 `%` is fmod (LLVM frem), which is what JavaScriptCore does (`Math::fmodDouble`).
         Op::BinRem => left % right,
         Op::BinPow => js_ast::math::pow(left, right),
         Op::BinShl => {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1978,6 +1978,44 @@ pub(crate) fn float_to_int32(f: f64) -> i32 {
     if f < 0.0 { 0i32.wrapping_sub(int) } else { int }
 }
 
+/// The arithmetic and bitwise binary operators applied to two numbers with
+/// JavaScript semantics. `None` for any other operator.
+pub(crate) fn fold_numeric_binary_operator(
+    op: js_ast::OpCode,
+    left: f64,
+    right: f64,
+) -> Option<f64> {
+    use js_ast::OpCode as Op;
+    Some(match op {
+        Op::BinAdd => left + right,
+        Op::BinSub => left - right,
+        Op::BinMul => left * right,
+        Op::BinDiv => left / right,
+        // Rust `%` on f64 has libc fmod semantics (LLVM frem),
+        // which matches what JavaScriptCore does:
+        // https://github.com/oven-sh/WebKit/blob/7a0b13626e5db69aa5a32d037431d381df5dfb61/Source/JavaScriptCore/runtime/MathCommon.cpp#L574-L597
+        Op::BinRem => left % right,
+        Op::BinPow => js_ast::math::pow(left, right),
+        Op::BinShl => {
+            let right: u32 = (float_to_int32(right) as u32) % 32;
+            float_to_int32(left).wrapping_shl(right) as f64
+        }
+        Op::BinShr => {
+            let right: u32 = (float_to_int32(right) as u32) % 32;
+            // wrapping_shr on i32 is an arithmetic shift right
+            float_to_int32(left).wrapping_shr(right) as f64
+        }
+        Op::BinUShr => {
+            let right: u32 = (float_to_int32(right) as u32) % 32;
+            (float_to_int32(left) as u32).wrapping_shr(right) as f64
+        }
+        Op::BinBitwiseAnd => (float_to_int32(left) & float_to_int32(right)) as f64,
+        Op::BinBitwiseOr => (float_to_int32(left) | float_to_int32(right)) as f64,
+        Op::BinBitwiseXor => (float_to_int32(left) ^ float_to_int32(right)) as f64,
+        _ => return None,
+    })
+}
+
 #[derive(Clone, Copy, Default)]
 pub struct ParseBindingOptions {
     /// This will prevent parsing of destructuring patterns, as using statement

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1520,19 +1520,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let mut preprocessed_enums: ListManaged<'a, &'a [Stmt]> = ListManaged::new_in(p.arena);
             if p.scopes_in_order_for_enum.count() > 0 {
                 for stmt in stmts.iter_mut() {
-                    if matches!(stmt.data, StmtData::SEnum(_)) {
-                        // `scope_order_to_visit: &'a [ScopeOrder<'a>]` is `Copy`;
-                        // plain save/restore.
-                        let old_scopes_in_order = p.scope_order_to_visit;
+                    match stmt.data {
+                        StmtData::SEnum(_) => {
+                            // `scope_order_to_visit: &'a [ScopeOrder<'a>]` is `Copy`;
+                            // plain save/restore.
+                            let old_scopes_in_order = p.scope_order_to_visit;
 
-                        p.scope_order_to_visit =
-                            scopes_for_enum_at(&p.scopes_in_order_for_enum, stmt.loc);
+                            p.scope_order_to_visit =
+                                scopes_for_enum_at(&p.scopes_in_order_for_enum, stmt.loc);
 
-                        let mut temp = ListManaged::new_in(p.arena);
-                        let res = p.visit_and_append_stmt(&mut temp, stmt);
-                        p.scope_order_to_visit = old_scopes_in_order;
-                        res?;
-                        preprocessed_enums.push(temp.into_bump_slice());
+                            let mut temp = ListManaged::new_in(p.arena);
+                            let res = p.visit_and_append_stmt(&mut temp, stmt);
+                            p.scope_order_to_visit = old_scopes_in_order;
+                            res?;
+                            preprocessed_enums.push(temp.into_bump_slice());
+                        }
+                        // An enum above can only see the constants declared before it.
+                        StmtData::SLocal(local) => p.record_ts_enum_constants(&local),
+                        _ => {}
                     }
                 }
             }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1522,8 +1522,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 for stmt in stmts.iter_mut() {
                     match stmt.data {
                         StmtData::SEnum(_) => {
-                            // `scope_order_to_visit: &'a [ScopeOrder<'a>]` is `Copy`;
-                            // plain save/restore.
+                            // `scope_order_to_visit` is a `Copy` slice: plain save/restore.
                             let old_scopes_in_order = p.scope_order_to_visit;
 
                             p.scope_order_to_visit =

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -3,7 +3,7 @@ use bun_collections::VecExt;
 use core::cmp::Ordering;
 
 use crate::p::P;
-use crate::parser::{ExprIn, float_to_int32, prefill};
+use crate::parser::{ExprIn, fold_numeric_binary_operator, prefill};
 use crate::scan::scan_side_effects::SideEffects;
 use bun_ast::fold_string_addition::{FoldStringAdditionKind, fold_string_addition};
 use bun_ast::{
@@ -456,123 +456,23 @@ impl BinaryExpressionVisitor {
                     }
                 }
             }
-            Op::Code::BinSub => {
+            Op::Code::BinSub
+            | Op::Code::BinMul
+            | Op::Code::BinDiv
+            | Op::Code::BinRem
+            | Op::Code::BinPow
+            | Op::Code::BinShl
+            | Op::Code::BinShr
+            | Op::Code::BinUShr
+            | Op::Code::BinBitwiseAnd
+            | Op::Code::BinBitwiseOr
+            | Op::Code::BinBitwiseXor => {
                 if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
+                    if let Some([left, right]) =
+                        Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
+                        && let Some(result) = fold_numeric_binary_operator(e_.op, left, right)
                     {
-                        return p.new_expr(E::Number::new(vals[0] - vals[1]), v.loc);
-                    }
-                }
-            }
-            Op::Code::BinMul => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        return p.new_expr(E::Number::new(vals[0] * vals[1]), v.loc);
-                    }
-                }
-            }
-            Op::Code::BinDiv => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        return p.new_expr(E::Number::new(vals[0] / vals[1]), v.loc);
-                    }
-                }
-            }
-            Op::Code::BinRem => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        return p.new_expr(
-                            // Rust `%` on f64 has libc fmod semantics (LLVM frem),
-                            // which matches what JavaScriptCore does:
-                            // https://github.com/oven-sh/WebKit/blob/7a0b13626e5db69aa5a32d037431d381df5dfb61/Source/JavaScriptCore/runtime/MathCommon.cpp#L574-L597
-                            E::Number::new(vals[0] % vals[1]),
-                            v.loc,
-                        );
-                    }
-                }
-            }
-            Op::Code::BinPow => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        return p
-                            .new_expr(E::Number::new(bun_ast::math::pow(vals[0], vals[1])), v.loc);
-                    }
-                }
-            }
-            Op::Code::BinShl => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        let left = float_to_int32(vals[0]);
-                        let right: u32 = (float_to_int32(vals[1]) as u32) % 32;
-                        let result: i32 = left.wrapping_shl(right);
-                        return p.new_expr(E::Number::new(result as f64), v.loc);
-                    }
-                }
-            }
-            Op::Code::BinShr => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        let left = float_to_int32(vals[0]);
-                        let right: u32 = (float_to_int32(vals[1]) as u32) % 32;
-                        // wrapping_shr on i32 is an arithmetic shift right
-                        let result: i32 = left.wrapping_shr(right);
-                        return p.new_expr(E::Number::new(result as f64), v.loc);
-                    }
-                }
-            }
-            Op::Code::BinUShr => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        let left: u32 = float_to_int32(vals[0]) as u32;
-                        let right: u32 = (float_to_int32(vals[1]) as u32) % 32;
-                        let result: u32 = left.wrapping_shr(right);
-                        return p.new_expr(E::Number::new(result as f64), v.loc);
-                    }
-                }
-            }
-            Op::Code::BinBitwiseAnd => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        return p.new_expr(
-                            E::Number::new(
-                                (float_to_int32(vals[0]) & float_to_int32(vals[1])) as f64,
-                            ),
-                            v.loc,
-                        );
-                    }
-                }
-            }
-            Op::Code::BinBitwiseOr => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        return p.new_expr(
-                            E::Number::new(
-                                (float_to_int32(vals[0]) | float_to_int32(vals[1])) as f64,
-                            ),
-                            v.loc,
-                        );
-                    }
-                }
-            }
-            Op::Code::BinBitwiseXor => {
-                if p.should_fold_typescript_constant_expressions {
-                    if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
-                    {
-                        return p.new_expr(
-                            E::Number::new(
-                                (float_to_int32(vals[0]) ^ float_to_int32(vals[1])) as f64,
-                            ),
-                            v.loc,
-                        );
+                        return p.new_expr(E::Number::new(result), v.loc);
                     }
                 }
             }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -35,8 +35,7 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
     StmtNodeList::from_bump(list)
 }
 
-/// Appends `value` the way JavaScript string concatenation would. Only 8-bit
-/// (ASCII) strings are folded, like the other string folding in the parser.
+/// JavaScript string concatenation onto `bytes`. 8-bit strings only, like the parser's other folds.
 fn append_ts_constant_value(
     bytes: &mut BumpVec<'_, u8>,
     value: TSConstantValue,
@@ -2202,9 +2201,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// Records the value of each `const` in `local` whose initializer is a
-    /// constant expression, so that enum member initializers can reference it
-    /// (see `P::ts_enum_constants`). `local` has not been visited yet.
+    /// Records the `const`s of the unvisited `local` whose initializers are constant expressions.
     pub(crate) fn record_ts_enum_constants(&mut self, local: &S::Local) {
         if local.kind != S::Kind::KConst {
             return;
@@ -2215,8 +2212,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             else {
                 continue;
             };
-            // With tree shaking, a top-level declaration comes through here once
-            // for the module and again as its own part.
+            // With tree shaking a top-level declaration comes through twice (module, own part).
             if self.ts_enum_constants.contains_key(&id.r#ref) {
                 continue;
             }
@@ -2226,9 +2222,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Evaluates an unvisited expression by the rules the TypeScript compiler
-    /// uses for enum member initializers (`evaluate` in its checker):
-    /// https://github.com/microsoft/TypeScript/pull/50528
+    /// tsc's `evaluate` for enum member initializers (microsoft/TypeScript#50528), on an unvisited expression.
     fn eval_ts_constant_expression(&mut self, expr: &Expr) -> Option<TSConstantValue> {
         if !self.stack_check.is_safe_to_recurse() {
             return None;
@@ -2296,8 +2290,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_ast::ExprData::EIdentifier(ident) => {
                 let name = self.load_name_from_ref(ident.ref_);
-                // Looking up "arguments" where it is forbidden logs an error,
-                // which the visit of this expression will do on its own.
+                // Where "arguments" is forbidden the lookup logs an error: leave that to the visit.
                 if name == b"arguments" {
                     return None;
                 }
@@ -2348,9 +2341,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Resolves an unvisited `a.b.c` to the member map of the enum or namespace
-    /// it names. The parser builds a long chain as a deep `EDot` nest without
-    /// recursing, so this walks it without recursing too.
+    /// The member map of the enum or namespace that an unvisited, possibly deep, `a.b.c` names.
     fn eval_ts_namespace_chain(
         &mut self,
         expr: &Expr,

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1,10 +1,10 @@
 #![warn(unused_must_use)]
 use crate::Error;
 use crate::lexer as js_lexer;
-use crate::p::{P, ReactRefreshExportKind};
+use crate::p::{P, ReactRefreshExportKind, TSConstantValue};
 use crate::parser::{
     PrependTempRefsOpts, ReactRefresh, Ref, RelocateVarsMode, SideEffects, StmtsKind,
-    statement_cares_about_scope,
+    float_to_int32, fold_numeric_binary_operator, statement_cares_about_scope,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast::ast_result::CommonJSExportValue;
@@ -33,6 +33,27 @@ fn stmts_to_list<'a>(arena: &'a bun_alloc::Arena, ptr: StmtNodeList) -> StmtList
 #[inline]
 fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
     StmtNodeList::from_bump(list)
+}
+
+/// Appends `value` the way JavaScript string concatenation would. Only 8-bit
+/// (ASCII) strings are folded, like the other string folding in the parser.
+fn append_ts_constant_value(
+    bytes: &mut BumpVec<'_, u8>,
+    value: TSConstantValue,
+    arena: &bun_alloc::Arena,
+) -> Option<()> {
+    match value {
+        TSConstantValue::String(str_) => {
+            if !str_.is_utf8() {
+                return None;
+            }
+            bytes.extend_from_slice(str_.slice8());
+        }
+        TSConstantValue::Number(num) => {
+            bytes.extend_from_slice(E::Number::to_string_from_f64(num, arena)?.slice());
+        }
+    }
+    Some(())
 }
 
 // a direct `impl P` block. The 30+ per-variant `s_*` helpers are private; only
@@ -2181,6 +2202,217 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
+    /// Records the value of each `const` in `local` whose initializer is a
+    /// constant expression, so that enum member initializers can reference it
+    /// (see `P::ts_enum_constants`). `local` has not been visited yet.
+    pub(crate) fn record_ts_enum_constants(&mut self, local: &S::Local) {
+        if local.kind != S::Kind::KConst {
+            return;
+        }
+        for decl in local.decls.slice() {
+            let (js_ast::binding::Data::BIdentifier(id), Some(value)) =
+                (decl.binding.data, decl.value)
+            else {
+                continue;
+            };
+            // With tree shaking, a top-level declaration comes through here once
+            // for the module and again as its own part.
+            if self.ts_enum_constants.contains_key(&id.r#ref) {
+                continue;
+            }
+            if let Some(value) = self.eval_ts_constant_expression(&value) {
+                self.ts_enum_constants.insert(id.r#ref, value);
+            }
+        }
+    }
+
+    /// Evaluates an unvisited expression by the rules the TypeScript compiler
+    /// uses for enum member initializers (`evaluate` in its checker):
+    /// https://github.com/microsoft/TypeScript/pull/50528
+    fn eval_ts_constant_expression(&mut self, expr: &Expr) -> Option<TSConstantValue> {
+        if !self.stack_check.is_safe_to_recurse() {
+            return None;
+        }
+        match expr.data {
+            js_ast::ExprData::ENumber(num) => Some(TSConstantValue::Number(num.value())),
+            js_ast::ExprData::EString(str_) => self.ts_constant_string(str_),
+            js_ast::ExprData::EUnary(unary) => {
+                let TSConstantValue::Number(value) =
+                    self.eval_ts_constant_expression(&unary.value)?
+                else {
+                    return None;
+                };
+                match unary.op {
+                    js_ast::OpCode::UnPos => Some(TSConstantValue::Number(value)),
+                    js_ast::OpCode::UnNeg => Some(TSConstantValue::Number(-value)),
+                    js_ast::OpCode::UnCpl => {
+                        Some(TSConstantValue::Number(f64::from(!float_to_int32(value))))
+                    }
+                    _ => None,
+                }
+            }
+            js_ast::ExprData::EBinary(binary) => {
+                let left = self.eval_ts_constant_expression(&binary.left)?;
+                let right = self.eval_ts_constant_expression(&binary.right)?;
+                match (left, right) {
+                    (TSConstantValue::Number(left), TSConstantValue::Number(right)) => {
+                        fold_numeric_binary_operator(binary.op, left, right)
+                            .map(TSConstantValue::Number)
+                    }
+                    _ if binary.op == js_ast::OpCode::BinAdd => {
+                        let mut bytes: BumpVec<'a, u8> = BumpVec::new_in(self.arena);
+                        append_ts_constant_value(&mut bytes, left, self.arena)?;
+                        append_ts_constant_value(&mut bytes, right, self.arena)?;
+                        Some(self.new_ts_constant_string(E::EString::init(bytes.into_bump_slice())))
+                    }
+                    _ => None,
+                }
+            }
+            js_ast::ExprData::ETemplate(template) => {
+                if template.tag.is_some() {
+                    return None;
+                }
+                let E::TemplateContents::Cooked(head) = &template.head else {
+                    return None;
+                };
+                if !head.is_utf8() {
+                    return None;
+                }
+                let mut bytes: BumpVec<'a, u8> = BumpVec::new_in(self.arena);
+                bytes.extend_from_slice(head.slice8());
+                for part in template.parts() {
+                    let value = self.eval_ts_constant_expression(&part.value)?;
+                    append_ts_constant_value(&mut bytes, value, self.arena)?;
+                    let E::TemplateContents::Cooked(tail) = &part.tail else {
+                        return None;
+                    };
+                    if !tail.is_utf8() {
+                        return None;
+                    }
+                    bytes.extend_from_slice(tail.slice8());
+                }
+                Some(self.new_ts_constant_string(E::EString::init(bytes.into_bump_slice())))
+            }
+            js_ast::ExprData::EIdentifier(ident) => {
+                let name = self.load_name_from_ref(ident.ref_);
+                // Looking up "arguments" where it is forbidden logs an error,
+                // which the visit of this expression will do on its own.
+                if name == b"arguments" {
+                    return None;
+                }
+                let result = self
+                    .find_symbol_with_record_usage::<false>(expr.loc, name)
+                    .ok()?;
+                if result.is_inside_with_scope {
+                    return None;
+                }
+                if result.r#ref.is_empty()
+                    || self.symbols[result.r#ref.inner_index() as usize].kind
+                        == js_ast::symbol::Kind::Unbound
+                {
+                    return match name {
+                        b"Infinity" => Some(TSConstantValue::Number(f64::INFINITY)),
+                        b"NaN" => Some(TSConstantValue::Number(f64::NAN)),
+                        _ => None,
+                    };
+                }
+                if let Some(&value) = self.ts_enum_constants.get(&result.r#ref) {
+                    return Some(value);
+                }
+                let data = *self.ref_to_ts_namespace_member.get(&result.r#ref)?;
+                self.ts_namespace_member_value(data)
+            }
+            js_ast::ExprData::EDot(dot) => {
+                if dot.optional_chain.is_some() {
+                    return None;
+                }
+                let map = self.eval_ts_namespace_chain(&dot.target)?;
+                let data = (*map).get(dot.name.slice())?.data;
+                self.ts_namespace_member_value(data)
+            }
+            js_ast::ExprData::EIndex(index) => {
+                if index.optional_chain.is_some() {
+                    return None;
+                }
+                let js_ast::ExprData::EString(name) = index.index.data else {
+                    return None;
+                };
+                if !name.is_utf8() || name.next.is_some() {
+                    return None;
+                }
+                let map = self.eval_ts_namespace_chain(&index.target)?;
+                let data = (*map).get(name.slice8())?.data;
+                self.ts_namespace_member_value(data)
+            }
+            _ => None,
+        }
+    }
+
+    /// Resolves an unvisited `a.b.c` to the member map of the enum or namespace
+    /// it names.
+    fn eval_ts_namespace_chain(
+        &mut self,
+        expr: &Expr,
+    ) -> Option<js_ast::StoreRef<js_ast::TSNamespaceMemberMap>> {
+        let data = match expr.data {
+            js_ast::ExprData::EIdentifier(ident) => {
+                let name = self.load_name_from_ref(ident.ref_);
+                if name == b"arguments" {
+                    return None;
+                }
+                let result = self
+                    .find_symbol_with_record_usage::<false>(expr.loc, name)
+                    .ok()?;
+                if result.is_inside_with_scope || result.r#ref.is_empty() {
+                    return None;
+                }
+                *self.ref_to_ts_namespace_member.get(&result.r#ref)?
+            }
+            js_ast::ExprData::EDot(dot) => {
+                if dot.optional_chain.is_some() {
+                    return None;
+                }
+                let map = self.eval_ts_namespace_chain(&dot.target)?;
+                (*map).get(dot.name.slice())?.data
+            }
+            _ => return None,
+        };
+        match data {
+            js_ast::ts::Data::Namespace(map) => Some(map),
+            _ => None,
+        }
+    }
+
+    fn ts_namespace_member_value(&mut self, data: js_ast::ts::Data) -> Option<TSConstantValue> {
+        match data {
+            js_ast::ts::Data::EnumNumber(num) => Some(TSConstantValue::Number(num)),
+            js_ast::ts::Data::EnumString(str_) => self.ts_constant_string(str_),
+            _ => None,
+        }
+    }
+
+    /// `TSConstantValue::String` is never a rope: each substitution copies the
+    /// node it points at, and copies of a rope would share its tail.
+    fn ts_constant_string(
+        &mut self,
+        str_: js_ast::StoreRef<E::EString>,
+    ) -> Option<TSConstantValue> {
+        if str_.next.is_none() {
+            return Some(TSConstantValue::String(str_));
+        }
+        if !str_.is_utf8() {
+            return None;
+        }
+        let flat = str_.flattened(self.arena).shallow_clone();
+        Some(self.new_ts_constant_string(flat))
+    }
+
+    fn new_ts_constant_string(&mut self, string: E::EString) -> TSConstantValue {
+        debug_assert!(string.next.is_none());
+        let expr = self.new_expr(string, bun_ast::Loc::EMPTY);
+        TSConstantValue::String(expr.data.e_string().expect("infallible: just created"))
+    }
+
     fn s_enum(
         p: &mut Self,
         stmts: &mut StmtList<'a>,
@@ -2238,6 +2470,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let old_should_fold_typescript_constant_expressions =
             p.should_fold_typescript_constant_expressions;
         p.should_fold_typescript_constant_expressions = true;
+        let old_is_visiting_ts_enum_initializer = p.is_visiting_ts_enum_initializer;
+        p.is_visiting_ts_enum_initializer = true;
 
         // Create an assignment for each enum value
         for value in values.iter_mut() {
@@ -2366,6 +2600,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.pop_scope();
         p.should_fold_typescript_constant_expressions =
             old_should_fold_typescript_constant_expressions;
+        p.is_visiting_ts_enum_initializer = old_is_visiting_ts_enum_initializer;
 
         let mut value_stmts: StmtList<'a> = BumpVec::with_capacity_in(value_exprs.len(), p.arena);
         // Generate statements from expressions

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2213,7 +2213,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             };
             // With tree shaking a top-level declaration comes through twice (module, own part).
-            if self.ts_enum_constants.contains_key(&id.r#ref) {
+            if self.ts_enum_constants.contains_key(&id.r#ref)
+                || self.ts_annotated_constants.contains_key(&id.r#ref)
+            {
                 continue;
             }
             if let Some(value) = self.eval_ts_constant_expression(&value) {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -35,6 +35,99 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
     StmtNodeList::from_bump(list)
 }
 
+// ─── TypeScript constant expressions (see `P::eval_ts_constant_expression`) ─────
+// The parts that do not need the parser are free functions so they are compiled once.
+
+fn ts_constant_string(str_: js_ast::StoreRef<E::EString>) -> TSConstantValue {
+    debug_assert!(
+        str_.next.is_none(),
+        "each substitution copies this node, and copies of a rope would share its tail"
+    );
+    TSConstantValue::String(str_)
+}
+
+fn new_ts_constant_string(bytes: &[u8]) -> TSConstantValue {
+    let expr = Expr::init(E::EString::init(bytes), bun_ast::Loc::EMPTY);
+    ts_constant_string(expr.data.e_string().expect("infallible: just created"))
+}
+
+fn ts_namespace_member_value(data: js_ast::ts::Data) -> Option<TSConstantValue> {
+    match data {
+        js_ast::ts::Data::EnumNumber(num) => Some(TSConstantValue::Number(num)),
+        // `s_enum` stores string members flat.
+        js_ast::ts::Data::EnumString(str_) => Some(ts_constant_string(str_)),
+        _ => None,
+    }
+}
+
+/// An unbound `Infinity` or `NaN`, which tsc folds too.
+fn ts_global_constant(name: &[u8]) -> Option<TSConstantValue> {
+    match name {
+        b"Infinity" => Some(TSConstantValue::Number(f64::INFINITY)),
+        b"NaN" => Some(TSConstantValue::Number(f64::NAN)),
+        _ => None,
+    }
+}
+
+fn fold_ts_constant_unary(op: js_ast::OpCode, value: TSConstantValue) -> Option<TSConstantValue> {
+    let TSConstantValue::Number(value) = value else {
+        return None;
+    };
+    match op {
+        js_ast::OpCode::UnPos => Some(TSConstantValue::Number(value)),
+        js_ast::OpCode::UnNeg => Some(TSConstantValue::Number(-value)),
+        js_ast::OpCode::UnCpl => Some(TSConstantValue::Number(f64::from(!float_to_int32(value)))),
+        _ => None,
+    }
+}
+
+fn fold_ts_constant_binary(
+    op: js_ast::OpCode,
+    left: TSConstantValue,
+    right: TSConstantValue,
+    arena: &bun_alloc::Arena,
+) -> Option<TSConstantValue> {
+    match (left, right) {
+        (TSConstantValue::Number(left), TSConstantValue::Number(right)) => {
+            fold_numeric_binary_operator(op, left, right).map(TSConstantValue::Number)
+        }
+        _ if op == js_ast::OpCode::BinAdd => {
+            let mut bytes: BumpVec<'_, u8> = BumpVec::new_in(arena);
+            append_ts_constant_value(&mut bytes, left, arena)?;
+            append_ts_constant_value(&mut bytes, right, arena)?;
+            Some(new_ts_constant_string(bytes.into_bump_slice()))
+        }
+        _ => None,
+    }
+}
+
+/// An untagged template whose parts evaluated to `values`.
+fn fold_ts_constant_template(
+    template: &E::Template,
+    values: &[TSConstantValue],
+    arena: &bun_alloc::Arena,
+) -> Option<TSConstantValue> {
+    let E::TemplateContents::Cooked(head) = &template.head else {
+        return None;
+    };
+    if !head.is_utf8() {
+        return None;
+    }
+    let mut bytes: BumpVec<'_, u8> = BumpVec::new_in(arena);
+    bytes.extend_from_slice(head.slice8());
+    for (part, value) in template.parts().iter().zip(values) {
+        append_ts_constant_value(&mut bytes, *value, arena)?;
+        let E::TemplateContents::Cooked(tail) = &part.tail else {
+            return None;
+        };
+        if !tail.is_utf8() {
+            return None;
+        }
+        bytes.extend_from_slice(tail.slice8());
+    }
+    Some(new_ts_constant_string(bytes.into_bump_slice()))
+}
+
 /// JavaScript string concatenation onto `bytes`. 8-bit strings only, like the parser's other folds.
 fn append_ts_constant_value(
     bytes: &mut BumpVec<'_, u8>,
@@ -2232,63 +2325,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match expr.data {
             js_ast::ExprData::ENumber(num) => Some(TSConstantValue::Number(num.value())),
             // The parse pass builds no ropes.
-            js_ast::ExprData::EString(str_) => Some(Self::ts_constant_string(str_)),
+            js_ast::ExprData::EString(str_) => Some(ts_constant_string(str_)),
             js_ast::ExprData::EUnary(unary) => {
-                let TSConstantValue::Number(value) =
-                    self.eval_ts_constant_expression(&unary.value)?
-                else {
-                    return None;
-                };
-                match unary.op {
-                    js_ast::OpCode::UnPos => Some(TSConstantValue::Number(value)),
-                    js_ast::OpCode::UnNeg => Some(TSConstantValue::Number(-value)),
-                    js_ast::OpCode::UnCpl => {
-                        Some(TSConstantValue::Number(f64::from(!float_to_int32(value))))
-                    }
-                    _ => None,
-                }
+                let value = self.eval_ts_constant_expression(&unary.value)?;
+                fold_ts_constant_unary(unary.op, value)
             }
             js_ast::ExprData::EBinary(binary) => {
                 let left = self.eval_ts_constant_expression(&binary.left)?;
                 let right = self.eval_ts_constant_expression(&binary.right)?;
-                match (left, right) {
-                    (TSConstantValue::Number(left), TSConstantValue::Number(right)) => {
-                        fold_numeric_binary_operator(binary.op, left, right)
-                            .map(TSConstantValue::Number)
-                    }
-                    _ if binary.op == js_ast::OpCode::BinAdd => {
-                        let mut bytes: BumpVec<'a, u8> = BumpVec::new_in(self.arena);
-                        append_ts_constant_value(&mut bytes, left, self.arena)?;
-                        append_ts_constant_value(&mut bytes, right, self.arena)?;
-                        Some(self.new_ts_constant_string(E::EString::init(bytes.into_bump_slice())))
-                    }
-                    _ => None,
-                }
+                fold_ts_constant_binary(binary.op, left, right, self.arena)
             }
             js_ast::ExprData::ETemplate(template) => {
                 if template.tag.is_some() {
                     return None;
                 }
-                let E::TemplateContents::Cooked(head) = &template.head else {
-                    return None;
-                };
-                if !head.is_utf8() {
-                    return None;
-                }
-                let mut bytes: BumpVec<'a, u8> = BumpVec::new_in(self.arena);
-                bytes.extend_from_slice(head.slice8());
+                let mut values: smallvec::SmallVec<[TSConstantValue; 4]> =
+                    smallvec::SmallVec::new();
                 for part in template.parts() {
-                    let value = self.eval_ts_constant_expression(&part.value)?;
-                    append_ts_constant_value(&mut bytes, value, self.arena)?;
-                    let E::TemplateContents::Cooked(tail) = &part.tail else {
-                        return None;
-                    };
-                    if !tail.is_utf8() {
-                        return None;
-                    }
-                    bytes.extend_from_slice(tail.slice8());
+                    values.push(self.eval_ts_constant_expression(&part.value)?);
                 }
-                Some(self.new_ts_constant_string(E::EString::init(bytes.into_bump_slice())))
+                fold_ts_constant_template(&template, &values, self.arena)
             }
             js_ast::ExprData::EIdentifier(ident) => {
                 let name = self.load_name_from_ref(ident.ref_);
@@ -2306,25 +2362,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     || self.symbols[result.r#ref.inner_index() as usize].kind
                         == js_ast::symbol::Kind::Unbound
                 {
-                    return match name {
-                        b"Infinity" => Some(TSConstantValue::Number(f64::INFINITY)),
-                        b"NaN" => Some(TSConstantValue::Number(f64::NAN)),
-                        _ => None,
-                    };
+                    return ts_global_constant(name);
                 }
                 if let Some(&value) = self.ts_enum_constants.get(&result.r#ref) {
                     return Some(value);
                 }
-                Self::ts_namespace_member_value(
-                    *self.ref_to_ts_namespace_member.get(&result.r#ref)?,
-                )
+                ts_namespace_member_value(*self.ref_to_ts_namespace_member.get(&result.r#ref)?)
             }
             js_ast::ExprData::EDot(dot) => {
                 if dot.optional_chain.is_some() {
                     return None;
                 }
                 let map = self.eval_ts_namespace_chain(&dot.target)?;
-                Self::ts_namespace_member_value((*map).get(dot.name.slice())?.data)
+                ts_namespace_member_value((*map).get(dot.name.slice())?.data)
             }
             js_ast::ExprData::EIndex(index) => {
                 if index.optional_chain.is_some() {
@@ -2337,7 +2387,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return None;
                 }
                 let map = self.eval_ts_namespace_chain(&index.target)?;
-                Self::ts_namespace_member_value((*map).get(name.slice8())?.data)
+                ts_namespace_member_value((*map).get(name.slice8())?.data)
             }
             _ => None,
         }
@@ -2386,28 +2436,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ts::Data::Namespace(map) => Some(map),
             _ => None,
         }
-    }
-
-    fn ts_namespace_member_value(data: js_ast::ts::Data) -> Option<TSConstantValue> {
-        match data {
-            js_ast::ts::Data::EnumNumber(num) => Some(TSConstantValue::Number(num)),
-            // `s_enum` stores string members flat.
-            js_ast::ts::Data::EnumString(str_) => Some(Self::ts_constant_string(str_)),
-            _ => None,
-        }
-    }
-
-    fn ts_constant_string(str_: js_ast::StoreRef<E::EString>) -> TSConstantValue {
-        debug_assert!(
-            str_.next.is_none(),
-            "each substitution copies this node, and copies of a rope would share its tail"
-        );
-        TSConstantValue::String(str_)
-    }
-
-    fn new_ts_constant_string(&mut self, string: E::EString) -> TSConstantValue {
-        let expr = self.new_expr(string, bun_ast::Loc::EMPTY);
-        Self::ts_constant_string(expr.data.e_string().expect("infallible: just created"))
     }
 
     fn s_enum(

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -35,8 +35,7 @@ fn list_to_stmts<'a>(list: StmtList<'a>) -> StmtNodeList {
     StmtNodeList::from_bump(list)
 }
 
-// ─── TypeScript constant expressions (see `P::eval_ts_constant_expression`) ─────
-// The parts that do not need the parser are free functions so they are compiled once.
+// ─── `P::eval_ts_constant_expression` helpers: free functions, so not compiled per `P` instantiation ───
 
 fn ts_constant_string(str_: js_ast::StoreRef<E::EString>) -> TSConstantValue {
     debug_assert!(

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2235,7 +2235,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         match expr.data {
             js_ast::ExprData::ENumber(num) => Some(TSConstantValue::Number(num.value())),
-            js_ast::ExprData::EString(str_) => self.ts_constant_string(str_),
+            // The parse pass builds no ropes.
+            js_ast::ExprData::EString(str_) => Some(Self::ts_constant_string(str_)),
             js_ast::ExprData::EUnary(unary) => {
                 let TSConstantValue::Number(value) =
                     self.eval_ts_constant_expression(&unary.value)?
@@ -2319,16 +2320,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if let Some(&value) = self.ts_enum_constants.get(&result.r#ref) {
                     return Some(value);
                 }
-                let data = *self.ref_to_ts_namespace_member.get(&result.r#ref)?;
-                self.ts_namespace_member_value(data)
+                Self::ts_namespace_member_value(
+                    *self.ref_to_ts_namespace_member.get(&result.r#ref)?,
+                )
             }
             js_ast::ExprData::EDot(dot) => {
                 if dot.optional_chain.is_some() {
                     return None;
                 }
                 let map = self.eval_ts_namespace_chain(&dot.target)?;
-                let data = (*map).get(dot.name.slice())?.data;
-                self.ts_namespace_member_value(data)
+                Self::ts_namespace_member_value((*map).get(dot.name.slice())?.data)
             }
             js_ast::ExprData::EIndex(index) => {
                 if index.optional_chain.is_some() {
@@ -2341,8 +2342,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return None;
                 }
                 let map = self.eval_ts_namespace_chain(&index.target)?;
-                let data = (*map).get(name.slice8())?.data;
-                self.ts_namespace_member_value(data)
+                Self::ts_namespace_member_value((*map).get(name.slice8())?.data)
             }
             _ => None,
         }
@@ -2383,34 +2383,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    fn ts_namespace_member_value(&mut self, data: js_ast::ts::Data) -> Option<TSConstantValue> {
+    fn ts_namespace_member_value(data: js_ast::ts::Data) -> Option<TSConstantValue> {
         match data {
             js_ast::ts::Data::EnumNumber(num) => Some(TSConstantValue::Number(num)),
-            js_ast::ts::Data::EnumString(str_) => self.ts_constant_string(str_),
+            // `s_enum` stores string members flat.
+            js_ast::ts::Data::EnumString(str_) => Some(Self::ts_constant_string(str_)),
             _ => None,
         }
     }
 
-    /// `TSConstantValue::String` is never a rope: each substitution copies the
-    /// node it points at, and copies of a rope would share its tail.
-    fn ts_constant_string(
-        &mut self,
-        str_: js_ast::StoreRef<E::EString>,
-    ) -> Option<TSConstantValue> {
-        if str_.next.is_none() {
-            return Some(TSConstantValue::String(str_));
-        }
-        if !str_.is_utf8() {
-            return None;
-        }
-        let flat = str_.flattened(self.arena).shallow_clone();
-        Some(self.new_ts_constant_string(flat))
+    fn ts_constant_string(str_: js_ast::StoreRef<E::EString>) -> TSConstantValue {
+        debug_assert!(
+            str_.next.is_none(),
+            "each substitution copies this node, and copies of a rope would share its tail"
+        );
+        TSConstantValue::String(str_)
     }
 
     fn new_ts_constant_string(&mut self, string: E::EString) -> TSConstantValue {
-        debug_assert!(string.next.is_none());
         let expr = self.new_expr(string, bun_ast::Loc::EMPTY);
-        TSConstantValue::String(expr.data.e_string().expect("infallible: just created"))
+        Self::ts_constant_string(expr.data.e_string().expect("infallible: just created"))
     }
 
     fn s_enum(
@@ -2502,8 +2494,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                         next_numeric_value = Some(num.value() + 1.0);
                     }
-                    js_ast::ExprData::EString(str_) => {
+                    js_ast::ExprData::EString(mut str_) => {
                         has_string_value = true;
+
+                        // Inlined uses share this node's rope and folds append to ropes in place: store it flat.
+                        str_.resolve_rope_if_needed(p.arena);
 
                         exported_members.get_ptr_mut(name).unwrap().data =
                             js_ast::ts::Data::EnumString(str_);

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2349,34 +2349,46 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     /// Resolves an unvisited `a.b.c` to the member map of the enum or namespace
-    /// it names.
+    /// it names. The parser builds a long chain as a deep `EDot` nest without
+    /// recursing, so this walks it without recursing too.
     fn eval_ts_namespace_chain(
         &mut self,
         expr: &Expr,
     ) -> Option<js_ast::StoreRef<js_ast::TSNamespaceMemberMap>> {
-        let data = match expr.data {
-            js_ast::ExprData::EIdentifier(ident) => {
-                let name = self.load_name_from_ref(ident.ref_);
-                if name == b"arguments" {
-                    return None;
+        let mut member_names: smallvec::SmallVec<[&[u8]; 4]> = smallvec::SmallVec::new();
+        let mut current = *expr;
+        let root = loop {
+            match current.data {
+                js_ast::ExprData::EDot(dot) => {
+                    if dot.optional_chain.is_some() {
+                        return None;
+                    }
+                    member_names.push(dot.name.slice());
+                    current = dot.target;
                 }
-                let result = self
-                    .find_symbol_with_record_usage::<false>(expr.loc, name)
-                    .ok()?;
-                if result.is_inside_with_scope || result.r#ref.is_empty() {
-                    return None;
-                }
-                *self.ref_to_ts_namespace_member.get(&result.r#ref)?
+                js_ast::ExprData::EIdentifier(ident) => break ident,
+                _ => return None,
             }
-            js_ast::ExprData::EDot(dot) => {
-                if dot.optional_chain.is_some() {
-                    return None;
-                }
-                let map = self.eval_ts_namespace_chain(&dot.target)?;
-                (*map).get(dot.name.slice())?.data
-            }
-            _ => return None,
         };
+
+        let name = self.load_name_from_ref(root.ref_);
+        if name == b"arguments" {
+            return None;
+        }
+        let result = self
+            .find_symbol_with_record_usage::<false>(current.loc, name)
+            .ok()?;
+        if result.is_inside_with_scope || result.r#ref.is_empty() {
+            return None;
+        }
+        let mut data = *self.ref_to_ts_namespace_member.get(&result.r#ref)?;
+        // The innermost member was pushed last.
+        for member_name in member_names.iter().rev() {
+            let js_ast::ts::Data::Namespace(map) = data else {
+                return None;
+            };
+            data = (*map).get(member_name)?.data;
+        }
         match data {
             js_ast::ts::Data::Namespace(map) => Some(map),
             _ => None,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: TypeScript enum initializers fold references to `const` variables.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2356,7 +2356,7 @@ describe("bundler", () => {
 					X25 = (321),
 
 					// a dotted name (e.g. x.y.z) that references a const variable with a constant expression initializer and no type annotation,
-					/* (we don't implement this one) */
+					/* (see ts/EnumConstVariableReferences below) */
 
 					// a dotted name that references an enum member with an enum literal type, or
 					X26 = X0,
@@ -2512,6 +2512,54 @@ describe("bundler", () => {
         '"123"',
         '"4132879497321892437432187943789312894378237491578123414321431"',
       ]);
+    },
+  });
+  itBundled("ts/EnumConstVariableReferences", {
+    files: {
+      "/entry.ts": /* ts */ `
+        const base = 100;
+        const prefix = "app";
+        const chained = base + 1, mask = ~chained, route = \`\${prefix}/home\`, joined = prefix + base;
+        enum Status { Ok = base, Created, Accepted }
+        enum Tag { Home = prefix, Route = route, Joined = joined, Nested = \`\${route}/x\` }
+        enum Derived { A = chained, B, C = mask, D = Status.Accepted + 1, E }
+        const fromEnum = Derived.E * 2;
+        enum Again { X = fromEnum, Y }
+        function inner() {
+          enum Inner { A = declaredAfterInner, B }
+          return Inner;
+        }
+        const declaredAfterInner = 7;
+        let notConst = 1;
+        const notConstant = Math.min(4, 2);
+        enum Computed { A = notConst, B = notConstant }
+        console.log(JSON.stringify([Status, Tag, Derived, Again, inner(), Computed]));
+        export { Status, Tag };
+      `,
+      "/other.ts": /* ts */ `
+        import { Status, Tag } from "./entry";
+        console.log(JSON.stringify([Status.Created, Tag.Route]));
+      `,
+    },
+    entryPoints: ["/entry.ts", "/other.ts"],
+    run: [
+      {
+        file: "/out/entry.js",
+        stdout:
+          '[{"100":"Ok","101":"Created","102":"Accepted","Ok":100,"Created":101,"Accepted":102},{"Home":"app","Route":"app/home","Joined":"app100","Nested":"app/home/x"},{"101":"A","102":"B","103":"D","104":"E","A":101,"B":102,"C":-102,"-102":"C","D":103,"E":104},{"208":"X","209":"Y","X":208,"Y":209},{"7":"A","8":"B","A":7,"B":8},{"1":"A","2":"B","A":1,"B":2}]',
+      },
+      {
+        file: "/out/other.js",
+        stdout:
+          '[{"100":"Ok","101":"Created","102":"Accepted","Ok":100,"Created":101,"Accepted":102},{"Home":"app","Route":"app/home","Joined":"app100","Nested":"app/home/x"},{"101":"A","102":"B","103":"D","104":"E","A":101,"B":102,"C":-102,"-102":"C","D":103,"E":104},{"208":"X","209":"Y","X":208,"Y":209},{"7":"A","8":"B","A":7,"B":8},{"1":"A","2":"B","A":1,"B":2}]\n[101,"app/home"]',
+      },
+    ],
+    onAfterBundle(api) {
+      // The values are known at bundle time, so cross-module uses are inlined too.
+      const other = api.readFile("/out/other.js");
+      expect(other).toContain("101");
+      expect(other).toContain('"app/home"');
+      expect(other).not.toMatch(/Status\.Created|Tag\.Route/);
     },
   });
   itBundled("ts/EnumUseBeforeDeclare", {

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2356,7 +2356,7 @@ describe("bundler", () => {
 					X25 = (321),
 
 					// a dotted name (e.g. x.y.z) that references a const variable with a constant expression initializer and no type annotation,
-					/* (see ts/EnumConstVariableReferences below) */
+					/* (a bare const identifier folds, see ts/EnumConstVariableReferences below; a namespace member such as ns.x does not) */
 
 					// a dotted name that references an enum member with an enum literal type, or
 					X26 = X0,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1243,7 +1243,8 @@ function foo() {}
 
       it("a long dotted name in a const initializer is walked without recursion", () => {
         // The visitor still rejects the nesting depth; the const pre-pass must not overflow the stack first.
-        const code = "declare const a: any;\nconst x = a" + Buffer.alloc(100_000, ".b").toString() + ";\nenum E { A = 1 }";
+        const code =
+          "declare const a: any;\nconst x = a" + Buffer.alloc(100_000, ".b").toString() + ";\nenum E { A = 1 }";
         expect(() => ts.parsed(code, false, false)).toThrow("Maximum call stack size exceeded");
       });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1243,7 +1243,7 @@ function foo() {}
 
       it("a long dotted name in a const initializer is walked without recursion", () => {
         // The visitor still rejects the nesting depth; the const pre-pass must not overflow the stack first.
-        const code = "declare const a: any;\nconst x = a" + ".b".repeat(50000) + ";\nenum E { A = 1 }";
+        const code = "declare const a: any;\nconst x = a" + Buffer.alloc(100_000, ".b").toString() + ";\nenum E { A = 1 }";
         expect(() => ts.parsed(code, false, false)).toThrow("Maximum call stack size exceeded");
       });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1233,6 +1233,20 @@ function foo() {}
         );
       });
 
+      it("enum nested in a namespace, read through a dotted name", () => {
+        // The namespace body is visited before the function body, so the member value is known there.
+        exp(
+          "namespace N { export enum E { A = 4 } }\nexport function f() {\n  const c = N.E.A + 1;\n  enum X { Q = c, R }\n  return X;\n}",
+          'var N;\n((N) => {\n  let E;\n  ((E) => {\n    E[E["A"] = 4] = "A";\n  })(E = N.E ||= {});\n})(N ||= {});\nexport function f() {\n  const c = 4 /* A */ + 1;\n  let X;\n  ((X) => {\n    X[X["Q"] = 5] = "Q";\n    X[X["R"] = 6] = "R";\n  })(X ||= {});\n  return X;\n}',
+        );
+      });
+
+      it("a long dotted name in a const initializer is walked without recursion", () => {
+        // The visitor still rejects the nesting depth; the const pre-pass must not overflow the stack first.
+        const code = "declare const a: any;\nconst x = a" + ".b".repeat(50000) + ";\nenum E { A = 1 }";
+        expect(() => ts.parsed(code, false, false)).toThrow("Maximum call stack size exceeded");
+      });
+
       // tsc folds a dotted name to a namespace's exported const too. Not implemented:
       // the namespace member map does not carry the value.
       it.todo("const reached through a namespace", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1202,10 +1202,10 @@ function foo() {}
       });
 
       it("leaves alone what TypeScript does not fold", () => {
-        // declared after the enum, not const, or not a constant expression
+        // declared after the enum, not const, not a constant expression, or declared with a type annotation
         exp(
-          "let x = 1;\nconst y = Math.PI;\nenum E { A = later, B = x, C = y }\nconst later = 5;",
-          'let x = 1;\nconst y = Math.PI;\nvar E;\n((E) => {\n  E[E["A"] = later] = "A";\n  E[E["B"] = x] = "B";\n  E[E["C"] = y] = "C";\n})(E ||= {});\nconst later = 5',
+          "let x = 1;\nconst y = Math.PI;\nconst z: number = 3;\nenum E { A = later, B = x, C = y, D = z, F }\nconst later = 5;",
+          'let x = 1;\nconst y = Math.PI;\nconst z = 3;\nvar E;\n((E) => {\n  E[E["A"] = later] = "A";\n  E[E["B"] = x] = "B";\n  E[E["C"] = y] = "C";\n  E[E["D"] = z] = "D";\n  E[E["F"] = undefined] = "F";\n})(E ||= {});\nconst later = 5',
         );
         // shadowed by a hoisted variable in the enum's scope
         exp(

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1232,6 +1232,32 @@ function foo() {}
           'var N;\n((N) => {\n  N.a = 1;\n  let E;\n  ((E) => {\n    E[E["X"] = 1] = "X";\n    E[E["Y"] = 2] = "Y";\n  })(E = N.E ||= {});\n})(N ||= {})',
         );
       });
+
+      // tsc folds a dotted name to a namespace's exported const too. Not implemented:
+      // the namespace member map does not carry the value.
+      it.todo("const reached through a namespace", () => {
+        exp(
+          "namespace N { export const a = 1; }\nenum E { X = N.a, Y }",
+          'var N;\n((N) => {\n  N.a = 1;\n})(N ||= {});\nvar E;\n((E) => {\n  E[E["X"] = 1] = "X";\n  E[E["Y"] = 2] = "Y";\n})(E ||= {})',
+        );
+      });
+
+      it("folds through to uses of the member", () => {
+        // https://github.com/oven-sh/bun/issues/19581
+        const out = ts.parsedMin(
+          "const enum First { A = 1, B = 2, C = 3 }\nconst multiplier = 5;\nconst enum Second { D = First.A * multiplier, E = First.B * multiplier, F = First.C * multiplier }\nconsole.log(Second.E + Second.F);",
+        );
+        expect(out.split("\n").at(-1)).toBe("console.log(25)");
+      });
+
+      it("a folded string member can be read by more than one template literal", () => {
+        // The member is stored flat. A rope would be shared by every inlined copy,
+        // and folding the first template literal would append to it.
+        ts.expectPrintedMin_(
+          'const prefix = "app";\nenum Tag { Upper = prefix + "!" }\nconsole.log(`${Tag.Upper}x`, `${Tag.Upper}y`);',
+          'const prefix = "app";\nvar Tag;\n((Tag) => Tag.Upper = "app!")(Tag ||= {});\nconsole.log("app!x", "app!y")',
+        );
+      });
     });
 
     // TODO: fix all the cases that report generic "Parse error"

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1175,6 +1175,65 @@ function foo() {}
       `);
     });
 
+    // Since TypeScript 5.0, an enum member initializer may reference a `const`
+    // variable whose own initializer is a constant expression.
+    describe("enum initializers that reference const variables", () => {
+      const exp = ts.expectPrinted_;
+
+      it("numeric const continues auto-increment", () => {
+        exp(
+          "const base = 100;\nenum Status { Ok = base, Created, Accepted }",
+          'const base = 100;\nvar Status;\n((Status) => {\n  Status[Status["Ok"] = 100] = "Ok";\n  Status[Status["Created"] = 101] = "Created";\n  Status[Status["Accepted"] = 102] = "Accepted";\n})(Status ||= {})',
+        );
+      });
+
+      it("string const gets no reverse mapping", () => {
+        exp(
+          'const prefix = "app";\nenum Tag { Home = prefix, About = `${prefix}/about`, Upper = prefix + "!" }',
+          'const prefix = "app";\nvar Tag;\n((Tag) => {\n  Tag["Home"] = "app";\n  Tag["About"] = "app/about";\n  Tag["Upper"] = "app!";\n})(Tag ||= {})',
+        );
+      });
+
+      it("const initializers are evaluated as constant expressions", () => {
+        exp(
+          'enum Base { One = 1 }\nconst a = Base.One + 1, b = -a, c = ~a, d = `${a}${b}`, e = a + "x", f = Base["One"] << 3, inf = -Infinity;\nenum V { A = a, B, C = b, D = c, E = d, F = e, G = f, H = inf }',
+          'var Base;\n((Base) => {\n  Base[Base["One"] = 1] = "One";\n})(Base ||= {});\nconst a = 1 /* One */ + 1, b = -a, c = ~a, d = `${a}${b}`, e = a + "x", f = 1 /* One */ << 3, inf = -1 / 0;\nvar V;\n((V) => {\n  V[V["A"] = 2] = "A";\n  V[V["B"] = 3] = "B";\n  V[V["C"] = -2] = "C";\n  V[V["D"] = -3] = "D";\n  V["E"] = "2-2";\n  V["F"] = "2x";\n  V[V["G"] = 8] = "G";\n  V[V["H"] = -1 / 0] = "H";\n})(V ||= {})',
+        );
+      });
+
+      it("leaves alone what TypeScript does not fold", () => {
+        // declared after the enum, not const, or not a constant expression
+        exp(
+          "let x = 1;\nconst y = Math.PI;\nenum E { A = later, B = x, C = y }\nconst later = 5;",
+          'let x = 1;\nconst y = Math.PI;\nvar E;\n((E) => {\n  E[E["A"] = later] = "A";\n  E[E["B"] = x] = "B";\n  E[E["C"] = y] = "C";\n})(E ||= {});\nconst later = 5',
+        );
+        // shadowed by a hoisted variable in the enum's scope
+        exp(
+          "const v = 1;\nfunction g() {\n  enum E { A = v }\n  var v = 2;\n  return E;\n}",
+          'const v = 1;\nfunction g() {\n  let E;\n  ((E) => {\n    E[E["A"] = v] = "A";\n  })(E ||= {});\n  var v = 2;\n  return E;\n}',
+        );
+        // the const is only substituted inside enum initializers
+        exp(
+          "const n = 5;\nenum E { A = n }\nconsole.log(n, E.A);",
+          'const n = 5;\nvar E;\n((E) => {\n  E[E["A"] = 5] = "A";\n})(E ||= {});\nconsole.log(n, 5 /* A */)',
+        );
+      });
+
+      it("a function body sees an outer const declared after it", () => {
+        exp(
+          "export function f() {\n  enum E { A = outer, B }\n  return E;\n}\nconst outer = 7;",
+          'export function f() {\n  let E;\n  ((E) => {\n    E[E["A"] = 7] = "A";\n    E[E["B"] = 8] = "B";\n  })(E ||= {});\n  return E;\n}\nconst outer = 7',
+        );
+      });
+
+      it("exported const inside a namespace", () => {
+        exp(
+          "namespace N {\n  export const a = 1;\n  export enum E { X = a, Y }\n}",
+          'var N;\n((N) => {\n  N.a = 1;\n  let E;\n  ((E) => {\n    E[E["X"] = 1] = "X";\n    E[E["Y"] = 2] = "Y";\n  })(E = N.E ||= {});\n})(N ||= {})',
+        );
+      });
+    });
+
     // TODO: fix all the cases that report generic "Parse error"
     it("types", () => {
       const exp = ts.expectPrinted_;


### PR DESCRIPTION
### Problem
- An enum initializer that references a `const` is not folded. With `const base = 100; enum Status { Ok = base, Created }`, `Status.Created` is `undefined`, and a string const gets a reverse mapping. tsc emits `Created = 101` and no reverse mapping. Fixes #19581.
- Cause: enums are visited ahead of the rest of their statement list so earlier uses can be inlined (`src/js_parser/visit/mod.rs:1512`, `parse_entry.rs:974`). A sibling `const` is unvisited at that point, and `s_enum` (`visit_stmt.rs`) folds only literals and enum members, so the `const` stays a runtime reference.

### Fix
- The enum pre-visit loop gets a second arm, not a new pass: `record_ts_enum_constants` evaluates each earlier `const` of the list over the unvisited AST, by tsc's rules.
- While an enum initializer is visited, `handle_identifier` substitutes a recorded value the way it inlines an enum member. Nothing outside enum initializers changes. `s_enum` now stores a folded string member flat so inlined copies cannot share a rope (the line from #41973).
- The visitor's numeric operator folding moved into `fold_numeric_binary_operator` so both paths share it.
- Verified: 10 new cases in `transpiler/transpiler.test.js` and `ts/EnumConstVariableReferences` in `esbuild/ts.test.ts` fail on stock bun and pass now. Self-reviewed: 4 concerns raised, 4 addressed (rope crash route, test comment, namespace gaps pinned, cache version note).

### Background
- tsc compiles `enum E { A = 1 }` to `E[E["A"] = 1] = "A"` and a string member to `E["A"] = "x"` only. A member without an initializer is the previous value plus one.
- Since TypeScript 5.0 (microsoft/TypeScript#50528) a `const` with a constant initializer is a constant expression. `ts.transpileModule` folds same-file references, so single-file transpilers are expected to (esbuild does not yet).

<details><summary>Notes</summary>

- The evaluator covers what tsc's `evaluate` does: number and string literals, `+ - ~`, the arithmetic and bitwise binary operators, string `+`, untagged templates, other recorded consts, enum members (`E.A`, `E["A"]`, `N.E.A`), `Infinity`, `NaN`.
- The review found that `const p = "app"; enum Tag { U = p + "!" }` read by two template literals panicked (`Option::unwrap()` on `None` in `EString::push`): the folded member was a rope shared by every inlined copy, the hazard #41973 fixes. The `resolve_rope_if_needed` line in `s_enum` is taken from #41973 so this PR is safe on its own. Both PRs bump `EXPECTED_VERSION` to 30, so the second one to land must bump it to 31.
- A `const` with a type annotation is not folded, as in tsc: `const x: number = 1; enum E { A = x, B }` keeps `A = x` and `B = undefined` (tsc also reports TS1061). The parse pass records those declarations because the annotation is gone afterwards.
- `Infinity` and `NaN` fold when they are not shadowed, as in tsc.
- The substitution happens only for the `const` binding that the enum's scope resolves the name to. A shadowing `var`, parameter, or `let` leaves the reference alone.
- A const declared after the enum in the same list is left alone (tsc: TS2448). A const in an enclosing list is used wherever it is declared, which matches tsc for function bodies and is more lenient for plain blocks.
- Not folded yet (tsc folds both): a const reached through a namespace, `namespace N { export const a = 1 } enum E { X = N.a }` (the namespace member map carries no value, pinned as a todo test), and a member of an enum nested in a namespace, `M.Z.Q`, which is a pre-existing visit-order gap with or without a const in between.
- Strings are concatenated only when every piece is 8-bit, like the parser's other string folding. A UTF-16 literal on its own is still substituted.
- A 20000-term initializer stops at the stack check and stays a runtime reference.
- `declare enum D { A = 1 }; enum E { B = D.A + 1 }` (tsc folds `B = 2`) is not handled here. It needs a symbol for the ambient `D` that still prints as a global. That is a separate change.
- #27167 tried this before with a separate loop that filled `const_values`. This version adds an arm to the loop that already walks the list for enums, keeps declaration order, and keeps the values out of `const_values`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/transpiler.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CAR
... (truncated)

release without fix: 39 skipped
bun test v1.4.3-canary.1 (b4104db6b)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.09ms]
(pass) Bun.Transpiler > normalizes \r\n [0.15ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.07ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.75ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.30ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [5.65ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.34ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.06ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 39 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.84ms]
(pass) Bun.Transpiler > normalizes \r\n [6.78ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [5.46ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.28ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.62ms]
(pass) Bun.Transpiler > property access inlining > works [2.89ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [53.98ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [24.66ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [308.81ms]
(pass) Bun.Transpiler > property access i
... (truncated)

release with fix: 39 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 709ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                               |   2 +-
 src/js_parser/p.rs                         |  56 +++++-
 src/js_parser/parse/mod.rs                 |   5 +
 src/js_parser/parse/parse_entry.rs         |  36 ++--
 src/js_parser/parser.rs                    |  35 ++++
 src/js_parser/visit/mod.rs                 |  30 ++--
 src/js_parser/visit/visit_binary.rs        | 132 ++------------
 src/js_parser/visit/visit_stmt.rs          | 268 ++++++++++++++++++++++++++++-
 src/jsc/RuntimeTranspilerCache.rs          |   3 +-
 test/bundler/esbuild/ts.test.ts            |  50 +++++-
 test/bundler/transpiler/transpiler.test.js | 100 +++++++++++
 11 files changed, 557 insertions(+), 160 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/ast/e.rs                                    4      1     24
src/js_parser/p.rs                             12      8     24
src/js_parser/parse/mod.rs                      1      1     24
src/js_parser/parse/parse_entry.rs              3      1     24
src/js_parser/parser.rs                         1      1     24
src/js_parser/visit/mod.rs                      2      1     27
src/js_parser/visit/visit_binary.rs             2      2     24
src/js_parser/visit/visit_stmt.rs              15     17     24
src/jsc/RuntimeTranspilerCache.rs               1      1     24
test/bundler/esbuild/ts.test.ts                 2      3     13
test/bundler/transpiler/transpiler.test.js      4      6     22
```

</details>

<!-- robobun:evidence:end -->