### PR TITLE
bundler: escape <!-- in scripts inlined into standalone HTML

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -318,12 +318,11 @@ impl Chunk {
         Ok(order)
     }
 
-    /// Returns the HTML closing tag that must be escaped when this chunk's content
-    /// is inlined into a standalone HTML file (e.g. "</script" for JS, "</style" for CSS).
-    pub(crate) fn closing_tag_for_content(&self) -> &'static [u8] {
+    /// The element this chunk's content is inlined into in a standalone HTML file.
+    pub(crate) fn html_inline_context(&self) -> HtmlInlineContext {
         match self.content {
-            Content::Javascript(_) => b"</script",
-            Content::Css(_) => b"</style",
+            Content::Javascript(_) => HtmlInlineContext::Script,
+            Content::Css(_) => HtmlInlineContext::Style,
             Content::Html => unreachable!(),
         }
     }
@@ -546,65 +545,142 @@ fn additional_output_file_index(f: &AdditionalFile) -> usize {
     }
 }
 
+/// The element a chunk's text is inlined into when compiling to a standalone
+/// HTML file. Decides which byte sequences the HTML tokenizer would act on
+/// inside that element, and so must be rewritten before inlining.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HtmlInlineContext {
+    /// `</script` closes the element. `<!--` moves the tokenizer into the
+    /// "script data escaped" state, where a later `<script` makes the real
+    /// `</script>` no longer close the element (the script then never runs).
+    Script,
+    /// `</style` closes the element. `<style>` is raw text, so nothing else matters.
+    Style,
+}
+
+enum HtmlInlineEscape {
+    /// `</script` or `</style`, ASCII case-insensitive. `</` becomes `<\/`.
+    CloseTag,
+    /// `<!--` becomes `<!-\x2D`. The second dash is the byte to escape because
+    /// it is the only one of the four that is never JS syntax: `<!` is part of
+    /// a regex lookbehind `(?<!--`, and the first dash can be a character class
+    /// range operator `[<!--x]`. `\x2D` is valid in strings, templates and
+    /// every regex mode, so the rewrite needs no knowledge of JS context.
+    CommentOpen,
+}
+
+impl HtmlInlineEscape {
+    /// How many bytes of the input the escape replaces, and with what.
+    fn rewrite(&self) -> (usize, &'static [u8]) {
+        match self {
+            HtmlInlineEscape::CloseTag => (2, b"<\\/"),
+            HtmlInlineEscape::CommentOpen => (4, b"<!-\\x2D"),
+        }
+    }
+}
+
+/// `current` is how far `code()` has come in the printed text (`before`) and in
+/// the text it writes (`after`). Each time the two diverge, a copy goes onto
+/// `list`, which later corrects the chunk's source map (`SourceMapPieces::finalize`).
+pub(crate) struct ShiftTracker<'a> {
+    pub current: &'a mut source_map::SourceMapShifts,
+    pub list: &'a mut Vec<source_map::SourceMapShifts>,
+}
+
+impl HtmlInlineContext {
+    fn tag_name(self) -> &'static [u8] {
+        match self {
+            HtmlInlineContext::Script => b"script",
+            HtmlInlineContext::Style => b"style",
+        }
+    }
+
+    /// Finds the next sequence in `text` that must be escaped. Returns the
+    /// offset of its leading `<` and the escape that applies.
+    fn next_escape(self, text: &[u8]) -> Option<(usize, HtmlInlineEscape)> {
+        let tag = self.tag_name();
+        let mut from: usize = 0;
+        while let Some(i) = strings::index_of_char_usize(&text[from..], b'<') {
+            let at = from + i;
+            let rest = &text[at + 1..];
+            match rest.first() {
+                Some(b'/') if strings::starts_with_case_insensitive_ascii(&rest[1..], tag) => {
+                    return Some((at, HtmlInlineEscape::CloseTag));
+                }
+                Some(b'!') if self == HtmlInlineContext::Script && rest.starts_with(b"!--") => {
+                    return Some((at, HtmlInlineEscape::CommentOpen));
+                }
+                _ => {}
+            }
+            from = at + 1;
+        }
+        None
+    }
+
+    pub(crate) fn needs_escape(self, text: &[u8]) -> bool {
+        self.next_escape(text).is_some()
+    }
+
+    /// `text.len()` plus the bytes `write_escaped` adds.
+    pub(crate) fn escaped_len(self, text: &[u8]) -> usize {
+        let mut len = text.len();
+        let mut remaining = text;
+        while let Some((at, escape)) = self.next_escape(remaining) {
+            let (consumed, replacement) = escape.rewrite();
+            len += replacement.len() - consumed;
+            remaining = &remaining[at + consumed..];
+        }
+        len
+    }
+
+    /// Copies `text` into `dest` with every `</tag` and (for scripts) `<!--`
+    /// rewritten. `dest` must hold `escaped_len(text)` bytes. Returns the
+    /// number of bytes written. With `shifts`, advances it through the text
+    /// and records a shift after each rewrite.
+    pub(crate) fn write_escaped(
+        self,
+        dest: &mut [u8],
+        text: &[u8],
+        mut shifts: Option<ShiftTracker<'_>>,
+    ) -> usize {
+        let mut remaining = text;
+        let mut dst: usize = 0;
+        loop {
+            let found = self.next_escape(remaining);
+            let upto = found.as_ref().map_or(remaining.len(), |(at, _)| *at);
+            let unchanged = &remaining[..upto];
+            dest[dst..][..upto].copy_from_slice(unchanged);
+            dst += upto;
+            if let Some(tracker) = &mut shifts {
+                let mut offset = source_map::LineColumnOffset::default();
+                offset.advance(unchanged);
+                tracker.current.before.add(offset);
+                tracker.current.after.add(offset);
+            }
+            let Some((_, escape)) = found else {
+                return dst;
+            };
+            let (consumed, replacement) = escape.rewrite();
+            dest[dst..][..replacement.len()].copy_from_slice(replacement);
+            dst += replacement.len();
+            if let Some(tracker) = &mut shifts {
+                tracker
+                    .current
+                    .before
+                    .advance(&remaining[upto..upto + consumed]);
+                tracker.current.after.advance(replacement);
+                tracker.list.push(*tracker.current);
+            }
+            remaining = &remaining[upto + consumed..];
+        }
+    }
+}
+
 impl IntermediateOutput {
     pub(crate) fn allocator_for_size(_size: usize) -> &'static DynAlloc {
         // mimalloc serves large allocations via mmap already, so the global
         // allocator suffices (see `alloc_buf`).
         &()
-    }
-
-    /// Count occurrences of a closing HTML tag (e.g. `</script`, `</style`) in content.
-    /// Used to calculate the extra bytes needed when escaping `</` → `<\/`.
-    fn count_closing_tags(content: &[u8], close_tag: &[u8]) -> usize {
-        let tag_suffix = &close_tag[2..];
-        let mut count: usize = 0;
-        let mut remaining = content;
-        while let Some(idx) = strings::index_of(remaining, b"</") {
-            remaining = &remaining[idx + 2..];
-            if remaining.len() >= tag_suffix.len()
-                && strings::eql_case_insensitive_ascii_ignore_length(
-                    &remaining[..tag_suffix.len()],
-                    tag_suffix,
-                )
-            {
-                count += 1;
-                remaining = &remaining[tag_suffix.len()..];
-            }
-        }
-        count
-    }
-
-    /// Copy `content` into `dest`, escaping occurrences of `close_tag` by
-    /// replacing `</` with `<\/`. Returns the number of bytes written.
-    /// Caller must ensure `dest` has room for `content.len + countClosingTags(...)` bytes.
-    fn memcpy_escaping_closing_tags(dest: &mut [u8], content: &[u8], close_tag: &[u8]) -> usize {
-        let tag_suffix = &close_tag[2..];
-        let mut remaining = content;
-        let mut dst: usize = 0;
-        while let Some(idx) = strings::index_of(remaining, b"</") {
-            dest[dst..][..idx].copy_from_slice(&remaining[..idx]);
-            dst += idx;
-            remaining = &remaining[idx + 2..];
-
-            if remaining.len() >= tag_suffix.len()
-                && strings::eql_case_insensitive_ascii_ignore_length(
-                    &remaining[..tag_suffix.len()],
-                    tag_suffix,
-                )
-            {
-                dest[dst] = b'<';
-                dest[dst + 1] = b'\\';
-                dest[dst + 2] = b'/';
-                dst += 3;
-            } else {
-                dest[dst] = b'<';
-                dest[dst + 1] = b'/';
-                dst += 2;
-            }
-        }
-        dest[dst..][..remaining.len()].copy_from_slice(remaining);
-        dst += remaining.len();
-        dst
     }
 
     pub(crate) fn get_size(&self) -> usize {
@@ -737,6 +813,16 @@ impl IntermediateOutput {
             graph.input_files.items_unique_key_for_additional_file();
         let mut relative_platform_buf = bun_paths::path_buffer_pool::get();
         let mut file_path_buf = bun_paths::path_buffer_pool::get();
+        // A script or stylesheet chunk resolved in standalone mode is headed into a
+        // `<script>`/`<style>` element of the HTML document, so its own text is escaped
+        // for that element here, where the chunk's source map can account for it.
+        let inline_escape: Option<HtmlInlineContext> =
+            match (standalone_chunk_contents, &chunk.content) {
+                (Some(_), Content::Javascript(_) | Content::Css(_)) => {
+                    Some(chunk.html_inline_context())
+                }
+                _ => None,
+            };
         match self {
             IntermediateOutput::Pieces(pieces) => {
                 let entry_point_chunks_for_scb = linker_graph.files.items_entry_point_chunk_index();
@@ -777,7 +863,10 @@ impl IntermediateOutput {
                 };
 
                 for piece in pieces.slice() {
-                    count += piece.data.len();
+                    count += match inline_escape {
+                        Some(ctx) => ctx.escaped_len(piece.data()),
+                        None => piece.data.len(),
+                    };
 
                     match piece.query.kind() {
                         QueryKind::ChunkId => {
@@ -794,13 +883,7 @@ impl IntermediateOutput {
                                 match piece.query.kind() {
                                     QueryKind::Chunk => {
                                         if let Some(content) = scc[index].as_deref() {
-                                            // Account for escaping </script or </style inside inline content.
-                                            // Each occurrence of the closing tag adds 1 byte (`</` → `<\/`).
-                                            count += content.len()
-                                                + Self::count_closing_tags(
-                                                    content,
-                                                    chunks[index].closing_tag_for_content(),
-                                                );
+                                            count += content.len();
                                             continue;
                                         }
                                     }
@@ -897,18 +980,32 @@ impl IntermediateOutput {
                 for piece in pieces.slice() {
                     let data = piece.data();
 
-                    if ENABLE_SOURCE_MAP_SHIFTS {
-                        let mut data_offset = source_map::LineColumnOffset::default();
-                        data_offset.advance(data);
-                        shift.before.add(data_offset);
-                        shift.after.add(data_offset);
-                    }
+                    let written = match inline_escape {
+                        Some(ctx) => ctx.write_escaped(
+                            remain,
+                            data,
+                            if ENABLE_SOURCE_MAP_SHIFTS {
+                                Some(ShiftTracker {
+                                    current: &mut shift,
+                                    list: &mut shifts,
+                                })
+                            } else {
+                                None
+                            },
+                        ),
+                        None => {
+                            if ENABLE_SOURCE_MAP_SHIFTS {
+                                let mut data_offset = source_map::LineColumnOffset::default();
+                                data_offset.advance(data);
+                                shift.before.add(data_offset);
+                                shift.after.add(data_offset);
+                            }
+                            remain[..data.len()].copy_from_slice(data);
+                            data.len()
+                        }
+                    };
 
-                    if !data.is_empty() {
-                        remain[..data.len()].copy_from_slice(data);
-                    }
-
-                    remain = &mut remain[data.len()..];
+                    remain = &mut remain[written..];
 
                     match piece.query.kind() {
                         QueryKind::ChunkId => {
@@ -957,19 +1054,10 @@ impl IntermediateOutput {
                                         shift.after.advance(content);
                                         shifts.push(shift);
                                     }
-                                    // For chunk content, escape closing tags (</script, </style)
-                                    // that would prematurely terminate the inline tag.
-                                    if piece.query.kind() == QueryKind::Chunk {
-                                        let written = Self::memcpy_escaping_closing_tags(
-                                            remain,
-                                            content,
-                                            chunks[index].closing_tag_for_content(),
-                                        );
-                                        remain = &mut remain[written..];
-                                    } else {
-                                        remain[..content.len()].copy_from_slice(content);
-                                        remain = &mut remain[content.len()..];
-                                    }
+                                    // Chunk content was already escaped for its <script>/<style>
+                                    // element when that chunk was resolved (`inline_escape`).
+                                    remain[..content.len()].copy_from_slice(content);
+                                    remain = &mut remain[content.len()..];
                                     continue;
                                 }
                             }
@@ -1125,9 +1213,7 @@ impl IntermediateOutput {
                 let arena =
                     allocator_to_use.unwrap_or_else(|| Self::allocator_for_size(joiner.len));
 
-                if let Some(amt) = display_size {
-                    *amt = joiner.len;
-                }
+                let mut size_for_display = joiner.len;
 
                 let buffer = 'brk: {
                     if ENABLE_SOURCE_MAP_SHIFTS && FeatureFlags::SOURCE_MAP_DEBUG_ID {
@@ -1149,10 +1235,55 @@ impl IntermediateOutput {
                     break 'brk joiner.done()?;
                 };
 
-                Ok(CodeResult {
-                    buffer,
-                    shifts: Vec::new(),
-                })
+                let result = match inline_escape.filter(|ctx| ctx.needs_escape(&buffer)) {
+                    None => CodeResult {
+                        buffer,
+                        shifts: Vec::new(),
+                    },
+                    // Same escaping as the `Pieces` path, over the one piece this chunk is.
+                    Some(ctx) => {
+                        let escaped_len = ctx.escaped_len(&buffer);
+                        size_for_display += escaped_len - buffer.len();
+                        let mut escaped = alloc_buf(*arena, escaped_len)?;
+                        let mut shift = source_map::SourceMapShifts {
+                            after: Default::default(),
+                            before: Default::default(),
+                        };
+                        let mut shifts: Vec<source_map::SourceMapShifts> = Vec::new();
+                        if ENABLE_SOURCE_MAP_SHIFTS {
+                            shifts.push(shift);
+                        }
+                        // SAFETY: `write_escaped` fills exactly `escaped_len` bytes; only those are committed.
+                        let dest: &mut [u8] = unsafe {
+                            &mut bun_core::vec::spare_bytes_mut(&mut escaped)[..escaped_len]
+                        };
+                        let written = ctx.write_escaped(
+                            dest,
+                            &buffer,
+                            if ENABLE_SOURCE_MAP_SHIFTS {
+                                Some(ShiftTracker {
+                                    current: &mut shift,
+                                    list: &mut shifts,
+                                })
+                            } else {
+                                None
+                            },
+                        );
+                        debug_assert!(written == escaped_len);
+                        // SAFETY: `write_escaped` initialized the first `written` bytes.
+                        unsafe { bun_core::vec::commit_spare(&mut escaped, written) };
+                        CodeResult {
+                            buffer: escaped.into_boxed_slice(),
+                            shifts,
+                        }
+                    }
+                };
+
+                if let Some(amt) = display_size {
+                    *amt = size_for_display;
+                }
+
+                Ok(result)
             }
             IntermediateOutput::Empty => Ok(CodeResult {
                 buffer: Box::default(),

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -883,7 +883,9 @@ impl IntermediateOutput {
                                 match piece.query.kind() {
                                     QueryKind::Chunk => {
                                         if let Some(content) = scc[index].as_deref() {
-                                            count += content.len();
+                                            count += chunks[index]
+                                                .html_inline_context()
+                                                .escaped_len(content);
                                             continue;
                                         }
                                     }
@@ -1054,10 +1056,19 @@ impl IntermediateOutput {
                                         shift.after.advance(content);
                                         shifts.push(shift);
                                     }
-                                    // Chunk content was already escaped for its <script>/<style>
-                                    // element when that chunk was resolved (`inline_escape`).
-                                    remain[..content.len()].copy_from_slice(content);
-                                    remain = &mut remain[content.len()..];
+                                    let written = if piece.query.kind() == QueryKind::Chunk {
+                                        // The chunk escaped its own text when it was resolved
+                                        // (`inline_escape`), so this finds nothing there. It catches
+                                        // what was appended after that, e.g. a sourceMappingURL
+                                        // comment that carries --public-path.
+                                        chunks[index]
+                                            .html_inline_context()
+                                            .write_escaped(remain, content, None)
+                                    } else {
+                                        remain[..content.len()].copy_from_slice(content);
+                                        content.len()
+                                    };
+                                    remain = &mut remain[written..];
                                     continue;
                                 }
                             }

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -678,8 +678,9 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     };
 
     // For standalone mode, resolve JS/CSS chunks so we can inline their content into HTML.
-    // Closing tag escaping (</script → <\\/script, </style → <\\/style) is handled during
-    // the HTML assembly step in codeWithSourceMapShifts, not here.
+    // `code_standalone` escapes each for its <script>/<style> element (</script → <\/script,
+    // <!-- → <!-\x2D, </style → <\/style) and the shifts it returns account for that, so
+    // the source map finalized below matches the inlined text.
     //
     // Buffers are freed via `Drop` (global mimalloc); if
     // `Chunk::allocator_for_size` ever becomes size-dependent, matched-arena

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -792,10 +792,12 @@ pub(crate) fn post_process_js_chunk(
         .set(crate::chunk::Flags::IS_EXECUTABLE, is_executable);
 
     if c.options.source_maps != options::SourceMapOption::None {
+        // Paths written over placeholders shift the text after them, and so does
+        // escaping the chunk for the <script> element of a standalone HTML file.
         let can_have_shifts = matches!(
             chunk.intermediate_output,
             crate::chunk::IntermediateOutput::Pieces(_)
-        );
+        ) || c.options.compile_mode.is_standalone_html();
         // Copy the `ParentRef` out (not `c.resolver()`) so the arg borrows the
         // local, not `c`, avoiding the split-borrow with
         // `c.generate_source_map_for_chunk(&mut self, …)`.

--- a/src/sourcemap/lib.rs
+++ b/src/sourcemap/lib.rs
@@ -168,6 +168,11 @@ impl LineColumnOffset {
             debug_assert!(i >= offset);
             debug_assert!((i as usize) < input.len());
 
+            // `input[offset..i]` is the ASCII run the search skipped over.
+            this.columns = this
+                .columns
+                .add_scalar(i32::try_from(i - offset).expect("int cast"));
+
             let iter = strings::CodepointIterator::init(input);
             let mut cursor = strings::Cursor {
                 i,

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -97,6 +97,69 @@ console.log(x);`,
     expect(html).toContain("<\\/script>");
   });
 
+  // Inside <script>, `<!--` switches the HTML tokenizer to "script data escaped",
+  // and a `<script` after that to "double escaped", where `</script>` no longer
+  // closes the element. The inlined script then runs to EOF unclosed and the
+  // browser never executes it. Escaping `<!--` keeps the tokenizer out of those
+  // states; the escape must mean the same thing in every JS context it can
+  // appear in (strings, templates, regex literals incl. /u and lookbehind).
+  test("escapes <!-- in inlined JS so the script element still closes", async () => {
+    using dir = tempDir("compile-browser-escape-comment-open", {
+      "index.html": `<!DOCTYPE html><html><body><p>page</p><script src="./app.js"></script></body></html>`,
+      "app.js": `function inspect(open, tag) {
+  return [
+    open.length,
+    open.charCodeAt(3),
+    tag,
+    \`<!--\${tag}\`,
+    /<!--/u.test(open),
+    /(?<!--)>/.test("->"),
+    /(?<!--)>/.test("-\\x2D>"),
+    /[<!--x]/.test("-"),
+    /[<!--x]/.test("."),
+  ];
+}
+const open = "<!--";
+const tag = "<script>";
+console.log(JSON.stringify(inspect(open, tag)));`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/index.html`],
+      compile: true,
+      target: "browser",
+    });
+    expect(result.success).toBe(true);
+    const html = await result.outputs[0].text();
+
+    // What an HTML tokenizer sees as the script's text must end where the JS ends.
+    let scriptText = "";
+    await new HTMLRewriter()
+      .on("script", {
+        text(chunk) {
+          scriptText += chunk.text;
+        },
+      })
+      .transform(new Response(html))
+      .text();
+    expect(scriptText).not.toContain("</body>");
+    expect(scriptText.trimEnd().endsWith("console.log(JSON.stringify(inspect(open, tag)));")).toBe(true);
+    expect(scriptText).not.toContain("<!--");
+
+    // The escaped script must evaluate exactly as the unescaped one would.
+    await Bun.write(`${dir}/inlined.mjs`, scriptText);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), `${dir}/inlined.mjs`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([4, 45, "<script>", "<!--<script>", true, true, false, true, false]);
+    expect(exitCode).toBe(0);
+  });
+
   test("escapes </style> in inlined CSS", async () => {
     using dir = tempDir("compile-browser-escape-style", {
       "index.html": `<!DOCTYPE html>
@@ -734,6 +797,36 @@ console.log(greet("world"));`,
       expect(html.match(/\/\/# debugId=/g)).toHaveLength(1);
       expect(html).toEndWith("</html>\n");
       await expectInlinedScriptToBeMapped(html, map);
+    });
+
+    // `</script` and `<!--` in the script are escaped for the <script> element
+    // (1 and 3 extra bytes each). The map must account for those bytes too.
+    test("the inlined script's map accounts for </script and <!-- escapes before a mapping", async () => {
+      const marker = "<!--".repeat(8) + "</script>";
+      const appJs = `export const marker = ${JSON.stringify(marker)};\nexport function greet(name) {\n  return name + marker;\n}\nconsole.log(greet("x"));\n`;
+      for (const outdir of [undefined, "dist"]) {
+        using dir = tempDir("compile-browser-escape-sourcemap", { ...assetFixture, "app.js": appJs });
+        const { html, map } = await buildWithAsset(String(dir), {
+          sourcemap: "linked",
+          outdir: outdir && `${dir}/${outdir}`,
+        });
+
+        const open = '<script type="module">';
+        const script = html.slice(html.indexOf(open) + open.length, html.indexOf("</script>"));
+        const [firstLine] = script.split("\n");
+        const escaped = "<!-\\x2D".repeat(8) + "<\\/script>";
+        expect(firstLine).toContain(escaped);
+        const column = firstLine.indexOf("function greet");
+        expect(column).toBeGreaterThan(firstLine.indexOf(escaped));
+
+        const original = await SourceMapConsumer.with(map, null, consumer =>
+          consumer.originalPositionFor({ line: 1, column }),
+        );
+        expect({ line: original.line, column: original.column }).toEqual({
+          line: 2,
+          column: appJs.split("\n")[1].indexOf("function greet"),
+        });
+      }
     });
   });
 });

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -800,10 +800,13 @@ console.log(greet("world"));`,
     });
 
     // `</script` and `<!--` in the script are escaped for the <script> element
-    // (1 and 3 extra bytes each). The map must account for those bytes too.
-    test("the inlined script's map accounts for </script and <!-- escapes before a mapping", async () => {
+    // (1 and 3 extra bytes each). The map must account for those bytes: a
+    // mapping after the escapes moves by their total, and one before them (but
+    // after non-ASCII text on the same line) stays where it is.
+    test("the inlined script's map accounts for </script and <!-- escapes", async () => {
       const marker = "<!--".repeat(8) + "</script>";
-      const appJs = `export const marker = ${JSON.stringify(marker)};\nexport function greet(name) {\n  return name + marker;\n}\nconsole.log(greet("x"));\n`;
+      const appJs = `export const pre = "h\u00e9llo w\u00f6rld";\nexport const marker = ${JSON.stringify(marker)};\nexport function greet(name) {\n  return name + pre + marker;\n}\nconsole.log(greet("x"));\n`;
+      const lines = appJs.split("\n");
       for (const outdir of [undefined, "dist"]) {
         using dir = tempDir("compile-browser-escape-sourcemap", { ...assetFixture, "app.js": appJs });
         const { html, map } = await buildWithAsset(String(dir), {
@@ -815,16 +818,24 @@ console.log(greet("world"));`,
         const script = html.slice(html.indexOf(open) + open.length, html.indexOf("</script>"));
         const [firstLine] = script.split("\n");
         const escaped = "<!-\\x2D".repeat(8) + "<\\/script>";
+        expect(firstLine).toContain("h\u00e9llo w\u00f6rld");
         expect(firstLine).toContain(escaped);
-        const column = firstLine.indexOf("function greet");
-        expect(column).toBeGreaterThan(firstLine.indexOf(escaped));
+        const before = firstLine.indexOf("marker");
+        const after = firstLine.indexOf("function greet");
+        expect(before).toBeGreaterThan(firstLine.indexOf("w\u00f6rld"));
+        expect(before).toBeLessThan(firstLine.indexOf(escaped));
+        expect(after).toBeGreaterThan(firstLine.indexOf(escaped));
 
-        const original = await SourceMapConsumer.with(map, null, consumer =>
-          consumer.originalPositionFor({ line: 1, column }),
-        );
-        expect({ line: original.line, column: original.column }).toEqual({
-          line: 2,
-          column: appJs.split("\n")[1].indexOf("function greet"),
+        const original = await SourceMapConsumer.with(map, null, consumer => ({
+          before: consumer.originalPositionFor({ line: 1, column: before }),
+          after: consumer.originalPositionFor({ line: 1, column: after }),
+        }));
+        expect({
+          before: { line: original.before.line, column: original.before.column },
+          after: { line: original.after.line, column: original.after.column },
+        }).toEqual({
+          before: { line: 2, column: lines[1].indexOf("marker") },
+          after: { line: 3, column: lines[2].indexOf("function greet") },
         });
       }
     });


### PR DESCRIPTION
### Problem
- `bun build --compile --target=browser ./index.html` inlines the JS chunk into `<script type="module">`. It escaped `</script` but not `<!--`. A `<!--` followed later by `<script>` puts the HTML tokenizer in the double-escaped state, where `</script>` does not close the element. The script never runs. The build exits 0.
- Real case: `vue/dist/vue.esm-browser.js` 3.5.13 has both strings, so the page never boots.
- Cause: `IntermediateOutput::memcpy_escaping_closing_tags` (`src/bundler/Chunk.rs`) only knew `</script` and `</style`.

### Fix
- Also escape `<!--`, as `<!-\x2D`. The rewrite is context-free like the `</script` one, so it must stay valid JS anywhere. The second dash is the only byte of the four that is never syntax (`(?<!--` is a regex lookbehind, `[<!--x]` a class range), and `\x2D` is valid in strings, templates and every regex mode.
- Escape when the JS/CSS chunk is resolved and record a source map shift for the added bytes, so map columns match the inlined text. The HTML chunk escapes again when it inlines: a no-op for the chunk text, it covers what is appended later (the `sourceMappingURL` comment carries `--public-path`).
- `LineColumnOffset::advance` dropped the ASCII columns before each non-ASCII character, which placed shifts on such a line too early. Count them (#38666 has the same one-line change).
- Verified: `test/bundler/standalone.test.ts`, two new tests, both fail on canary. More bundler and sourcemap suites pass (list in Notes).

### Background
- Standalone HTML is built in two passes: each script and stylesheet chunk is resolved to text, then the HTML chunk writes those into `<script>` and `<style>` elements.
- Tokenizer: `<!--` moves "script data" to "escaped", `<script>` moves that to "double escaped", and there `</script>` only returns to "escaped". Neither state is reachable without `<!--`.
- `SourceMapShifts` record where `code()` writes text of another length than printed. `SourceMapPieces::finalize` moves later columns by the difference.

<details><summary>Notes</summary>

- Reproduced with the report's snippet on 1.4.3-canary (f42e98025): Bun's `HTMLRewriter` reports the script text ending in `</script></body></html>\n`. With this change it ends at the last JS statement. vue has `"Unexpected '<!--' in comment."` and later ``<script>`` in its compiler messages. The page's inlined script now closes and parses (`bun build` of the extracted text succeeds, before it failed).
- The source map part is for exactness, not a reported symptom: before this change each `</script` escape moved the columns after it on its line by one without telling the map.
- A chunk with no placeholders kept its whole map JSON in one buffer and `finalize` returned it untouched, so `post_process_js_chunk` now keeps the mappings separate in standalone mode (`can_have_shifts`). Without that the new shifts were computed and ignored.
- The `advance` undercount is old and also affects the shifts recorded for paths and data: URLs written over placeholders. The new sourcemap test puts `héllo wörld` before a mapped identifier before the escapes on one minified line. Without the `advance` change that identifier maps to column 7 instead of 13.
- esbuild (0.21 through 0.28) escapes `</script` in strings and templates but leaves `<!--` and `<script` alone. terser (`inline_script`) and Closure Compiler escape `<!--` in strings only. Bun escapes at the chunk level without JS context, which is why the replacement byte was chosen as above: `<\!--` is a SyntaxError in `/u` regexes, and `\x3C!--` breaks `(?<!--` and a backslash-escaped `<`.
- Cases checked for `<!-\x2D`: string and template literals (cooked value unchanged), regex body, regex with `u` and `v` flags, `(?<!--` negative lookbehind, `[<!--x]` character class (the range `!`..`-` is preserved, `.` still does not match), `\<!--`, comments. `String.raw` and tagged templates see the escaped raw text, the same caveat the existing `<\/script` rewrite (and esbuild's) has.
- `-->` and `<script` are left alone. In "script data" they are inert, and no `<!--` survives to leave that state.
- CSS is unchanged in effect: `<style>` is raw text, only `</style` matters.
- Suites run: `standalone`, `bundler_html`, `bundler_splitting`, `bundler_compile_splitting`, `bundler_edgecase`, `bundler_banner`, `bundler_comments`, `bundler_bun`, `esbuild/default`, `esbuild/splitting`, `esbuild/css`, `esbuild/metafile`, `metafile`, `html-import-manifest`, `compile-asset-bunfs`, `bun-build-compile-sourcemap`, `compile-sourcemap-internal`, `test/js/bun/sourcemap/`, the `bundler_compile` sourcemap tests, and regression tests 22003, 28159, 29240, 32492.
- While testing I saw that `Bun.build({ compile: true, target: "browser", sourcemap: "linked" })` writes `//# sourceMappingURL=/$bunfs/root/chunk-….js.map` where the CLI writes `./index-….js.map`. Unrelated to this change, tracked separately.
- Self-reviewed: 4 concerns raised, 4 addressed (the `advance` undercount plus a test for it, the second escape pass for appended text, and the wording about the old column drift).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/standalone.test.ts

<!-- robobun:evidence:end -->