### PR TITLE
URLPattern: do not read a leading // in a non-special pathname as an authority

### DIFF
--- a/src/jsc/bindings/webcore/URLPatternCanonical.cpp
+++ b/src/jsc/bindings/webcore/URLPatternCanonical.cpp
@@ -177,7 +177,13 @@ ExceptionOr<String> canonicalizeOpaquePathname(StringView value)
     if (value.isEmpty())
         return value.toString();
 
-    URL dummyURL(makeString("a:"_s, value));
+    // URLParser has no state override, and after "a:" a leading '/' selects the path state rather than the
+    // opaque path state, so such a value is canonicalized like the pathname of "foo://h/b". Give it a host,
+    // otherwise a leading "//" is read as an authority and a leading "/." is dropped by URL::pathStart().
+    // URLParser skips tabs and newlines before it looks for that '/', so skip them here too.
+    auto firstKeptCodeUnit = value.find([](char16_t c) { return c != '\t' && c != '\n' && c != '\r'; });
+    bool hasLeadingSlash = firstKeptCodeUnit != notFound && value[firstKeptCodeUnit] == '/';
+    URL dummyURL(hasLeadingSlash ? makeString("a://a"_s, value) : makeString("a:"_s, value));
 
     if (!dummyURL.isValid())
         return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL opaque path string."_s };

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -161,6 +161,80 @@ describe("URLPattern", () => {
     });
   });
 
+  // With a non-special protocol, a dictionary or pattern pathname is canonicalized by parsing it
+  // behind a dummy scheme. A value that starts with "/" takes the URL parser's path state there, like
+  // the pathname of "foo://h/b", so it has to be parsed behind a host as well: otherwise a leading
+  // "//" is read as an authority and a leading "/." is dropped.
+  describe("non-special protocol pathname canonicalization", () => {
+    test("dictionary input keeps a pathname that starts with //", () => {
+      const any = new URLPattern({ pathname: "*" });
+      expect(any.exec({ protocol: "foo", pathname: "//a" })!.pathname.input).toBe("//a");
+      expect(any.exec({ pathname: "//a", baseURL: "about:blank" })!.pathname.input).toBe("//a");
+      // The URL parser removes tabs and newlines before it looks at the first character.
+      expect(any.exec({ protocol: "foo", pathname: "\t//a" })!.pathname.input).toBe("//a");
+      // The string form of the same URL already reported "//a".
+      expect(any.exec("foo://h//a")!.pathname.input).toBe("//a");
+    });
+
+    test("dictionary and string forms of the same URL match alike", () => {
+      const pattern = new URLPattern({ pathname: "/{/*}+" });
+      expect(pattern.test({ protocol: "foo", hostname: "[::1]", port: "8080", pathname: "//a/b/c" })).toBe(true);
+      expect(pattern.test("foo://[::1]:8080//a/b/c")).toBe(true);
+    });
+
+    test("constructor string keeps // in the pathname", () => {
+      const pattern = new URLPattern("foo://h//:x");
+      expect(pattern.pathname).toBe("//:x");
+      expect(pattern.exec("foo://h//y")!.pathname).toEqual({ input: "//y", groups: { x: "y" } });
+      expect(pattern.test("foo://h/y")).toBe(false);
+      expect(new URLPattern("foo://h/:a//:b").exec("foo://h/x//y")!.pathname.groups).toEqual({ a: "x", b: "y" });
+    });
+
+    test("a first segment that starts with a dot is kept", () => {
+      const pattern = new URLPattern("myapp://host/.well-known/:file");
+      expect(pattern.pathname).toBe("/.well-known/:file");
+      expect(pattern.exec("myapp://host/.well-known/assetlinks.json")!.pathname).toEqual({
+        input: "/.well-known/assetlinks.json",
+        groups: { file: "assetlinks.json" },
+      });
+      expect(new URLPattern({ protocol: "foo", pathname: "/.a" }).pathname).toBe("/.a");
+      expect(new URLPattern({ protocol: "foo", pathname: "/..a" }).pathname).toBe("/..a");
+      // "/." is a single-dot segment here, so only "//a" is left.
+      expect(new URLPattern({ protocol: "foo", pathname: "/.//a" }).pathname).toBe("//a");
+    });
+
+    test("a pathname that starts with / is canonicalized like the same pathname in a URL string", () => {
+      const any = new URLPattern({ pathname: "*" });
+      expect(any.exec({ protocol: "foo", pathname: "/z/../a" })!.pathname.input).toBe("/a");
+      expect(any.exec("foo://h/z/../a")!.pathname.input).toBe("/a");
+      expect(any.exec({ protocol: "foo", pathname: "/a b/{c}/\\/caf\u00e9" })!.pathname.input).toBe(
+        "/a%20b/%7Bc%7D/\\/caf%C3%A9",
+      );
+      expect(any.exec("foo://h/a b/{c}/\\/caf\u00e9")!.pathname.input).toBe("/a%20b/%7Bc%7D/\\/caf%C3%A9");
+      expect(new URLPattern({ protocol: "vscode", pathname: "/a b" }).test("vscode://ext/a b")).toBe(true);
+      expect(new URLPattern("./c", "app://h/a/b").pathname).toBe("/a/c");
+      expect(new URLPattern("./c", "app://h/a/b").test("app://h/a/c")).toBe(true);
+      expect(new URLPattern("../c", "app://h/a/b/").test("app://h/a/c")).toBe(true);
+    });
+
+    test("a pathname that does not start with / stays opaque", () => {
+      const any = new URLPattern({ pathname: "*" });
+      expect(any.exec({ protocol: "foo", pathname: "z/../a b" })!.pathname.input).toBe("z/../a b");
+      expect(any.exec({ protocol: "data", pathname: "text/plain,a b" })!.pathname.input).toBe("text/plain,a b");
+      expect(new URLPattern("mailto\\::user@:host").exec("mailto:me@example.com")!.pathname.groups).toEqual({
+        user: "me",
+        host: "example.com",
+      });
+    });
+
+    test("special schemes and protocol-less dictionaries are unchanged", () => {
+      const any = new URLPattern({ pathname: "*" });
+      expect(any.exec({ pathname: "//a" })!.pathname.input).toBe("//a");
+      expect(any.exec({ pathname: "/z/../a" })!.pathname.input).toBe("/a");
+      expect(any.exec({ protocol: "https", pathname: "/z/../a" })!.pathname.input).toBe("/a");
+    });
+  });
+
   describe("hasRegExpGroups", () => {
     test("match-everything pattern", () => {
       expect(new URLPattern({}).hasRegExpGroups).toBe(false);


### PR DESCRIPTION
### Problem
- With a non-special protocol, a dictionary or pattern pathname that starts with `//` canonicalizes to `""`. `new URLPattern({pathname:'*'}).exec({protocol:'foo', pathname:'//a'}).pathname.input` is `""` and `new URLPattern('foo://h//:x').pathname` is `":x"` (Chromium, Deno: `"//a"`, `"//:x"`). The string input `foo://h//a` gives `//a`, so the two forms disagreed. Also `new URLPattern('myapp://host/.well-known/:f').pathname` is `"well-known/:f"`.
- Cause: `canonicalizeOpaquePathname` (`src/jsc/bindings/webcore/URLPatternCanonical.cpp:175`) parses `"a:" + value` as a whole URL. After a non-special scheme a leading `/` selects the path state, so `//a` is an authority with an empty path, and `URL::pathStart()` skips a leading `/.` in a host-less URL.

### Fix
- When `value` starts with `/` (past tabs and newlines, which the parser drops), parse `"a://a" + value`. Behind a host, `//a` and `/.well-known` are plain path text.
- The path state still applies to such a value, as before: `{protocol:'foo', pathname:'/z/../a b'}` stays `/a%20b`, like the pathname of `foo://h/z/../a b`. Deno chose this too (denoland/rust-urlpattern#62). Chromium keeps `/z/../a b`, per a spec step its editor calls broken here (whatwg/urlpattern#267). Notes has the trade-off.
- Self-reviewed: 5 concerns raised on a first, spec-literal version (four behaviour flips, a clash with #39457), all addressed by this narrower shape.
- Verified: `test/js/web/urlpattern/urlpattern.test.ts` (7 new tests, stock bun fails 4). Its 349 WPT entries and `test-urlpattern.js` pass. A 29-case probe matches Deno 2.9.6 except a known `URL.pathname` difference (Notes).

### Background
- Special schemes are `http`, `https`, `ws`, `wss`, `ftp`, `file`. Other schemes have a hierarchical path (`foo://h/p`) or an opaque one (`foo:p`).
- For a non-special pathname the spec runs the URL parser with a state override. `WTF::URLParser` has none, so this file parses a dummy URL instead.
- `URL::pathStart()` skips `/.` after the scheme of a host-less URL, because `foo:/.//p` is how a path that starts with `//` serializes. It also fires on `foo:/.a` (#39457).

<details><summary>Notes</summary>

Upstream WebKit (`Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp`) and Node 26 (ada) have the same code and give the same wrong results as bun 1.4.3.

**Host-less input URLs with a dot-leading first segment.** `new URL('foo:/.a').pathname` is still `a` on the current WebKit pin (#39457, oven-sh/WebKit#460). So after this change `new URLPattern({protocol:'foo', pathname:'/.a'})` has pathname `/.a` and matches `foo://h/.a` (before: pathname `a`, no match), but it no longer matches the host-less string `foo:/.a` until that WebKit fix lands (before: matched, because both sides dropped `/.`). The with-host form is the common one (`myapp://host/.well-known/...`) and was broken.

**Why not the literal spec step (Chromium's behaviour).** Forcing the opaque path state for every non-special pathname also fixes the reported cases, and I had that version first. It changes more: no dot-segment resolution and C0-only percent-encoding for any `/`-leading non-special pathname. On that build these flip from `true` to `false` compared with bun 1.4.3, Node 26 and Deno 2.9.6 (Chrome 152 also says `false`):

```js
new URLPattern("./c", "app://h/a/b").test("app://h/a/c")             // pattern pathname becomes "/a/./c"
new URLPattern("../c", "app://h/a/b/").test("app://h/a/c")           // "/a/b/../c"
new URLPattern({ protocol: "vscode", pathname: "/a b" }).test("vscode://x/a b")  // "/a b" vs "/a%20b"
new URLPattern("foo://h/a b").test("foo://h/a b")
```

whatwg/urlpattern#267 (spec editor): "It's also pretty broken that this is used for all non-special URLs. Not all non-special URLs have an opaque path." Deno resolved the same question toward hierarchical handling of `/`-leading pathnames in denoland/rust-urlpattern#62. If Chromium parity is preferred instead, the change is `URL(makeString("a:-"_s, value))` plus `path().substring(1)` unconditionally, and the fifth test block flips its expectations.

**Probe** (bun with this change; Deno 2.9.6 is identical except `hostlessDotTest`, `gitTest`, `hostlessDotURL`, which are the `URL.pathname` issue above, and `q`, where bun ends the opaque path at `?` like the URL parser and Deno keeps `a?b`; neither moves in this PR):

```
r1 {protocol:'foo', pathname:'//a'}            "//a"      (was "")
r2 {pathname:'//a', baseURL:'about:blank'}     "//a"      (was "")
r4 /{/*}+ dict vs string                       true true  (was false true)
r5 new URLPattern('foo://h//:x').pathname      "//:x"     (was ":x")
foo://h/:a//:b exec foo://h/x//y               {a:'x', b:'y'}  (was no match)
wellKnown myapp://host/.well-known/:file       "/.well-known/:file" (was "well-known/:file"), test true (was false)
hostlessDot {protocol:'foo', pathname:'/.a'}   "/.a"      (was "a")
tabSlashes {protocol:'foo', pathname:'\t//a'}  "//a"      (was "")
fooDots /z/../a                                "/a"       unchanged
fooSpace /a b                                  "/a%20b"   unchanged
relPat ./c on app://h/a/b                      "/a/c"     unchanged, test true
dotSlashSlash /.//a                            "//a"      unchanged
curly /{a}                                     "/%7Ba%7D" unchanged
opaqueNoSlash z/../a b                         "z/../a b" unchanged
mailto\::user@:host                            {user:'me', host:'example.com'} unchanged
```

#39457's URLPattern test rows agree with this change (`/.//a` stays `//a`).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocatio
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [0.55ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [0.03ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [0.07ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [0.21ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [0.08ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [0.06ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] [0.07ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] [0.07ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [35.82ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [7.01ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [6.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [6.81ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [12.14ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [8.12ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [11.74ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     216e0270bf
  features     baseline

23 deps, 131 codegen, 1172 objects in 827ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [22.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[5/1244] gen ErrorCode+*.h
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 14ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen .bind.ts → G
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/URLPatternCanonical.cpp |  8 ++-
 test/js/web/urlpattern/urlpattern.test.ts        | 74 ++++++++++++++++++++++++
 2 files changed, 81 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/bindings/webcore/URLPatternCanonical.cpp      2      3     17
test/js/web/urlpattern/urlpattern.test.ts             2      3     17
```

</details>

<!-- robobun:evidence:end -->