### PR TITLE
install: make `bun outdated` and `bun update -i` read dependency ranges from package.json

### DIFF
--- a/src/install/PackageManager/add_catalog.rs
+++ b/src/install/PackageManager/add_catalog.rs
@@ -21,7 +21,7 @@ use crate::bun_fs::FileSystem;
 
 use super::add_remove_with_filter::{
     WorkspaceMembers, WorkspaceTarget, fetch_entry_root, load_workspace_members,
-    local_relative_path, root_package_json_path,
+    local_relative_path,
 };
 use super::options::LogLevel;
 use super::package_json_editor::{self as PackageJSONEditor, EditOptions};
@@ -89,14 +89,6 @@ fn root_entry<'a>(root_entries: &'a [RootEntry], name: &[u8]) -> Option<&'a [u8]
         .iter()
         .find(|(entry_name, _)| **entry_name == *name)
         .map(|(_, text)| &text[..])
-}
-
-fn root_target() -> WorkspaceTarget {
-    WorkspaceTarget {
-        name: Box::default(),
-        name_hash: None,
-        package_json_path: root_package_json_path(),
-    }
 }
 
 fn target_label(package_json: &Expr) -> Box<[u8]> {
@@ -422,7 +414,7 @@ pub(crate) fn prepare(manager: &mut PackageManager, updates: &[UpdateRequest]) {
                 Global::crash();
             }
         }
-        let root = fetch_entry_root(manager, &root_target());
+        let root = fetch_entry_root(manager, &WorkspaceTarget::root());
         if root.get(b"workspaces").is_none() {
             Output::err_generic(
                 "--catalog requires a \"workspaces\" field in the root package.json",
@@ -436,7 +428,7 @@ pub(crate) fn prepare(manager: &mut PackageManager, updates: &[UpdateRequest]) {
         return;
     }
 
-    let root = fetch_entry_root(manager, &root_target());
+    let root = fetch_entry_root(manager, &WorkspaceTarget::root());
     if !root_defines_catalogs(&root) {
         return;
     }

--- a/src/install/PackageManager/add_remove_with_filter.rs
+++ b/src/install/PackageManager/add_remove_with_filter.rs
@@ -1,9 +1,10 @@
 use bstr::BStr;
 
-use crate::Error;
 use crate::bun_fs::FileSystem;
+use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile_real::package::value_loc_of;
 use crate::lockfile_real::package::workspace_map::{MissingWorkspace, NamesArray, WorkspaceMap};
+use crate::{Error, ResolutionTag};
 use bun_collections::{StringArrayHashMap, index_sort};
 use bun_core::time::nano_timestamp;
 use bun_core::{Global, Output, strings};
@@ -34,6 +35,44 @@ pub(crate) struct WorkspaceTarget {
     /// `None` = the workspace root.
     pub(crate) name_hash: Option<PackageNameHash>,
     pub(crate) package_json_path: Box<[u8]>,
+}
+
+impl WorkspaceTarget {
+    pub(crate) fn root() -> WorkspaceTarget {
+        WorkspaceTarget {
+            name: Box::default(),
+            name_hash: None,
+            package_json_path: root_package_json_path(),
+        }
+    }
+
+    /// The package.json behind lockfile package `pkg_id`: the root's, or a member's at the path its `workspace:` resolution stores. `None` for any other kind of package.
+    pub(crate) fn of_lockfile_package(
+        lockfile: &Lockfile,
+        pkg_id: PackageID,
+    ) -> Option<WorkspaceTarget> {
+        let res = lockfile.packages.items_resolution()[pkg_id as usize];
+        match res.tag {
+            ResolutionTag::Root => Some(WorkspaceTarget::root()),
+            ResolutionTag::Workspace => {
+                let buf = lockfile.buffers.string_bytes.as_slice();
+                let top_level =
+                    strings::without_trailing_slash(FileSystem::instance().top_level_dir());
+                let mut path_buf = path_buffer_pool::get();
+                Some(WorkspaceTarget {
+                    name: Box::from(lockfile.packages.items_name()[pkg_id as usize].slice(buf)),
+                    name_hash: Some(lockfile.packages.items_name_hash()[pkg_id as usize]),
+                    package_json_path: join_abs_string_buf::<platform::Auto>(
+                        top_level,
+                        &mut path_buf.0,
+                        &[res.workspace().slice(buf), b"package.json"],
+                    )
+                    .into(),
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 pub(crate) fn root_package_json_path() -> Box<[u8]> {

--- a/src/install/PackageManager/package_json_write_back.rs
+++ b/src/install/PackageManager/package_json_write_back.rs
@@ -14,8 +14,7 @@ use crate::{PackageID, PackageNameHash, invalid_package_id};
 
 use super::add_catalog;
 use super::add_remove_with_filter::{
-    WorkspaceTarget, fetch_entry, fetch_entry_root, root_package_json_path, store_entry,
-    write_target,
+    WorkspaceTarget, fetch_entry, fetch_entry_root, store_entry, write_target,
 };
 use super::options::Do;
 use super::package_json_editor::{self as PackageJSONEditor, EditOptions};
@@ -49,14 +48,6 @@ pub(crate) fn record(
     received_requests: bool,
 ) {
     push(&mut manager.edited_package_jsons, target, received_requests);
-}
-
-fn root_target() -> WorkspaceTarget {
-    WorkspaceTarget {
-        name: Box::default(),
-        name_hash: None,
-        package_json_path: root_package_json_path(),
-    }
 }
 
 /// Phase 1 (before bun.lock is saved): write the resolved versions into the edited package.json entries and re-derive bun.lock's declared columns from them.
@@ -180,7 +171,7 @@ fn edit_update_targets(
     }
 
     if !manager.updating_catalogs.is_empty() {
-        let root = root_target();
+        let root = WorkspaceTarget::root();
         let root_ast = fetch_entry_root(manager, &root);
         if PackageJSONEditor::edit_catalogs_after_update(manager, &root_ast)? {
             store_entry(manager, &root, root_ast);
@@ -226,7 +217,7 @@ fn edit_cwd(
         return Ok(());
     }
 
-    let root = root_target();
+    let root = WorkspaceTarget::root();
     let root_ast = fetch_entry_root(manager, &root);
     let mut changed = catalog_mode && !updates.is_empty();
     if !manager.updating_catalogs.is_empty() {

--- a/src/install/PackageManager/package_json_write_back.rs
+++ b/src/install/PackageManager/package_json_write_back.rs
@@ -10,7 +10,7 @@ use crate::dependency::DependencyExt as _;
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::{Lockfile, Package};
 use crate::resolution::Tag as ResolutionTag;
-use crate::{Dependency, PackageID, PackageNameHash, invalid_package_id};
+use crate::{PackageID, PackageNameHash, invalid_package_id};
 
 use super::add_catalog;
 use super::add_remove_with_filter::{
@@ -20,6 +20,7 @@ use super::add_remove_with_filter::{
 use super::options::Do;
 use super::package_json_editor::{self as PackageJSONEditor, EditOptions};
 use super::update_package_json_and_install::print_package_json_into_cache_entry;
+use super::workspace_manifests::{ScratchManifests, same_row};
 use super::{PackageManager, Subcommand, UpdateRequest};
 
 /// A package.json whose cache entry was re-printed; `target.name_hash == None` is the root.
@@ -266,7 +267,7 @@ fn target_package_ids(lockfile: &Lockfile, edited: &[EditedPackageJson]) -> Vec<
 
 /// Re-parses the edited files the way `bun install` would and copies every declared literal that differs (and, for the root, `overrides` + `catalogs`) into `manager.lockfile`, so the next install's differ sees no change.
 fn sync_lockfile(manager: &mut PackageManager, edited: &[EditedPackageJson]) -> crate::Result<()> {
-    let mut scratch = super::workspace_manifests::ScratchManifests::new();
+    let mut scratch = ScratchManifests::new();
     scratch.parse_root(manager)?;
     let mut root_pkg = Some(core::mem::take(&mut scratch.root));
     let mut parsed: Vec<(usize, Package)> = Vec::with_capacity(edited.len());
@@ -277,7 +278,7 @@ fn sync_lockfile(manager: &mut PackageManager, edited: &[EditedPackageJson]) -> 
         }
         parsed.push((i, scratch.parse_member(manager, &e.target)?));
     }
-    let super::workspace_manifests::ScratchManifests {
+    let ScratchManifests {
         lockfile: scratch, ..
     } = scratch;
 
@@ -365,10 +366,6 @@ fn sync_lockfile(manager: &mut PackageManager, edited: &[EditedPackageJson]) -> 
         builder.clamp();
     }
     Ok(())
-}
-
-fn same_row(scratch: &Dependency, row: &Dependency) -> bool {
-    row.name_hash == scratch.name_hash && row.behavior == scratch.behavior
 }
 
 /// Compared against the file, not `stale_contents`: the before-install print in `update_package_json_and_install` replaces the cwd entry's contents without recording them.

--- a/src/install/PackageManager/workspace_manifests.rs
+++ b/src/install/PackageManager/workspace_manifests.rs
@@ -77,8 +77,7 @@ impl ScratchManifests {
         Ok(pkg)
     }
 
-    /// The package.json behind package `pkg_id` of `manager.lockfile`: the root's (already parsed by `parse_root`, not
-    /// parsed again), or a workspace member's, read from the path its `workspace:` resolution stores.
+    /// Root: what `parse_root` parsed. Workspace: parsed from the path its `workspace:` resolution stores.
     pub(crate) fn parse_lockfile_package(
         &mut self,
         manager: &mut PackageManager,
@@ -94,8 +93,7 @@ impl ScratchManifests {
     }
 }
 
-/// Whether bun.lock row `row` is the one the last install wrote for package.json dependency `scratch` of the same
-/// package. A name listed in two groups (`dependencies` and `peerDependencies`) has one row per group.
+/// A name listed in two groups (`dependencies` and `peerDependencies`) has one row per group, so the group counts.
 pub(crate) fn same_row(scratch: &Dependency, row: &Dependency) -> bool {
     row.name_hash == scratch.name_hash && row.behavior == scratch.behavior
 }
@@ -111,10 +109,7 @@ pub struct DeclaredDependency {
     pub package_id: PackageID,
 }
 
-/// The npm dependencies that the package.json files declare now, for the commands that report on direct
-/// dependencies (`bun outdated`, `bun update -i`). bun.lock keeps the names, groups and ranges of the last
-/// install, so only the installed package is taken from it. A dependency that is declared but not installed
-/// yet has no row.
+/// The npm dependencies the package.json files declare now; bun.lock only supplies what is installed for each.
 pub struct DeclaredDependencies {
     /// The package.json parse: dependency rows, their strings and the root catalogs. No packages.
     lockfile: Lockfile,
@@ -122,9 +117,7 @@ pub struct DeclaredDependencies {
 }
 
 impl DeclaredDependencies {
-    /// Parses the root package.json and the package.json of each of `workspace_pkg_ids` the way `bun install`
-    /// does, and exits with its errors when one does not parse. Rows keep the order of `workspace_pkg_ids`, then
-    /// package.json order (group, then name).
+    /// Exits with `bun install`'s errors when a package.json does not parse. Declared but not installed: no row.
     pub fn load(manager: &mut PackageManager, workspace_pkg_ids: &[PackageID]) -> Self {
         let mut scratch = ScratchManifests::new();
         if let Err(err) = scratch.parse_root(manager) {
@@ -192,8 +185,7 @@ impl DeclaredDependencies {
         &self.lockfile.buffers.dependencies[row.dep_id as usize]
     }
 
-    /// The declared range with a `catalog:` reference resolved through the root package.json: an npm range or a
-    /// dist tag.
+    /// An npm range or a dist tag, `catalog:` references resolved through the root package.json.
     pub fn range(&self, row: &DeclaredDependency) -> &DependencyVersion {
         self.lockfile
             .catalogs
@@ -226,8 +218,7 @@ impl DeclaredDependencies {
     }
 }
 
-/// The bun.lock row, out of one package's `rows`, that the last install wrote for package.json dependency `dep` of
-/// that package. A dependency that moved to another group since then still finds its old row.
+/// Falls back to a row of the same name when `dep` moved to another group since the last install.
 fn installed_row(
     lockfile: &Lockfile,
     rows: DependencySlice,

--- a/src/install/PackageManager/workspace_manifests.rs
+++ b/src/install/PackageManager/workspace_manifests.rs
@@ -1,14 +1,21 @@
+use core::fmt;
+
 use bstr::BStr;
 use bun_collections::HashMap;
 use bun_core::{Global, Output};
 use bun_semver as Semver;
 
-use crate::dependency::{Behavior, Tag as DependencyTag};
-use crate::lockfile::{self, Lockfile, Package};
-use crate::{Features, PackageNameHash};
+use crate::dependency::{Behavior, Tag as DependencyTag, Version as DependencyVersion};
+use crate::lockfile::package::PackageColumns as _;
+use crate::lockfile::{self, DependencySlice, Lockfile, Package};
+use crate::npm::{FindVersionResult, PackageManifest};
+use crate::{
+    Dependency, DependencyID, Features, PackageID, PackageNameHash, ResolutionTag,
+    invalid_package_id,
+};
 
 use super::PackageManager;
-use super::add_remove_with_filter::{WorkspaceTarget, fetch_entry, root_package_json_path};
+use super::add_remove_with_filter::{WorkspaceTarget, fetch_entry};
 use super::workspace_selection::WorkspaceGraph;
 
 /// Root + member package.json files parsed the way `bun install` parses them, into a throw-away lockfile.
@@ -29,14 +36,9 @@ impl ScratchManifests {
 
     /// Must run first: it fills `lockfile.workspace_paths`, which `workspace:` rows in every file resolve through.
     pub(crate) fn parse_root(&mut self, manager: &mut PackageManager) -> crate::Result<()> {
-        let root_target = WorkspaceTarget {
-            name: Box::default(),
-            name_hash: None,
-            package_json_path: root_package_json_path(),
-        };
         // Cloned because the `workspaces` walk below may grow the cache holding this entry.
         let (root_source, root_json) = {
-            let entry = fetch_entry(manager, &root_target);
+            let entry = fetch_entry(manager, &WorkspaceTarget::root());
             (entry.source.clone(), entry.root)
         };
         let mut resolver: () = ();
@@ -74,6 +76,174 @@ impl ScratchManifests {
         )?;
         Ok(pkg)
     }
+
+    /// The package.json behind package `pkg_id` of `manager.lockfile`: the root's (already parsed by `parse_root`, not
+    /// parsed again), or a workspace member's, read from the path its `workspace:` resolution stores.
+    pub(crate) fn parse_lockfile_package(
+        &mut self,
+        manager: &mut PackageManager,
+        pkg_id: PackageID,
+    ) -> crate::Result<Package> {
+        let Some(target) = WorkspaceTarget::of_lockfile_package(&manager.lockfile, pkg_id) else {
+            return Err(crate::Error::InvalidPackageID);
+        };
+        if target.name_hash.is_none() {
+            return Ok(self.root);
+        }
+        self.parse_member(manager, &target)
+    }
+}
+
+/// Whether bun.lock row `row` is the one the last install wrote for package.json dependency `scratch` of the same
+/// package. A name listed in two groups (`dependencies` and `peerDependencies`) has one row per group.
+pub(crate) fn same_row(scratch: &Dependency, row: &Dependency) -> bool {
+    row.name_hash == scratch.name_hash && row.behavior == scratch.behavior
+}
+
+/// One npm dependency that a package.json declares now, with the package bun.lock has installed for it.
+#[derive(Clone, Copy)]
+pub struct DeclaredDependency {
+    /// The root or workspace package whose package.json declares it.
+    pub workspace_pkg_id: PackageID,
+    /// Its row in the package.json parse, for [`DeclaredDependencies::dependency`].
+    pub dep_id: DependencyID,
+    /// The npm package that the last install resolved it to, in `manager.lockfile`.
+    pub package_id: PackageID,
+}
+
+/// The npm dependencies that the package.json files declare now, for the commands that report on direct
+/// dependencies (`bun outdated`, `bun update -i`). bun.lock keeps the names, groups and ranges of the last
+/// install, so only the installed package is taken from it. A dependency that is declared but not installed
+/// yet has no row.
+pub struct DeclaredDependencies {
+    /// The package.json parse: dependency rows, their strings and the root catalogs. No packages.
+    lockfile: Lockfile,
+    rows: Vec<DeclaredDependency>,
+}
+
+impl DeclaredDependencies {
+    /// Parses the root package.json and the package.json of each of `workspace_pkg_ids` the way `bun install`
+    /// does, and exits with its errors when one does not parse. Rows keep the order of `workspace_pkg_ids`, then
+    /// package.json order (group, then name).
+    pub fn load(manager: &mut PackageManager, workspace_pkg_ids: &[PackageID]) -> Self {
+        let mut scratch = ScratchManifests::new();
+        if let Err(err) = scratch.parse_root(manager) {
+            crash(
+                &mut scratch.log,
+                err,
+                format_args!("failed to read package.json"),
+            );
+        }
+        let mut rows = Vec::new();
+        for &workspace_pkg_id in workspace_pkg_ids {
+            let pkg = match scratch.parse_lockfile_package(manager, workspace_pkg_id) {
+                Ok(pkg) => pkg,
+                Err(err) => crash(
+                    &mut scratch.log,
+                    err,
+                    format_args!("failed to read a workspace package.json"),
+                ),
+            };
+            let installed =
+                manager.lockfile.packages.items_dependencies()[workspace_pkg_id as usize];
+            for dep_id in pkg.dependencies.begin()..pkg.dependencies.end() {
+                let dep = &scratch.lockfile.buffers.dependencies[dep_id as usize];
+                let range = scratch
+                    .lockfile
+                    .catalogs
+                    .resolve_range(scratch.lockfile.buffers.string_bytes.as_slice(), dep);
+                if !matches!(range.tag, DependencyTag::Npm | DependencyTag::DistTag) {
+                    continue;
+                }
+                let Some(installed_dep_id) = installed_row(&manager.lockfile, installed, dep)
+                else {
+                    continue;
+                };
+                let package_id = manager.lockfile.buffers.resolutions[installed_dep_id as usize];
+                if package_id == invalid_package_id
+                    || manager.lockfile.packages.items_resolution()[package_id as usize].tag
+                        != ResolutionTag::Npm
+                {
+                    continue;
+                }
+                rows.push(DeclaredDependency {
+                    workspace_pkg_id,
+                    dep_id,
+                    package_id,
+                });
+            }
+        }
+        DeclaredDependencies {
+            lockfile: scratch.lockfile,
+            rows,
+        }
+    }
+
+    pub fn rows(&self) -> &[DeclaredDependency] {
+        &self.rows
+    }
+
+    /// The buffer that [`Self::dependency`] names, catalog names and [`Self::range`] slice into.
+    pub fn string_bytes(&self) -> &[u8] {
+        self.lockfile.buffers.string_bytes.as_slice()
+    }
+
+    pub fn dependency(&self, row: &DeclaredDependency) -> &Dependency {
+        &self.lockfile.buffers.dependencies[row.dep_id as usize]
+    }
+
+    /// The declared range with a `catalog:` reference resolved through the root package.json: an npm range or a
+    /// dist tag.
+    pub fn range(&self, row: &DeclaredDependency) -> &DependencyVersion {
+        self.lockfile
+            .catalogs
+            .resolve_range(self.string_bytes(), self.dependency(row))
+    }
+
+    /// The newest version of `manifest` that [`Self::range`] allows, under the minimum release age.
+    pub fn find_update<'m>(
+        &self,
+        row: &DeclaredDependency,
+        manifest: &'m PackageManifest,
+        minimum_release_age_ms: Option<f64>,
+        exclusions: Option<&[&[u8]]>,
+    ) -> FindVersionResult<'m> {
+        let range = self.range(row);
+        if range.tag == DependencyTag::Npm {
+            manifest.find_best_version_with_filter(
+                &range.npm().version,
+                self.string_bytes(),
+                minimum_release_age_ms,
+                exclusions,
+            )
+        } else {
+            manifest.find_by_dist_tag_with_filter(
+                range.dist_tag().tag.slice(self.string_bytes()),
+                minimum_release_age_ms,
+                exclusions,
+            )
+        }
+    }
+}
+
+/// The bun.lock row, out of one package's `rows`, that the last install wrote for package.json dependency `dep` of
+/// that package. A dependency that moved to another group since then still finds its old row.
+fn installed_row(
+    lockfile: &Lockfile,
+    rows: DependencySlice,
+    dep: &Dependency,
+) -> Option<DependencyID> {
+    let mut same_name = None;
+    for id in rows.begin()..rows.end() {
+        let row = &lockfile.buffers.dependencies[id as usize];
+        if same_row(dep, row) {
+            return Some(id);
+        }
+        if row.name_hash == dep.name_hash {
+            same_name.get_or_insert(id);
+        }
+    }
+    same_name
 }
 
 /// Graph index i == `targets[i]`; the target whose `name_hash` is `None` is the root.
@@ -84,7 +254,7 @@ pub(crate) fn relation_graph(
 ) -> WorkspaceGraph {
     let mut scratch = ScratchManifests::new();
     if let Err(err) = scratch.parse_root(manager) {
-        crash(&mut scratch.log, pattern, err);
+        crash_for_filter(&mut scratch.log, pattern, err);
     }
 
     let mut parsed: Vec<(u32, Package)> = Vec::with_capacity(targets.len());
@@ -95,7 +265,7 @@ pub(crate) fn relation_graph(
         }
         match scratch.parse_member(manager, target) {
             Ok(pkg) => parsed.push((i as u32, pkg)),
-            Err(err) => crash(&mut scratch.log, pattern, err),
+            Err(err) => crash_for_filter(&mut scratch.log, pattern, err),
         }
     }
 
@@ -152,14 +322,23 @@ pub(crate) fn relation_graph(
     WorkspaceGraph::from_edges(targets.len(), edges)
 }
 
-fn crash(log: &mut bun_ast::Log, pattern: &[u8], err: crate::Error) -> ! {
+fn crash_for_filter(log: &mut bun_ast::Log, pattern: &[u8], err: crate::Error) -> ! {
+    crash(
+        log,
+        err,
+        format_args!(
+            "failed to read the workspace dependencies for --filter \"{}\"",
+            BStr::new(pattern)
+        ),
+    )
+}
+
+/// The parse errors explain the failure when there are any; `what` and `err` are the fallback.
+fn crash(log: &mut bun_ast::Log, err: crate::Error, what: fmt::Arguments<'_>) -> ! {
     if log.has_errors() {
         let _ = log.print(std::ptr::from_mut(Output::error_writer()));
     } else {
-        Output::err_generic(
-            "failed to read the workspace dependencies for --filter \"{}\": {}",
-            (BStr::new(pattern), err.name()),
-        );
+        Output::err_generic("{}: {}", (what, err.name()));
     }
     Global::crash();
 }

--- a/src/install/audit_fix/package_json_edits.rs
+++ b/src/install/audit_fix/package_json_edits.rs
@@ -2,19 +2,15 @@ use bun_ast::{E, Expr};
 use bun_collections::VecExt as _;
 use bun_collections::index_sort;
 use bun_core::strings;
-use bun_paths::path_buffer_pool;
-use bun_paths::resolve_path::{join_abs_string_buf, platform};
 use bun_semver::{PinnedVersion, Version};
 
-use crate::bun_fs::FileSystem;
 use crate::lockfile::CatalogMap;
-use crate::lockfile::package::PackageColumns as _;
 use crate::package_manager_real::add_remove_with_filter::{
-    WorkspaceTarget, fetch_entry_root, root_package_json_path, store_entry,
+    WorkspaceTarget, fetch_entry_root, store_entry,
 };
 use crate::package_manager_real::package_json_editor::for_each_catalog_object;
 use crate::package_manager_real::package_json_write_back;
-use crate::{PackageID, PackageManager, ResolutionTag};
+use crate::{PackageID, PackageManager};
 
 const DEPENDENCY_GROUPS: [&[u8]; 4] = [
     b"dependencies",
@@ -88,51 +84,14 @@ pub(super) fn apply(manager: &mut PackageManager, plan: &super::FixPlan) -> crat
         let owned = &edits[start..end];
         start = end;
 
-        let Some(target) = target_for(manager, owner) else {
+        let Some(target) = WorkspaceTarget::of_lockfile_package(&manager.lockfile, owner) else {
+            debug_assert!(false, "audit fix edit owned by a non-importer package");
             continue;
         };
         apply_to_target(manager, &target, owned)?;
         package_json_write_back::record(manager, target, false);
     }
     Ok(())
-}
-
-fn target_for(manager: &PackageManager, owner: PackageID) -> Option<WorkspaceTarget> {
-    if owner == 0 {
-        return Some(WorkspaceTarget {
-            name: Box::default(),
-            name_hash: None,
-            package_json_path: root_package_json_path(),
-        });
-    }
-    let lockfile = &manager.lockfile;
-    let res = lockfile.packages.items_resolution()[owner as usize];
-    match res.tag {
-        ResolutionTag::Root => Some(WorkspaceTarget {
-            name: Box::default(),
-            name_hash: None,
-            package_json_path: root_package_json_path(),
-        }),
-        ResolutionTag::Workspace => {
-            let buf = lockfile.buffers.string_bytes.as_slice();
-            let top_level = strings::without_trailing_slash(FileSystem::instance().top_level_dir());
-            let mut path_buf = path_buffer_pool::get();
-            Some(WorkspaceTarget {
-                name: Box::from(lockfile.packages.items_name()[owner as usize].slice(buf)),
-                name_hash: Some(lockfile.packages.items_name_hash()[owner as usize]),
-                package_json_path: join_abs_string_buf::<platform::Auto>(
-                    top_level,
-                    &mut path_buf.0,
-                    &[res.workspace().slice(buf), b"package.json"],
-                )
-                .into(),
-            })
-        }
-        _ => {
-            debug_assert!(false, "audit fix edit owned by a non-importer package");
-            None
-        }
-    }
 }
 
 fn apply_to_target(

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -9,28 +9,19 @@ use bun_glob as glob;
 use bun_install::dependency::{self, Behavior};
 use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::lockfile::{LoadResult, LoadStep};
+use bun_install::package_manager::workspace_manifests::{DeclaredDependencies, DeclaredDependency};
 use bun_install::package_manager::{
     LogLevel, Subcommand, WorkspaceFilter, populate_manifest_cache,
 };
-use bun_install::{CommandLineArguments, DependencyID, PackageID, PackageManager, resolution};
+use bun_install::{CommandLineArguments, PackageID, PackageManager};
 use bun_wyhash::hash;
 
 use crate::Command;
 
 pub(crate) struct OutdatedCommand;
 
-#[derive(Clone, Copy)]
-struct OutdatedInfo {
-    package_id: PackageID,
-    dep_id: DependencyID,
-    workspace_pkg_id: PackageID,
-    is_catalog: bool,
-}
-
 struct GroupedOutdatedInfo {
-    package_id: PackageID,
-    dep_id: DependencyID,
-    workspace_pkg_id: PackageID,
+    dep: DeclaredDependency,
     grouped_workspace_names: Option<Box<[u8]>>,
 }
 
@@ -199,14 +190,15 @@ impl OutdatedCommand {
 
     fn group_catalog_dependencies(
         manager: &PackageManager,
-        outdated_items: &[OutdatedInfo],
-        _: &[PackageID],
+        declared: &DeclaredDependencies,
+        outdated_items: &[DeclaredDependency],
     ) -> Vec<GroupedOutdatedInfo> {
-        let lockfile = &manager.lockfile;
-        let string_buf = lockfile.buffers.string_bytes.as_slice();
-        let packages = lockfile.packages.slice();
-        let pkg_names = packages.items_name();
-        let dependencies = lockfile.buffers.dependencies.as_slice();
+        let pkg_names = manager.lockfile.packages.items_name();
+        let pkg_names_buf = manager.lockfile.buffers.string_bytes.as_slice();
+        let string_buf = declared.string_bytes();
+        let is_catalog = |item: &DeclaredDependency| {
+            declared.dependency(item).version.tag == dependency::Tag::Catalog
+        };
 
         let mut result: Vec<GroupedOutdatedInfo> = Vec::new();
 
@@ -220,8 +212,8 @@ impl OutdatedCommand {
             bun_collections::HashMap::new();
 
         for item in outdated_items {
-            if item.is_catalog {
-                let dep = &dependencies[item.dep_id as usize];
+            if is_catalog(item) {
+                let dep = declared.dependency(item);
                 let name_hash = hash(dep.name.slice(string_buf));
                 let catalog = *dep.version.catalog();
                 let catalog_name = catalog.slice(string_buf);
@@ -237,9 +229,7 @@ impl OutdatedCommand {
                     .push(item.workspace_pkg_id);
             } else {
                 result.push(GroupedOutdatedInfo {
-                    package_id: item.package_id,
-                    dep_id: item.dep_id,
-                    workspace_pkg_id: item.workspace_pkg_id,
+                    dep: *item,
                     grouped_workspace_names: None,
                 });
             }
@@ -247,11 +237,11 @@ impl OutdatedCommand {
 
         // Second pass: add grouped catalog dependencies
         for item in outdated_items {
-            if !item.is_catalog {
+            if !is_catalog(item) {
                 continue;
             }
 
-            let dep = &dependencies[item.dep_id as usize];
+            let dep = declared.dependency(item);
             let name_hash = hash(dep.name.slice(string_buf));
             let catalog = *dep.version.catalog();
             let catalog_name = catalog.slice(string_buf);
@@ -283,15 +273,13 @@ impl OutdatedCommand {
                 if i > 0 {
                     workspace_names.extend_from_slice(b", ");
                 }
-                let workspace_name = pkg_names[workspace_id as usize].slice(string_buf);
+                let workspace_name = pkg_names[workspace_id as usize].slice(pkg_names_buf);
                 workspace_names.extend_from_slice(workspace_name);
             }
             workspace_names.push(b')');
 
             result.push(GroupedOutdatedInfo {
-                package_id: item.package_id,
-                dep_id: item.dep_id,
-                workspace_pkg_id: item.workspace_pkg_id,
+                dep: *item,
                 grouped_workspace_names: Some(workspace_names.into_boxed_slice()),
             });
         }
@@ -355,170 +343,138 @@ impl OutdatedCommand {
 
         let mut version_buf: String = String::new();
 
-        let mut outdated_ids: Vec<OutdatedInfo> = Vec::new();
+        // Names, groups and ranges come from each package.json as it is now; bun.lock keeps the ones of the
+        // last install and only says which version that installed.
+        let declared = DeclaredDependencies::load(manager, workspace_pkg_ids);
+        let mut outdated_ids: Vec<DeclaredDependency> = Vec::new();
 
-        for &workspace_pkg_id in workspace_pkg_ids {
-            let pkg_deps =
-                manager.lockfile.packages.items_dependencies()[workspace_pkg_id as usize];
-            for dep_id in pkg_deps.begin()..pkg_deps.end() {
-                let package_id = manager.lockfile.buffers.resolutions[dep_id as usize];
-                if package_id == bun_install::INVALID_PACKAGE_ID {
-                    continue;
-                }
-                let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
-                let Some(resolved_version) = manager.lockfile.resolve_catalog_dependency(dep)
-                else {
-                    continue;
-                };
-                if resolved_version.tag != dependency::Tag::Npm
-                    && resolved_version.tag != dependency::Tag::DistTag
-                {
-                    continue;
-                }
-                let resolution = manager.lockfile.packages.items_resolution()[package_id as usize];
-                if resolution.tag != resolution::Tag::Npm {
-                    continue;
-                }
+        for row in declared.rows() {
+            let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+            let dep = declared.dependency(row);
+            let resolution = manager.lockfile.packages.items_resolution()[row.package_id as usize];
 
-                // package patterns match against dependency name (name in package.json)
-                if let Some(patterns) = &package_patterns {
-                    let matched = 'match_: {
-                        for pattern in patterns {
-                            match pattern {
-                                FilterType::Path => unreachable!(),
-                                FilterType::Name(name_pattern) => {
-                                    if name_pattern.is_empty() {
-                                        continue;
-                                    }
-                                    if !glob::r#match(name_pattern, dep.name.slice(string_buf))
-                                        .matches()
-                                    {
-                                        break 'match_ false;
-                                    }
+            // package patterns match against dependency name (name in package.json)
+            if let Some(patterns) = &package_patterns {
+                let matched = 'match_: {
+                    for pattern in patterns {
+                        match pattern {
+                            FilterType::Path => unreachable!(),
+                            FilterType::Name(name_pattern) => {
+                                if name_pattern.is_empty() {
+                                    continue;
                                 }
-                                FilterType::All => {}
+                                if !glob::r#match(
+                                    name_pattern,
+                                    dep.name.slice(declared.string_bytes()),
+                                )
+                                .matches()
+                                {
+                                    break 'match_ false;
+                                }
                             }
+                            FilterType::All => {}
                         }
-                        true
-                    };
-                    if !matched {
-                        continue;
                     }
-                }
-
-                let package_name =
-                    manager.lockfile.packages.items_name()[package_id as usize].slice(string_buf);
-                let scope = manager.options.scope_for_package_name(package_name).clone();
-                let mut expired = false;
-                let Some(manifest) = manager.manifests.by_name_allow_expired(
-                    cache_ctx,
-                    &scope,
-                    package_name,
-                    Some(&mut expired),
-                    needs_extended,
-                ) else {
-                    continue;
+                    true
                 };
-
-                let Some(actual_latest) = manifest.find_by_dist_tag(b"latest") else {
-                    continue;
-                };
-
-                let latest = manifest.find_by_dist_tag_with_filter(b"latest", min_age_ms, excludes);
-
-                let update_version = if resolved_version.tag == dependency::Tag::Npm {
-                    manifest.find_best_version_with_filter(
-                        &resolved_version.npm().version,
-                        string_buf,
-                        min_age_ms,
-                        excludes,
-                    )
-                } else {
-                    manifest.find_by_dist_tag_with_filter(
-                        resolved_version.dist_tag().tag.slice(string_buf),
-                        min_age_ms,
-                        excludes,
-                    )
-                };
-
-                let current_version = resolution.npm().version;
-                if current_version.order(actual_latest.version, string_buf, &manifest.string_buf)
-                    != core::cmp::Ordering::Less
-                {
+                if !matched {
                     continue;
                 }
-
-                let has_filtered_update = update_version.latest_is_filtered();
-                let has_filtered_latest = latest.latest_is_filtered();
-                if has_filtered_update || has_filtered_latest {
-                    has_filtered_versions = true;
-                }
-
-                let package_name_len = package_name.len()
-                    + if dep.behavior.is_dev() {
-                        " (dev)".len()
-                    } else if dep.behavior.is_peer() {
-                        " (peer)".len()
-                    } else if dep.behavior.is_optional() {
-                        " (optional)".len()
-                    } else {
-                        0
-                    };
-                if package_name_len > max_name {
-                    max_name = package_name_len;
-                }
-
-                version_buf.clear();
-                write!(version_buf, "{}", current_version.fmt(string_buf))
-                    .expect("OOM writing version");
-                if version_buf.len() > max_current {
-                    max_current = version_buf.len();
-                }
-
-                version_buf.clear();
-                if let Some(uv) = update_version.unwrap() {
-                    write!(version_buf, "{}", uv.version.fmt(&manifest.string_buf))
-                        .expect("OOM writing version");
-                } else {
-                    write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
-                        .expect("OOM writing version");
-                }
-                let update_version_len =
-                    version_buf.len() + if has_filtered_update { " *".len() } else { 0 };
-                if update_version_len > max_update {
-                    max_update = update_version_len;
-                }
-
-                version_buf.clear();
-                if let Some(lv) = latest.unwrap() {
-                    write!(version_buf, "{}", lv.version.fmt(&manifest.string_buf))
-                        .expect("OOM writing version");
-                } else {
-                    write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
-                        .expect("OOM writing version");
-                }
-                let latest_version_len =
-                    version_buf.len() + if has_filtered_latest { " *".len() } else { 0 };
-                if latest_version_len > max_latest {
-                    max_latest = latest_version_len;
-                }
-                version_buf.clear();
-
-                let workspace_name = manager.lockfile.packages.items_name()
-                    [workspace_pkg_id as usize]
-                    .slice(string_buf);
-                if workspace_name.len() > max_workspace {
-                    max_workspace = workspace_name.len();
-                }
-
-                outdated_ids.push(OutdatedInfo {
-                    package_id,
-                    dep_id,
-                    workspace_pkg_id,
-                    is_catalog: dep.version.tag == dependency::Tag::Catalog,
-                });
             }
+
+            let package_name =
+                manager.lockfile.packages.items_name()[row.package_id as usize].slice(string_buf);
+            let scope = manager.options.scope_for_package_name(package_name).clone();
+            let mut expired = false;
+            let Some(manifest) = manager.manifests.by_name_allow_expired(
+                cache_ctx,
+                &scope,
+                package_name,
+                Some(&mut expired),
+                needs_extended,
+            ) else {
+                continue;
+            };
+
+            let Some(actual_latest) = manifest.find_by_dist_tag(b"latest") else {
+                continue;
+            };
+
+            let latest = manifest.find_by_dist_tag_with_filter(b"latest", min_age_ms, excludes);
+            let update_version = declared.find_update(row, manifest, min_age_ms, excludes);
+
+            // `DeclaredDependencies` only has rows installed from npm.
+            let current_version = resolution.npm().version;
+            if current_version.order(actual_latest.version, string_buf, &manifest.string_buf)
+                != core::cmp::Ordering::Less
+            {
+                continue;
+            }
+
+            let has_filtered_update = update_version.latest_is_filtered();
+            let has_filtered_latest = latest.latest_is_filtered();
+            if has_filtered_update || has_filtered_latest {
+                has_filtered_versions = true;
+            }
+
+            let package_name_len = package_name.len()
+                + if dep.behavior.is_dev() {
+                    " (dev)".len()
+                } else if dep.behavior.is_peer() {
+                    " (peer)".len()
+                } else if dep.behavior.is_optional() {
+                    " (optional)".len()
+                } else {
+                    0
+                };
+            if package_name_len > max_name {
+                max_name = package_name_len;
+            }
+
+            version_buf.clear();
+            write!(version_buf, "{}", current_version.fmt(string_buf))
+                .expect("OOM writing version");
+            if version_buf.len() > max_current {
+                max_current = version_buf.len();
+            }
+
+            version_buf.clear();
+            if let Some(uv) = update_version.unwrap() {
+                write!(version_buf, "{}", uv.version.fmt(&manifest.string_buf))
+                    .expect("OOM writing version");
+            } else {
+                write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
+                    .expect("OOM writing version");
+            }
+            let update_version_len =
+                version_buf.len() + if has_filtered_update { " *".len() } else { 0 };
+            if update_version_len > max_update {
+                max_update = update_version_len;
+            }
+
+            version_buf.clear();
+            if let Some(lv) = latest.unwrap() {
+                write!(version_buf, "{}", lv.version.fmt(&manifest.string_buf))
+                    .expect("OOM writing version");
+            } else {
+                write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
+                    .expect("OOM writing version");
+            }
+            let latest_version_len =
+                version_buf.len() + if has_filtered_latest { " *".len() } else { 0 };
+            if latest_version_len > max_latest {
+                max_latest = latest_version_len;
+            }
+            version_buf.clear();
+
+            let workspace_name = manager.lockfile.packages.items_name()
+                [row.workspace_pkg_id as usize]
+                .slice(string_buf);
+            if workspace_name.len() > max_workspace {
+                max_workspace = workspace_name.len();
+            }
+
+            outdated_ids.push(*row);
         }
 
         if outdated_ids.is_empty() {
@@ -526,8 +482,7 @@ impl OutdatedCommand {
         }
 
         // Group catalog dependencies
-        let grouped_ids =
-            Self::group_catalog_dependencies(manager, &outdated_ids, workspace_pkg_ids);
+        let grouped_ids = Self::group_catalog_dependencies(manager, &declared, &outdated_ids);
 
         // Recalculate max workspace length after grouping
         let mut new_max_workspace: usize = max_workspace;
@@ -594,11 +549,10 @@ impl OutdatedCommand {
             Behavior::OPTIONAL,
         ] {
             for item in &grouped_ids {
-                let package_id = item.package_id;
-                let dep_id = item.dep_id;
+                let package_id = item.dep.package_id;
 
                 let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
+                let dep = declared.dependency(&item.dep);
                 if !dep.behavior.includes(group_behavior) {
                     continue;
                 }
@@ -620,26 +574,9 @@ impl OutdatedCommand {
                 };
 
                 let latest = manifest.find_by_dist_tag_with_filter(b"latest", min_age_ms, excludes);
-                let Some(resolved_version) = manager.lockfile.resolve_catalog_dependency(dep)
-                else {
-                    continue;
-                };
-                let update = if resolved_version.tag == dependency::Tag::Npm {
-                    manifest.find_best_version_with_filter(
-                        &resolved_version.npm().version,
-                        string_buf,
-                        min_age_ms,
-                        excludes,
-                    )
-                } else {
-                    manifest.find_by_dist_tag_with_filter(
-                        resolved_version.dist_tag().tag.slice(string_buf),
-                        min_age_ms,
-                        excludes,
-                    )
-                };
+                let update = declared.find_update(&item.dep, manifest, min_age_ms, excludes);
 
-                // resolution.tag == Npm (verified in first pass).
+                // `DeclaredDependencies` only has rows installed from npm.
                 let current_version = resolution.npm().version;
 
                 table.print_line_separator();
@@ -755,7 +692,7 @@ impl OutdatedCommand {
                     let workspace_name: &[u8] = if let Some(names) = &item.grouped_workspace_names {
                         names
                     } else {
-                        manager.lockfile.packages.items_name()[item.workspace_pkg_id as usize]
+                        manager.lockfile.packages.items_name()[item.dep.workspace_pkg_id as usize]
                             .slice(string_buf)
                     };
                     bun_core::pretty!("{}", BStr::new(workspace_name));

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -443,7 +443,7 @@ impl OutdatedCommand {
                 write!(version_buf, "{}", uv.version.fmt(&manifest.string_buf))
                     .expect("OOM writing version");
             } else {
-                write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
+                write!(version_buf, "{}", current_version.fmt(string_buf))
                     .expect("OOM writing version");
             }
             let update_version_len =
@@ -457,7 +457,7 @@ impl OutdatedCommand {
                 write!(version_buf, "{}", lv.version.fmt(&manifest.string_buf))
                     .expect("OOM writing version");
             } else {
-                write!(version_buf, "{}", current_version.fmt(&manifest.string_buf))
+                write!(version_buf, "{}", current_version.fmt(string_buf))
                     .expect("OOM writing version");
             }
             let latest_version_len =

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -343,8 +343,6 @@ impl OutdatedCommand {
 
         let mut version_buf: String = String::new();
 
-        // Names, groups and ranges come from each package.json as it is now; bun.lock keeps the ones of the
-        // last install and only says which version that installed.
         let declared = DeclaredDependencies::load(manager, workspace_pkg_ids);
         let mut outdated_ids: Vec<DeclaredDependency> = Vec::new();
 

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -12,6 +12,7 @@ use bun_install::dependency::{self, Behavior};
 use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::package_manager::options::Do;
+use bun_install::package_manager::workspace_manifests::DeclaredDependencies;
 use bun_install::package_manager::{
     LogLevel, Subcommand, WorkspaceFilter, populate_manifest_cache,
     update_package_json_and_install_with_manager,
@@ -840,171 +841,139 @@ impl UpdateInteractiveCommand {
         let global_uses_default_registry = manager.options.scope.url_hash == default_url_hash;
 
         let mut outdated_packages: Vec<OutdatedPackage> = Vec::new();
-        let mut checked: usize = 0;
 
         let mut version_buf: String = String::new();
 
-        for &workspace_pkg_id in workspace_pkg_ids {
-            let pkg_deps =
-                manager.lockfile.packages.items_dependencies()[workspace_pkg_id as usize];
-            for dep_id in pkg_deps.begin()..pkg_deps.end() {
-                let package_id = manager.lockfile.buffers.resolutions[dep_id as usize];
-                if package_id == INVALID_PACKAGE_ID {
-                    continue;
-                }
-                checked += 1;
-                let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
-                if !selects(groups, dep.behavior) {
-                    continue;
-                }
-                let Some(resolved_version) = manager.lockfile.resolve_catalog_dependency(dep)
-                else {
-                    continue;
-                };
-                if resolved_version.tag != dependency::Tag::Npm
-                    && resolved_version.tag != dependency::Tag::DistTag
-                {
-                    continue;
-                }
-                let resolution = manager.lockfile.packages.items_resolution()[package_id as usize];
-                if resolution.tag != resolution::Tag::Npm {
-                    continue;
-                }
+        // Names, groups and ranges come from each package.json as it is now; bun.lock keeps the ones of the
+        // last install and only says which version that installed.
+        let declared = DeclaredDependencies::load(manager, workspace_pkg_ids);
+        let checked = declared.rows().len();
 
-                let name_slice = dep.name.slice(string_buf);
-                let package_name =
-                    manager.lockfile.packages.items_name()[package_id as usize].slice(string_buf);
-
-                let scope = manager.options.scope_for_package_name(package_name).clone();
-                // Snapshot for `OutdatedPackage.uses_default_registry` (see
-                // field comment) — cannot be deferred to render time, since a
-                // stored manager back-pointer cannot be soundly aliased.
-                let uses_default_registry = global_uses_default_registry
-                    && manager.options.scope_for_package_name(name_slice).url_hash
-                        == default_url_hash;
-                let mut expired = false;
-                let Some(manifest) = manager.manifests.by_name_allow_expired(
-                    cache_ctx,
-                    &scope,
-                    package_name,
-                    Some(&mut expired),
-                    needs_extended,
-                ) else {
-                    continue;
-                };
-
-                let Some(latest) = manifest
-                    .find_by_dist_tag_with_filter(b"latest", min_age_ms, excludes)
-                    .unwrap()
-                else {
-                    continue;
-                };
-
-                // In interactive mode, show the constrained update version as "Target"
-                // but always include packages (don't filter out breaking changes)
-                let update_version = if resolved_version.tag == dependency::Tag::Npm {
-                    manifest
-                        .find_best_version_with_filter(
-                            &resolved_version.npm().version,
-                            string_buf,
-                            min_age_ms,
-                            excludes,
-                        )
-                        .unwrap()
-                        .unwrap_or(latest)
-                } else {
-                    manifest
-                        .find_by_dist_tag_with_filter(
-                            resolved_version.dist_tag().tag.slice(string_buf),
-                            min_age_ms,
-                            excludes,
-                        )
-                        .unwrap()
-                        .unwrap_or(latest)
-                };
-
-                // Skip only if both the constrained update AND the latest version are the same as current
-                // This ensures we show packages where latest is newer even if constrained update isn't
-                let current_ver = resolution.npm().version;
-                let update_ver = update_version.version;
-                let latest_ver = latest.version;
-
-                let update_is_same = current_ver.major == update_ver.major
-                    && current_ver.minor == update_ver.minor
-                    && current_ver.patch == update_ver.patch
-                    && current_ver.tag.eql(update_ver.tag);
-
-                let latest_is_same = current_ver.major == latest_ver.major
-                    && current_ver.minor == latest_ver.minor
-                    && current_ver.patch == latest_ver.patch
-                    && current_ver.tag.eql(latest_ver.tag);
-
-                if update_is_same && latest_is_same {
-                    continue;
-                }
-
-                version_buf.clear();
-                write!(version_buf, "{}", current_ver.fmt(string_buf)).expect("OOM");
-                let current_version_buf: Box<[u8]> = Box::from(version_buf.as_bytes());
-
-                version_buf.clear();
-                write!(
-                    version_buf,
-                    "{}",
-                    update_version.version.fmt(&manifest.string_buf)
-                )
-                .expect("OOM");
-                let update_version_buf: Box<[u8]> = Box::from(version_buf.as_bytes());
-
-                version_buf.clear();
-                write!(version_buf, "{}", latest.version.fmt(&manifest.string_buf)).expect("OOM");
-                let latest_version_buf: Box<[u8]> = Box::from(version_buf.as_bytes());
-
-                // Already filtered by version.order check above
-
-                version_buf.clear();
-                let dep_type: &'static [u8] = DependencyGroup::prop_for_behavior(dep.behavior);
-
-                // Get workspace name but only show if it's actually a workspace
-                let workspace_resolution =
-                    manager.lockfile.packages.items_resolution()[workspace_pkg_id as usize];
-                let workspace_name: &[u8] =
-                    if workspace_resolution.tag == resolution::Tag::Workspace {
-                        manager.lockfile.packages.items_name()[workspace_pkg_id as usize]
-                            .slice(string_buf)
-                    } else {
-                        b""
-                    };
-
-                let is_catalog = dep.version.tag == dependency::Tag::Catalog;
-                let catalog_name_str: &[u8] = if is_catalog {
-                    dep.version.catalog().slice(string_buf)
-                } else {
-                    b""
-                };
-
-                let catalog_name: Option<Box<[u8]>> = if !catalog_name_str.is_empty() {
-                    Some(Box::from(catalog_name_str))
-                } else {
-                    None
-                };
-
-                outdated_packages.push(OutdatedPackage {
-                    name: Box::from(name_slice),
-                    current_version: current_version_buf,
-                    latest_version: latest_version_buf,
-                    update_version: update_version_buf,
-                    workspace_pkg_id,
-                    dependency_type: dep_type,
-                    workspace_name: Box::from(workspace_name),
-                    behavior: dep.behavior,
-                    uses_default_registry,
-                    is_catalog,
-                    catalog_name,
-                    use_latest: update_to_latest, // default to --latest flag value
-                });
+        for row in declared.rows() {
+            let workspace_pkg_id = row.workspace_pkg_id;
+            let package_id = row.package_id;
+            let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+            let json_buf = declared.string_bytes();
+            let dep = declared.dependency(row);
+            if !selects(groups, dep.behavior) {
+                continue;
             }
+            let resolution = manager.lockfile.packages.items_resolution()[package_id as usize];
+
+            let name_slice = dep.name.slice(json_buf);
+            let package_name =
+                manager.lockfile.packages.items_name()[package_id as usize].slice(string_buf);
+
+            let scope = manager.options.scope_for_package_name(package_name).clone();
+            // Snapshot for `OutdatedPackage.uses_default_registry` (see
+            // field comment) — cannot be deferred to render time, since a
+            // stored manager back-pointer cannot be soundly aliased.
+            let uses_default_registry = global_uses_default_registry
+                && manager.options.scope_for_package_name(name_slice).url_hash == default_url_hash;
+            let mut expired = false;
+            let Some(manifest) = manager.manifests.by_name_allow_expired(
+                cache_ctx,
+                &scope,
+                package_name,
+                Some(&mut expired),
+                needs_extended,
+            ) else {
+                continue;
+            };
+
+            let Some(latest) = manifest
+                .find_by_dist_tag_with_filter(b"latest", min_age_ms, excludes)
+                .unwrap()
+            else {
+                continue;
+            };
+
+            // In interactive mode, show the constrained update version as "Target"
+            // but always include packages (don't filter out breaking changes)
+            let update_version = declared
+                .find_update(row, manifest, min_age_ms, excludes)
+                .unwrap()
+                .unwrap_or(latest);
+
+            // Skip only if both the constrained update AND the latest version are the same as current
+            // This ensures we show packages where latest is newer even if constrained update isn't
+            // `DeclaredDependencies` only has rows installed from npm.
+            let current_ver = resolution.npm().version;
+            let update_ver = update_version.version;
+            let latest_ver = latest.version;
+
+            let update_is_same = current_ver.major == update_ver.major
+                && current_ver.minor == update_ver.minor
+                && current_ver.patch == update_ver.patch
+                && current_ver.tag.eql(update_ver.tag);
+
+            let latest_is_same = current_ver.major == latest_ver.major
+                && current_ver.minor == latest_ver.minor
+                && current_ver.patch == latest_ver.patch
+                && current_ver.tag.eql(latest_ver.tag);
+
+            if update_is_same && latest_is_same {
+                continue;
+            }
+
+            version_buf.clear();
+            write!(version_buf, "{}", current_ver.fmt(string_buf)).expect("OOM");
+            let current_version_buf: Box<[u8]> = Box::from(version_buf.as_bytes());
+
+            version_buf.clear();
+            write!(
+                version_buf,
+                "{}",
+                update_version.version.fmt(&manifest.string_buf)
+            )
+            .expect("OOM");
+            let update_version_buf: Box<[u8]> = Box::from(version_buf.as_bytes());
+
+            version_buf.clear();
+            write!(version_buf, "{}", latest.version.fmt(&manifest.string_buf)).expect("OOM");
+            let latest_version_buf: Box<[u8]> = Box::from(version_buf.as_bytes());
+
+            // Already filtered by version.order check above
+
+            version_buf.clear();
+            let dep_type: &'static [u8] = DependencyGroup::prop_for_behavior(dep.behavior);
+
+            // Get workspace name but only show if it's actually a workspace
+            let workspace_resolution =
+                manager.lockfile.packages.items_resolution()[workspace_pkg_id as usize];
+            let workspace_name: &[u8] = if workspace_resolution.tag == resolution::Tag::Workspace {
+                manager.lockfile.packages.items_name()[workspace_pkg_id as usize].slice(string_buf)
+            } else {
+                b""
+            };
+
+            let is_catalog = dep.version.tag == dependency::Tag::Catalog;
+            let catalog_name_str: &[u8] = if is_catalog {
+                dep.version.catalog().slice(json_buf)
+            } else {
+                b""
+            };
+
+            let catalog_name: Option<Box<[u8]>> = if !catalog_name_str.is_empty() {
+                Some(Box::from(catalog_name_str))
+            } else {
+                None
+            };
+
+            outdated_packages.push(OutdatedPackage {
+                name: Box::from(name_slice),
+                current_version: current_version_buf,
+                latest_version: latest_version_buf,
+                update_version: update_version_buf,
+                workspace_pkg_id,
+                dependency_type: dep_type,
+                workspace_name: Box::from(workspace_name),
+                behavior: dep.behavior,
+                uses_default_registry,
+                is_catalog,
+                catalog_name,
+                use_latest: update_to_latest, // default to --latest flag value
+            });
         }
 
         // Group catalog dependencies

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -863,9 +863,7 @@ impl UpdateInteractiveCommand {
                 manager.lockfile.packages.items_name()[package_id as usize].slice(string_buf);
 
             let scope = manager.options.scope_for_package_name(package_name).clone();
-            // Snapshot for `OutdatedPackage.uses_default_registry` (see
-            // field comment) — cannot be deferred to render time, since a
-            // stored manager back-pointer cannot be soundly aliased.
+            // Snapshot now; see the `uses_default_registry` field comment.
             let uses_default_registry = global_uses_default_registry
                 && manager.options.scope_for_package_name(name_slice).url_hash == default_url_hash;
             let mut expired = false;
@@ -886,15 +884,13 @@ impl UpdateInteractiveCommand {
                 continue;
             };
 
-            // In interactive mode, show the constrained update version as "Target"
-            // but always include packages (don't filter out breaking changes)
+            // "Target" is the in-range update; a row whose only newer version is "Latest" still shows.
             let update_version = declared
                 .find_update(row, manifest, min_age_ms, excludes)
                 .unwrap()
                 .unwrap_or(latest);
 
-            // Skip only if both the constrained update AND the latest version are the same as current
-            // This ensures we show packages where latest is newer even if constrained update isn't
+            // Skip only when both "Target" and "Latest" are the installed version.
             let current_ver = resolution.npm().version;
             let update_ver = update_version.version;
             let latest_ver = latest.version;

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -844,8 +844,6 @@ impl UpdateInteractiveCommand {
 
         let mut version_buf: String = String::new();
 
-        // Names, groups and ranges come from each package.json as it is now; bun.lock keeps the ones of the
-        // last install and only says which version that installed.
         let declared = DeclaredDependencies::load(manager, workspace_pkg_ids);
         let checked = declared.rows().len();
 
@@ -897,7 +895,6 @@ impl UpdateInteractiveCommand {
 
             // Skip only if both the constrained update AND the latest version are the same as current
             // This ensures we show packages where latest is newer even if constrained update isn't
-            // `DeclaredDependencies` only has rows installed from npm.
             let current_ver = resolution.npm().version;
             let update_ver = update_version.version;
             let latest_ver = latest.version;

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9112,6 +9112,55 @@ describe("outdated", () => {
     // The catalog grouping should show which workspaces use it
     expect(out).toMatch(/catalog.*workspace-a.*workspace-b|workspace-b.*workspace-a/);
   });
+
+  test("reads dependency ranges from package.json, not bun.lock", async () => {
+    const writeManifests = (root: object, pkg1: object, pkg2: object) =>
+      Promise.all([
+        write(packageJson, JSON.stringify(root)),
+        write(join(packageDir, "packages", "pkg1", "package.json"), JSON.stringify(pkg1)),
+        write(join(packageDir, "packages", "pkg2", "package.json"), JSON.stringify(pkg2)),
+      ]);
+
+    await writeManifests(
+      {
+        name: "root",
+        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "1.0.0" } },
+        dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" },
+      },
+      { name: "pkg1", dependencies: { "a-dep": "1.0.1" } },
+      { name: "pkg2", dependencies: { "no-deps": "catalog:" } },
+    );
+    await runBunInstall(env, packageDir);
+    const lockfile = await file(join(packageDir, "bun.lockb")).arrayBuffer();
+
+    // Edit every range without running `bun install` again. bun.lockb still
+    // has the exact pins, and `a-dep` is gone from the root package.json.
+    await writeManifests(
+      {
+        name: "root",
+        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^1.0.0" } },
+        dependencies: { "no-deps": "~1.0.0" },
+      },
+      { name: "pkg1", devDependencies: { "a-dep": "^1.0.1" } },
+      { name: "pkg2", dependencies: { "no-deps": "catalog:" } },
+    );
+
+    const out = await runBunOutdated({ ...env, NO_COLOR: "1" }, packageDir, "--filter", "*");
+    expect(out.slice(out.indexOf("\n") + 1)).toMatchInlineSnapshot(`
+      "|----------------------------------------------------------|
+      | Package     | Current | Update | Latest | Workspace      |
+      |-------------|---------|--------|--------|----------------|
+      | no-deps     | 1.0.0   | 1.0.1  | 2.0.0  | root           |
+      |-------------|---------|--------|--------|----------------|
+      | no-deps     | 1.0.0   | 1.1.0  | 2.0.0  | catalog (pkg2) |
+      |-------------|---------|--------|--------|----------------|
+      | a-dep (dev) | 1.0.1   | 1.0.10 | 1.0.10 | pkg1           |
+      |----------------------------------------------------------|
+      "
+    `);
+    // `bun outdated` only reads: the lockfile on disk is untouched.
+    expect(await file(join(packageDir, "bun.lockb")).arrayBuffer()).toEqual(lockfile);
+  });
 });
 
 // TODO: setup registry to run across multiple test files, then move this and a few other describe

--- a/test/cli/update_interactive_formatting.test.ts
+++ b/test/cli/update_interactive_formatting.test.ts
@@ -119,6 +119,39 @@ describe.concurrent("bun update --interactive", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("should offer what package.json declares now, not what bun.lock recorded", async () => {
+    await using dir = tempDir("update-interactive-edited-package-json", {
+      "bunfig.toml": bunfig(),
+      "package.json": JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: { "a-dep": "1.0.1", "dep-with-tags": "1.0.0", "no-deps": "1.0.0" },
+      }),
+    });
+    await install(dir);
+    const lockfile = await Bun.file(join(dir, "bun.lock")).text();
+
+    // Edited after the install, no reinstall: ranges widened, `a-dep` moved to
+    // devDependencies, `dep-with-tags` removed. bun.lock still has the old list.
+    await Bun.write(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: { "no-deps": "^1.0.0" },
+        devDependencies: { "a-dep": "^1.0.1" },
+      }),
+    );
+    const { stdout, exitCode } = await updateInteractive(dir, { args: ["--dry-run"], input: "\n" });
+
+    // Name, Current, Target, Latest: Target follows the new ranges, not the exact pins bun.lock still has.
+    expect(stdout).toMatch(/no-deps\s+1\.0\.0\s+1\.1\.0\s+2\.0\.0/);
+    expect(stdout).toMatch(/a-dep dev\s+1\.0\.1\s+1\.0\.10\s/);
+    expect(stdout).not.toContain("dep-with-tags");
+    expect(await Bun.file(join(dir, "bun.lock")).text()).toBe(lockfile);
+    expect(exitCode).toBe(0);
+  });
+
   it("should render mixed dependency types under separate section headers", async () => {
     await using dir = tempDir("update-interactive-mixed-sections", {
       "bunfig.toml": bunfig(),


### PR DESCRIPTION
### Problem
- `bun outdated` and `bun update -i` compute the "Update" / "Target" column from the dependency range stored in bun.lock, not from package.json. Change `"no-deps": "1.0.0"` to `"^1.0.0"` without a reinstall and both still print `1.0.0`. A dependency removed from package.json stays listed (as #34262 reports).
- The cause: `print_outdated_info_table` (`src/runtime/cli/outdated_command.rs:365`) and its copy `get_outdated_packages` (`update_interactive_command.rs:847`) walk the lockfile's dependency rows, which keep the names, groups and ranges of the last `bun install`.

### Fix
- Add `DeclaredDependencies` to `bun_install`. It parses the root and each selected workspace package.json the way `bun install` does and joins each declared npm dependency, by name and group, with the package bun.lock installed for it. Both commands iterate it.
- Correct because `bun install` makes the same split: it diffs a fresh package.json parse against the lockfile, which records what is installed, not what is wanted.
- Self-reviewed: 6 concerns raised, 6 addressed (the first draft fixed `bun outdated` alone).
- Verified: new cases in `test/cli/install/bun-install-registry.test.ts` and `test/cli/update_interactive_formatting.test.ts`, both failing on stock bun, plus every other `outdated` and `update -i` test.

### Background
- Both commands print, per direct dependency, `Current` (installed), `Update`/`Target` (best version in the declared range) and `Latest` (`latest` dist-tag).
- bun.lock stores, per workspace package, a copy of its package.json dependency list at the last install, next to the resolved package of each entry.
- `ScratchManifests` (`workspace_manifests.rs`) parses package.json files into a throw-away `Lockfile`, as `bun add --filter` already does. `DeclaredDependencies` is a public facade over it.

<details><summary>Notes</summary>

- Repro without the tests: `echo '{"name":"app","dependencies":{"pkg":"1.0.0"}}' > package.json && bun install`, change `"1.0.0"` to `"^1.0.0"`, run `bun outdated`. Before: `Update 1.0.0`, while `npm outdated` prints the new wanted version for the same tree. A no-op `bun install` refreshes the lockfile copy and the next `bun outdated` is right, which shows where the range came from.
- The `bun outdated` test ("reads dependency ranges from package.json, not bun.lock") covers four cases in one table: a changed root range (`~1.0.0`), a changed catalog range used by a member (`catalog:`), a member dependency that changed range and moved to `devDependencies`, and a root dependency removed from package.json. It also checks that bun.lockb is byte-identical afterwards. The `update -i` test ("should offer what package.json declares now, not what bun.lock recorded") covers a widened range, a moved group and a removed dependency, and checks bun.lock is untouched.
- `WorkspaceTarget::of_lockfile_package` is the former private `target_for` of `audit_fix/package_json_edits.rs`. `same_row` is the former private helper of `package_json_write_back.rs`. Both move next to `ScratchManifests` so each has one copy. `DeclaredDependencies` uses `same_row` to match a declared dependency to its lockfile row, and falls back to a same-name row when the dependency moved to another group.
- A dependency that is in package.json but has no lockfile row yet (added, never installed) is still not listed, as before. npm prints `MISSING` for it. Left for a follow-up.
- A workspace whose package.json cannot be read now fails the command with `failed to read/parse package.json for workspace '<name>'`, the message `bun add --filter` uses. Before, its stale lockfile rows were printed. Plain `bun outdated` (no `--filter`/`-r`) only reads the root and the current workspace, which `bun install` already requires.
- `bun update -i`'s "Checked N dependencies" line now counts declared npm dependencies that are installed. It no longer counts `workspace:` links or git dependencies, which it never offered anyway. `bun update` (non-interactive) already excluded workspace links.
- The root parse uses `Features::main()`, so it walks the `workspaces` globs like an install. That keeps fidelity: a root dependency that names a workspace member by version becomes a `workspace:` dependency only through that walk.
- #38813 touches the same file for pack/publish. This PR keeps `ScratchManifests` crate-private behind a public facade, the shape #38813 uses, and the same `crash(log, err, what)` helper, so either order rebases cleanly.
- Also in the first pass of `bun outdated`: the installed version is now formatted with the lockfile string buffer in the two fallback branches (it was formatted with the manifest buffer, which mis-sizes the column for a pre-release current version). #38649 changes the same two lines.
- Other suites run locally: `bun-update-transitive.test.ts` (all 174), `bun-add-filter.test.ts`, `bun-audit.test.ts -t fix`, `update_interactive_install.test.ts`, `update_interactive_snapshots.test.ts`, the `outdated` tests in `bun-update.test.ts` and `minimum-release-age.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/update_interactive_formatting.test.ts, test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->