### PR TITLE
Bun.serve: settle the request body stream when the response ends after req.clone()

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1528,9 +1528,7 @@ where
                     sink_ptr.as_ptr().cast::<ResponseStream<SSL_ENABLED>>(),
                 );
             }
-            // Reject a parked request-body read now, while this abort still
-            // drains microtasks (any_js_calls is already set), rather than from
-            // finalize_without_deinit whenever the last ref happens to drop.
+            // Reject a parked request-body read while this abort still drains microtasks.
             let _ = this.end_request_streaming();
             this.reclaim_promise_cell();
             return;
@@ -1565,8 +1563,7 @@ where
 
         // Reclaim only after the block above: the claim's ref must still
         // count in `is_dead_request`, so a parked request-body read goes
-        // through `end_request_streaming` here, where `any_js_calls` gets its
-        // rejection drained, instead of in `finalize_without_deinit`.
+        // through `end_request_streaming` here and its rejection is drained.
         this.reclaim_promise_cell();
     }
 
@@ -1605,10 +1602,7 @@ where
         }
         self.response_weakref.set(response::WeakRef::EMPTY);
 
-        // `end_request_streaming()` below errors and releases
-        // `request_body_readable_stream_ref`; only cut the producer backref
-        // here so the abort listeners fired first cannot reach this context
-        // through the stream.
+        // The stream ref itself is errored and released by `end_request_streaming()` below.
         self.detach_request_body_producer();
 
         // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
@@ -2412,8 +2406,7 @@ where
 
         let mut any_js_calls = false;
 
-        // User called .blob(), .json(), text(), or .arrayBuffer() on the Request object
-        // but we received nothing or the connection was aborted: reject that promise.
+        // Reject a pending .text()/.json()/.blob()/... whose body never fully arrived.
         if let Some(body) = self.request_body_mut() {
             if matches!(body, Body::Value::Locked(_)) {
                 let global_this = self.server().global_this();
@@ -2425,13 +2418,7 @@ where
             }
         }
 
-        // This context is the producer of the body's ByteStream and nothing
-        // feeds it after this point, so settle it here whatever the body
-        // `Value` looks like. The `Value` alone does not reach it once
-        // `req.clone()` re-pointed `Locked.readable` at a tee branch, or
-        // `req.textStream()` made the body `Used`; an unsettled pull keeps its
-        // promise protected (and every tee branch alive) forever. Erroring the
-        // source rejects a pending read on any branch instead of hanging it.
+        // Nothing feeds our ByteStream from here on; after `req.clone()`/`textStream()` only this ref reaches it.
         let strong = self
             .request_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
@@ -2442,8 +2429,7 @@ where
                     .parent_const()
                     .producer
                     .set(WebCore::streams::SourceHandle::None);
-                // `to_error_instance` above already delivered the terminal
-                // error when the body still pointed at this same stream.
+                // False unless `to_error_instance` above reached this same stream through the body.
                 if !bytes.has_received_last_chunk.get() {
                     let global_this = self.server().global_this();
                     let mut err =

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2438,18 +2438,22 @@ where
         if let Some(readable) = strong.get() {
             readable.value.ensure_still_alive();
             if let Some(bytes) = readable.ptr.bytes() {
-                let global_this = self.server().global_this();
                 bytes
                     .parent_const()
                     .producer
                     .set(WebCore::streams::SourceHandle::None);
-                let mut err =
-                    Body::ValueError::AbortReason(jsc::CommonAbortReason::ConnectionClosed);
-                bytes.on_data(WebCore::streams::Result::Err(
-                    err.to_stream_error(global_this),
-                ));
-                err.reset();
-                any_js_calls = true;
+                // `to_error_instance` above already delivered the terminal
+                // error when the body still pointed at this same stream.
+                if !bytes.has_received_last_chunk.get() {
+                    let global_this = self.server().global_this();
+                    let mut err =
+                        Body::ValueError::AbortReason(jsc::CommonAbortReason::ConnectionClosed);
+                    bytes.on_data(WebCore::streams::Result::Err(
+                        err.to_stream_error(global_this),
+                    ));
+                    err.reset();
+                    any_js_calls = true;
+                }
             }
         }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1528,10 +1528,9 @@ where
                     sink_ptr.as_ptr().cast::<ResponseStream<SSL_ENABLED>>(),
                 );
             }
-            // End request streaming here, not in deinit: a `Used` body
-            // (textStream) can only be rejected through
-            // request_body_readable_stream_ref, and finalize_without_deinit
-            // drops that ref without erroring it. any_js_calls is already set.
+            // Reject a parked request-body read now, while this abort still
+            // drains microtasks (any_js_calls is already set), rather than from
+            // finalize_without_deinit whenever the last ref happens to drop.
             let _ = this.end_request_streaming();
             this.reclaim_promise_cell();
             return;
@@ -1566,8 +1565,8 @@ where
 
         // Reclaim only after the block above: the claim's ref must still
         // count in `is_dead_request`, so a parked request-body read goes
-        // through `end_request_streaming` and rejects instead of being
-        // silently dropped by `finalize_without_deinit`.
+        // through `end_request_streaming` here, where `any_js_calls` gets its
+        // rejection drained, instead of in `finalize_without_deinit`.
         this.reclaim_promise_cell();
     }
 
@@ -1606,9 +1605,11 @@ where
         }
         self.response_weakref.set(response::WeakRef::EMPTY);
 
+        // `end_request_streaming()` below errors and releases
+        // `request_body_readable_stream_ref`; only cut the producer backref
+        // here so the abort listeners fired first cannot reach this context
+        // through the stream.
         self.detach_request_body_producer();
-        self.request_body_readable_stream_ref
-            .with_mut(|s| s.deinit());
 
         // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
         drop(self.cookies.replace(None));
@@ -2409,44 +2410,50 @@ where
 
         self.request_body_buf.set(Vec::new());
 
-        // if we cannot, we have to reject pending promises
-        // first, we reject the request body promise
+        let mut any_js_calls = false;
+
+        // User called .blob(), .json(), text(), or .arrayBuffer() on the Request object
+        // but we received nothing or the connection was aborted: reject that promise.
         if let Some(body) = self.request_body_mut() {
-            // User called .blob(), .json(), text(), or .arrayBuffer() on the Request object
-            // but we received nothing or the connection was aborted
             if matches!(body, Body::Value::Locked(_)) {
                 let global_this = self.server().global_this();
                 body.to_error_instance(
                     Body::ValueError::AbortReason(jsc::CommonAbortReason::ConnectionClosed),
                     global_this,
                 )?;
-                return Ok(true);
+                any_js_calls = true;
             }
         }
 
-        // `req.textStream()` transitions the body to `Value::Used`, so the
-        // Locked check above falls through. Error the ByteStream via our own
-        // strong ref instead so a pending read rejects rather than hanging.
-        if self.request_body_readable_stream_ref.with_mut(|s| s.has()) {
-            let global_this = self.server().global_this();
-            let strong = self
-                .request_body_readable_stream_ref
-                .replace(readable_stream::Strong::default());
-            if let Some(readable) = strong.get() {
-                readable.value.ensure_still_alive();
-                if let Some(bytes) = readable.ptr.bytes() {
-                    let mut err =
-                        Body::ValueError::AbortReason(jsc::CommonAbortReason::ConnectionClosed);
-                    bytes.on_data(WebCore::streams::Result::Err(
-                        err.to_stream_error(global_this),
-                    ));
-                    err.reset();
-                    return Ok(true);
-                }
+        // This context is the producer of the body's ByteStream and nothing
+        // feeds it after this point, so settle it here whatever the body
+        // `Value` looks like. The `Value` alone does not reach it once
+        // `req.clone()` re-pointed `Locked.readable` at a tee branch, or
+        // `req.textStream()` made the body `Used`; an unsettled pull keeps its
+        // promise protected (and every tee branch alive) forever. Erroring the
+        // source rejects a pending read on any branch instead of hanging it.
+        let strong = self
+            .request_body_readable_stream_ref
+            .replace(readable_stream::Strong::default());
+        if let Some(readable) = strong.get() {
+            readable.value.ensure_still_alive();
+            if let Some(bytes) = readable.ptr.bytes() {
+                let global_this = self.server().global_this();
+                bytes
+                    .parent_const()
+                    .producer
+                    .set(WebCore::streams::SourceHandle::None);
+                let mut err =
+                    Body::ValueError::AbortReason(jsc::CommonAbortReason::ConnectionClosed);
+                bytes.on_data(WebCore::streams::Result::Err(
+                    err.to_stream_error(global_this),
+                ));
+                err.reset();
+                any_js_calls = true;
             }
         }
 
-        Ok(false)
+        Ok(any_js_calls)
     }
 
     fn detach_response(&self) {

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1145,3 +1145,120 @@ describe("Response.clone() of a stream body shares chunk references between tee 
     expect(exitCode).toBe(0);
   });
 });
+
+// A `Bun.serve` handler that calls `req.clone()` and responds without reading
+// either body. The server stops feeding the request body once the response
+// ends, so it must also settle the native byte stream behind the tee: an
+// unsettled pull kept its promise GC-protected, and with it both tee branches,
+// the reader, and the controllers of every such request, forever.
+describe("Bun.serve: clone() of an incoming request whose body nobody reads", () => {
+  test("does not leak the teed body streams", async () => {
+    const requests = 100;
+    const script = `
+      const { heapStats } = require("bun:jsc");
+      const body = Buffer.alloc(256, "a").toString();
+      using server = Bun.serve({
+        port: 0,
+        routes: {
+          // BunRequest has its own native clone entry point.
+          "/bun-request": req => {
+            req.clone();
+            return new Response("k");
+          },
+        },
+        fetch(req) {
+          // Tee through the stream that the body getter already materialized.
+          if (req.url.endsWith("/observed")) req.body;
+          req.clone();
+          return new Response("k");
+        },
+      });
+      const paths = ["/plain", "/observed", "/bun-request"];
+      const hit = async path => {
+        const res = await fetch(new URL(path, server.url), { method: "POST", body });
+        if ((await res.text()) !== "k") throw new Error("bad response for " + path);
+      };
+      const counts = () => {
+        Bun.gc(true);
+        Bun.gc(true);
+        const stats = heapStats();
+        return {
+          ReadableStream: stats.objectTypeCounts.ReadableStream ?? 0,
+          StreamTeeState: stats.objectTypeCounts.StreamTeeState ?? 0,
+          protectedPromise: stats.protectedObjectTypeCounts.Promise ?? 0,
+        };
+      };
+      for (const path of paths) await hit(path);
+      const before = counts();
+      for (const path of paths) for (let i = 0; i < ${requests}; i++) await hit(path);
+      const after = counts();
+      const delta = {};
+      for (const key in before) delta[key] = after[key] - before[key];
+      console.log(JSON.stringify(delta));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Leaking retained 3 ReadableStream + 1 StreamTeeState + 1 protected Promise
+    // per request (x 3 paths x `requests`); a settled tee is collectable at once.
+    const delta = JSON.parse(stdout);
+    expect(delta.ReadableStream).toBeWithin(-10, 10);
+    expect(delta.StreamTeeState).toBeWithin(-4, 4);
+    expect(delta.protectedPromise).toBeWithin(-4, 4);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a read started on the clone rejects once the response ends ahead of the body", async () => {
+    let state = "handler not reached";
+    await using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname === "/state") return new Response(state);
+        state = "pending";
+        req
+          .clone()
+          .text()
+          .then(
+            text => (state = `resolved: ${JSON.stringify(text)}`),
+            e => (state = `rejected: ${e?.name}: ${e?.message}`),
+          );
+        return new Response("k");
+      },
+    });
+
+    // Announce a body but never send it, so the response always finishes first.
+    const responded = Promise.withResolvers<string>();
+    let received = "";
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        data(_socket, chunk) {
+          received += chunk.toString();
+          const bodyAt = received.indexOf("\r\n\r\n");
+          if (bodyAt !== -1 && received.length > bodyAt + 4) responded.resolve(received);
+        },
+        close() {
+          responded.reject(new Error(`closed after ${JSON.stringify(received)}`));
+        },
+        error(_socket, err) {
+          responded.reject(err);
+        },
+      },
+    });
+    socket.write("POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\n");
+    const response = await responded.promise;
+    expect(response).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(response).toEndWith("\r\n\r\nk");
+
+    const res = await fetch(new URL("/state", server.url));
+    expect(await res.text()).toBe("rejected: AbortError: The connection was closed.");
+    socket.end();
+  });
+});

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1203,19 +1203,23 @@ describe("Bun.serve: clone() of an incoming request whose body nobody reads", ()
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    if (exitCode !== 0 || !stdout.startsWith("{")) {
+      throw new Error(`fixture failed (exit code ${exitCode}):\n${stderr}\n${stdout}`);
+    }
     // Leaking retained 3 ReadableStream + 1 StreamTeeState + 1 protected Promise
     // per request (x 3 paths x `requests`); a settled tee is collectable at once.
     const delta = JSON.parse(stdout);
     expect(delta.ReadableStream).toBeWithin(-10, 10);
     expect(delta.StreamTeeState).toBeWithin(-4, 4);
     expect(delta.protectedPromise).toBeWithin(-4, 4);
-    expect(exitCode).toBe(0);
   });
 
-  test("a read started on the clone rejects once the response ends ahead of the body", async () => {
+  // The two ways the server stops feeding a body that has not arrived: the
+  // handler responds first, or the client goes away first. Either must reject
+  // a read parked on the clone's branch instead of leaving it pending forever.
+  async function serveCloneReader(park: boolean) {
     let state = "handler not reached";
-    await using server = Bun.serve({
+    const server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
       fetch(req) {
@@ -1228,37 +1232,56 @@ describe("Bun.serve: clone() of an incoming request whose body nobody reads", ()
             text => (state = `resolved: ${JSON.stringify(text)}`),
             e => (state = `rejected: ${e?.name}: ${e?.message}`),
           );
-        return new Response("k");
+        return park ? new Promise<Response>(() => {}) : new Response("k");
       },
     });
-
-    // Announce a body but never send it, so the response always finishes first.
-    const responded = Promise.withResolvers<string>();
-    let received = "";
+    const readState = async () => (await fetch(new URL("/state", server.url))).text();
+    // Announce a body but never send it.
+    const received = Promise.withResolvers<string>();
+    let data = "";
     const socket = await Bun.connect({
       hostname: "127.0.0.1",
       port: server.port,
       socket: {
         data(_socket, chunk) {
-          received += chunk.toString();
-          const bodyAt = received.indexOf("\r\n\r\n");
-          if (bodyAt !== -1 && received.length > bodyAt + 4) responded.resolve(received);
+          data += chunk.toString();
+          const bodyAt = data.indexOf("\r\n\r\n");
+          if (bodyAt !== -1 && data.length > bodyAt + 4) received.resolve(data);
         },
         close() {
-          responded.reject(new Error(`closed after ${JSON.stringify(received)}`));
+          // The abort case ends the socket itself and never reads `response`.
+          received.resolve(data);
         },
         error(_socket, err) {
-          responded.reject(err);
+          received.reject(err);
         },
       },
     });
     socket.write("POST /upload HTTP/1.1\r\nHost: example.com\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\n");
-    const response = await responded.promise;
-    expect(response).toStartWith("HTTP/1.1 200 OK\r\n");
-    expect(response).toEndWith("\r\n\r\nk");
+    return { server, socket, response: received.promise, readState };
+  }
 
-    const res = await fetch(new URL("/state", server.url));
-    expect(await res.text()).toBe("rejected: AbortError: The connection was closed.");
+  test("a read started on the clone rejects once the response ends ahead of the body", async () => {
+    const { server, socket, response, readState } = await serveCloneReader(false);
+    await using _server = server;
+    using _socket = socket;
+    expect(await response).toMatch(/^HTTP\/1\.1 200 OK\r\n[\s\S]*\r\n\r\nk$/);
+    // The server settled the stream before it returned to the event loop, so
+    // the very next request already observes the rejection.
+    expect(await readState()).toBe("rejected: AbortError: The connection was closed.");
+  });
+
+  test("a read started on the clone rejects when the client disconnects before sending the body", async () => {
+    const { server, socket, readState } = await serveCloneReader(true);
+    await using _server = server;
+    // The handler is parked; wait until it has run, then drop the connection.
+    let state = await readState();
+    while (state === "handler not reached") state = await readState();
+    expect(state).toBe("pending");
     socket.end();
+    // The abort is processed on the server's next loop turn; poll with a bound
+    // instead of sleeping. Unfixed builds never leave "pending".
+    for (let i = 0; i < 200 && state === "pending"; i++) state = await readState();
+    expect(state).toBe("rejected: AbortError: The connection was closed.");
   });
 });

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1274,9 +1274,10 @@ describe("Bun.serve: clone() of an incoming request whose body nobody reads", ()
   test("a read started on the clone rejects when the client disconnects before sending the body", async () => {
     const { server, socket, readState } = await serveCloneReader(true);
     await using _server = server;
+    using _socket = socket;
     // The handler is parked; wait until it has run, then drop the connection.
     let state = await readState();
-    while (state === "handler not reached") state = await readState();
+    for (let i = 0; i < 200 && state === "handler not reached"; i++) state = await readState();
     expect(state).toBe("pending");
     socket.end();
     // The abort is processed on the server's next loop turn; poll with a bound


### PR DESCRIPTION
### Problem
- A `Bun.serve` handler that calls `req.clone()` and reads neither body leaks about 7.3 KB per request, independent of body size. Full GC keeps it.
- The root is the `protect()`ed pull promise of the request body's `ByteStream`. `end_request_streaming` (`src/runtime/server/RequestContext.rs`) reached that stream only through the body `Value`, and `clone()` re-points `Locked.readable` at a tee branch. It aborted that reader-less branch (a no-op) and returned before erroring the source the context holds in `request_body_readable_stream_ref`. `finalize_without_deinit` then dropped that ref silently.

### Fix
- `end_request_streaming` rejects a `Locked` body as before, then errors and releases the `ByteStream` behind `request_body_readable_stream_ref` whenever that stream has not already ended. `finalize_without_deinit` leaves the ref to that call.
- Correct because the context is the stream's only producer and nothing feeds it once request streaming ends. Erroring the source settles the parked pull and errors both branches, so a pending clone read rejects with the `AbortError` an un-cloned read already gets.
- Self-reviewed: 2 concerns raised, 2 addressed (a guard so the non-clone paths do not deliver a second error, and a test for the client-abort path).
- Verified: three new tests in `test/js/web/fetch/body-clone.test.ts` fail on 1.4.3 and with `src/` reverted, and pass with the fix.

### Background
- `req.body`, `clone()` and `textStream()` wrap an incoming body in a native `ByteStream` source that the `RequestContext` feeds from the socket.
- A pull with nothing buffered parks. Its promise stays `protect()`ed until the producer settles it, and it roots the whole tee.
- `clone()` tees that stream and each branch pulls at once. A synchronous handler's response ends before uWS delivers the body bytes, and `detach_response` stops reading them. So only `end_request_streaming` can settle that pull.

<details><summary>Notes</summary>

- The `has_received_last_chunk` guard keeps the non-clone paths byte-identical. There, `to_error_instance` reaches the same `ByteStream` through the body `Value` and errors it first, and the context still holds its ref. `ByteStream::on_data` does tolerate a repeated `AbortReason` (the `done` arm returns early, a stored `Err` is a plain enum value), but the fix does not want to depend on that.
- Repro from the report on release 1.4.3, 20k requests, `req.clone()` only: `4000:+40MB 8000:+69MB 12000:+97MB 16000:+123MB 20000:+149MB => ~7811 B/request`. `no-clone`, `clone-consume-clone` and `clone-consume-original` plateau. `heapStats()` per leaked request: +3 `ReadableStream`, +3 `ReadableStreamDefaultController`, +1 `ReadableStreamDefaultReader`, +1 `BytesInternalReadableStreamSource`, +1 `NativeStreamSourceAdapter`, +1 `ReadRequest`, +1 `StreamTeeState`, +1 `Uint8Array`, +3 `Promise`, +3 `FullPromiseReaction`; `protectedObjectTypeCounts`: +1 `Promise`, +1 `Uint8Array`. That graph is exactly what the protected pull promise reaches.
- Why the body size does not matter: the response of a synchronous handler ends inside uWS's request callback, before uWS delivers the body bytes of the same packet, and `detach_response()` clears the body handler. The bytes are never buffered; only the tee machinery is retained.
- `req.body.tee()` done by hand did not leak: the body `Value` still pointed at the native stream, so `to_error_instance` errored the `ByteStream` directly. Only the native clone paths (`Request.prototype.clone`, `BunRequest` clone, with or without `.body` observed first) re-point the body at a branch. The first new test covers all three.
- Two tests pin the observable behaviour of a `clone().text()` started in the handler, for a body the client never sends: it rejects when the response ends first, and when the client disconnects while the handler is still parked. Before, both stayed pending forever. `req.text()` without a clone already rejects in both cases.
- `finalize_without_deinit` is the first place that sees the held ref when `on_abort` takes the `is_dead_request()` shortcut with a `Used` (`textStream()`) body. Dropping the ref there left that read pending too; it now goes through the same erroring path thirty lines later.
- The fetch client's `Response.clone()` with nothing read does not leak (checked separately, 500 iterations, zero retained streams).
- Suites run on the debug ASAN build: `test/js/web/fetch/body-clone.test.ts` (65 pass), `test/js/bun/http/serve-body-leak.test.ts` (15 pass, HTTP/1 and HTTP/2), `test/js/bun/http/serve.test.ts` (295 pass; 2 failures that also fail on the release binary in this container: root port range, `/bun:info` loopback), `serve-http2-lifecycle.test.ts`, `serve-pending-promise-abort-leak.test.ts`, `bun-serve-routes.test.ts`, `bun-serve-body-json-async.test.ts`, `test/js/web/fetch/body.test.ts`, `body-stream.test.ts`, `body-mixin-errors.test.ts`, `wpt/textstream-wpt.test.ts`, `fetch-abort-stream-body.test.ts`.
- Related open PRs that touch the same function but not this bug: #33524 (keep delivering a late body after the response), #39660 (release the body slot once complete).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/body-clone.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-mod
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (427e0a08e)

test/js/web/fetch/body-clone.test.ts:
(pass) Request with streaming body can be cloned [0.30ms]
(pass) Response with streaming body can be cloned [0.15ms]
(pass) Request with large streaming body can be cloned [5.63ms]
(pass) Request with large streaming body can be cloned (pull) [4.43ms]
(pass) Response with chunked streaming body can be cloned [30.88ms]
(pass) Request with streaming body can be cloned multiple times [0.33ms]
(pass) Request with string body can be cloned [0.11ms]
(pass) Response with string body can be cloned [0.07ms]
(pass) Request with ArrayBuffer body can be cloned [0.15ms]
(pass) Response with ArrayBuffer body can be cloned [0.09ms]
(pass) Request with Uint8Array body can be cloned [0.11ms]
(pass) Response with Uint8Array body can be cloned [0.07ms]
(pass) Request with mixed body types can be cloned [0.30ms]
(pass) Response with mixed body types can be cloned [0.21ms]
(pass) Request with non-ASCII string body can be cloned [0.10ms]
(pass) Response with non-ASCII string body can be cloned [0.06ms]
(pass) Request with streaming non-ASCII body can be cloned [0.12ms]
(pass) Response with streaming non-ASCII bod
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/body-clone.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/fetch/body-clone.test.ts:
(pass) Request with streaming body can be cloned [37.67ms]
(pass) Response with streaming body can be cloned [12.72ms]
(pass) Request with large streaming body can be cloned [25.39ms]
(pass) Request with large streaming body can be cloned (pull) [32.80ms]
(pass) Response with chunked streaming body can be cloned [51.79ms]
(pass) Request with streaming body can be cloned multiple times [14.25ms]
(pass) Request with string body can be cloned [8.76ms]
(pass) Response with string body can be cloned [7.99ms]
(pass) Request with ArrayBuffer body can be cloned [11.92ms]
(pass) Response with ArrayBuffer body can be cloned [9.39ms]
(pass) Request with Uint8Array body can be cloned [9.30ms]
(pass) Response with Uint8Array body can be cloned [8.50ms]
(pass) Request with mixed body types can be cloned [22.29ms]
(pass) Response with mixed body types can be cloned [20.63ms]
(pass) Request with non-ASCII string body can be cloned [7.49ms]
(pass) Res
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 812ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs |  49 ++++++------
 test/js/web/fetch/body-clone.test.ts | 141 +++++++++++++++++++++++++++++++++++
 2 files changed, 164 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/runtime/server/RequestContext.rs      9      5     19
test/js/web/fetch/body-clone.test.ts      6      6     19
```

</details>

<!-- robobun:evidence:end -->