### PR TITLE
bin linker, hoisted install, bun remove: do not follow a symlink at node_modules/.bin or @scope

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -685,6 +685,7 @@ impl<'a> PackageInstaller<'a> {
                     abs_target_buf: link_target_buf,
                     abs_dest_buf: link_dest_buf,
                     rel_buf: link_rel_buf,
+                    bin_dir: None,
                     err: None,
                     skipped_due_to_missing_bin: false,
                 };

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1815,6 +1815,17 @@ impl<'a> PackageInstaller<'a> {
                 }
             };
 
+            // A scoped alias installs one level deeper (`@scope/name`), and
+            // each install method resolves that subpath by path. The install
+            // creates the scope directory, so open it the way `.bin` is
+            // opened: a symlink there would send the package, and the
+            // `delete_tree` of the destination that runs first, into the
+            // symlink's target directory, outside the tree.
+            #[cfg(not(windows))]
+            if let Some((scope, _)) = strings::split_once_char(alias.slice(string_buf!()), b'/') {
+                let _ = crate::make_open_real_dir(&destination_dir, scope);
+            }
+
             let install_result: package_install::InstallResult = match resolution.tag {
                 resolution::Tag::Symlink | resolution::Tag::Workspace => {
                     installer.install_from_link(self.skip_delete, &destination_dir)

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1791,8 +1791,7 @@ impl<'a> PackageInstaller<'a> {
                 .node_modules
                 .make_and_open_dir(&self.root_node_modules_folder)
                 .and_then(|dir| {
-                    // `@scope/name` is installed by path below, so the scope level
-                    // must be a real directory, not a planted symlink.
+                    // `@scope` must be a real directory here, not a planted symlink.
                     #[cfg(not(windows))]
                     if let Some((scope, _)) =
                         strings::split_once_char(alias.slice(string_buf!()), b'/')

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1791,12 +1791,8 @@ impl<'a> PackageInstaller<'a> {
                 .node_modules
                 .make_and_open_dir(&self.root_node_modules_folder)
                 .and_then(|dir| {
-                    // A scoped alias installs one level deeper (`@scope/name`),
-                    // and each install method resolves that subpath by path.
-                    // The install creates the scope directory, so open it the
-                    // way `.bin` is opened: a symlink there would send the
-                    // package, and the `delete_tree` of the destination that
-                    // runs first, into the symlink's target directory.
+                    // `@scope/name` is installed by path below, so the scope level
+                    // must be a real directory, not a planted symlink.
                     #[cfg(not(windows))]
                     if let Some((scope, _)) =
                         strings::split_once_char(alias.slice(string_buf!()), b'/')

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1789,7 +1789,21 @@ impl<'a> PackageInstaller<'a> {
             let destination_dir = match self
                 .node_modules
                 .make_and_open_dir(&self.root_node_modules_folder)
-            {
+                .and_then(|dir| {
+                    // A scoped alias installs one level deeper (`@scope/name`),
+                    // and each install method resolves that subpath by path.
+                    // The install creates the scope directory, so open it the
+                    // way `.bin` is opened: a symlink there would send the
+                    // package, and the `delete_tree` of the destination that
+                    // runs first, into the symlink's target directory.
+                    #[cfg(not(windows))]
+                    if let Some((scope, _)) =
+                        strings::split_once_char(alias.slice(string_buf!()), b'/')
+                    {
+                        crate::make_open_real_dir(&dir, scope)?;
+                    }
+                    Ok(dir)
+                }) {
                 Ok(d) => d,
                 Err(err) => {
                     if log_level != Options::LogLevel::Silent {
@@ -1814,17 +1828,6 @@ impl<'a> PackageInstaller<'a> {
                     return;
                 }
             };
-
-            // A scoped alias installs one level deeper (`@scope/name`), and
-            // each install method resolves that subpath by path. The install
-            // creates the scope directory, so open it the way `.bin` is
-            // opened: a symlink there would send the package, and the
-            // `delete_tree` of the destination that runs first, into the
-            // symlink's target directory, outside the tree.
-            #[cfg(not(windows))]
-            if let Some((scope, _)) = strings::split_once_char(alias.slice(string_buf!()), b'/') {
-                let _ = crate::make_open_real_dir(&destination_dir, scope);
-            }
 
             let install_result: package_install::InstallResult = match resolution.tag {
                 resolution::Tag::Symlink | resolution::Tag::Workspace => {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -724,10 +724,8 @@ pub(super) fn remove_leftover_node_modules(
     updates: &[UpdateRequest],
 ) {
     let cwd = bun_sys::Dir::cwd();
-    // `node_modules` itself can be a symlink the user made. The levels inside
-    // it (`@scope`, `.bin`) are the install's, and a symlink at one of them is
-    // not followed: the package directory and the dangling bin links would be
-    // deleted from the symlink's target directory instead.
+    // `node_modules` may be the user's symlink. `@scope` and `.bin` inside it
+    // are not followed, so nothing is deleted outside the tree.
     let node_modules = cwd.open_at(b"node_modules").ok();
     let name_hashes = manager.lockfile.packages.items_name_hash();
     if let Some(node_modules) = &node_modules {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -724,8 +724,7 @@ pub(super) fn remove_leftover_node_modules(
     updates: &[UpdateRequest],
 ) {
     let cwd = bun_sys::Dir::cwd();
-    // `node_modules` may be the user's symlink. `@scope` and `.bin` inside it
-    // are not followed, so nothing is deleted outside the tree.
+    // `node_modules` may be the user's symlink. `@scope` and `.bin` under it are not followed.
     let node_modules = cwd.open_at(b"node_modules").ok();
     let name_hashes = manager.lockfile.packages.items_name_hash();
     if let Some(node_modules) = &node_modules {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -767,16 +767,13 @@ pub(super) fn remove_leftover_node_modules(
         if entry.kind != bun_sys::EntryKind::SymLink {
             continue;
         }
-        // access(2) does not follow symlinks, so open() is the dangling check.
         let name = entry.name.slice_u8();
         name_buf[..name.len()].copy_from_slice(name);
         name_buf[name.len()] = 0;
         let name: &ZStr = ZStr::from_buf(&name_buf, name.len());
-        match bun_sys::File::openat(bin_dir.fd(), name, bun_sys::O::RDONLY, 0) {
-            Ok(file) => {
-                let _ = file.close();
-            }
-            Err(_) => {
+        // `fstatat` follows the link, so a missing target is a dangling bin.
+        if let Err(err) = bun_sys::fstatat(bin_dir.fd(), name) {
+            if matches!(err.get_errno(), bun_sys::E::ENOENT | bun_sys::E::ENOTDIR) {
                 let _ = bun_sys::unlinkat(bin_dir.fd(), name);
             }
         }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -8,6 +8,7 @@ use bstr::BStr;
 use crate::Error;
 use crate::ShellCompletions;
 use crate::bun_fs::FileSystem;
+use crate::package_installer::alias_is_safe_install_target;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
 use bun_js_printer as js_printer;
@@ -723,57 +724,60 @@ pub(super) fn remove_leftover_node_modules(
     updates: &[UpdateRequest],
 ) {
     let cwd = bun_sys::Dir::cwd();
-    let mut node_modules_buf = bun_paths::path_buffer_pool::get();
-    node_modules_buf[..b"node_modules".len()].copy_from_slice(b"node_modules");
-    node_modules_buf[b"node_modules".len()] = bun_paths::SEP;
+    // `node_modules` itself can be a symlink the user made. The levels inside
+    // it (`@scope`, `.bin`) are the install's, and a symlink at one of them is
+    // not followed: the package directory and the dangling bin links would be
+    // deleted from the symlink's target directory instead.
+    let node_modules = cwd.open_at(b"node_modules").ok();
     let name_hashes = manager.lockfile.packages.items_name_hash();
-    for request in updates.iter() {
-        // Only top-level folders are removed; nested copies are left alone.
-        let name_hash = bun_semver::semver_string::Builder::string_hash(request.name);
-        if !name_hashes.contains(&name_hash) {
-            let offset_buf = &mut node_modules_buf[b"node_modules/".len()..];
-            offset_buf[..request.name.len()].copy_from_slice(request.name);
-            let _ =
-                cwd.delete_tree(&node_modules_buf[..b"node_modules/".len() + request.name.len()]);
+    if let Some(node_modules) = &node_modules {
+        for request in updates.iter() {
+            // Only top-level folders are removed; nested copies are left alone.
+            let name_hash = bun_semver::semver_string::Builder::string_hash(request.name);
+            if name_hashes.contains(&name_hash) || !alias_is_safe_install_target(request.name) {
+                continue;
+            }
+            match strings::split_once_char(request.name, b'/') {
+                Some((scope, name)) => {
+                    if let Some(scope_dir) = crate::prune::open_real_subdir(node_modules, scope) {
+                        let _ = scope_dir.delete_tree(name);
+                    }
+                }
+                None => {
+                    let _ = node_modules.delete_tree(request.name);
+                }
+            }
         }
     }
 
-    match bun_sys::open_dir_for_iteration(cwd.fd(), manager.options.bin_path.as_bytes()) {
-        Ok(node_modules_bin) => {
-            let mut iter = bun_sys::iterate_dir(node_modules_bin);
-            'iterator: loop {
-                let Ok(Some(entry)) = iter.next() else { break };
-                match entry.kind {
-                    bun_sys::EntryKind::SymLink => {
-                        // access(2) does not follow symlinks, so open() is the dangling check.
-                        let name = entry.name.slice_u8();
-                        node_modules_buf[..name.len()].copy_from_slice(name);
-                        node_modules_buf[name.len()] = 0;
-                        let buf: &ZStr = ZStr::from_buf(&node_modules_buf, name.len());
-
-                        match bun_sys::File::openat(node_modules_bin, buf, bun_sys::O::RDONLY, 0) {
-                            Ok(file) => {
-                                let _ = file.close();
-                            }
-                            Err(_) => {
-                                let _ = bun_sys::unlinkat(node_modules_bin, buf);
-                                continue 'iterator;
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            let _ = bun_sys::close(node_modules_bin);
+    let bin_dir = if manager.options.global {
+        // The global bin directory is the user's own, opened the way it is configured.
+        bun_sys::Dir::open(manager.options.bin_path.as_bytes()).ok()
+    } else {
+        node_modules
+            .as_ref()
+            .and_then(|node_modules| crate::prune::open_real_subdir(node_modules, b".bin"))
+    };
+    let Some(bin_dir) = bin_dir else {
+        return;
+    };
+    let mut name_buf = bun_paths::path_buffer_pool::get();
+    let mut iter = bun_sys::iterate_dir(bin_dir.fd());
+    while let Ok(Some(entry)) = iter.next() {
+        if entry.kind != bun_sys::EntryKind::SymLink {
+            continue;
         }
-        Err(err) => {
-            if err.get_errno() != bun_sys::E::ENOENT {
-                Output::err(
-                    crate::Error::from(err),
-                    "while reading node_modules/.bin",
-                    (),
-                );
-                Global::crash();
+        // access(2) does not follow symlinks, so open() is the dangling check.
+        let name = entry.name.slice_u8();
+        name_buf[..name.len()].copy_from_slice(name);
+        name_buf[name.len()] = 0;
+        let name: &ZStr = ZStr::from_buf(&name_buf, name.len());
+        match bun_sys::File::openat(bin_dir.fd(), name, bun_sys::O::RDONLY, 0) {
+            Ok(file) => {
+                let _ = file.close();
+            }
+            Err(_) => {
+                let _ = bun_sys::unlinkat(bin_dir.fd(), name);
             }
         }
     }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -942,7 +942,11 @@ impl<'a> Linker<'a> {
         }
 
         if self.err.is_some() {
-            // cleanup on error just in case
+            // A shim is two files, so a failed one can leave the other behind.
+            // A symlink is one `symlinkat`, which leaves nothing when it fails,
+            // and `abs_dest` must not be resolved by path again (see
+            // `open_bin_dir`).
+            #[cfg(windows)]
             Self::unlink_bin_or_shim(abs_dest);
             return;
         }
@@ -1252,11 +1256,72 @@ impl<'a> Linker<'a> {
         }
     }
 
+    /// Open the directory the bin links are written into.
+    ///
+    /// The install creates `node_modules/.bin`, so it is opened without
+    /// following a symlink at `.bin`, and a symlink there is replaced (see
+    /// `crate::make_open_real_dir`). The global bin directory is the user's
+    /// own (`BUN_INSTALL_BIN`, bunfig `globalBinDir`), so it is opened the way
+    /// the user wrote it.
+    #[cfg(not(windows))]
+    fn open_bin_dir(
+        node_modules_path: &AbsPath,
+        global_bin_path: &ZStr,
+        global: bool,
+    ) -> sys::Maybe<sys::Dir> {
+        if global {
+            return sys::Dir::open(strings::without_trailing_slash(global_bin_path.as_bytes()));
+        }
+
+        let node_modules = strings::without_trailing_slash(node_modules_path.slice());
+        let node_modules = match sys::Dir::open(node_modules) {
+            Ok(dir) => dir,
+            Err(err) if err.get_errno() == sys::Errno::ENOENT => {
+                sys::Dir::cwd().make_path(node_modules)?;
+                sys::Dir::open(node_modules)?
+            }
+            Err(err) => return Err(err),
+        };
+        crate::make_open_real_dir(&node_modules, b".bin")
+    }
+
+    /// `symlinkat`, with the retry `sys::symlink_running_executable` does when
+    /// the name holds the running executable.
+    #[cfg(not(windows))]
+    fn symlink_bin(bin_dir: &sys::Dir, rel_target: &ZStr, name: &ZStr) -> sys::Maybe<()> {
+        match sys::symlinkat(rel_target, bin_dir.fd(), name) {
+            Err(err)
+                if err.get_errno() == sys::Errno::EBUSY
+                    || err.get_errno() == sys::Errno::ETXTBSY =>
+            {
+                let _ = sys::unlinkat(bin_dir.fd(), name);
+                sys::symlinkat(rel_target, bin_dir.fd(), name)
+            }
+            result => result,
+        }
+    }
+
     #[cfg(not(windows))]
     fn create_symlink(&mut self, abs_target: &ZStr, abs_dest: &ZStr, global: bool) {
         // hoisted from `defer { if (this.err == null) chmod }` — scopeguard
         // cannot capture `&mut self.err` without conflicting with the body's writes,
         // so each return path calls `Self::chmod_on_ok` explicitly instead.
+
+        let bin_dir = match Self::open_bin_dir(self.node_modules_path, self.global_bin_path, global)
+        {
+            Ok(dir) => dir,
+            Err(err) => {
+                self.err = Some(err.into());
+                Self::chmod_on_ok(self.err, abs_target);
+                return;
+            }
+        };
+
+        // `build_destination_dir` put the name directly inside `bin_dir`.
+        let name = ZStr::from_slice_with_nul(
+            &abs_dest.as_bytes_with_nul()
+                [abs_dest.len() - path::basename(abs_dest.as_bytes()).len()..],
+        );
 
         let abs_dest_dir = resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes());
         let rel_target =
@@ -1264,56 +1329,18 @@ impl<'a> Linker<'a> {
 
         debug_assert!(strings::has_prefix(rel_target.as_bytes(), b".."));
 
-        match sys::symlink_running_executable(rel_target, abs_dest) {
-            sys::Result::Err(err) => {
-                if err.get_errno() != sys::Errno::EEXIST && err.get_errno() != sys::Errno::ENOENT {
+        match Self::symlink_bin(&bin_dir, rel_target, name) {
+            Ok(()) => {}
+            Err(err) if err.get_errno() == sys::Errno::EEXIST => {
+                // delete and try again
+                let _ = bin_dir.delete_tree(name.as_bytes());
+                if let Err(err) = Self::symlink_bin(&bin_dir, rel_target, name) {
                     self.err = Some(err.into());
-                    Self::chmod_on_ok(self.err, abs_target);
-                    return;
                 }
-
-                // ENOENT means `.bin` hasn't been created yet. Should only happen if this isn't global
-                if err.get_errno() == sys::Errno::ENOENT {
-                    if global {
-                        self.err = Some(err.into());
-                        Self::chmod_on_ok(self.err, abs_target);
-                        return;
-                    }
-
-                    // Capture `len()` and restore via `set_length()` so the path
-                    // can be re-borrowed for `append`/`slice` in between.
-                    let node_modules_path_save = self.node_modules_path.len();
-                    let _ = self.node_modules_path.append(b".bin");
-                    let _ = sys::Dir::cwd().make_path(self.node_modules_path.slice());
-                    self.node_modules_path.set_length(node_modules_path_save);
-
-                    match sys::symlink_running_executable(rel_target, abs_dest) {
-                        sys::Result::Err(real_error) => {
-                            // It was just created, no need to delete destination and symlink again
-                            self.err = Some(real_error.into());
-                            Self::chmod_on_ok(self.err, abs_target);
-                            return;
-                        }
-                        sys::Result::Ok(()) => {
-                            Self::chmod_on_ok(self.err, abs_target);
-                            return;
-                        }
-                    }
-                }
-
-                // beyond this error can only be `.EXIST`
-                debug_assert!(err.get_errno() == sys::Errno::EEXIST);
             }
-            sys::Result::Ok(()) => {
-                Self::chmod_on_ok(self.err, abs_target);
-                return;
+            Err(err) => {
+                self.err = Some(err.into());
             }
-        }
-
-        // delete and try again
-        let _ = sys::delete_tree_absolute(abs_dest.as_bytes());
-        if let Err(err) = sys::symlink_running_executable(rel_target, abs_dest) {
-            self.err = Some(err.into());
         }
         Self::chmod_on_ok(self.err, abs_target);
     }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -945,8 +945,7 @@ impl<'a> Linker<'a> {
         }
 
         if self.err.is_some() {
-            // Remove a half-written shim pair. POSIX made one `symlinkat` on the
-            // `.bin` fd and does not touch `abs_dest` by path.
+            // Remove a half-written shim pair. POSIX has nothing to undo.
             #[cfg(windows)]
             Self::unlink_bin_or_shim(abs_dest);
             return;
@@ -1257,8 +1256,7 @@ impl<'a> Linker<'a> {
         }
     }
 
-    /// `node_modules/.bin` without following a symlink planted at `.bin` (see
-    /// `crate::make_open_real_dir`), or the user's global bin directory as configured.
+    /// `node_modules/.bin` opened without following a planted symlink, or the global bin dir.
     #[cfg(not(windows))]
     fn open_bin_dir(
         node_modules_path: &AbsPath,

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -827,6 +827,10 @@ pub struct Linker<'a> {
     pub abs_dest_buf: &'a mut [u8],
     pub rel_buf: &'a mut [u8],
 
+    /// `node_modules/.bin` (or the global bin directory), opened by the first
+    /// link this `Linker` writes and reused for the package's other bins.
+    pub bin_dir: Option<sys::Dir>,
+
     pub err: Option<Error>,
     pub skipped_due_to_missing_bin: bool,
 }
@@ -1307,15 +1311,24 @@ impl<'a> Linker<'a> {
         // cannot capture `&mut self.err` without conflicting with the body's writes,
         // so each return path calls `Self::chmod_on_ok` explicitly instead.
 
-        let bin_dir = match Self::open_bin_dir(self.node_modules_path, self.global_bin_path, global)
-        {
-            Ok(dir) => dir,
-            Err(err) => {
-                self.err = Some(err.into());
-                Self::chmod_on_ok(self.err, abs_target);
-                return;
+        let bin_fd = match self.bin_dir.as_ref().map(sys::Dir::fd) {
+            Some(fd) => fd,
+            None => {
+                match Self::open_bin_dir(self.node_modules_path, self.global_bin_path, global) {
+                    Ok(dir) => {
+                        let fd = dir.fd();
+                        self.bin_dir = Some(dir);
+                        fd
+                    }
+                    Err(err) => {
+                        self.err = Some(err.into());
+                        Self::chmod_on_ok(self.err, abs_target);
+                        return;
+                    }
+                }
             }
         };
+        let bin_dir = sys::Dir::borrow(&bin_fd);
 
         // `build_destination_dir` put the name directly inside `bin_dir`.
         let name = ZStr::from_slice_with_nul(
@@ -1329,12 +1342,12 @@ impl<'a> Linker<'a> {
 
         debug_assert!(strings::has_prefix(rel_target.as_bytes(), b".."));
 
-        match Self::symlink_bin(&bin_dir, rel_target, name) {
+        match Self::symlink_bin(bin_dir, rel_target, name) {
             Ok(()) => {}
             Err(err) if err.get_errno() == sys::Errno::EEXIST => {
                 // delete and try again
                 let _ = bin_dir.delete_tree(name.as_bytes());
-                if let Err(err) = Self::symlink_bin(&bin_dir, rel_target, name) {
+                if let Err(err) = Self::symlink_bin(bin_dir, rel_target, name) {
                     self.err = Some(err.into());
                 }
             }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -827,8 +827,7 @@ pub struct Linker<'a> {
     pub abs_dest_buf: &'a mut [u8],
     pub rel_buf: &'a mut [u8],
 
-    /// `node_modules/.bin` (or the global bin directory), opened by the first
-    /// link this `Linker` writes and reused for the package's other bins.
+    /// The opened `.bin` (or global bin) directory, reused across this package's bins.
     pub bin_dir: Option<sys::Dir>,
 
     pub err: Option<Error>,
@@ -946,10 +945,8 @@ impl<'a> Linker<'a> {
         }
 
         if self.err.is_some() {
-            // A shim is two files, so a failed one can leave the other behind.
-            // A symlink is one `symlinkat`, which leaves nothing when it fails,
-            // and `abs_dest` must not be resolved by path again (see
-            // `open_bin_dir`).
+            // Remove a half-written shim pair. POSIX made one `symlinkat` on the
+            // `.bin` fd and does not touch `abs_dest` by path.
             #[cfg(windows)]
             Self::unlink_bin_or_shim(abs_dest);
             return;
@@ -1260,13 +1257,8 @@ impl<'a> Linker<'a> {
         }
     }
 
-    /// Open the directory the bin links are written into.
-    ///
-    /// The install creates `node_modules/.bin`, so it is opened without
-    /// following a symlink at `.bin`, and a symlink there is replaced (see
-    /// `crate::make_open_real_dir`). The global bin directory is the user's
-    /// own (`BUN_INSTALL_BIN`, bunfig `globalBinDir`), so it is opened the way
-    /// the user wrote it.
+    /// `node_modules/.bin` without following a symlink planted at `.bin` (see
+    /// `crate::make_open_real_dir`), or the user's global bin directory as configured.
     #[cfg(not(windows))]
     fn open_bin_dir(
         node_modules_path: &AbsPath,
@@ -1289,8 +1281,7 @@ impl<'a> Linker<'a> {
         crate::make_open_real_dir(&node_modules, b".bin")
     }
 
-    /// `symlinkat`, with the retry `sys::symlink_running_executable` does when
-    /// the name holds the running executable.
+    /// `symlinkat` with the `EBUSY`/`ETXTBSY` retry of `sys::symlink_running_executable`.
     #[cfg(not(windows))]
     fn symlink_bin(bin_dir: &sys::Dir, rel_target: &ZStr, name: &ZStr) -> sys::Maybe<()> {
         match sys::symlinkat(rel_target, bin_dir.fd(), name) {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1823,6 +1823,7 @@ impl Task {
                         abs_target_buf: &mut *abs_target_buf,
                         abs_dest_buf: &mut *abs_dest_buf,
                         rel_buf: &mut *rel_buf,
+                        bin_dir: None,
                         err: None,
                         skipped_due_to_missing_bin: false,
                     };
@@ -2397,6 +2398,7 @@ impl<'a> Installer<'a> {
                 abs_target_buf: &mut *link_target_buf,
                 abs_dest_buf: &mut *link_dest_buf,
                 rel_buf: &mut *link_rel_buf,
+                bin_dir: None,
                 err: None,
                 skipped_due_to_missing_bin: false,
             };

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -888,6 +888,61 @@ pub(crate) fn buntaghashbuf_make(buf: &mut BuntagHashBuf, patch_hash: u64) -> &m
     &mut buf[..BUN_HASH_TAG.len() + digits_len]
 }
 
+/// Open `name` inside `parent` as a directory, without following a symlink at
+/// `name`. Creates the directory when it is missing, and replaces a symlink
+/// with an empty directory.
+///
+/// The install creates the directory levels of a `node_modules` tree (`.bin`,
+/// `@scope`), and the steps that write into them resolve those levels by path
+/// again. A symlink at one of the levels sends the write into the symlink's
+/// target directory, outside the tree, where it deletes and replaces files the
+/// user owns. `node_modules` belongs to the install, so a symlink at a level it
+/// creates is replaced.
+#[cfg(not(windows))]
+pub(crate) fn make_open_real_dir(
+    parent: &bun_sys::Dir,
+    name: &[u8],
+) -> bun_sys::Maybe<bun_sys::Dir> {
+    use bun_sys::{E, EntryKind, O};
+    const FLAGS: i32 = O::RDONLY | O::CLOEXEC | O::NOFOLLOW;
+
+    let mut buf = bun_paths::path_buffer_pool::get();
+    if name.len() >= buf.0.len() {
+        return Err(bun_sys::Error::from_code(
+            E::ENAMETOOLONG,
+            bun_sys::Tag::open,
+        ));
+    }
+    buf.0[..name.len()].copy_from_slice(name);
+    buf.0[name.len()] = 0;
+    let name_z = bun_core::ZStr::from_buf(&buf.0[..], name.len());
+
+    let err = match parent.open_at_with(name, FLAGS) {
+        Ok(dir) => return Ok(dir),
+        Err(err) => err,
+    };
+    match err.get_errno() {
+        E::ENOENT => {}
+        // `O_NOFOLLOW` refuses a symlink with `ELOOP`. Together with
+        // `O_DIRECTORY`, Linux reports `ENOTDIR` for it instead, the same as for
+        // a regular file, so `lstat` tells the two apart.
+        E::ELOOP | E::ENOTDIR
+            if bun_sys::lstatat(parent.fd(), name_z).is_ok_and(|stat| {
+                bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode) == EntryKind::SymLink
+            }) =>
+        {
+            bun_sys::unlinkat(parent.fd(), name_z)?;
+        }
+        _ => return Err(err),
+    }
+    if let Err(err) = bun_sys::mkdirat(parent.fd(), name_z, 0o755) {
+        if err.get_errno() != E::EEXIST {
+            return Err(err);
+        }
+    }
+    parent.open_at_with(name, FLAGS)
+}
+
 pub struct StorePathFormatter<'a> {
     str: &'a [u8],
 }

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -888,15 +888,10 @@ pub(crate) fn buntaghashbuf_make(buf: &mut BuntagHashBuf, patch_hash: u64) -> &m
     &mut buf[..BUN_HASH_TAG.len() + digits_len]
 }
 
-/// Open `name` inside `parent` as a directory, without following a symlink at
-/// `name`. Creates the directory when it is missing, and replaces a symlink
-/// with an empty directory.
-///
-/// For the levels of a `node_modules` tree that the install creates (`.bin`,
-/// `@scope`) and that later steps resolve by path again. A symlink at one of
-/// them sends those steps into the symlink's target directory, outside the
-/// tree, where they delete and replace files the user owns. Concurrent
-/// callers for the same `name` all end up with the one real directory.
+/// Open the directory `name` in `parent` with `O_NOFOLLOW`. A missing one is
+/// created, and a symlink planted at `name` is replaced by a real directory, so
+/// the `node_modules` levels the install creates (`.bin`, `@scope`) cannot
+/// redirect later path-based steps outside the tree. Safe for concurrent callers.
 #[cfg(not(windows))]
 pub(crate) fn make_open_real_dir(
     parent: &bun_sys::Dir,
@@ -922,9 +917,8 @@ pub(crate) fn make_open_real_dir(
     };
     match err.get_errno() {
         E::ENOENT => {}
-        // `O_NOFOLLOW` refuses a symlink with `ELOOP`. Together with
-        // `O_DIRECTORY`, Linux reports `ENOTDIR` for it instead, the same as for
-        // a regular file, so `lstat` tells the two apart.
+        // A symlink is `ELOOP`, or `ENOTDIR` on Linux because of `O_DIRECTORY`,
+        // which a regular file also gives: `lstat` tells them apart.
         E::ELOOP | E::ENOTDIR
             if bun_sys::lstatat(parent.fd(), name_z).is_ok_and(|stat| {
                 bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode) == EntryKind::SymLink

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -892,12 +892,11 @@ pub(crate) fn buntaghashbuf_make(buf: &mut BuntagHashBuf, patch_hash: u64) -> &m
 /// `name`. Creates the directory when it is missing, and replaces a symlink
 /// with an empty directory.
 ///
-/// The install creates the directory levels of a `node_modules` tree (`.bin`,
-/// `@scope`), and the steps that write into them resolve those levels by path
-/// again. A symlink at one of the levels sends the write into the symlink's
-/// target directory, outside the tree, where it deletes and replaces files the
-/// user owns. `node_modules` belongs to the install, so a symlink at a level it
-/// creates is replaced.
+/// For the levels of a `node_modules` tree that the install creates (`.bin`,
+/// `@scope`) and that later steps resolve by path again. A symlink at one of
+/// them sends those steps into the symlink's target directory, outside the
+/// tree, where they delete and replace files the user owns. Concurrent
+/// callers for the same `name` all end up with the one real directory.
 #[cfg(not(windows))]
 pub(crate) fn make_open_real_dir(
     parent: &bun_sys::Dir,
@@ -931,7 +930,11 @@ pub(crate) fn make_open_real_dir(
                 bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode) == EntryKind::SymLink
             }) =>
         {
-            bun_sys::unlinkat(parent.fd(), name_z)?;
+            if let Err(err) = bun_sys::unlinkat(parent.fd(), name_z) {
+                if err.get_errno() != E::ENOENT {
+                    return Err(err);
+                }
+            }
         }
         _ => return Err(err),
     }

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -888,10 +888,7 @@ pub(crate) fn buntaghashbuf_make(buf: &mut BuntagHashBuf, patch_hash: u64) -> &m
     &mut buf[..BUN_HASH_TAG.len() + digits_len]
 }
 
-/// Open the directory `name` in `parent` with `O_NOFOLLOW`. A missing one is
-/// created, and a symlink planted at `name` is replaced by a real directory, so
-/// the `node_modules` levels the install creates (`.bin`, `@scope`) cannot
-/// redirect later path-based steps outside the tree. Safe for concurrent callers.
+/// `O_NOFOLLOW` open of directory `name`: created when missing, a planted symlink is replaced.
 #[cfg(not(windows))]
 pub(crate) fn make_open_real_dir(
     parent: &bun_sys::Dir,
@@ -917,8 +914,7 @@ pub(crate) fn make_open_real_dir(
     };
     match err.get_errno() {
         E::ENOENT => {}
-        // A symlink is `ELOOP`, or `ENOTDIR` on Linux because of `O_DIRECTORY`,
-        // which a regular file also gives: `lstat` tells them apart.
+        // A symlink gives `ELOOP`, or `ENOTDIR` on Linux like a regular file: `lstat` decides.
         E::ELOOP | E::ENOTDIR
             if bun_sys::lstatat(parent.fd(), name_z).is_ok_and(|stat| {
                 bun_sys::kind_from_mode(stat.st_mode as bun_sys::Mode) == EntryKind::SymLink

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1557,7 +1557,8 @@ fn entry_kind_of(dir: &Dir, alias: &[u8]) -> EntryKind {
     }
 }
 
-fn open_real_subdir(dir: &Dir, name: &[u8]) -> Option<Dir> {
+/// Open `name` in `dir` when it is a directory, and not a symlink to one.
+pub(crate) fn open_real_subdir(dir: &Dir, name: &[u8]) -> Option<Dir> {
     if lstat_kind(dir, name) != EntryKind::Directory {
         return None;
     }

--- a/src/runtime/cli/link_command.rs
+++ b/src/runtime/cli/link_command.rs
@@ -261,6 +261,7 @@ fn link(ctx: command::Context) -> crate::Result<()> {
                 abs_target_buf: link_target_buf.as_mut_slice(),
                 abs_dest_buf: link_dest_buf.as_mut_slice(),
                 rel_buf: link_rel_buf.as_mut_slice(),
+                bin_dir: None,
                 err: None,
                 skipped_due_to_missing_bin: false,
             };

--- a/src/runtime/cli/unlink_command.rs
+++ b/src/runtime/cli/unlink_command.rs
@@ -210,6 +210,7 @@ fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
                 abs_target_buf: link_target_buf.as_mut_slice(),
                 abs_dest_buf: link_dest_buf.as_mut_slice(),
                 rel_buf: link_rel_buf.as_mut_slice(),
+                bin_dir: None,
                 err: None,
                 skipped_due_to_missing_bin: false,
             };

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -1010,3 +1010,183 @@ it.skipIf(isWindows)(
   },
   60000,
 );
+
+it.skipIf(isWindows)(
+  "does not write bin links through a symlinked node_modules/.bin",
+  async () => {
+    // `node_modules/.bin` is created by the install. The project's author, or a
+    // postinstall script of an earlier package, can leave a symlink there. Every
+    // bin link is then written into the symlink's target directory, outside the
+    // tree. A `bin` key is a free-form file name, so a file in that directory is
+    // deleted and replaced by a link that dangles.
+    using dir = tempDir("bin-dir-symlink-test", {
+      "bunfig.toml": `[install]\nlinker = "hoisted"\n`,
+      "package.json": JSON.stringify({
+        name: "bin-dir-symlink-app",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+        dependencies: { dep: "workspace:*" },
+      }),
+      "packages/dep/package.json": JSON.stringify({
+        name: "dep",
+        version: "1.0.0",
+        bin: { dep: "bin/cli.js", "notes.txt": "bin/cli.js" },
+      }),
+      "packages/dep/bin/cli.js": `#!/usr/bin/env node\nconsole.log("ok");\n`,
+      "victim/dep": "keep me\n",
+      "victim/notes.txt": "keep me\n",
+    });
+    const installDir = await realpath(String(dir));
+    await mkdir(join(installDir, "node_modules"));
+    await symlink(join(installDir, "victim"), join(installDir, "node_modules", ".bin"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: installDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const victim = join(installDir, "victim");
+    expect((await lstat(join(victim, "dep"))).isFile()).toBe(true);
+    expect((await lstat(join(victim, "notes.txt"))).isFile()).toBe(true);
+    expect(await Bun.file(join(victim, "dep")).text()).toBe("keep me\n");
+    expect((await readdir(victim)).sort()).toEqual(["dep", "notes.txt"]);
+
+    // the symlink is replaced by the directory the links belong in
+    const binDir = join(installDir, "node_modules", ".bin");
+    expect((await lstat(binDir)).isDirectory()).toBe(true);
+    expect((await readdir(binDir)).sort()).toEqual(["dep", "notes.txt"]);
+    expect(await readlink(join(binDir, "dep"))).toBe("../dep/bin/cli.js");
+
+    if (exitCode !== 0) {
+      console.error("stdout:", stdout);
+      console.error("stderr:", stderr);
+    }
+    expect(exitCode).toBe(0);
+  },
+  60000,
+);
+
+it.skipIf(isWindows)(
+  "does not install a scoped package through a symlinked scope directory",
+  async () => {
+    // A scoped package installs at `node_modules/@scope/name`. With a symlink at
+    // `node_modules/@scope`, the install resolves that path through the link: it
+    // deletes the destination first, so an existing directory of the same name
+    // in the symlink's target is removed with everything in it.
+    using dir = tempDir("scope-dir-symlink-test", {
+      "bunfig.toml": `[install]\nlinker = "hoisted"\n`,
+      "package.json": JSON.stringify({
+        name: "scope-dir-symlink-app",
+        version: "1.0.0",
+        dependencies: { "@scope/dep": "file:./src" },
+      }),
+      "src/package.json": JSON.stringify({ name: "@scope/dep", version: "1.0.0" }),
+      "src/index.js": `module.exports = 1;\n`,
+      "victim/dep/notes.txt": "keep me\n",
+    });
+    const installDir = await realpath(String(dir));
+    await mkdir(join(installDir, "node_modules"));
+    await symlink(join(installDir, "victim"), join(installDir, "node_modules", "@scope"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: installDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const victim = join(installDir, "victim");
+    expect(await readdir(join(victim, "dep"))).toEqual(["notes.txt"]);
+    expect(await Bun.file(join(victim, "dep", "notes.txt")).text()).toBe("keep me\n");
+    expect(await readdir(victim)).toEqual(["dep"]);
+
+    // the symlink is replaced by the directory the package belongs in
+    const scopeDir = join(installDir, "node_modules", "@scope");
+    expect((await lstat(scopeDir)).isDirectory()).toBe(true);
+    expect(await readdir(scopeDir)).toEqual(["dep"]);
+    expect(await readdir(join(scopeDir, "dep"))).toContain("index.js");
+
+    if (exitCode !== 0) {
+      console.error("stdout:", stdout);
+      console.error("stderr:", stderr);
+    }
+    expect(exitCode).toBe(0);
+  },
+  60000,
+);
+
+it.skipIf(isWindows)(
+  "bun remove does not delete through a symlinked scope directory or node_modules/.bin",
+  async () => {
+    // `bun remove @scope/dep` deletes `node_modules/@scope/dep`, and then the bin
+    // links that dangle. With a symlink at `node_modules/@scope` or at
+    // `node_modules/.bin`, both deletes would run in the symlink's target.
+    using dir = tempDir("remove-scope-symlink-test", {
+      "bunfig.toml": `[install]\nlinker = "hoisted"\n`,
+      "package.json": JSON.stringify({
+        name: "remove-scope-symlink-app",
+        version: "1.0.0",
+        dependencies: { "@scope/dep": "file:./dep", plain: "file:./plain" },
+      }),
+      "dep/package.json": JSON.stringify({ name: "@scope/dep", version: "1.0.0" }),
+      "dep/index.js": `module.exports = 1;\n`,
+      "plain/package.json": JSON.stringify({ name: "plain", version: "1.0.0" }),
+      "plain/index.js": `module.exports = 2;\n`,
+      "victim/dep/notes.txt": "keep me\n",
+    });
+    const installDir = await realpath(String(dir));
+    const victim = join(installDir, "victim");
+    // a dangling link of the user's own, which the `.bin` cleanup would take for a stale bin
+    await symlink("./moved-away", join(victim, "stale"));
+
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: installDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) {
+        console.error("stdout:", stdout);
+        console.error("stderr:", stderr);
+      }
+      expect(exitCode).toBe(0);
+    }
+    expect(await readdir(join(installDir, "node_modules", "@scope"))).toEqual(["dep"]);
+
+    await rm(join(installDir, "node_modules", "@scope"), { recursive: true });
+    await symlink(victim, join(installDir, "node_modules", "@scope"));
+    await symlink(victim, join(installDir, "node_modules", ".bin"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "remove", "@scope/dep"],
+      cwd: installDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect((await readdir(victim)).sort()).toEqual(["dep", "stale"]);
+    expect(await readdir(join(victim, "dep"))).toEqual(["notes.txt"]);
+    expect(await Bun.file(join(victim, "dep", "notes.txt")).text()).toBe("keep me\n");
+    expect(JSON.parse(await Bun.file(join(installDir, "package.json")).text()).dependencies).toEqual({
+      plain: "file:./plain",
+    });
+
+    if (exitCode !== 0) {
+      console.error("stdout:", stdout);
+      console.error("stderr:", stderr);
+    }
+    expect(exitCode).toBe(0);
+  },
+  60000,
+);


### PR DESCRIPTION
### Problem
- With `node_modules/.bin` replaced by a symlink to a directory V, `bun install` links bins through it. `Linker::create_symlink` (`src/install/bin.rs`) worked by absolute path (`symlink`, and on `EEXIST` `delete_tree_absolute` plus `symlink` again), so `V/<bin name>` (any file name, bin keys are free-form) was deleted and replaced by a dangling link. Both linkers share this code.
- With `node_modules/@scope` replaced by a symlink to V, the hoisted install of `@scope/name` went through the link. It deletes the destination first, so it removed `V/name` recursively. `bun remove @scope/name` did the same, and its stale-bin sweep unlinked dangling links inside a symlinked `.bin`.

### Fix
- New `make_open_real_dir(parent, name)` (`src/install/lib.rs`): `openat(O_NOFOLLOW|O_DIRECTORY)`, and a symlink at `name` is replaced by a real directory. `create_symlink` opens `.bin` this way from the `node_modules` fd, once per package, and writes links with `symlinkat`/`unlinkat` on it.
- The hoisted installer makes a scope level a real directory the same way before the package installs, and fails that package if it cannot. `bun remove` skips a scope or `.bin` that is not a real directory.
- The global bin directory is the user's own and is opened as written. Windows is unchanged. The isolated linker's dependency links (`Symlinker`) are still path-based and are a follow-up (see Notes).
- Verified: `test/cli/install/symlink-path-traversal.test.ts` (3 new tests, all fail on 1.4.3), plus the bin, remove, link and add suites.

### Background
- `.bin` and `@scope` are levels of `node_modules` that the install creates. A tree author or an earlier postinstall can leave a symlink there. `bun prune` already refuses to follow one at both levels (`open_real_subdir`).
- `O_NOFOLLOW` guards only the last path component. Opening a level by its single name from the parent fd, then using `*at` calls on that fd, keeps later steps off the path.

<details><summary>Notes</summary>

- Reproduces on a single install with the link planted before it, for example:
  ```sh
  mkdir node_modules && ln -s /path/to/V node_modules/.bin && bun install   # hoisted, any dep with a bin
  ```
  Every bin name that exists in V is unlinked and replaced by `name -> ../<pkg>/...`.
- The isolated linker is affected for `.bin` too once the tree is an isolated tree (same `create_symlink`), and that is fixed here. A `node_modules` without the isolated layout is moved aside first, which hides it in a quick test.
- Not fixed here, isolated linker: with an existing isolated tree, a symlink planted at `node_modules/@scope` makes `Symlinker::ensure_symlink` (`src/install/isolated_install/Symlinker.rs`, path-based `readlink`/`unlink`/`symlink`) unlink a regular file `V/name` and write the dependency link into V, and a symlink at `node_modules/.bun` makes the store entries be created inside V. That code path has its own strategies (`ExpectExisting`/`ExpectMissing`, Windows junctions, detached `bun patch` directories) and gets its own change on top of `make_open_real_dir`.
- Linux reports `ENOTDIR`, not `ELOOP`, for a symlink opened with `O_NOFOLLOW|O_DIRECTORY`, so the helper confirms with `lstat` before it unlinks. A lost race on the unlink (`ENOENT`) or the mkdir (`EEXIST`) is fine; the final `O_NOFOLLOW` open decides.
- After the scope directory is made real, the hoisted install methods still resolve `@scope/name` from the `node_modules` fd by path. A party that can `RENAME_EXCHANGE` entries inside `node_modules` while the install runs is not covered by this change.
- `bun remove` no longer aborts when `node_modules/.bin` cannot be opened for the stale-bin sweep. The sweep is skipped instead. Names passed to `bun remove` that are not plain or scoped package names are not used as paths.
- `bun pm pack` reading members by path after its directory walk (the race variant of this report) is a separate change.
- Self-reviewed: 4 concerns raised, 3 addressed (per-package `.bin` open instead of per bin, race-tolerant replace, title and scope narrowed to what the diff covers). The fourth, folding the isolated `Symlinker` into this PR, is split out as described above.

</details>
