### PR TITLE
Response: keep the body-derived Content-Type when the body is read before the headers

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -963,10 +963,7 @@ impl RewriterPipe {
         original: &Response,
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
-        // The output inherits status and headers: https://github.com/oven-sh/bun/issues/3334
-        // A Content-Type pending from the input's body becomes a real header:
-        // the output body is a stream, and `finalize_without_stream` types a
-        // waiting `.blob()` from `get_fetch_headers()`, which does not see it.
+        // Inherit status and headers (#3334); `finalize_without_stream` reads `get_fetch_headers()`, so materialize.
         let mut init = original.clone_init(global)?;
         init.materialize_headers(global)?;
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -964,7 +964,11 @@ impl RewriterPipe {
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
         // The output inherits status and headers: https://github.com/oven-sh/bun/issues/3334
-        let init = original.clone_init(global)?;
+        // A Content-Type pending from the input's body becomes a real header:
+        // the output body is a stream, and `finalize_without_stream` types a
+        // waiting `.blob()` from `get_fetch_headers()`, which does not see it.
+        let mut init = original.clone_init(global)?;
+        init.materialize_headers(global)?;
 
         let pipe = bun_core::heap::alloc_nn(RewriterPipe {
             global: GlobalRef::from(global),

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -963,6 +963,9 @@ impl RewriterPipe {
         original: &Response,
         sync_only_noun: Option<&'static str>,
     ) -> JsResult<JSValue> {
+        // The output inherits status and headers: https://github.com/oven-sh/bun/issues/3334
+        let init = original.clone_init(global)?;
+
         let pipe = bun_core::heap::alloc_nn(RewriterPipe {
             global: GlobalRef::from(global),
             cell: Cell::new(JSValue::ZERO),
@@ -1023,10 +1026,7 @@ impl RewriterPipe {
         // the sink buffers into `output_buffer`, and `on_start_streaming`
         // hands that over as `DrainResult::Owned`.
         let result = bun_core::heap::alloc_nn(Response::init(
-            webcore::response::Init {
-                status_code: 200,
-                ..Default::default()
-            },
+            init,
             webcore::Body::new({
                 let mut pv = webcore::body::PendingValue::new(global);
                 pv.task = Some(pipe.cast::<c_void>());
@@ -1043,15 +1043,6 @@ impl RewriterPipe {
         // SAFETY: `result` is the live Response just allocated above.
         this.response
             .set(Some(unsafe { RefPtr::init_ref(result.as_ptr()) }));
-
-        result_ref.set_init(
-            original.get_method(),
-            original.get_init_status_code(),
-            original.get_init_status_text().clone(),
-        );
-
-        // https://github.com/oven-sh/bun/issues/3334
-        result_ref.set_init_headers(original.clone_init_headers(global)?);
 
         let response_js_value = result_ref.to_js(&this.global);
 

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -165,6 +165,11 @@ impl FileRoute {
                     "expected blob not to be heap-allocated"
                 );
                 *body_value = BodyValue::Blob(blob.dupe());
+                // A Content-Type the Response has not put in a header list yet
+                // (`Init::pending_content_type`) belongs in the route's headers too.
+                if !response.pending_content_type().is_empty() {
+                    response.get_or_create_headers(global)?;
+                }
                 let headers = headers_from(response.get_init_headers(), &blob);
                 let status_code = response.status_code();
 

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -165,9 +165,8 @@ impl FileRoute {
                     "expected blob not to be heap-allocated"
                 );
                 *body_value = BodyValue::Blob(blob.dupe());
-                // A Content-Type the Response has not put in a header list yet
-                // (`Init::pending_content_type`) belongs in the route's headers too.
                 if !response.pending_content_type().is_empty() {
+                    // Folds it into the header list read below.
                     response.get_or_create_headers(global)?;
                 }
                 let headers = headers_from(response.get_init_headers(), &blob);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3799,8 +3799,11 @@ where
             blob.size()
         };
 
-        let (content_type, needs_content_type, content_type_needs_free) =
-            get_content_type(response.get_init_headers_mut(), blob);
+        let (content_type, needs_content_type, content_type_needs_free) = get_content_type(
+            response.get_init_headers_mut(),
+            response.pending_content_type(),
+            blob,
+        );
         // NOTE: `MimeType` owns a `Cow<'static, [u8]>`; Drop handles the owned case.
         // Hold the value past all reads below, then let it drop at scope end.
         let _ct_guard = scopeguard::guard(content_type_needs_free, |_needs| {
@@ -4788,7 +4791,15 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
     }
 }
 
-fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (MimeType, bool, bool) {
+/// `pending_content_type` is the response's `Content-Type` header when its
+/// header list was never allocated (`Response::pending_content_type`). It was
+/// taken from the body at construction, so it survives the body being turned
+/// into a stream and back, which `blob` may not.
+fn get_content_type(
+    headers: Option<&mut FetchHeaders>,
+    pending_content_type: &[u8],
+    blob: &AnyBlob,
+) -> (MimeType, bool, bool) {
     let mut needs_content_type = true;
     let mut content_type_needs_free = false;
 
@@ -4810,7 +4821,9 @@ fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (Mime
             }
         }
 
-        if !blob.content_type().is_empty() {
+        if !pending_content_type.is_empty() {
+            bun_http_types::MimeType::by_name(pending_content_type)
+        } else if !blob.content_type().is_empty() {
             bun_http_types::MimeType::by_name(blob.content_type())
         } else if let Some(content) = bun_http_types::MimeType::sniff(blob.slice()) {
             content

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4791,10 +4791,7 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
     }
 }
 
-/// `pending_content_type` is the response's `Content-Type` header when its
-/// header list was never allocated (`Response::pending_content_type`). It was
-/// taken from the body at construction, so it survives the body being turned
-/// into a stream and back, which `blob` may not.
+/// Precedence: the header, `Response::pending_content_type`, then `blob` (which may be re-derived from a stream).
 fn get_content_type(
     headers: Option<&mut FetchHeaders>,
     pending_content_type: &[u8],

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -222,8 +222,7 @@ impl StaticRoute {
                     global_this,
                 )?;
             } else if !response.pending_content_type().is_empty() {
-                // A Content-Type the Response has not put in a header list yet
-                // (`Init::pending_content_type`) belongs in the route's headers too.
+                // Folds it into the header list read below.
                 response.get_or_create_headers(global_this)?;
             }
 

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -221,6 +221,10 @@ impl StaticRoute {
                     &bun_core::String::ascii(text_mime.value.as_ref()),
                     global_this,
                 )?;
+            } else if !response.pending_content_type().is_empty() {
+                // A Content-Type the Response has not put in a header list yet
+                // (`Init::pending_content_type`) belongs in the route's headers too.
+                response.get_or_create_headers(global_this)?;
             }
 
             let mut headers: Headers = bun_http_jsc::headers_jsc::from_fetch_headers(

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1157,18 +1157,13 @@ impl Request {
                     }
 
                     if !fields.contains(Fields::Headers) {
-                        if let Some(headers) = response.get_init_headers_mut() {
-                            // The flag is set unconditionally once `getInitHeaders()` yielded a
-                            // value, even if `cloneThis` returns null — so a later arg can't
-                            // repopulate headers from a different source.
-                            match headers.clone_this(global_this) {
-                                Ok(h) => {
-                                    // SAFETY: clone_this returns a +1 ref FetchHeaders.
-                                    req.headers.set(h.map(|p| unsafe { HeadersRef::adopt(p) }));
-                                    fields.insert(Fields::Headers);
-                                }
-                                Err(e) => bail!(Err(e)),
+                        match response.clone_headers(global_this) {
+                            Ok(Some(headers)) => {
+                                req.headers.set(Some(headers));
+                                fields.insert(Fields::Headers);
                             }
+                            Ok(None) => {}
+                            Err(e) => bail!(Err(e)),
                         }
                     }
 
@@ -1398,22 +1393,21 @@ impl Request {
 
         req.url.set(href);
 
-        if matches!(req.body_value(), BodyValue::Blob(_)) && req.headers.get().is_some() {
-            if let BodyValue::Blob(blob) = req.body_value() {
-                let ct: &[u8] = blob.content_type_slice();
-                if !ct.is_empty()
-                    && !req
-                        .headers_mut()
-                        .as_mut()
-                        .unwrap()
-                        .fast_has(HTTPHeaderName::ContentType)
-                {
-                    // Reshaped for borrowck — split borrow of req.body and req.headers
-                    let ct_ptr: *const [u8] = ct;
-                    match req.headers_mut().as_mut().unwrap().put(
+        // https://fetch.spec.whatwg.org/#dom-request step 41: append the body's
+        // `Content-Type` unless the header list has one. `Response` defers this
+        // while it has no header list (`Init::pending_content_type`). `Request`
+        // allocates the list instead: `fetch()` builds one from it anyway, and
+        // nothing keys off its absence.
+        if let BodyValue::Blob(blob) = req.body_value() {
+            let content_type = blob.content_type_slice();
+            if !content_type.is_empty() {
+                let headers = req
+                    .headers_mut()
+                    .get_or_insert_with(HeadersRef::create_empty);
+                if !headers.fast_has(HTTPHeaderName::ContentType) {
+                    match headers.put(
                         HTTPHeaderName::ContentType,
-                        // SAFETY: ct_ptr borrows req.body which is not mutated here.
-                        &BunString::ascii(unsafe { &*ct_ptr }),
+                        &BunString::ascii(content_type),
                         global_this,
                     ) {
                         Ok(()) => {}

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1393,11 +1393,7 @@ impl Request {
 
         req.url.set(href);
 
-        // https://fetch.spec.whatwg.org/#dom-request step 41: append the body's
-        // `Content-Type` unless the header list has one. `Response` defers this
-        // while it has no header list (`Init::pending_content_type`). `Request`
-        // allocates the list instead: `fetch()` builds one from it anyway, and
-        // nothing keys off its absence.
+        // Fetch: append the body's `Content-Type` unless the header list has one (allocating the list).
         if let BodyValue::Blob(blob) = req.body_value() {
             let content_type = blob.content_type_slice();
             if !content_type.is_empty() {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -15,6 +15,7 @@ use bun_core::Output;
 use bun_core::{String as BunString, Utf8Bytes};
 use bun_http_types::Method::Method;
 
+use super::blob::BlobContentType;
 use super::body::{Body, BodyMixin, Value as BodyValue, ValueError as BodyValueError};
 use super::{FetchHeaders, ReadableStream, Request};
 
@@ -310,11 +311,12 @@ impl BodyMixin for Response {
 
 impl Response {
     pub(crate) fn init(
-        response_init: Init,
+        mut response_init: Init,
         body: Body,
         url: BunString,
         redirected: bool,
     ) -> Response {
+        response_init.capture_content_type(body.value.get());
         Response {
             init: JsCell::new(response_init),
             body: JsCell::new(body),
@@ -324,29 +326,10 @@ impl Response {
         }
     }
 
-    #[inline]
-    pub(crate) fn set_init(&self, method: Method, status_code: u16, status_text: BunString) {
-        self.init.with_mut(|init| {
-            init.method = method;
-            init.status_code = status_code;
-            init.status_text = status_text;
-        });
-    }
-
-    #[inline]
-    pub(crate) fn set_init_headers(&self, headers: Option<HeadersRef>) {
-        // old headers dropped (HeadersRef::Drop derefs the C++ handle)
-        self.init.with_mut(|init| init.headers = headers);
-    }
-
-    #[inline]
-    pub(crate) fn get_init_status_code(&self) -> u16 {
-        self.init.get().status_code
-    }
-
-    #[inline]
-    pub(crate) fn get_init_status_text(&self) -> &BunString {
-        &self.init.get().status_text
+    /// Deep-copy `init` for a derived response: status, status text, method,
+    /// the header list, and a body `Content-Type` not yet in the header list.
+    pub(crate) fn clone_init(&self, global: &JSGlobalObject) -> JsResult<Init> {
+        self.init.get().clone(global)
     }
 
     #[inline]
@@ -389,18 +372,23 @@ impl Response {
         self.init_mut().headers.as_deref_mut()
     }
 
-    /// Deep-copy this response's init headers (if any) into a fresh
-    /// `HeadersRef`. Centralises the `FetchHeaders::clone_this` +
-    /// `HeadersRef::adopt` pair so callers stay `unsafe`-free.
-    #[inline]
-    pub(crate) fn clone_init_headers(
-        &self,
-        global: &JSGlobalObject,
-    ) -> JsResult<Option<HeadersRef>> {
-        match self.init_mut().headers.as_ref() {
-            Some(headers) => headers.clone_this(global),
-            None => Ok(None),
+    /// Deep-copy the header list for another owner. A body `Content-Type` that
+    /// is not yet in `init.headers` goes into the copy, not into `self`.
+    pub(crate) fn clone_headers(&self, global: &JSGlobalObject) -> JsResult<Option<HeadersRef>> {
+        let init = self.init.get();
+        if let Some(headers) = init.headers.as_ref() {
+            return headers.clone_this(global);
         }
+        if init.pending_content_type.is_empty() {
+            return Ok(None);
+        }
+        let mut headers = HeadersRef::create_empty();
+        headers.put(
+            HTTPHeaderName::ContentType,
+            &BunString::ascii(init.pending_content_type.as_slice()),
+            global,
+        )?;
+        Ok(Some(headers))
     }
 
     #[inline]
@@ -593,35 +581,34 @@ impl Response {
         // borrows `self.init`; callers (`get_headers`, `construct_*`) do not
         // hold the borrow across calls that re-enter Response host-fns.
         let init = self.init_mut();
-        if init.headers.is_none() {
-            init.headers = Some(HeadersRef::create_empty());
-
-            if let BodyValue::Blob(blob) = self.body.get().value.get() {
-                let content_type = blob.content_type_slice();
-                if !content_type.is_empty() {
-                    init.headers.as_mut().unwrap().put(
-                        HTTPHeaderName::ContentType,
-                        &BunString::ascii(content_type),
-                        global_this,
-                    )?;
-                }
-            }
-        }
-
-        Ok(init.headers.as_mut().unwrap())
+        init.materialize_headers(global_this)?;
+        Ok(init.headers.get_or_insert_with(HeadersRef::create_empty))
     }
 
     pub(crate) fn get_headers(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(this.get_or_create_headers(global_this)?.to_js(global_this))
     }
 
+    /// The `Content-Type` that [`get_or_create_headers`] would report, without
+    /// allocating the header list.
+    pub(crate) fn pending_content_type(&self) -> &[u8] {
+        self.init.get().pending_content_type.as_slice()
+    }
+
     pub(crate) fn get_content_type(&self) -> JsResult<Option<Utf8Bytes<'_>>> {
         // R-2 escape hatch via `init_mut()` — `fast_get` (FFI out-param write)
         // does not re-enter JS.
-        if let Some(headers) = self.init_mut().headers.as_mut() {
+        let init = self.init_mut();
+        if let Some(headers) = init.headers.as_mut() {
             if let Some(value) = headers.fast_get(HTTPHeaderName::ContentType) {
                 return Ok(Some(value.to_utf8()));
             }
+        }
+
+        if !init.pending_content_type.is_empty() {
+            return Ok(Some(Utf8Bytes::Borrowed(
+                init.pending_content_type.as_slice(),
+            )));
         }
 
         if let BodyValue::Blob(blob) = self.body.get().value.get() {
@@ -1166,6 +1153,7 @@ impl Response {
                 }
             }
         }
+        init.capture_content_type(body.value.get());
 
         // Disarm: all fallible ops have succeeded.
         let body = scopeguard::ScopeGuard::into_inner(body);
@@ -1194,6 +1182,13 @@ impl Response {
 // the fields' own drop glue releases `headers` and `status_text`.
 pub struct Init {
     pub(crate) headers: Option<HeadersRef>,
+    /// The `Content-Type` extracted from the body at construction
+    /// (<https://fetch.spec.whatwg.org/#concept-bodyinit-extract>). The spec
+    /// appends it to the header list right away; `headers` is allocated
+    /// lazily here, so until then the value waits in this field.
+    /// [`Response::get_or_create_headers`] folds it in and clears it, so it
+    /// is only ever non-empty while `headers` is `None`.
+    pub(crate) pending_content_type: BlobContentType,
     pub(crate) status_code: u16,
     pub(crate) status_text: BunString,
     pub method: Method,
@@ -1203,6 +1198,7 @@ impl Default for Init {
     fn default() -> Self {
         Self {
             headers: None,
+            pending_content_type: BlobContentType::default(),
             status_code: 0,
             status_text: BunString::EMPTY,
             method: Method::GET,
@@ -1221,10 +1217,40 @@ impl Init {
         };
         Ok(Init {
             headers,
+            pending_content_type: self.pending_content_type.clone(),
             status_code: self.status_code,
             status_text: self.status_text.clone(),
             method: self.method,
         })
+    }
+
+    /// With no header list to append a `Blob` body's `Content-Type` to, keep
+    /// it in `pending_content_type`. A value that is already pending (copied
+    /// from another `Response` used as the init) wins, as a header would.
+    pub(crate) fn capture_content_type(&mut self, body: &BodyValue) {
+        if self.headers.is_some() || !self.pending_content_type.is_empty() {
+            return;
+        }
+        if let BodyValue::Blob(blob) = body {
+            self.pending_content_type = blob.content_type.get().clone();
+        }
+    }
+
+    /// Allocate `headers` if a `Content-Type` is pending, so that code which
+    /// hands the header list to another owner does not drop it.
+    pub(crate) fn materialize_headers(&mut self, global: &JSGlobalObject) -> JsResult<()> {
+        if self.headers.is_some() || self.pending_content_type.is_empty() {
+            return Ok(());
+        }
+        let mut headers = HeadersRef::create_empty();
+        headers.put(
+            HTTPHeaderName::ContentType,
+            &BunString::ascii(self.pending_content_type.as_slice()),
+            global,
+        )?;
+        self.pending_content_type = BlobContentType::default();
+        self.headers = Some(headers);
+        Ok(())
     }
 
     pub(crate) fn init(

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -326,8 +326,7 @@ impl Response {
         }
     }
 
-    /// Deep-copy `init` for a derived response: status, status text, method,
-    /// the header list, and a body `Content-Type` not yet in the header list.
+    /// Deep copy of `init`, including a pending body `Content-Type`.
     pub(crate) fn clone_init(&self, global: &JSGlobalObject) -> JsResult<Init> {
         self.init.get().clone(global)
     }
@@ -372,8 +371,7 @@ impl Response {
         self.init_mut().headers.as_deref_mut()
     }
 
-    /// Deep-copy the header list for another owner. A body `Content-Type` that
-    /// is not yet in `init.headers` goes into the copy, not into `self`.
+    /// Deep copy of the header list for another owner; a pending `Content-Type` goes into the copy only.
     pub(crate) fn clone_headers(&self, global: &JSGlobalObject) -> JsResult<Option<HeadersRef>> {
         let init = self.init.get();
         if let Some(headers) = init.headers.as_ref() {
@@ -589,8 +587,7 @@ impl Response {
         Ok(this.get_or_create_headers(global_this)?.to_js(global_this))
     }
 
-    /// The `Content-Type` that [`get_or_create_headers`] would report, without
-    /// allocating the header list.
+    /// See [`Init::pending_content_type`]. Empty once the header list exists.
     pub(crate) fn pending_content_type(&self) -> &[u8] {
         self.init.get().pending_content_type.as_slice()
     }
@@ -1182,12 +1179,7 @@ impl Response {
 // the fields' own drop glue releases `headers` and `status_text`.
 pub struct Init {
     pub(crate) headers: Option<HeadersRef>,
-    /// The `Content-Type` extracted from the body at construction
-    /// (<https://fetch.spec.whatwg.org/#concept-bodyinit-extract>). The spec
-    /// appends it to the header list right away; `headers` is allocated
-    /// lazily here, so until then the value waits in this field.
-    /// [`Response::get_or_create_headers`] folds it in and clears it, so it
-    /// is only ever non-empty while `headers` is `None`.
+    /// The body's `Content-Type`, owed to `headers` (allocated lazily); non-empty only while `headers` is `None`.
     pub(crate) pending_content_type: BlobContentType,
     pub(crate) status_code: u16,
     pub(crate) status_text: BunString,
@@ -1224,9 +1216,7 @@ impl Init {
         })
     }
 
-    /// With no header list to append a `Blob` body's `Content-Type` to, keep
-    /// it in `pending_content_type`. A value that is already pending (copied
-    /// from another `Response` used as the init) wins, as a header would.
+    /// Park a `Blob` body's `Content-Type` while there is no header list; an already pending value wins.
     pub(crate) fn capture_content_type(&mut self, body: &BodyValue) {
         if self.headers.is_some() || !self.pending_content_type.is_empty() {
             return;
@@ -1236,8 +1226,7 @@ impl Init {
         }
     }
 
-    /// Allocate `headers` if a `Content-Type` is pending, so that code which
-    /// hands the header list to another owner does not drop it.
+    /// Allocate `headers` now if a `Content-Type` is pending.
     pub(crate) fn materialize_headers(&mut self, global: &JSGlobalObject) -> JsResult<()> {
         if self.headers.is_some() || self.pending_content_type.is_empty() {
             return Ok(());

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -116,6 +116,11 @@ describe("Bun.file in serve routes", () => {
         const res = new Response(Bun.file(join(tempDir, "hello.txt"), { type: "image/png" }));
         return new Response(res.body, res);
       },
+      // The same rewrapped response registered as a file route, not a handler.
+      "/type-override-rewrap-route": (() => {
+        const res = new Response(Bun.file(join(tempDir, "hello.txt"), { type: "image/png" }));
+        return new Response(res.body, res);
+      })(),
     } as const;
 
     server = Bun.serve({
@@ -892,7 +897,7 @@ describe("Bun.file in serve routes", () => {
       expect(res.headers.get("Content-Type")).toMatch(/application\/octet-stream/);
     });
 
-    it.each(["/type-override", "/type-override-body-read", "/type-override-rewrap"])(
+    it.each(["/type-override", "/type-override-body-read", "/type-override-rewrap", "/type-override-rewrap-route"])(
       "a Bun.file() type override wins over the extension (%s)",
       async path => {
         const res = await fetch(new URL(path, server.url));

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -104,6 +104,18 @@ describe("Bun.file in serve routes", () => {
         new Response(Bun.file(join(tempDir, "partial.txt")), {
           headers: { "Cache-Control": "max-age=3600", "X-Custom": "abc" },
         }),
+      // `Bun.file(path, { type })` overrides the extension-derived type. The
+      // override must reach the wire no matter what the handler read first.
+      "/type-override": () => new Response(Bun.file(join(tempDir, "hello.txt"), { type: "image/png" })),
+      "/type-override-body-read": () => {
+        const res = new Response(Bun.file(join(tempDir, "hello.txt"), { type: "image/png" }));
+        if (!res.body) throw new Error("no body");
+        return res;
+      },
+      "/type-override-rewrap": () => {
+        const res = new Response(Bun.file(join(tempDir, "hello.txt"), { type: "image/png" }));
+        return new Response(res.body, res);
+      },
     } as const;
 
     server = Bun.serve({
@@ -879,6 +891,15 @@ describe("Bun.file in serve routes", () => {
       const res = await fetch(new URL(`/binary.bin`, server.url));
       expect(res.headers.get("Content-Type")).toMatch(/application\/octet-stream/);
     });
+
+    it.each(["/type-override", "/type-override-body-read", "/type-override-rewrap"])(
+      "a Bun.file() type override wins over the extension (%s)",
+      async path => {
+        const res = await fetch(new URL(path, server.url));
+        expect(res.headers.get("Content-Type")).toBe("image/png");
+        expect(await res.text()).toBe(files["hello.txt"]);
+      },
+    );
   });
 
   describe.concurrent.each([

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -50,7 +50,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (11.70 KB) {
+    "Response (13.37 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -217,10 +217,10 @@ describe("clone()", () => {
   });
 });
 
-// The Content-Type that `new Response(body)` takes from a Blob/File body is
-// part of the response from construction on (fetch spec "initialize a
-// response"), so it must not depend on whether `.headers` is read before or
-// after something moves the body out of its Blob state.
+// The Content-Type that `new Response(body)` takes from its body is part of the
+// response from construction on (fetch spec "initialize a response"), so it
+// must not depend on whether `.headers` is read before or after something moves
+// the body out of its Blob state.
 describe("body-derived Content-Type does not depend on access order", () => {
   let dir: string;
   beforeAll(() => {
@@ -228,65 +228,100 @@ describe("body-derived Content-Type does not depend on access order", () => {
   });
   const file = () => Bun.file(join(dir, "page.html"), { type: "image/png" });
   const blob = () => new Blob(["<p>hi</p>"], { type: "text/x-custom" });
+  const formData = () => {
+    const fd = new FormData();
+    fd.append("field", "<p>hi</p>");
+    return fd;
+  };
+  const searchParams = () => new URLSearchParams({ p: "<p>hi</p>" });
 
-  for (const [name, body, expected] of [
+  const cases: [string, () => BodyInit, string | RegExp][] = [
     ["Blob", blob, "text/x-custom"],
     ["Bun.file with type override", file, "image/png"],
-  ] as const) {
+    ["FormData", formData, /^multipart\/form-data; boundary=.+/],
+    ["URLSearchParams", searchParams, "application/x-www-form-urlencoded;charset=UTF-8"],
+  ];
+  for (const [name, body, expected] of cases) {
+    const check = (contentType: string | null | undefined) =>
+      typeof expected === "string" ? expect(contentType).toBe(expected) : expect(contentType).toMatch(expected);
+
     describe(name, () => {
       test(".headers first", () => {
         const res = new Response(body());
-        expect(res.headers.get("content-type")).toBe(expected);
+        check(res.headers.get("content-type"));
       });
 
       test(".body first", () => {
         const res = new Response(body());
         expect(res.body).toBeInstanceOf(ReadableStream);
-        expect(res.headers.get("content-type")).toBe(expected);
+        check(res.headers.get("content-type"));
       });
 
       test.each(["text", "arrayBuffer", "bytes", "blob"] as const)(".%s() first", async method => {
         const res = new Response(body());
         await res[method]();
-        expect(res.headers.get("content-type")).toBe(expected);
+        check(res.headers.get("content-type"));
       });
 
       test("new Response(res.body, res)", () => {
         const res = new Response(body());
         const rewrapped = new Response(res.body, res);
-        expect(rewrapped.headers.get("content-type")).toBe(expected);
-        expect(res.headers.get("content-type")).toBe(expected);
+        check(rewrapped.headers.get("content-type"));
+        expect(res.headers.get("content-type")).toBe(rewrapped.headers.get("content-type"));
       });
 
       test("used as ResponseInit, its Content-Type wins over the new body's", () => {
         // Same as `{ headers: res.headers }`: the init's header list already
         // has a Content-Type, so the new body's is not appended.
         const res = new Response(body());
-        expect(new Response(new Blob(["x"], { type: "text/plain" }), res).headers.get("content-type")).toBe(expected);
-        expect(new Response("x", res).headers.get("content-type")).toBe(expected);
+        check(new Response(new Blob(["x"], { type: "text/plain" }), res).headers.get("content-type"));
+        check(new Response("x", res).headers.get("content-type"));
       });
 
       test("used as RequestInit", () => {
         const res = new Response(body());
-        expect(new Request("http://example.com/", res).headers.get("content-type")).toBe(expected);
+        check(new Request("http://example.com/", res).headers.get("content-type"));
       });
 
       test("clone() after .body", () => {
         const res = new Response(body());
         void res.body;
         const clone = res.clone();
-        expect(clone.headers.get("content-type")).toBe(expected);
-        expect(res.headers.get("content-type")).toBe(expected);
+        check(clone.headers.get("content-type"));
+        expect(res.headers.get("content-type")).toBe(clone.headers.get("content-type"));
       });
 
       test("HTMLRewriter output", async () => {
+        const rewriter = new HTMLRewriter().on("p", { element: e => void e.setInnerContent("yo") });
         const res = new Response(body());
-        const out = new HTMLRewriter().on("p", { element: e => void e.setInnerContent("yo") }).transform(res);
-        expect(out.headers.get("content-type")).toBe(expected);
-        expect(await out.text()).toBe("<p>yo</p>");
+        const input = await res.clone().text();
+        const out = rewriter.transform(res);
+        check(out.headers.get("content-type"));
+        expect(await out.text()).toBe(input.replaceAll("<p>hi</p>", "<p>yo</p>"));
+        // .blob() is typed from the same header, whether or not .headers was read.
+        check((await rewriter.transform(new Response(body())).blob()).type);
       });
     });
   }
+
+  test("a FormData boundary in the header is the one in the body", async () => {
+    const res = new Response(formData());
+    const text = await res.text();
+    const contentType = res.headers.get("content-type")!;
+    expect(contentType).toStartWith("multipart/form-data; boundary=");
+    expect(text).toStartWith("--" + contentType.slice("multipart/form-data; boundary=".length));
+  });
+
+  // These responses are built natively, not by the Response constructor.
+  test.each([
+    ["data:", () => "data:text/x-custom,hi", "text/x-custom"],
+    ["blob:", () => URL.createObjectURL(blob()), "text/x-custom"],
+    ["file:", () => Bun.pathToFileURL(join(dir, "page.html")).href, "text/html;charset=utf-8"],
+  ] as const)("fetch() of a %s URL, body read first", async (_, url, expected) => {
+    const res = await fetch(url());
+    await res.text();
+    expect(res.headers.get("content-type")).toBe(expected);
+  });
 
   test("a ReadableStream body contributes no Content-Type, the init still does", () => {
     const stream = () => new ReadableStream({ start: c => c.close() });

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -50,7 +50,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (13.37 KB) {
+    "Response (13.25 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -241,68 +241,66 @@ describe("body-derived Content-Type does not depend on access order", () => {
     ["FormData", formData, /^multipart\/form-data; boundary=.+/],
     ["URLSearchParams", searchParams, "application/x-www-form-urlencoded;charset=UTF-8"],
   ];
-  for (const [name, body, expected] of cases) {
+  describe.each(cases)("%s", (_name, body, expected) => {
     const check = (contentType: string | null | undefined) =>
       typeof expected === "string" ? expect(contentType).toBe(expected) : expect(contentType).toMatch(expected);
 
-    describe(name, () => {
-      test(".headers first", () => {
-        const res = new Response(body());
-        check(res.headers.get("content-type"));
-      });
-
-      test(".body first", () => {
-        const res = new Response(body());
-        expect(res.body).toBeInstanceOf(ReadableStream);
-        check(res.headers.get("content-type"));
-      });
-
-      test.each(["text", "arrayBuffer", "bytes", "blob"] as const)(".%s() first", async method => {
-        const res = new Response(body());
-        await res[method]();
-        check(res.headers.get("content-type"));
-      });
-
-      test("new Response(res.body, res)", () => {
-        const res = new Response(body());
-        const rewrapped = new Response(res.body, res);
-        check(rewrapped.headers.get("content-type"));
-        expect(res.headers.get("content-type")).toBe(rewrapped.headers.get("content-type"));
-      });
-
-      test("used as ResponseInit, its Content-Type wins over the new body's", () => {
-        // Same as `{ headers: res.headers }`: the init's header list already
-        // has a Content-Type, so the new body's is not appended.
-        const res = new Response(body());
-        check(new Response(new Blob(["x"], { type: "text/plain" }), res).headers.get("content-type"));
-        check(new Response("x", res).headers.get("content-type"));
-      });
-
-      test("used as RequestInit", () => {
-        const res = new Response(body());
-        check(new Request("http://example.com/", res).headers.get("content-type"));
-      });
-
-      test("clone() after .body", () => {
-        const res = new Response(body());
-        void res.body;
-        const clone = res.clone();
-        check(clone.headers.get("content-type"));
-        expect(res.headers.get("content-type")).toBe(clone.headers.get("content-type"));
-      });
-
-      test("HTMLRewriter output", async () => {
-        const rewriter = new HTMLRewriter().on("p", { element: e => void e.setInnerContent("yo") });
-        const res = new Response(body());
-        const input = await res.clone().text();
-        const out = rewriter.transform(res);
-        check(out.headers.get("content-type"));
-        expect(await out.text()).toBe(input.replaceAll("<p>hi</p>", "<p>yo</p>"));
-        // .blob() is typed from the same header, whether or not .headers was read.
-        check((await rewriter.transform(new Response(body())).blob()).type);
-      });
+    test(".headers first", () => {
+      const res = new Response(body());
+      check(res.headers.get("content-type"));
     });
-  }
+
+    test(".body first", () => {
+      const res = new Response(body());
+      expect(res.body).toBeInstanceOf(ReadableStream);
+      check(res.headers.get("content-type"));
+    });
+
+    test.each(["text", "arrayBuffer", "bytes", "blob"] as const)(".%s() first", async method => {
+      const res = new Response(body());
+      await res[method]();
+      check(res.headers.get("content-type"));
+    });
+
+    test("new Response(res.body, res)", () => {
+      const res = new Response(body());
+      const rewrapped = new Response(res.body, res);
+      check(rewrapped.headers.get("content-type"));
+      expect(res.headers.get("content-type")).toBe(rewrapped.headers.get("content-type"));
+    });
+
+    test("used as ResponseInit, its Content-Type wins over the new body's", () => {
+      // Same as `{ headers: res.headers }`: the init's header list already
+      // has a Content-Type, so the new body's is not appended.
+      const res = new Response(body());
+      check(new Response(new Blob(["x"], { type: "text/plain" }), res).headers.get("content-type"));
+      check(new Response("x", res).headers.get("content-type"));
+    });
+
+    test("used as RequestInit", () => {
+      const res = new Response(body());
+      check(new Request("http://example.com/", res).headers.get("content-type"));
+    });
+
+    test("clone() after .body", () => {
+      const res = new Response(body());
+      void res.body;
+      const clone = res.clone();
+      check(clone.headers.get("content-type"));
+      expect(res.headers.get("content-type")).toBe(clone.headers.get("content-type"));
+    });
+
+    test("HTMLRewriter output", async () => {
+      const rewriter = new HTMLRewriter().on("p", { element: e => void e.setInnerContent("yo") });
+      const res = new Response(body());
+      const input = await res.clone().text();
+      const out = rewriter.transform(res);
+      check(out.headers.get("content-type"));
+      expect(await out.text()).toBe(input.replaceAll("<p>hi</p>", "<p>yo</p>"));
+      // .blob() is typed from the same header, whether or not .headers was read.
+      check((await rewriter.transform(new Response(body())).blob()).type);
+    });
+  });
 
   test("a FormData boundary in the header is the one in the body", async () => {
     const res = new Response(formData());

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
-import { normalizeBunSnapshot } from "harness";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { normalizeBunSnapshot, tempDirWithFiles } from "harness";
+import { join } from "node:path";
 
 test("zero args returns an otherwise empty 200 response", () => {
   const response = new Response();
@@ -49,7 +50,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (8.0 KB) {
+    "Response (11.70 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -213,5 +214,89 @@ describe("clone()", () => {
 
     expect(originalText).toBe("Hello, world!");
     expect(clonedText).toBe("Hello, world!");
+  });
+});
+
+// The Content-Type that `new Response(body)` takes from a Blob/File body is
+// part of the response from construction on (fetch spec "initialize a
+// response"), so it must not depend on whether `.headers` is read before or
+// after something moves the body out of its Blob state.
+describe("body-derived Content-Type does not depend on access order", () => {
+  let dir: string;
+  beforeAll(() => {
+    dir = tempDirWithFiles("response-content-type", { "page.html": "<p>hi</p>" });
+  });
+  const file = () => Bun.file(join(dir, "page.html"), { type: "image/png" });
+  const blob = () => new Blob(["<p>hi</p>"], { type: "text/x-custom" });
+
+  for (const [name, body, expected] of [
+    ["Blob", blob, "text/x-custom"],
+    ["Bun.file with type override", file, "image/png"],
+  ] as const) {
+    describe(name, () => {
+      test(".headers first", () => {
+        const res = new Response(body());
+        expect(res.headers.get("content-type")).toBe(expected);
+      });
+
+      test(".body first", () => {
+        const res = new Response(body());
+        expect(res.body).toBeInstanceOf(ReadableStream);
+        expect(res.headers.get("content-type")).toBe(expected);
+      });
+
+      test.each(["text", "arrayBuffer", "bytes", "blob"] as const)(".%s() first", async method => {
+        const res = new Response(body());
+        await res[method]();
+        expect(res.headers.get("content-type")).toBe(expected);
+      });
+
+      test("new Response(res.body, res)", () => {
+        const res = new Response(body());
+        const rewrapped = new Response(res.body, res);
+        expect(rewrapped.headers.get("content-type")).toBe(expected);
+        expect(res.headers.get("content-type")).toBe(expected);
+      });
+
+      test("used as ResponseInit, its Content-Type wins over the new body's", () => {
+        // Same as `{ headers: res.headers }`: the init's header list already
+        // has a Content-Type, so the new body's is not appended.
+        const res = new Response(body());
+        expect(new Response(new Blob(["x"], { type: "text/plain" }), res).headers.get("content-type")).toBe(expected);
+        expect(new Response("x", res).headers.get("content-type")).toBe(expected);
+      });
+
+      test("used as RequestInit", () => {
+        const res = new Response(body());
+        expect(new Request("http://example.com/", res).headers.get("content-type")).toBe(expected);
+      });
+
+      test("clone() after .body", () => {
+        const res = new Response(body());
+        void res.body;
+        const clone = res.clone();
+        expect(clone.headers.get("content-type")).toBe(expected);
+        expect(res.headers.get("content-type")).toBe(expected);
+      });
+
+      test("HTMLRewriter output", async () => {
+        const res = new Response(body());
+        const out = new HTMLRewriter().on("p", { element: e => void e.setInnerContent("yo") }).transform(res);
+        expect(out.headers.get("content-type")).toBe(expected);
+        expect(await out.text()).toBe("<p>yo</p>");
+      });
+    });
+  }
+
+  test("a ReadableStream body contributes no Content-Type, the init still does", () => {
+    const stream = () => new ReadableStream({ start: c => c.close() });
+    expect(new Response(stream()).headers.get("content-type")).toBeNull();
+    expect(new Response(stream(), new Response(blob())).headers.get("content-type")).toBe("text/x-custom");
+  });
+
+  test("an explicit Content-Type header wins over the body's", () => {
+    const res = new Response(blob(), { headers: { "Content-Type": "text/plain" } });
+    void res.body;
+    expect(res.headers.get("content-type")).toBe("text/plain");
   });
 });

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -76,6 +76,48 @@ test("clone() does not lock original body when body was accessed before clone", 
   expect(clonedText).toBe("Hello, world!");
 });
 
+// The Content-Type that `new Request(url, { body })` takes from a Blob body is
+// part of the request from construction on, so it must not depend on whether
+// `.headers` is read before or after the body leaves its Blob state.
+describe("body-derived Content-Type does not depend on access order", () => {
+  const make = () =>
+    new Request("http://example.com/", { method: "POST", body: new Blob(["x"], { type: "text/x-custom" }) });
+
+  test(".body first", () => {
+    const req = make();
+    expect(req.body).toBeInstanceOf(ReadableStream);
+    expect(req.headers.get("content-type")).toBe("text/x-custom");
+  });
+
+  test(".text() first", async () => {
+    const req = make();
+    await req.text();
+    expect(req.headers.get("content-type")).toBe("text/x-custom");
+  });
+
+  test("new Request(req, { body }) keeps the original Content-Type", () => {
+    // Same as `{ headers: req.headers, body }`: the copied header list already
+    // has a Content-Type, so the new body's is not appended.
+    expect(new Request(make(), { body: "y" }).headers.get("content-type")).toBe("text/x-custom");
+  });
+
+  test("used as ResponseInit", () => {
+    expect(new Response("y", make()).headers.get("content-type")).toBe("text/x-custom");
+  });
+
+  test("fetch() sends it after .body was read", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req => new Response(req.headers.get("content-type") ?? "(none)"),
+    });
+    const req = new Request(server.url, { method: "POST", body: new Blob(["x"], { type: "text/x-custom" }) });
+    expect(req.body).toBeInstanceOf(ReadableStream);
+    const res = await fetch(req);
+    expect(await res.text()).toBe("text/x-custom");
+    expect(req.headers.get("content-type")).toBe("text/x-custom");
+  });
+});
+
 describe("RequestInit signal presence", () => {
   // Fetch spec step 27: "If init['signal'] exists, then set signal to it."
   // A present `signal: null` must replace (detach from) the input Request's signal.

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -95,6 +95,16 @@ describe("body-derived Content-Type does not depend on access order", () => {
     expect(req.headers.get("content-type")).toBe("text/x-custom");
   });
 
+  test("the FormData boundary survives .arrayBuffer() first", async () => {
+    const fd = new FormData();
+    fd.append("field", "value");
+    const req = new Request("http://example.com/", { method: "POST", body: fd });
+    const body = new TextDecoder().decode(await req.arrayBuffer());
+    const contentType = req.headers.get("content-type")!;
+    expect(contentType).toStartWith("multipart/form-data; boundary=");
+    expect(body).toStartWith("--" + contentType.slice("multipart/form-data; boundary=".length));
+  });
+
   test("new Request(req, { body }) keeps the original Content-Type", () => {
     // Same as `{ headers: req.headers, body }`: the copied header list already
     // has a Content-Type, so the new body's is not appended.


### PR DESCRIPTION
### Problem
- `new Response(Bun.file(p, { type: "image/png" }))`: reading `.body` (or `.text()`, or `new Response(res.body, res)`) before `.headers` makes `headers.get("content-type")` return `null`, and `Bun.serve` then sends the extension-derived type instead of the override. A typed `Blob`, `FormData` and `URLSearchParams` body lose their header the same way, as do `HTMLRewriter` output and `fetch()` of `data:`/`file:`/`blob:` URLs.
- Cause: `Response::get_or_create_headers` (`src/runtime/webcore/Response.rs`) derived the header from whatever the body was at first `.headers` access. Once the body left its `Blob` state there was nothing to derive from. On the wire, `RequestContext::render_metadata` fell back to the Blob the server re-derives from a file stream, which carries the extension type, not the `{ type }` override.

### Fix
- `Init` gains `pending_content_type`: the `Content-Type` taken from the body when the `Response` is constructed (JS constructor and native `Response::init`). `get_or_create_headers` folds it into the header list when that is allocated, `Init::clone` carries it (`clone()`, a `Response` used as `ResponseInit`/`RequestInit`), `HTMLRewriter.transform` and the `routes:`/`static:` builders write it into a header list, and the server prefers it over the re-derived Blob type.
- `Request` appends the header at construction instead of deferring it. Nothing keys off a `Request`'s header list being unallocated, and `fetch()` builds one from it anyway. This also fixes `fetch(req)` sending no `Content-Type` after `req.body` was read.
- The header list of `new Response(body)` stays lazily allocated, so the sliced-`Bun.file()` auto-206 rule in `render_metadata` (which reads "no header list" as "no headers init") and the `new Response(file)` fast path are unchanged.
- Verified: `test/js/web/fetch/response.test.ts`, `test/js/web/request/request.test.ts`, `test/js/bun/http/bun-serve-file.test.ts` (new cases fail on 1.4.3, pass here). Other suites in the notes. Self-reviewed: 3 concerns raised, 2 addressed, 1 deferred (below).

### Background
- Fetch's "extract a body" returns the body and a `Content-Type`; the `Response` and `Request` constructors append it to the header list unless one is already there. So the header exists from construction, whatever is read first. Node behaves this way.
- Bun allocates a `Response`'s `FetchHeaders` (a C++ object) only on first use, so `return new Response(Bun.file(path))` never builds one. The derived `Content-Type` was the one piece of header state that lived only in the body.
- `Bun.serve` turns an unread file stream back into a file `Blob` before sending (`to_blob_if_possible`). That Blob is rebuilt from the store, whose type comes from the path extension.

<details><summary>Notes</summary>

- Ordering cells from the report, before / after: `.headers` first `image/png` / `image/png`; `.body` first `null` / `image/png`; `new Response(r.body, r)` `null` / `image/png`; typed `Blob` with `.body` first `null` / `text/html;charset=utf-8`. Wire: `/direct`, `/bodycheck`, `/rewrap` all `image/png` (were `image/png`, `text/html`, `text/html`).
- Also fixed by the same change: a rewrapped file `Response` registered under `routes:`, `.text()`/`.arrayBuffer()`/`.bytes()`/`.blob()`/`.textStream()` first, `clone()` after `.body`, `new Response("x", res)` and `new Request(url, res)` with an unread `res`, `HTMLRewriter.transform(res).headers` and `.blob().type`, `res.headers` after `Bun.write(dest, res)`, a `FormData` request read with `.arrayBuffer()` first (the boundary in `req.headers` was lost), and `fetch()` responses for `data:`, `file:` and `blob:` URLs read body-first.
- Not changed: a `ReadableStream` body contributes no `Content-Type`; an explicit `Content-Type` header always wins; the 200/206 status of a sliced `Bun.file()` response is exactly as before in every case.
- Supersedes #32913, which fixes the same ordering bug by materializing the header list in each `Body` mixin consumer and therefore has to change the auto-206 rule. Covers the typed-body part of #38570 (`HTMLRewriter` output `Content-Type`); its `text/plain` default for string-body input is independent.
- Follow-ups, not in this PR: a string body still has no `Content-Type` header (#8530), so `new Response("x")` with `.body` read first is served as `application/octet-stream`; reading `.headers` on `new Response(Bun.file(p).slice(a, b))` still turns the automatic 206 into a 200, because `render_metadata` keys that on the header list's existence; `(await res.blob()).type` for a body held as a stream ignores the header (#41922 routes `blob()` through `get_content_type()`, which reads the pending type added here).
- Self-review concerns: (1) `HTMLRewriter` output typed a waiting `.blob()` from `get_fetch_headers()`, so its type depended on whether `.headers` had been read: addressed by writing the pending type into the output's header list in `RewriterPipe::init`, with a test. (2) Port the `FormData`/`URLSearchParams`/`data:` URL cases from #32913 and the `HTMLRewriter` cases from #38570: done in `response.test.ts` and `request.test.ts`. (3) Decouple the auto-206 rule from header-list existence and allocate `Response` headers eagerly like `Request`: deferred, it changes the sliced-file status contract and the `new Response(file)` allocation profile, both out of scope for this bug.
- Suites run locally on the debug build: `response.test.ts`, `request.test.ts`, `bun-serve-file.test.ts`, `body.test.ts`, `body-stream.test.ts`, `body-clone.test.ts`, `blob.test.ts`, `FormData.test.ts`, `headers.test.ts`, `html-rewriter.test.js`, `htmlrewriter-additional-bugs.test.ts`, `serve.test.ts`, `bun-serve-static.test.ts`, `serve-body-leak.test.ts`, `fetch-file-upload.test.ts`, `client-fetch.test.ts`, `inspect.test.js`.
- `response.test.ts` "print size" snapshots the test file's own size, so its expected value changes with this diff.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts

<!-- robobun:evidence:end -->