### PR TITLE
css: keep light-dark() as written under the default browser targets

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -303,7 +303,7 @@ The `light-dark()` function takes two colors and applies one based on the used c
 }
 ```
 
-Under the default browser targets, Bun's CSS bundler keeps `light-dark()` and `color-scheme` as written. All major browsers support `light-dark()` natively since Chrome 123, Firefox 120, and Safari 17.5. The lowering for older browsers rewrites each call into `var(--buncss-light, <light>) var(--buncss-dark, <dark>)` and defines those two variables next to every `color-scheme` declaration in the compiled CSS. It only resolves when such a declaration applies to an ancestor element, and it produces an invalid value when the color scheme comes from `<meta name="color-scheme">`, from a stylesheet Bun did not compile, or from an inline style. For that reason the default targets leave it out.
+Under the default browser targets, Bun's CSS bundler keeps `light-dark()` and `color-scheme` as written. All major browsers support `light-dark()` natively since Chrome 123, Firefox 120, and Safari 17.5. The lowering for older browsers rewrites each call into `var(--buncss-light, <light>) var(--buncss-dark, <dark>)` and defines those two variables next to each compiled `color-scheme` declaration that names `light` or `dark`. It only resolves when such a declaration applies to the element or one of its ancestors, and it produces an invalid value when the color scheme comes from `<meta name="color-scheme">`, from a stylesheet Bun did not compile, or from an inline style. For that reason the default targets leave it out.
 
 ### Logical properties
 

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -278,7 +278,7 @@ Bun's CSS bundler converts these formats for older browsers:
 
 ### light-dark() color function
 
-The `light-dark()` function takes two colors and applies one based on the current color scheme, so styles respect the user's system preference without media queries.
+The `light-dark()` function takes two colors and applies one based on the used color scheme of the element. A page opts in to dark mode with the `color-scheme` property or with `<meta name="color-scheme">`, so styles respect the user's system preference without media queries.
 
 ```css title="styles.css" icon="file-code"
 :root {
@@ -303,40 +303,7 @@ The `light-dark()` function takes two colors and applies one based on the curren
 }
 ```
 
-For browsers that don't support `light-dark()`, Bun's CSS bundler converts it to CSS variables with fallbacks:
-
-```css title="styles.css" icon="file-code"
-:root {
-  --buncss-light: initial;
-  --buncss-dark: ;
-  color-scheme: light dark;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --buncss-light: ;
-    --buncss-dark: initial;
-  }
-}
-
-.light-theme {
-  --buncss-light: initial;
-  --buncss-dark: ;
-  color-scheme: light;
-}
-
-.dark-theme {
-  --buncss-light: ;
-  --buncss-dark: initial;
-  color-scheme: dark;
-}
-
-.themed-component {
-  background-color: var(--buncss-light, #ffffff) var(--buncss-dark, #121212);
-  color: var(--buncss-light, #333333) var(--buncss-dark, #eeeeee);
-  border-color: var(--buncss-light, #dddddd) var(--buncss-dark, #555555);
-}
-```
+Under the default browser targets, Bun's CSS bundler keeps `light-dark()` and `color-scheme` as written. All major browsers support `light-dark()` natively since Chrome 123, Firefox 120, and Safari 17.5. The lowering for older browsers rewrites each call into `var(--buncss-light, <light>) var(--buncss-dark, <dark>)` and defines those two variables next to every `color-scheme` declaration in the compiled CSS. It only resolves when such a declaration applies to an ancestor element, and it produces an invalid value when the color scheme comes from `<meta name="color-scheme">`, from a stylesheet Bun did not compile, or from an inline style. For that reason the default targets leave it out.
 
 ### Logical properties
 

--- a/src/css/build-prefixes.js
+++ b/src/css/build-prefixes.js
@@ -474,11 +474,20 @@ let flags = [
   "double_position_gradients",
   "vendor_prefixes",
   "logical_properties",
+  "light_dark",
   ["selectors", ["nesting", "not_selector_list", "dir_selector", "lang_selector_list", "is_selector"]],
   ["media_queries", ["media_interval_syntax", "media_range_syntax", "custom_media_queries"]],
   [
     "colors",
-    ["color_function", "oklab_colors", "lab_colors", "p3_colors", "hex_alpha_colors", "space_separated_color_notation"],
+    [
+      "color_function",
+      "oklab_colors",
+      "lab_colors",
+      "p3_colors",
+      "hex_alpha_colors",
+      "space_separated_color_notation",
+      "light_dark",
+    ],
   ],
 ];
 

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -943,7 +943,10 @@ impl UnresolvedColor {
                 dest.write_char(b')')
             }
             UnresolvedColor::LightDark { light, dark } => {
-                if !dest.targets.is_compatible(css::compat::Feature::LightDark) {
+                if dest
+                    .targets
+                    .should_compile_same(css::compat::Feature::LightDark)
+                {
                     dest.write_str("var(--buncss-light")?;
                     dest.delim(b',', false)?;
                     light.to_css(dest, is_custom_property)?;

--- a/src/css/properties/ui.rs
+++ b/src/css/properties/ui.rs
@@ -115,9 +115,9 @@ impl ColorSchemeHandler {
         match property {
             Property::ColorScheme(color_scheme_) => {
                 let color_scheme: ColorScheme = *color_scheme_;
-                if !context
+                if context
                     .targets
-                    .is_compatible(css::compat::Feature::LightDark)
+                    .should_compile_same(css::compat::Feature::LightDark)
                 {
                     if color_scheme.contains(ColorScheme::LIGHT) {
                         dest.push(define_var(b"--buncss-light", css::Token::Ident(b"initial")));

--- a/src/css/targets.rs
+++ b/src/css/targets.rs
@@ -20,10 +20,7 @@ impl Targets {
     pub(crate) fn browser_default() -> Targets {
         Targets {
             browsers: Some(*BROWSER_DEFAULT),
-            // The `light-dark()` polyfill only resolves under an ancestor whose
-            // `color-scheme` declaration was compiled in the same stylesheet. These
-            // defaults are bun's choice, not the user's, so they leave it out;
-            // explicitly requested targets still apply it.
+            // The light-dark() polyfill depends on a compiled `color-scheme` rule (docs/bundler/css.mdx).
             exclude: Features::LIGHT_DARK,
             ..Default::default()
         }

--- a/src/css/targets.rs
+++ b/src/css/targets.rs
@@ -20,6 +20,11 @@ impl Targets {
     pub(crate) fn browser_default() -> Targets {
         Targets {
             browsers: Some(*BROWSER_DEFAULT),
+            // The `light-dark()` polyfill only resolves under an ancestor whose
+            // `color-scheme` declaration was compiled in the same stylesheet. These
+            // defaults are bun's choice, not the user's, so they leave it out;
+            // explicitly requested targets still apply it.
+            exclude: Features::LIGHT_DARK,
             ..Default::default()
         }
     }
@@ -435,6 +440,7 @@ bitflags::bitflags! {
         const DOUBLE_POSITION_GRADIENTS         = 1 << 17;
         const VENDOR_PREFIXES                   = 1 << 18;
         const LOGICAL_PROPERTIES                = 1 << 19;
+        const LIGHT_DARK                        = 1 << 20;
 
         const SELECTORS = Self::NESTING.bits()
             | Self::NOT_SELECTOR_LIST.bits()
@@ -451,7 +457,8 @@ bitflags::bitflags! {
             | Self::LAB_COLORS.bits()
             | Self::P3_COLORS.bits()
             | Self::HEX_ALPHA_COLORS.bits()
-            | Self::SPACE_SEPARATED_COLOR_NOTATION.bits();
+            | Self::SPACE_SEPARATED_COLOR_NOTATION.bits()
+            | Self::LIGHT_DARK.bits();
     }
 }
 
@@ -488,6 +495,7 @@ impl Features {
             Feature::SpaceSeparatedColorNotation => Features::SPACE_SEPARATED_COLOR_NOTATION,
             Feature::FontFamilySystemUi => Features::FONT_FAMILY_SYSTEM_UI,
             Feature::DoublePositionGradients => Features::DOUBLE_POSITION_GRADIENTS,
+            Feature::LightDark => Features::LIGHT_DARK,
             // A tag with no matching `Features` field is a programmer error,
             // guarded by a runtime unreachable.
             _ => unreachable!(

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -508,7 +508,7 @@ impl CssColor {
                 // `as_css_color` drops here.
             }
             CssColor::LightDark { light, dark } => {
-                if !dest.targets.is_compatible(Feature::LightDark) {
+                if dest.targets.should_compile_same(Feature::LightDark) {
                     dest.write_str("var(--buncss-light")?;
                     dest.delim(b',', false)?;
                     light.to_css(dest)?;

--- a/test/bundler/css/light-dark-default-targets.test.ts
+++ b/test/bundler/css/light-dark-default-targets.test.ts
@@ -1,0 +1,95 @@
+import { describe } from "bun:test";
+import { itBundled } from "../expectBundled";
+
+// The default browser targets must not rewrite light-dark() into the
+// `var(--buncss-light, …) var(--buncss-dark, …)` polyfill. Those variables are
+// only defined next to a `color-scheme` declaration compiled in the same
+// stylesheet, so on a page that sets its scheme any other way (or not at all)
+// the rewritten value is invalid at computed-value time.
+describe("css", () => {
+  itBundled("css/light-dark-is-not-polyfilled-by-default", {
+    files: {
+      "index.css": /* css */ `
+        .b {
+          color: light-dark(#102030, #d0e0f0);
+          background-color: light-dark(white, black);
+        }
+        .c {
+          accent-color: light-dark(red, blue);
+          --c: light-dark(red, blue);
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        .b {
+          color: light-dark(#102030, #d0e0f0);
+          background-color: light-dark(#fff, #000);
+        }
+
+        .c {
+          accent-color: light-dark(red, #00f);
+          --c: light-dark(red, #00f);
+        }
+        "
+      `);
+    },
+  });
+
+  itBundled("css/light-dark-is-not-polyfilled-by-default-minified", {
+    files: {
+      "index.css": /* css */ `
+        .b { color: light-dark(#102030, #d0e0f0) }
+        .c { --c: light-dark(red, blue) }
+      `,
+    },
+    outdir: "/out",
+    minifyWhitespace: true,
+    minifySyntax: true,
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        ".b{color:light-dark(#102030,#d0e0f0)}.c{--c:light-dark(red,#00f)}
+        "
+      `);
+    },
+  });
+
+  itBundled("css/color-scheme-does-not-define-polyfill-vars-by-default", {
+    files: {
+      "index.css": /* css */ `
+        :root {
+          color-scheme: light dark;
+        }
+        .dark {
+          color-scheme: dark;
+        }
+        .b {
+          color: light-dark(red, blue);
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        :root {
+          color-scheme: light dark;
+        }
+
+        .dark {
+          color-scheme: dark;
+        }
+
+        .b {
+          color: light-dark(red, #00f);
+        }
+        "
+      `);
+    },
+  });
+});


### PR DESCRIPTION
### Problem
- `bun build` rewrites `light-dark(a, b)` into `var(--buncss-light, a) var(--buncss-dark, b)`. Only rules that declare `color-scheme` in the same compiled CSS define those variables. When the scheme comes from `<meta name="color-scheme">`, another stylesheet, or nowhere, the value is `a b`: invalid (reported in #20689).
- Cause: the gates at `src/css/values/color.rs:511`, `properties/custom.rs:946` and `properties/ui.rs:120` compare raw browser versions. The default floor (`src/css/targets.rs:190`, chrome 80) is below `light-dark()` support (chrome 123).

### Fix
- Add the `LIGHT_DARK` bit that lightningcss gates this lowering with to `targets::Features`, route the three gates through `should_compile_same`, and exclude the bit in `Targets::browser_default()`. Explicit targets still polyfill.
- Default builds print `light-dark()` and `color-scheme` as written, like esbuild and untargeted lightningcss. Correct because this lowering depends on page state bun cannot see, under targets it picked. It reverses documented default output (#24034), so it needs a maintainer yes.
- Self-reviewed: 7 concerns raised, 4 distinct, 3 addressed. Rejected: shipping only the plumbing and deciding the default in the targets-option work (#40368, #40133), because the plumbing alone changes no output.
- Verified: `test/bundler/css/light-dark-default-targets.test.ts` (3 cases, all fail on 1.4.3), plus `test/js/bun/css/css.test.ts` and `test/bundler/css/`.

### Background
- `Targets` holds `browsers` plus `include` and `exclude` feature bits. `should_compile` lowers a feature when `include` has its bit, or when `exclude` lacks it and a target lacks support.
- The polyfill adds `--buncss-light: initial; --buncss-dark: ;` to each `color-scheme` rule, swapped under `prefers-color-scheme: dark`. A `var()` of an `initial` or unset variable takes its fallback. An empty one vanishes.

<details><summary>Notes</summary>

- Repro: `.b { color: light-dark(#102030, #d0e0f0) }` with `bun build ./entry.css` on 1.4.3 prints `color: var(--buncss-light, #102030) var(--buncss-dark, #d0e0f0);`. In Chromium with no `color-scheme` rule the computed color is the inherited one in light and dark mode. After this change it prints `color: light-dark(#102030, #d0e0f0);`.
- #40369 (default floor to chrome 107) stays below chrome 123, so it does not change this on its own.
- With a future targets option (#40368), a user who asks for targets below `light-dark()` support gets the polyfill, the same as lightningcss with those targets. The docs paragraph describes the lowering and says the default targets leave it out, so it stays true either way.
- Trade-off for pre-2024 browsers: with an in-bundle `:root { color-scheme: light dark }` the polyfill gave them working colors. They now drop the declaration at parse time and fall back through the cascade. Modern browsers were wrong in the common case before and are always right now.
- A `var()` encoding that degrades to the light color when both variables are unset does not exist. With both unset every fallback is substituted, so any encoding yields both colors or an unresolved reference. Emitting the native declaration after the polyfilled one would fix regular properties in modern browsers but breaks custom properties in old ones (the later `--x: light-dark()` always wins at parse time), and doubles every declaration.
- `light-dark(oklch(), oklch())` still gets the rgb, p3 and lab fallback tiers, each inside `light-dark()`. lightningcss with `exclude: LightDark` and the same targets prints the same.
- The existing polyfill tests in `test/js/bun/css/css.test.ts` pass explicit chrome 90 targets through the internal test API, which does not set `exclude`, so they are unchanged. Open PRs #39251 and #37051 assert default-target polyfill output in bake fixtures and would need a fixture update if this lands first.
- `src/css/build-prefixes.js` regenerates the `Features` block, so the bit is added to its list too. `COLORS` includes it, as in lightningcss.
- Bun has no user-facing CSS targets option yet (#40361, #40133).
- Also ran `test/bundler/esbuild/css.test.ts`, `test/js/bun/css/color.test.ts`, `css-loader.test.ts`, `doesnt_crash.test.ts`, `duplicate-declaration-merge-hang.test.ts`, `token-list-backtracking.test.ts`, `test/regression/issue/css-system-color-contexts.test.ts`: all pass.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/css/light-dark-default-targets.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/css/light-dark-default-targets.test.ts:
21 |       `,
22 |     },
23 |     outdir: "/out",
24 |     entryPoints: ["/index.css"],
25 |     onAfterBundle(api) {
26 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
  .b {
-   color: light-dark(#102030, #d0e0f0);
-   background-color: light-dark(#fff, #000);
+   color: var(--buncss-light, #102030) var(--buncss-dark, #d0e0f0);
+   background-color: var(--buncss-light, #fff) var(--buncss-dark, #000);
  }
  
  .c {
-   accent-color: light-dark(red, #00f);
-   --c: light-dark(red, #00f);
+   accent-color: var(--buncss-light, red) var(--buncss-dark, #00f);
+   --c: var(--buncss-light, red) var(--buncss-dark, #00f);
  }
  "
  

- Expected  - 4
+ Received  + 4

      at onAfterBundle (/workspace/bun/test/bundler/css/light-dark-default-targets.test.ts:26:40)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1658:13)
(fail) css > css/light-dark-is-not-polyfilled-by-default [17.94ms]
49 |     outdir: "/out",
50 |     minifyWh
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/css/light-dark-default-targets.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/css/light-dark-default-targets.test.ts:
(pass) css > css/light-dark-is-not-polyfilled-by-default [492.22ms]
(pass) css > css/light-dark-is-not-polyfilled-by-default-minified [94.64ms]
(pass) css > css/color-scheme-does-not-define-polyfill-vars-by-default [96.74ms]

 3 pass
 0 fail
 3 snapshots, 3 expect() calls
Ran 3 tests across 1 file. [3.54s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 623ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/css.mdx                               | 37 +--------
 src/css/build-prefixes.js                          | 11 ++-
 src/css/properties/custom.rs                       |  5 +-
 src/css/properties/ui.rs                           |  4 +-
 src/css/targets.rs                                 |  7 +-
 src/css/values/color.rs                            |  2 +-
 .../bundler/css/light-dark-default-targets.test.ts | 95 ++++++++++++++++++++++
 7 files changed, 120 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
docs/bundler/css.mdx                                     2      4      6
src/css/build-prefixes.js                                1      1      6
src/css/properties/custom.rs                             1      1      6
src/css/properties/ui.rs                                 1      1      6
src/css/targets.rs                                       3      3      6
src/css/values/color.rs                                  1      1      6
test/bundler/css/light-dark-default-targets.test.ts      0      3      6
```

</details>

<!-- robobun:evidence:end -->