### PR TITLE
css: keep a manual border-image fallback when a target does not support the later value

### DIFF
--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1431,7 +1431,10 @@ mod border_handler_body {
                         self.flush(dest, context);
                         self.flush_unparsed(val, dest, context);
                     } else {
-                        if self.border_image_handler.will_flush(property) {
+                        if self
+                            .border_image_handler
+                            .will_flush(property, &context.targets)
+                        {
                             self.flush(dest, context);
                         }
                         return self
@@ -1443,7 +1446,10 @@ mod border_handler_body {
                     }
                 }
                 _ => {
-                    if self.border_image_handler.will_flush(property) {
+                    if self
+                        .border_image_handler
+                        .will_flush(property, &context.targets)
+                    {
                         self.flush(dest, context);
                     }
                     return self

--- a/src/css/properties/border_image.rs
+++ b/src/css/properties/border_image.rs
@@ -472,6 +472,19 @@ pub(crate) struct BorderImageHandler {
     pub has_any: bool,
 }
 
+/// A new value normally replaces the buffered one. When the two differ and some
+/// target does not support the new value, the buffered one is a manual fallback
+/// and has to be flushed to the output first.
+macro_rules! keeps_fallback {
+    ($buffered:expr, $new:expr, $targets:expr) => {
+        matches!(
+            (&$buffered, $targets.browsers),
+            (Some(buffered), Some(browsers))
+                if !buffered.eql($new) && !$new.is_compatible(&browsers)
+        )
+    };
+}
+
 impl BorderImageHandler {
     pub(crate) fn handle_property(
         &mut self,
@@ -485,11 +498,7 @@ impl BorderImageHandler {
         // per-field name dispatch without reflection.
         macro_rules! flush_helper {
             ($self:expr, $d:expr, $ctx:expr, $name:ident, $val:expr) => {
-                if $self.$name.is_some()
-                    && !$self.$name.as_ref().unwrap().eql($val)
-                    && $ctx.targets.browsers.is_some()
-                    && !$val.is_compatible(&$ctx.targets.browsers.unwrap())
-                {
+                if keeps_fallback!($self.$name, $val, $ctx.targets) {
                     $self.flush($d, $ctx);
                 }
             };
@@ -583,13 +592,35 @@ impl BorderImageHandler {
         self.repeat = None;
     }
 
-    pub(crate) fn will_flush(&self, property: &Property) -> bool {
+    /// Whether `handle_property(property)` flushes the buffered declarations
+    /// before it records `property`. `BorderHandler` flushes itself first in
+    /// that case, so a buffered `border` stays ahead of what this handler emits.
+    pub(crate) fn will_flush(&self, property: &Property, targets: &css::targets::Targets) -> bool {
+        let prefixed = self.vendor_prefix != VendorPrefix::NONE;
         match property {
-            Property::BorderImageSource(_)
-            | Property::BorderImageSlice(_)
-            | Property::BorderImageWidth(_)
-            | Property::BorderImageOutset(_)
-            | Property::BorderImageRepeat(_) => self.vendor_prefix != VendorPrefix::NONE,
+            Property::BorderImageSource(val) => {
+                prefixed || keeps_fallback!(self.source, val, targets)
+            }
+            Property::BorderImageSlice(val) => {
+                prefixed || keeps_fallback!(self.slice, val, targets)
+            }
+            Property::BorderImageWidth(val) => {
+                prefixed || keeps_fallback!(self.width, val, targets)
+            }
+            Property::BorderImageOutset(val) => {
+                prefixed || keeps_fallback!(self.outset, val, targets)
+            }
+            Property::BorderImageRepeat(val) => {
+                prefixed || keeps_fallback!(self.repeat, val, targets)
+            }
+            Property::BorderImage(val) => {
+                let val = &val.0;
+                keeps_fallback!(self.source, &val.source, targets)
+                    || keeps_fallback!(self.slice, &val.slice, targets)
+                    || keeps_fallback!(self.width, &val.width, targets)
+                    || keeps_fallback!(self.outset, &val.outset, targets)
+                    || keeps_fallback!(self.repeat, &val.repeat, targets)
+            }
             Property::Unparsed(val) => is_border_image_property(val.property_id.tag()),
             _ => false,
         }

--- a/src/css/properties/border_image.rs
+++ b/src/css/properties/border_image.rs
@@ -488,7 +488,7 @@ impl BorderImageHandler {
                 if $self.$name.is_some()
                     && !$self.$name.as_ref().unwrap().eql($val)
                     && $ctx.targets.browsers.is_some()
-                    && $val.is_compatible(&$ctx.targets.browsers.unwrap())
+                    && !$val.is_compatible(&$ctx.targets.browsers.unwrap())
                 {
                     $self.flush($d, $ctx);
                 }

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -1929,6 +1929,110 @@ describe("css tests", () => {
     prefix_test(
       `
       .foo {
+        -webkit-border-image: url(foo.png) 60;
+        -moz-border-image: url(foo.png) 60;
+        -o-border-image: url(foo.png) 60;
+        border-image: url(foo.png) 60;
+      }
+    `,
+      `
+      .foo {
+        border-image: url("foo.png") 60;
+      }
+    `,
+      {
+        chrome: 15 << 16,
+      },
+    );
+
+    // The next four are skipped: lightningcss prints the legacy direction keyword
+    // (`top,`) in generated -webkit-/-moz-linear-gradient() fallbacks since
+    // parcel-bundler/lightningcss#936, which bun's port does not have yet.
+    prefix_test(
+      `
+      .foo {
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
+      }
+    `,
+      `
+      .foo {
+        -webkit-border-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff)) 60;
+        -webkit-border-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff) 60;
+        border-image: linear-gradient(#ff0f0e, #7773ff) 60;
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
+      }
+    `,
+      {
+        chrome: 8 << 16,
+      },
+      true,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
+      }
+    `,
+      `
+      .foo {
+        -webkit-border-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ff0f0e), to(#7773ff)) 60;
+        -webkit-border-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff) 60;
+        -moz-border-image: -moz-linear-gradient(top, #ff0f0e, #7773ff) 60;
+        border-image: linear-gradient(#ff0f0e, #7773ff) 60;
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
+      }
+    `,
+      {
+        chrome: 8 << 16,
+        firefox: 4 << 16,
+      },
+      true,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
+      }
+    `,
+      `
+      .foo {
+        border-image: -webkit-linear-gradient(top, #ff0f0e, #7773ff) 60;
+        border-image: -moz-linear-gradient(top, #ff0f0e, #7773ff) 60;
+        border-image: linear-gradient(#ff0f0e, #7773ff) 60;
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 60;
+      }
+    `,
+      {
+        chrome: 15 << 16,
+        firefox: 15 << 16,
+      },
+      true,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      `
+      .foo {
+        border-image-source: -webkit-linear-gradient(top, #ff0f0e, #7773ff);
+        border-image-source: linear-gradient(#ff0f0e, #7773ff);
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      {
+        chrome: 15 << 16,
+      },
+      true,
+    );
+
+    prefix_test(
+      `
+      .foo {
         border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) var(--foo);
       }
     `,
@@ -2051,6 +2155,48 @@ describe("css tests", () => {
     `,
       {
         chrome: 56 << 16,
+      },
+    );
+
+    // `border` resets border-image, so a kept fallback must stay after it.
+    prefix_test(
+      `
+      .foo {
+        border: 2px solid red;
+        border-image: linear-gradient(red, green) 1;
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 1;
+      }
+    `,
+      `
+      .foo {
+        border: 2px solid red;
+        border-image: linear-gradient(red, green) 1;
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) 1;
+      }
+    `,
+      {
+        chrome: 95 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image-source: url(a.png);
+        border: 2px solid red;
+        border-image-source: url(fallback.png);
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      `
+      .foo {
+        border: 2px solid red;
+        border-image-source: url("fallback.png");
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      {
+        chrome: 95 << 16,
       },
     );
   });

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -1719,6 +1719,342 @@ describe("css tests", () => {
     );
   });
 
+  describe("border-image", () => {
+    cssTest(
+      `
+      .foo {
+        border-image: url(test.png) 60;
+      }
+    `,
+      `
+      .foo {
+        border-image: url("test.png") 60;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-image: url(test.png) 60;
+        border-image-source: url(foo.png);
+      }
+    `,
+      `
+      .foo {
+        border-image: url("foo.png") 60;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-image-source: url(foo.png);
+        border-image-slice: 10 40 10 40 fill;
+        border-image-width: 10px;
+        border-image-outset: 0;
+        border-image-repeat: round round;
+      }
+    `,
+      `
+      .foo {
+        border-image: url("foo.png") 10 40 fill / 10px round;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-image: url(foo.png) 60;
+        border-image-source: var(--test);
+      }
+    `,
+      `
+      .foo {
+        border-image: url("foo.png") 60;
+        border-image-source: var(--test);
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        -webkit-border-image: url("test.png") 60;
+      }
+    `,
+      `
+      .foo {
+        -webkit-border-image: url("test.png") 60;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        -webkit-border-image: url("test.png") 60;
+        border-image: url("test.png") 60;
+      }
+    `,
+      `
+      .foo {
+        -webkit-border-image: url("test.png") 60;
+        border-image: url("test.png") 60;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        -webkit-border-image: url("test.png") 60;
+        border-image-source: url(foo.png);
+      }
+    `,
+      `
+      .foo {
+        -webkit-border-image: url("test.png") 60;
+        border-image-source: url("foo.png");
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px solid red;
+        border-image: url(test.png) 60;
+      }
+    `,
+      `
+      .foo {
+        border: 1px solid red;
+        border-image: url("test.png") 60;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-image: url(test.png) 60;
+        border: 1px solid red;
+      }
+    `,
+      `
+      .foo {
+        border: 1px solid red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px solid red;
+        border-image: var(--border-image);
+      }
+    `,
+      `
+      .foo {
+        border: 1px solid red;
+        border-image: var(--border-image);
+      }
+    `,
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: url("test.png") 60;
+      }
+    `,
+      `
+      .foo {
+        -webkit-border-image: url("test.png") 60;
+        -moz-border-image: url("test.png") 60;
+        -o-border-image: url("test.png") 60;
+        border-image: url("test.png") 60;
+      }
+    `,
+      {
+        safari: 4 << 16,
+        firefox: 4 << 16,
+        opera: 12 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: url(foo.png) 10 40 fill / 10px round;
+      }
+    `,
+      `
+      .foo {
+        border-image: url("foo.png") 10 40 fill / 10px round;
+      }
+    `,
+      {
+        safari: 4 << 16,
+        firefox: 4 << 16,
+        opera: 12 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: var(--test) 60;
+      }
+    `,
+      `
+      .foo {
+        -webkit-border-image: var(--test) 60;
+        -moz-border-image: var(--test) 60;
+        -o-border-image: var(--test) 60;
+        border-image: var(--test) 60;
+      }
+    `,
+      {
+        safari: 4 << 16,
+        firefox: 4 << 16,
+        opera: 12 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364)) var(--foo);
+      }
+    `,
+      `
+      .foo {
+        border-image: linear-gradient(#ff0f0e, #7773ff) var(--foo);
+      }
+
+      @supports (color: lab(0% 0 0)) {
+        .foo {
+          border-image: linear-gradient(lab(56.208% 94.4644 98.8928), lab(51% 70.4544 -115.586)) var(--foo);
+        }
+      }
+    `,
+      {
+        chrome: 90 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image-source: linear-gradient(red, green);
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      `
+      .foo {
+        border-image-source: linear-gradient(red, green);
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      {
+        chrome: 95 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image-source: linear-gradient(red, green);
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      `
+      .foo {
+        border-image-source: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      {
+        chrome: 112 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: linear-gradient(red, green);
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      `
+      .foo {
+        border-image: linear-gradient(red, green);
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      {
+        chrome: 95 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: var(--fallback);
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      `
+      .foo {
+        border-image: var(--fallback);
+        border-image: linear-gradient(lch(56.208% 136.76 46.312), lch(51% 135.366 301.364));
+      }
+    `,
+      {
+        chrome: 95 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: url("fallback.png") 10 40 fill / 10px;
+        border-image: url("main.png") 10 40 fill / 10px space;
+      }
+    `,
+      `
+      .foo {
+        border-image: url("fallback.png") 10 40 fill / 10px;
+        border-image: url("main.png") 10 40 fill / 10px space;
+      }
+    `,
+      {
+        chrome: 50 << 16,
+      },
+    );
+
+    prefix_test(
+      `
+      .foo {
+        border-image: url("fallback.png") 10 40 fill / 10px;
+        border-image: url("main.png") 10 40 fill / 10px space;
+      }
+    `,
+      `
+      .foo {
+        border-image: url("main.png") 10 40 fill / 10px space;
+      }
+    `,
+      {
+        chrome: 56 << 16,
+      },
+    );
+  });
+
   describe("box-shadow", () => {
     minify_test(
       ".foo { box-shadow: 64px 64px 12px 40px rgba(0,0,0,0.4) }",


### PR DESCRIPTION
### Problem
- With browser targets set (`bun build`'s defaults included), a repeated `border-image` declaration loses its first value when an old target needs it. `border-image-source: linear-gradient(red, green); border-image-source: linear-gradient(lch(...))` with `chrome 95` drops the first. In the opposite case it keeps a dead one.
- Cause: `flush_helper!` in `BorderImageHandler::handle_property` (`src/css/properties/border_image.rs:486`) flushes the buffered value when the new value IS compatible with the targets. lightningcss and the sibling handlers (`border.rs:1231`, `background.rs:624`) flush when it is NOT.

### Fix
- Negate the check. The condition now lives in one `keeps_fallback!` macro.
- `will_flush` uses the same macro, so `BorderHandler` flushes a buffered `border` before this handler emits a kept fallback. Before, the fallback landed ahead of `border`, which resets `border-image`.
- Port upstream's `test_border_image` block into `test/js/bun/css/css.test.ts`, plus two ordering cases. 7 of 27 fail on stock bun. 4 are skipped, see Notes. Also ran `test/js/bun/css/`, the bundler CSS suites, and a byte compare of 15 real-world stylesheets.
- Self-reviewed: 3 concerns raised, 3 addressed (the `border` ordering, the `chrome 15` case, the skipped cases and their cause).

### Background
- Per-shorthand handlers in `DeclarationBlock::minify` buffer the properties they own and flush the shortest equivalent declarations later. A later value normally replaces the buffered one.
- A repeated declaration is often a manual fallback. When a target lacks support for the later value, the handler flushes the earlier one first so both survive.
- `BorderImageHandler` is nested in `BorderHandler` because `border` resets `border-image`. `will_flush` lets the parent keep its buffered output ahead of the child's.

<details><summary>Notes</summary>

- `css.test.ts` had no `border-image` cases before. Upstream reference: https://github.com/parcel-bundler/lightningcss/blob/master/src/properties/border_image.rs (`macro_rules! flush`, `will_flush`) and `test_border_image` in upstream `src/lib.rs`. By its code, upstream's `will_flush` does not model the fallback flush either (not run here), so the `will_flush` change goes one step past upstream.
- `flushed_properties` records what a flush already emitted, so the final flush does not add generated color fallbacks on top of the author's own. That is why the kept `linear-gradient(red, green)` replaces the generated `#ff0f0e, #7773ff` one rather than joining it.
- Cases that fail on stock bun: `border-image-source` x2 with `chrome 95` (fallback replaced by a generated one) and `chrome 112` (redundant fallback kept), `border-image` x2 with `chrome 95`, `border-image ... space` x2 with `chrome 56`, the four author-prefixed `-webkit-/-moz-/-o-/border-image` declarations with `chrome 15` (stock keeps all four because `Image::eql` compares `url()` import records by index, so identical urls never compare equal and the inverted check flushed between them), and the two ordering cases at the end of the block.
- The four skipped cases expect `-webkit-linear-gradient(top, ...)` in generated fallbacks. That comes from parcel-bundler/lightningcss#936 (legacy direction keyword conversion, fixes parcel-bundler/lightningcss#918), which bun's port predates. bun prints `-webkit-linear-gradient(#ff0f0e, #7773ff)` for the default direction, which is equivalent, but it also has the #918 bug for explicit directions (`linear-gradient(to right, ...)` becomes `-webkit-linear-gradient(right, ...)` instead of `left`). That is a separate port.
- Identical `image-set(url() ...)` values declared twice, with targets that need `-webkit-image-set`, now both stay in the output for `border-image-source`, as they already do for `background-image` and `mask-image`. Same `Image::eql` by-index cause. Output is larger, not wrong.
- The first revision only negated the check. Self-review found the `border` ordering and the chrome 15 case, both addressed here.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static
... (truncated)

release without fix: 7 failed, 71 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.18ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 71 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [4.00ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.06ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.01ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release with fix: 71 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6b132f8f30
  features     baseline

23 deps, 131 codegen, 1172 objects in 693ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [15.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] gen bindgenv2
[7/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen .bind.ts → Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/border.rs       |  10 +-
 src/css/properties/border_image.rs |  53 +++-
 test/js/bun/css/css.test.ts        | 482 +++++++++++++++++++++++++++++++++++++
 3 files changed, 532 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/css/properties/border.rs            2      2     17
src/css/properties/border_image.rs      4      4     17
test/js/bun/css/css.test.ts             6      3     17
```

</details>

<!-- robobun:evidence:end -->