### PR TITLE
build: print standalone HTML to stdout when no --outdir or --outfile is given

### DIFF
--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -75,6 +75,16 @@ bun build --compile --target=browser ./index.html --outdir=dist
 
 Open `dist/index.html` — the React app works with no server.
 
+## Output location
+
+`--outdir` writes one `.html` file per entrypoint into that directory. `--outfile` writes a single page to that path. With neither flag, Bun prints the page to stdout, the same as `bun build` does for a single JavaScript entrypoint:
+
+```bash terminal icon="terminal"
+bun build --compile --target=browser ./index.html > page.html
+```
+
+A page printed to stdout is one file, so `--sourcemap=linked` and `--sourcemap=external` need `--outdir` or `--outfile`. `--sourcemap=inline` works everywhere.
+
 ## Everything gets inlined
 
 Bun inlines every local asset it finds in your HTML: anything with a relative path, of any file type, is embedded into the output file.

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -165,21 +165,6 @@ impl BuildCommand {
             && outfile.is_empty()
             && ctx.bundler_options.outdir.is_empty();
 
-        if output_to_stdout {
-            let kind = match this_transpiler.options.source_map {
-                options::SourceMapOption::External => Some("an external"),
-                options::SourceMapOption::Linked => Some("a linked"),
-                options::SourceMapOption::Inline | options::SourceMapOption::None => None,
-            };
-            if let Some(kind) = kind {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r><d>:<r> cannot use {} source map without --outdir or --outfile (use --sourcemap=inline to print it to stdout)",
-                    kind
-                );
-                Global::exit(1);
-            }
-        }
-
         this_transpiler.options.supports_multiple_outputs =
             !(output_to_stdout || !outfile.is_empty());
 
@@ -303,10 +288,6 @@ impl BuildCommand {
                 this_transpiler.options.compile_mode = options::CompileMode::StandaloneHtml;
                 ctx.bundler_options.compile = false;
 
-                if ctx.bundler_options.outdir.is_empty() && outfile.is_empty() {
-                    outfile = bun_paths::basename(&first_entry_point);
-                }
-
                 this_transpiler.options.supports_multiple_outputs =
                     !ctx.bundler_options.outdir.is_empty();
             } else {
@@ -396,6 +377,21 @@ impl BuildCommand {
                     "<r><red>error<r><d>:<r> Must use <b>--outdir<r> when code splitting is enabled"
                 );
                 Global::exit(1);
+            }
+            // No --outfile either: the single output goes to stdout.
+            if outfile.is_empty() {
+                let kind = match this_transpiler.options.source_map {
+                    options::SourceMapOption::External => Some("an external"),
+                    options::SourceMapOption::Linked => Some("a linked"),
+                    options::SourceMapOption::Inline | options::SourceMapOption::None => None,
+                };
+                if let Some(kind) = kind {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r><d>:<r> cannot use {} source map without --outdir or --outfile (use --sourcemap=inline to print it to stdout)",
+                        kind
+                    );
+                    Global::exit(1);
+                }
             }
         }
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -444,7 +444,9 @@ describe.concurrent("--sourcemap never writes next to the entry point", () => {
     },
   );
 
-  test("a standalone html build with --sourcemap and no --outdir writes to the cwd", async () => {
+  // A standalone html build with no --outdir or --outfile prints the page to
+  // stdout (covered in standalone.test.ts), so a separate .map has nowhere to go.
+  test("a standalone html build with --sourcemap and no --outdir or --outfile is an error", async () => {
     using dir = tempDir("build-sourcemap-standalone-html", fixture);
     const { stdout, stderr, exitCode } = await build(
       join(String(dir), "work"),
@@ -453,15 +455,12 @@ describe.concurrent("--sourcemap never writes next to the entry point", () => {
       "--target=browser",
       "--sourcemap",
     );
-    expect(stderr).toBe("");
-    expect(stdout).toContain("index.html");
-    expect(exitCode).toBe(0);
-
-    const after = tree(String(dir));
-    const written = Object.keys(after).filter(file => !(file in fixture));
-    expect(written).toEqual([expect.stringMatching(/^work\/index(-\w+)?\.js\.map$/), "work/index.html"]);
-    expect(after["work/index.html"]).toContain("console.log(");
-    for (const file of Object.keys(fixture)) expect(after[file]).toBe(fixture[file]);
+    expect(stdout).toBe("");
+    expect(stderr).toBe(
+      `error: cannot use a linked source map without --outdir or --outfile (use --sourcemap=inline to print it to stdout)\n`,
+    );
+    expect(tree(String(dir))).toEqual(fixture);
+    expect(exitCode).toBe(1);
   });
 });
 

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { SourceMapConsumer } from "source-map";
 
 describe("compile --target=browser", () => {
@@ -464,6 +465,91 @@ body { color: blue; }`,
 
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
+  });
+
+  describe.concurrent("CLI without --outdir or --outfile", () => {
+    const source = `<!DOCTYPE html><html><body># my source<script src="./app.js"></script></body></html>\n`;
+    const fixture = {
+      "src/index.html": source,
+      "src/app.js": `console.log("no outdir");`,
+    };
+    const listFiles = (cwd: string) =>
+      Array.from(new Bun.Glob("**/*").scanSync({ cwd }))
+        .map(f => f.replaceAll("\\", "/"))
+        .sort();
+
+    async function build(cwd: string, ...args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "--target=browser", ...args],
+        env: bunEnv,
+        cwd,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    // Run from the source directory: this used to write ./index.html over the source.
+    test("prints the page to stdout and leaves the source file alone", async () => {
+      using dir = tempDir("compile-browser-cli-stdout", fixture);
+      const { stdout, stderr, exitCode } = await build(join(String(dir), "src"), "./index.html");
+
+      expect(stderr).toBe("");
+      expect(stdout).toStartWith('<!DOCTYPE html><html><body># my source<script type="module">');
+      expect(stdout).toContain('console.log("no outdir")');
+      expect(stdout).not.toContain("sourceMappingURL");
+      expect(await Bun.file(join(String(dir), "src", "index.html")).text()).toBe(source);
+      expect(listFiles(String(dir))).toEqual(["src/app.js", "src/index.html"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("--sourcemap=inline keeps it a single page on stdout", async () => {
+      using dir = tempDir("compile-browser-cli-stdout-inline", fixture);
+      const { stdout, stderr, exitCode } = await build(String(dir), "./src/index.html", "--sourcemap=inline");
+
+      expect(stderr).toBe("");
+      expect(stdout).toContain('console.log("no outdir")');
+      expect(stdout).toContain("//# sourceMappingURL=data:application/json;base64,");
+      expect(listFiles(String(dir))).toEqual(["src/app.js", "src/index.html"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.each(["linked", "external"])("--sourcemap=%s asks for an output location", async sourcemap => {
+      using dir = tempDir("compile-browser-cli-stdout-map-error", fixture);
+      const { stdout, stderr, exitCode } = await build(String(dir), "./src/index.html", `--sourcemap=${sourcemap}`);
+
+      expect(stderr).toBe(
+        `error: cannot use ${sourcemap === "external" ? "an external" : "a linked"} source map without --outdir or --outfile (use --sourcemap=inline to print it to stdout)\n`,
+      );
+      expect(stdout).toBe("");
+      expect(await Bun.file(join(String(dir), "src", "index.html")).text()).toBe(source);
+      expect(listFiles(String(dir))).toEqual(["src/app.js", "src/index.html"]);
+      expect(exitCode).toBe(1);
+    });
+
+    test("--outfile with --sourcemap=linked writes the page and the map next to the outfile", async () => {
+      using dir = tempDir("compile-browser-cli-outfile-sourcemap", fixture);
+      const { stdout, stderr, exitCode } = await build(
+        String(dir),
+        "./src/index.html",
+        "--outfile",
+        "out/page.html",
+        "--sourcemap=linked",
+      );
+
+      expect(stderr).toBe("");
+      expect(stdout).toContain("page.html");
+      const files = listFiles(String(dir));
+      const mapFile = files.find(f => f.endsWith(".js.map"));
+      expect(mapFile).toMatch(/^out\/index-[0-9a-z]+\.js\.map$/);
+      expect(files).toEqual([mapFile, "out/page.html", "src/app.js", "src/index.html"]);
+      expect(await Bun.file(join(String(dir), "src", "index.html")).text()).toBe(source);
+      const html = await Bun.file(join(String(dir), "out", "page.html")).text();
+      expect(html).toContain('console.log("no outdir")');
+      expect(html).toContain(`//# sourceMappingURL=./${mapFile!.slice("out/".length)}\n</script>`);
+      expect(exitCode).toBe(0);
+    });
   });
 
   test("malformed HTML without closing tags still inlines JS and CSS", async () => {


### PR DESCRIPTION
Stacked on #41879. Only the standalone HTML default changes here.

### Problem
- `bun build --compile --target=browser ./index.html` with no `--outdir` or `--outfile`, run from the project directory, writes the compiled page over the source `./index.html` and exits 0 (1.3.14 through 1.4.3).
- Cause: the standalone HTML branch in `BuildCommand::exec` defaulted `outfile` to `basename(entry)` (`src/runtime/cli/build_command.rs:306` on #41879). Unlike the executable default it keeps the extension, so it names the source. #41879 keeps this default.

### Fix
- Drop the default. The single page goes to stdout, like `bun build ./index.ts` (and `Bun.build()` without `outdir` keeps it in memory).
- Move #41879's "linked/external source map needs `--outdir` or `--outfile`" check below where the standalone branch clears `compile`, so it covers this mode. Before, `--sourcemap` here wrote `index.html` plus a `.map` into the cwd.
- Verified: `test/bundler/standalone.test.ts` (5 new cases, 4 fail on #41879 and on 1.4.3) and the flipped standalone row in `test/bundler/cli.test.ts`.

### Background
- `--compile --target=browser` with HTML entries builds no executable. It inlines JS, CSS and assets into one `.html` per entry.
- With one entry and no output location, `bun build` prints the single output to stdout. A linked or external source map is a second file, so #41879 rejects it there.
- Open decision: #41612 instead expects this command to write `./index.html` and fail with `Refusing to overwrite input file "index.html"`, so the shortest form always fails in the usual layout. If that is preferred, this PR reduces to the check move and a test flip.

<details><summary>Notes</summary>

Repro on 1.4.3 (also 1.4.2 and canary):

```sh
d=$(mktemp -d); cd $d
printf '<!doctype html><html><body># my source<script src="./app.js"></script></body></html>\n' > index.html
echo 'console.log(1)' > app.js
bun build --compile --target=browser ./index.html; cat index.html   # the source is now the inlined page
```

With the entry in a subdirectory (`./src/index.html`) the same command dropped an `index.html` into the cwd instead. Two HTML entries already fail with `Must use --outdir`.

Behavior after this PR (on top of #41879):

- `bun build --compile --target=browser ./index.html`: prints the page to stdout, writes nothing.
- `... --sourcemap=inline`: stdout, map inlined in the `<script>`.
- `... --sourcemap` / `--sourcemap=linked` / `--sourcemap=external`: `error: cannot use a linked source map without --outdir or --outfile (use --sourcemap=inline to print it to stdout)`, exit 1. Bare `--sourcemap` resolves to `linked` here because #41879 decides that in `Arguments.rs` while `--compile` is still set; making it fall back to `inline` for this mode would need the standalone decision earlier and is left out.
- `--outfile out/page.html [--sourcemap=...]` and `--outdir`: unchanged from #41879 (a new standalone test covers `--outfile` + linked).

`docs/bundler/standalone-html.mdx` only showed `--outdir=dist` for the CLI. It gains an "Output location" section that states the stdout form.

The build summary (`Bundled N modules`, the file table) is not printed on the stdout path, same as for JS entries, so the output can be redirected to a file.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/standalone.test.ts, test/bundler/cli.test.ts

<!-- robobun:evidence:end -->