### PR TITLE
node:http: honor res.useChunkedEncodingByDefault = false (close-delimited body, like Node)

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -381,7 +381,7 @@ private:
             }
             /* Same for bytes that arrive behind a finished response that closes the
              * connection while its body is still draining (onWritable closes then). */
-            if (httpResponseData->isDrainingBeforeClose() && !httpResponseData->isConnectRequest) {
+            if (httpResponseData->isDrainingBeforeClose() && !httpResponseData->isConnectRequest) [[unlikely]] {
                 us_socket_unref(s);
                 return s;
             }
@@ -429,7 +429,7 @@ private:
              * the uncork after this parse). Dispatching it would reset the
              * response state, drop HTTP_CONNECTION_CLOSE and answer it behind a
              * body the peer reads up to the FIN. */
-            if (IsNodeHttp && httpResponseData->isDrainingBeforeClose()) {
+            if (IsNodeHttp && httpResponseData->isDrainingBeforeClose()) [[unlikely]] {
                 stoppedBehindClosingResponse = true;
                 return nullptr;
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -379,6 +379,12 @@ private:
                 us_socket_unref(s);
                 return s;
             }
+            /* Same for bytes that arrive behind a finished response that closes the
+             * connection while its body is still draining (onWritable closes then). */
+            if (httpResponseData->isDrainingBeforeClose() && !httpResponseData->isConnectRequest) {
+                us_socket_unref(s);
+                return s;
+            }
         }
 
         /* Cork this socket */
@@ -409,15 +415,28 @@ private:
             auto *nodeHttpResponseData = (HttpResponseData<SSL, true> *) httpResponseData;
             nodeHttpRequestTrailers = &nodeHttpResponseData->nodeHttpRequestTrailers;
         }
+        /* node:http compat: set when the request handler below stops the parse at
+         * a request pipelined behind a response that closes the connection. */
+        bool stoppedBehindClosingResponse = false;
 
-        auto result = httpResponseData->template consumePostPadded<IsNodeHttp>(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, httpContextData->flags.useLenientTransferEncoding, nodeHttpRequestTrailers, &httpResponseData->chunkedExtensionsByteCount, data, (unsigned int) length, s, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
+        auto result = httpResponseData->template consumePostPadded<IsNodeHttp>(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, httpContextData->flags.useLenientTransferEncoding, nodeHttpRequestTrailers, &httpResponseData->chunkedExtensionsByteCount, data, (unsigned int) length, s, [httpContextData, &stoppedBehindClosingResponse](void *s, HttpRequest *httpRequest) -> void * {
 
+
+            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext((us_socket_t *) s);
+
+            /* node:http compat: never dispatch a request pipelined behind a
+             * response that closes the connection (still draining, or flushed by
+             * the uncork after this parse). Dispatching it would reset the
+             * response state, drop HTTP_CONNECTION_CLOSE and answer it behind a
+             * body the peer reads up to the FIN. */
+            if (IsNodeHttp && httpResponseData->isDrainingBeforeClose()) {
+                stoppedBehindClosingResponse = true;
+                return nullptr;
+            }
 
             /* For every request we reset the timeout and hang until user makes action */
             /* Warning: if we are in shutdown state, resetting the timer is a security issue! */
             us_socket_timeout((us_socket_t *) s, 0);
-
-            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext((us_socket_t *) s);
 
             /* node:http compat: the JS layer stopped HTTP processing on this
              * connection (the user emitted 'close' on the socket - Node frees
@@ -733,6 +752,16 @@ private:
 
         /* It is okay to uncork a closed socket and we need to */
         ((AsyncSocket<SSL> *) s)->uncork();
+
+        /* node:http compat: parsing stopped behind a response that closes the
+         * connection. If the uncork above flushed the last of it, close now;
+         * otherwise onWritable closes once the buffer drains. */
+        if constexpr (IsNodeHttp) {
+            if (stoppedBehindClosingResponse && !us_socket_is_closed(s)) {
+                us_socket_unref(s);
+                ((HttpResponse<SSL> *) s)->closeIfDoneAndMarked(httpResponseData);
+            }
+        }
 
         /* We cannot return nullptr to the underlying stack in any case */
         return s;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -630,6 +630,11 @@ public:
         /* This will be sent always when state is HTTP_WRITE_CALLED inside internalEnd, so no need to write the terminating 0 chunk here */
         /* Super::write("\r\n0\r\n\r\n", 7); */
 
+        /* As in end(): the close is what terminates a close-delimited body. */
+        if (httpResponseData->state & HttpResponseData<SSL>::HTTP_CLOSE_DELIMITED) {
+            httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+        }
+
         return internalEnd({nullptr, 0}, 0, false, false, closeConnection);
     }
 

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -232,6 +232,15 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
             || ((state & HTTP_NODE_RECEIVED_FIN) && nodeHttpQueuedPipelinedCount == 0)
             || ((state & HTTP_CLOSE_WHEN_IDLE) && this->isIdle);
     }
+
+    /* The response that closes this connection (Connection: close, HTTP/1.0, a
+     * close-delimited body) is complete; the socket only stays open until its
+     * buffered bytes drain. Nothing received from here on is a request this
+     * connection may answer (RFC 9112 9.6), and after a close-delimited body the
+     * peer would read whatever we send as more body. */
+    bool isDrainingBeforeClose() const {
+        return (state & (HTTP_CONNECTION_CLOSE | HTTP_RESPONSE_PENDING)) == HTTP_CONNECTION_CLOSE;
+    }
 };
 
 /* Per-connection state that only node:http compat servers need.

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2274,16 +2274,17 @@ function renderNativeHeaders(res) {
     // header is rendered so the advertised value matches the transport.
     let closeDelimited = false;
     let forceChunked = false;
-    // Node's _storeHeader shouldSendKeepAlive: without chunked encoding (HTTP/1.0,
-    // or the user cleared useChunkedEncodingByDefault) only an explicit
-    // Content-Length lets the connection persist.
-    const canPersist = storedContentLength !== undefined || !!res.useChunkedEncodingByDefault;
+    // False for HTTP/1.0 (set by the constructor) or when the user cleared it.
+    const chunkedByDefault = !!res.useChunkedEncodingByDefault;
+    // Node's _storeHeader shouldSendKeepAlive: without chunked encoding only an
+    // explicit Content-Length lets the connection persist.
+    const canPersist = chunkedByDefault || storedContentLength !== undefined;
     if (storedContentLength === undefined && storedTransferEncoding === undefined) {
       if (res._hasBody === false) {
         // HEAD / 204 / 304 / 1xx: there is no body to delimit, so removing the
         // framing headers must not close the connection (Node's _storeHeader
         // checks !_hasBody before its close-delimited else-branch).
-      } else if (!res.useChunkedEncodingByDefault) {
+      } else if (!chunkedByDefault) {
         // Node's _storeHeader `else if (!this.useChunkedEncodingByDefault) this._last = true`,
         // taken before the Content-Length branch: no framing header at all, the body
         // runs until the connection closes.

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2274,20 +2274,31 @@ function renderNativeHeaders(res) {
     // header is rendered so the advertised value matches the transport.
     let closeDelimited = false;
     let forceChunked = false;
+    // Node's _storeHeader shouldSendKeepAlive: without chunked encoding (HTTP/1.0,
+    // or the user cleared useChunkedEncodingByDefault) only an explicit
+    // Content-Length lets the connection persist.
+    const canPersist = storedContentLength !== undefined || !!res.useChunkedEncodingByDefault;
     if (storedContentLength === undefined && storedTransferEncoding === undefined) {
       if (res._hasBody === false) {
         // HEAD / 204 / 304 / 1xx: there is no body to delimit, so removing the
         // framing headers must not close the connection (Node's _storeHeader
         // checks !_hasBody before its close-delimited else-branch).
+      } else if (!res.useChunkedEncodingByDefault) {
+        // Node's _storeHeader `else if (!this.useChunkedEncodingByDefault) this._last = true`,
+        // taken before the Content-Length branch: no framing header at all, the body
+        // runs until the connection closes.
+        closeDelimited = true;
+        res[kMustCloseConnection] = true;
       } else if (res._removedTE) {
         closeDelimited = true;
         res[kMustCloseConnection] = true;
       } else if (res._removedContLen || res[kFramingFrozenChunked]) {
-        // Node's _storeHeader falls through to chunked only when useChunkedEncodingByDefault
-        // (false for HTTP/1.0); the native writer never chunk-frames HTTP/1.0, so the rest is
-        // close-delimited. An explicit writeHead() reaches the same null-_contentLength fallthrough.
+        // Node's _storeHeader falls through to chunked here. The flag is still set for an
+        // HTTP/1.0 request that sent `TE: chunked`, but the native writer never chunk-frames
+        // HTTP/1.0, so that stays close-delimited. An explicit writeHead() reaches the same
+        // null-_contentLength fallthrough.
         const req = res.req;
-        if (res.useChunkedEncodingByDefault && req.httpVersionMajor >= 1 && req.httpVersionMinor >= 1) {
+        if (req.httpVersionMajor >= 1 && req.httpVersionMinor >= 1) {
           forceChunked = true;
         } else {
           closeDelimited = true;
@@ -2307,6 +2318,7 @@ function renderNativeHeaders(res) {
       if (
         !defectiveNoBodyResponse &&
         !closeDelimited &&
+        canPersist &&
         !res.maxRequestsOnConnectionReached &&
         res.shouldKeepAlive !== false &&
         requestShouldKeepAlive(res.req)
@@ -2328,7 +2340,7 @@ function renderNativeHeaders(res) {
         // Like Node's shouldSendKeepAlive/_last handling: a user-cleared
         // shouldKeepAlive (graceful-shutdown helpers set it on in-flight
         // responses) must also end the socket after 'finish'.
-        if (res.shouldKeepAlive === false) {
+        if (res.shouldKeepAlive === false || !canPersist) {
           res[kMustCloseConnection] = true;
         }
         autoHeaders |= AUTO_HEADER_CONN_CLOSE;

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -1105,4 +1105,77 @@ describe("res.useChunkedEncodingByDefault = false makes the response close-delim
       connection: "closed",
     });
   });
+
+  test.concurrent("write() followed by an empty end() is close-delimited too", async () => {
+    const result = await exchange((req, res) => {
+      res.useChunkedEncodingByDefault = false;
+      res.write("hello");
+      res.end();
+    }, GET11);
+    expect(result).toEqual({
+      head: "HTTP/1.1 200 OK\r\nDate: <D>\r\nConnection: close",
+      body: "hello",
+      framing: "close-delimited",
+      connection: "closed",
+    });
+  });
+
+  // The body below is larger than the loopback socket buffers, so end() leaves
+  // part of it queued in the server while the pipelined request behind it is
+  // parsed from the same read. That request must not be answered (its bytes
+  // would land inside the close-delimited body) and the close must still come.
+  test.concurrent("a request pipelined behind a close-delimited response is not answered", async () => {
+    const body = Buffer.alloc(8 * 1024 * 1024, "a");
+    await using server = createServer((req, res) => {
+      if (req.url === "/first") {
+        res.useChunkedEncodingByDefault = false;
+        res.end(body);
+      } else {
+        res.end("SECOND");
+      }
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const done = Promise.withResolvers<{ head: string; bodyLength: number; tail: string; closedByServer: boolean }>();
+    const socket = connect(port, "127.0.0.1", () => {
+      socket.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\nGET /second HTTP/1.1\r\nHost: x\r\n\r\n");
+    });
+    const chunks: Buffer[] = [];
+    let received = 0;
+    let headBytes = Buffer.alloc(0);
+    let headLength = -1;
+    const settle = (closedByServer: boolean) => {
+      const raw = Buffer.concat(chunks);
+      done.resolve({
+        head: headBytes.toString("latin1").replace(/^Date: .*$/m, "Date: <D>"),
+        bodyLength: raw.length - headLength,
+        tail: raw.subarray(raw.length - 8).toString("latin1"),
+        closedByServer,
+      });
+      socket.destroy();
+    };
+    socket.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+      received += chunk.length;
+      if (headLength === -1) {
+        const soFar = chunks.length === 1 ? chunk : Buffer.concat(chunks);
+        const headEnd = soFar.indexOf("\r\n\r\n");
+        if (headEnd === -1) return;
+        headBytes = soFar.subarray(0, headEnd);
+        headLength = headEnd + 4;
+      }
+      // More than head + body can only be a second response inside the body.
+      if (received > headLength + body.length) settle(false);
+    });
+    socket.on("end", () => settle(true));
+    socket.on("error", done.reject);
+
+    expect(await done.promise).toEqual({
+      head: "HTTP/1.1 200 OK\r\nDate: <D>\r\nConnection: close",
+      bodyLength: body.length,
+      tail: "aaaaaaaa",
+      closedByServer: true,
+    });
+  });
 });

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -893,3 +893,215 @@ describe("tearing down a response with its headers on the wire adds no bytes", (
     expect(exitCode).toBe(0);
   });
 });
+
+// `res.useChunkedEncodingByDefault = false` is Node's switch for serving an
+// HTTP/1.1 body with neither Content-Length nor chunked framing: _storeHeader
+// takes its `!useChunkedEncodingByDefault` branch before it would write either
+// framing header, the body runs until the connection closes, and the response
+// advertises `Connection: close`. The expected heads and bodies below are what
+// node v26.3.0 puts on the wire for the same handlers.
+describe("res.useChunkedEncodingByDefault = false makes the response close-delimited", () => {
+  type Exchange = {
+    head: string;
+    body: string;
+    framing: "content-length" | "chunked" | "close-delimited";
+    connection: "closed" | "reused";
+  };
+
+  // Sends `request` and reads the response the way a client frames it. A
+  // body-less, Content-Length or chunked message is complete on its own, so
+  // once it is in, a second request probes whether the server kept the
+  // connection: either a second response arrives ("reused") or the server's
+  // FIN does ("closed"). With neither framing header the body is everything up
+  // to the FIN.
+  async function exchange(handler: (req: any, res: any) => void, request: string): Promise<Exchange> {
+    await using server = createServer(handler);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const done = Promise.withResolvers<Exchange>();
+    const socket = connect(port, "127.0.0.1", () => socket.write(request));
+    let raw = "";
+    let head: string | undefined;
+    let framing: Exchange["framing"] = "close-delimited";
+    let firstMessageEnd = -1;
+    socket.on("data", (chunk: Buffer) => {
+      raw += chunk.toString("latin1");
+      const headerEnd = raw.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      const bodyStart = headerEnd + 4;
+      if (head === undefined) {
+        head = raw.slice(0, headerEnd).replace(/^Date: .*$/m, "Date: <D>");
+        if (/^content-length:/im.test(head)) framing = "content-length";
+        else if (/^transfer-encoding: .*chunked/im.test(head)) framing = "chunked";
+      }
+      if (firstMessageEnd === -1) {
+        if (request.startsWith("HEAD ") || /^HTTP\/1\.1 (?:1\d\d|204|304) /.test(head)) {
+          // RFC 9112 6.3: ends at the blank line whatever the header fields say.
+          firstMessageEnd = bodyStart;
+        } else if (framing === "content-length") {
+          const end = bodyStart + Number(/^content-length: *(\d+)/im.exec(head)![1]);
+          if (raw.length >= end) firstMessageEnd = end;
+        } else if (framing === "chunked") {
+          const terminator = raw.indexOf("0\r\n\r\n", bodyStart);
+          if (terminator !== -1) firstMessageEnd = terminator + 5;
+        }
+        if (firstMessageEnd !== -1) socket.write("GET /probe HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+      } else if (raw.indexOf("HTTP/1.1 ", firstMessageEnd) === firstMessageEnd) {
+        done.resolve({ head: head!, body: raw.slice(bodyStart, firstMessageEnd), framing, connection: "reused" });
+        socket.destroy();
+      }
+    });
+    const onClosed = () => {
+      const bodyStart = raw.indexOf("\r\n\r\n") + 4;
+      done.resolve({
+        head: head ?? raw,
+        body: raw.slice(bodyStart, firstMessageEnd === -1 ? raw.length : firstMessageEnd),
+        framing,
+        connection: "closed",
+      });
+    };
+    // The probe written after the server's close may be answered with an RST.
+    socket.on("error", onClosed);
+    socket.on("close", onClosed);
+    return done.promise;
+  }
+
+  const GET11 = "GET / HTTP/1.1\r\nHost: x\r\n\r\n";
+
+  test.concurrent.each([
+    [
+      "write() + end()",
+      (res: any) => {
+        res.write("hel");
+        res.end("lo");
+      },
+    ],
+    ["end(data) with a known length", (res: any) => res.end("hello")],
+    [
+      "flushHeaders() first",
+      (res: any) => {
+        res.flushHeaders();
+        res.write("hel");
+        res.end("lo");
+      },
+    ],
+    [
+      "writeHead() first",
+      (res: any) => {
+        res.writeHead(200);
+        res.end("hello");
+      },
+    ],
+  ])("%s", async (_, respond) => {
+    const result = await exchange((req, res) => {
+      res.useChunkedEncodingByDefault = false;
+      respond(res);
+    }, GET11);
+    expect(result).toEqual({
+      head: "HTTP/1.1 200 OK\r\nDate: <D>\r\nConnection: close",
+      body: "hello",
+      framing: "close-delimited",
+      connection: "closed",
+    });
+  });
+
+  test.concurrent("a user Connection: keep-alive header still gets a close-delimited body", async () => {
+    const result = await exchange((req, res) => {
+      res.useChunkedEncodingByDefault = false;
+      res.setHeader("connection", "keep-alive");
+      res.write("hel");
+      res.end("lo");
+    }, GET11);
+    expect(result).toEqual({
+      head: "HTTP/1.1 200 OK\r\nconnection: keep-alive\r\nDate: <D>",
+      body: "hello",
+      framing: "close-delimited",
+      connection: "closed",
+    });
+  });
+
+  test.concurrent("a removed Connection header still gets a close-delimited body", async () => {
+    const result = await exchange((req, res) => {
+      res.useChunkedEncodingByDefault = false;
+      res.setHeader("connection", "keep-alive");
+      res.removeHeader("connection");
+      res.end("hello");
+    }, GET11);
+    expect(result).toEqual({
+      head: "HTTP/1.1 200 OK\r\nDate: <D>",
+      body: "hello",
+      framing: "close-delimited",
+      connection: "closed",
+    });
+  });
+
+  // Node's shouldSendKeepAlive is `shouldKeepAlive && (contLen || useChunkedEncodingByDefault)`:
+  // an explicit Transfer-Encoding keeps its chunked framing but the connection
+  // is not reused, a body-less response closes too, and only an explicit
+  // Content-Length keeps the connection alive.
+  test.concurrent("an explicit Transfer-Encoding: chunked stays chunked but closes the connection", async () => {
+    const result = await exchange((req, res) => {
+      res.useChunkedEncodingByDefault = false;
+      res.setHeader("transfer-encoding", "chunked");
+      res.write("hel");
+      res.end("lo");
+    }, GET11);
+    expect(result).toEqual({
+      head: "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\nDate: <D>\r\nConnection: close",
+      body: "3\r\nhel\r\n2\r\nlo\r\n0\r\n\r\n",
+      framing: "chunked",
+      connection: "closed",
+    });
+  });
+
+  test.concurrent.each([
+    ["HEAD", "HEAD / HTTP/1.1\r\nHost: x\r\n\r\n", (res: any) => res.end("hello"), "HTTP/1.1 200 OK"],
+    [
+      "204",
+      GET11,
+      (res: any) => {
+        res.statusCode = 204;
+        res.end();
+      },
+      "HTTP/1.1 204 No Content",
+    ],
+  ])("a body-less %s response advertises and performs the close", async (_, request, respond, statusLine) => {
+    const result = await exchange((req, res) => {
+      res.useChunkedEncodingByDefault = false;
+      respond(res);
+    }, request);
+    expect(result).toEqual({
+      head: `${statusLine}\r\nDate: <D>\r\nConnection: close`,
+      body: "",
+      framing: "close-delimited",
+      connection: "closed",
+    });
+  });
+
+  test.concurrent("an explicit Content-Length keeps the connection reusable", async () => {
+    const result = await exchange((req, res) => {
+      res.useChunkedEncodingByDefault = false;
+      res.setHeader("content-length", "5");
+      res.end("hello");
+    }, GET11);
+    expect(result).toEqual({
+      head: "HTTP/1.1 200 OK\r\ncontent-length: 5\r\nDate: <D>\r\nConnection: keep-alive\r\nKeep-Alive: timeout=5",
+      body: "hello",
+      framing: "content-length",
+      connection: "reused",
+    });
+  });
+
+  // HTTP/1.0 clears the flag in the ServerResponse constructor, so the same
+  // branch applies: node writes no Content-Length even for a one-shot end().
+  test.concurrent("HTTP/1.0 one-shot end(data) carries no Content-Length, like node", async () => {
+    const result = await exchange((req, res) => res.end("hello"), "GET / HTTP/1.0\r\nHost: x\r\n\r\n");
+    expect(result).toEqual({
+      head: "HTTP/1.1 200 OK\r\nDate: <D>\r\nConnection: close",
+      body: "hello",
+      framing: "close-delimited",
+      connection: "closed",
+    });
+  });
+});

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -964,7 +964,8 @@ describe("res.useChunkedEncodingByDefault = false makes the response close-delim
     // The probe written after the server's close may be answered with an RST.
     socket.on("error", onClosed);
     socket.on("close", onClosed);
-    return done.promise;
+    // Settle before `server` is disposed: server.close() ends the open connection.
+    return await done.promise;
   }
 
   const GET11 = "GET / HTTP/1.1\r\nHost: x\r\n\r\n";


### PR DESCRIPTION
### Problem
- The `node:http` server ignores `res.useChunkedEncodingByDefault = false` when the headers are implicit. For `res.write("hel"); res.end("lo")` Node sends `Connection: close`, a raw body and a FIN. Bun chunk-frames the body and keeps the connection alive. Found by a node/bun wire comparison, not a user report.
- `renderNativeHeaders` (`src/js/node/_http_server.ts:2277`) mirrors Node's `_storeHeader`, but read the flag only in the removed-Content-Length / `writeHead()` branch (#34418). Its keep-alive choice lacked Node's `contLen || useChunkedEncodingByDefault` rule.
- A close-delimited response that was still draining let a pipelined request through. Its dispatch dropped `HTTP_CONNECTION_CLOSE`, and the second response went out inside the first body.

### Fix
- Add Node's `!useChunkedEncodingByDefault` branch at the same position, and advertise keep-alive only when an explicit `Content-Length` frames the body. Every changed cell is byte-identical to node v26.3.0.
- node:http connections no longer dispatch a request behind a finished response that closes the connection (`HttpContext.h`).
- Deliberate visible change: a one-shot `end(data)` to an HTTP/1.0 client loses its auto `Content-Length`, as in Node.
- Verified: `test/js/node/http/node-http-transfer-encoding.test.ts` (13 new cases, 10 fail on stock bun), plus `34415.test.ts`, `node-http.test.ts` and vendored `test-http*`. Self-reviewed: 1 concern raised (the pipelining hole), addressed.

### Background
- A body is framed by `Content-Length`, by `Transfer-Encoding: chunked`, or by the connection close. After a close-delimited body the peer reads every later byte as body.
- Applications clear this flag to stream raw HTTP/1.1 bodies to clients that cannot de-chunk (ICY/shoutcast players), which otherwise read chunk sizes as content.
- Bun renders `node:http` headers in JS and frames the body in uWS. A sentinel entry makes uWS write the body raw and close once its buffer drains.

<details><summary>Notes</summary>

- Related: #34415 / #34418 (close-delimited HTTP/1.0 responses and the `writeHead()` freeze this extends), #33871 and #33872 (framing from the `Transfer-Encoding` value, HTTP/1.0 with an explicit `Transfer-Encoding: chunked`), #32945 (HTTP/1.0 keep-alive). This PR covers #32945's `!useChunkedEncodingByDefault -> _last` and `shouldSendKeepAlive` hunks with Node's exact bytes; on rebase #32945 shrinks to its uWS HTTP/1.0 keep-alive work.
- Node reference: `lib/_http_outgoing.js` `_storeHeader`, the keep-alive block (`shouldSendKeepAlive`) and the body-framing block (`!this._hasBody` → `!this.useChunkedEncodingByDefault` → `Content-Length` → chunked → both removed). Node's `ServerResponse` constructor clears the flag for HTTP/1.0 requests without `TE: chunked`; Bun's does the same.
- node v26.3.0 output for the handlers in the new tests (HTTP/1.1, flag cleared, `Date` normalised): `write()+end()`, `end("hello")`, `flushHeaders()+write+end`, `writeHead(200)+end`, `write("hello")+end()` → `HTTP/1.1 200 OK\r\nDate: <D>\r\nConnection: close\r\n\r\nhello` + FIN. User `connection: keep-alive` → `HTTP/1.1 200 OK\r\nconnection: keep-alive\r\nDate: <D>\r\n\r\nhello` + FIN. Removed `Connection` → `HTTP/1.1 200 OK\r\nDate: <D>\r\n\r\nhello` + FIN. Explicit `transfer-encoding: chunked` → `...transfer-encoding: chunked\r\nDate: <D>\r\nConnection: close\r\n\r\n3\r\nhel\r\n2\r\nlo\r\n0\r\n\r\n` + FIN. HEAD / 204 → status line, `Date`, `Connection: close`, FIN. Explicit `content-length: 5` → `Connection: keep-alive\r\nKeep-Alive: timeout=5`, connection reused. HTTP/1.0 `end("hello")` → `HTTP/1.1 200 OK\r\nDate: <D>\r\nConnection: close\r\n\r\nhello` + FIN. 8 MB close-delimited body with a pipelined `GET /second` in the same segment → exactly the body, then FIN (Node runs the second handler but never writes its response; Bun does not dispatch it, as it already did not behind a synchronous close-delimited response).
- Matrix check: 170 cells (HTTP/1.1 and 1.0, request `Connection` absent/close/keep-alive, flag on/off, 17 handler shapes) captured as raw bytes plus FIN state under node v26.3.0, stock bun and this branch. Every cell that changed against `main` now equals node. Remaining differences are pre-existing and untouched: HTTP/1.0 with an explicit `Transfer-Encoding: chunked` (#33872), HTTP/1.0 `Connection: keep-alive` with a `Content-Length` (#32945), the `Connection` value advertised after `removeHeader("transfer-encoding")`.
- On stock bun a one-shot `end(data)` with the flag cleared was `Content-Length`-framed and `write()` was chunked; both kept the connection alive. Cells that change for HTTP/1.1 with the flag cleared: `write()+end()`, `end(data)`, `end()`, user `Connection: keep-alive` / `close` / removed, explicit `Transfer-Encoding: chunked` (stays chunked, now `Connection: close` + FIN), HEAD, 204, 304, `shouldKeepAlive = false`. For HTTP/1.0 the only change is the dropped auto `Content-Length` on `end(data)` / `end()`; streaming HTTP/1.0 writes were already close-delimited.
- The pipelining hole predates this change (`removeHeader("Transfer-Encoding")`, or `writeHead()` with the flag cleared, plus a body large enough to leave bytes queued): the second response was appended to the close-delimited body and the connection stayed open. `socket.end()` with queued output sets `HTTP_CONNECTION_CLOSE` and relies on `onWritable` to close, so the same reset also defeated a plain `Connection: close` response under backpressure. The native guard is node:http-only; Bun.serve is unchanged.
- The vendored suite on the debug build: 442 of 445 `test-http*-*.js` files pass. `test-http-agent-keepalive.js`, `test-http-client-timeout-option.js` and `test-https-timeout.js` fail the same way on the debug build without this change (1 ms client timeouts under load) and pass on the release binary.
- The new tests read the response the way a client frames it and then probe the connection with a second request, so they fail fast on stock bun instead of waiting for a keep-alive timeout.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/164] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/164] gen cpp.rs (cppbind)
[3/164] gen JS modules (bundle-modules)
Preprocess modules (11927ms)
Bundle modules (137ms)
Postprocesss modules (110ms)
Bundle Functions (562ms)
Generate Code (44ms)

[12.79s] Bundled "src/js" for development
  2786 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/164] cargo bun_runtime → libbun_runtime.a
[4/164] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llv
... (truncated)

release without fix: 10 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [11.95ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [12.68ms]
(pass) empty Transfer-Encoding value is ignored like node, no clientError [5.59ms]
(pass) whitespace-only Transfer-Encoding value is ignored like node, no clientError [2.57ms]
(pass) empty Transfer-Encoding with Content-Length frames the body like node [2.78ms]
(pass) empty Transfer-Encoding field followed by chunked delivers the body like node [3.22ms]
(pass) whitespace-only Transfer-Encoding field followed by chunked delivers the body like node [2.72ms]
(pass) comma-only Transfer-Encoding value still fires clientError like node [4.19ms]
(pass) chunked request trailers parse at every field-value scan boundary [8.79ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [4.74ms]
(pass) bare-LF between trailer fields is rejected, not silently accepted [3.32ms]
(pass) CTL byte in a trailer value fires clientError HPE_INVALID_HEADER_TOKEN [2.80ms]
(pass) insecureHTTPParser accepts a CTL byte i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-transfer-encoding.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/http/node-http-transfer-encoding.test.ts:
(pass) should not duplicate transfer-encoding header in request [955.81ms]
(pass) should not duplicate transfer-encoding header in response when explicitly set [790.32ms]
(pass) empty Transfer-Encoding value is ignored like node, no clientError [194.88ms]
(pass) whitespace-only Transfer-Encoding value is ignored like node, no clientError [163.06ms]
(pass) empty Transfer-Encoding with Content-Length frames the body like node [247.46ms]
(pass) empty Transfer-Encoding field followed by chunked delivers the body like node [272.74ms]
(pass) whitespace-only Transfer-Encoding field followed by chunked delivers the body like node [207.92ms]
(pass) comma-only Transfer-Encoding value still fires clientError like node [172.00ms]
(pass) chunked request trailers parse at every field-value scan boundary [384.70ms]
(pass) bare-LF in trailer section fires clientError instead of hanging [121.73ms]
(pass) bare-LF betwe
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 959ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (11690ms)
Bundle modules (253ms)
Postprocesss modules (182ms)
Bundle Functions (677ms)
Generate Code (41ms)

[12.85s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpContext.h                 |  35 ++-
 packages/bun-uws/src/HttpResponse.h                |   5 +
 packages/bun-uws/src/HttpResponseData.h            |   9 +
 src/js/node/_http_server.ts                        |  23 +-
 .../node/http/node-http-transfer-encoding.test.ts  | 286 +++++++++++++++++++++
 5 files changed, 350 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
packages/bun-uws/src/HttpContext.h                         6      6     18
packages/bun-uws/src/HttpResponse.h                        5      1     18
packages/bun-uws/src/HttpResponseData.h                    1      1     18
src/js/node/_http_server.ts                               10      8     20
test/js/node/http/node-http-transfer-encoding.test.ts      6      3     18
```

</details>

<!-- robobun:evidence:end -->