### PR TITLE
Store non-ASCII define, env, macro and inlined path strings as UTF-16 so they fold like literals

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2068,6 +2068,55 @@ impl EString {
             self.end = Some(other_ref);
         }
     }
+
+    /// Longest result, in UTF-16 code units, that [`EString::append`] builds
+    /// by copying. Two 8-bit strings join as a rope in O(1), but ropes are
+    /// 8-bit only, so a UTF-16 operand makes the join copy both sides. The
+    /// visit pass joins `a + b + c + ...` one literal at a time, so without
+    /// a bound a long chain of non-ASCII literals copies quadratically.
+    pub const MAX_COPIED_JOIN_LEN: usize = 4096;
+
+    /// Whether [`EString::append`] can join `strings`: always when all are
+    /// 8-bit (a rope), else only up to [`MAX_COPIED_JOIN_LEN`](Self::MAX_COPIED_JOIN_LEN).
+    pub fn can_join(strings: &[&EString]) -> bool {
+        strings.iter().all(|s| s.is_utf8())
+            || strings.iter().map(|s| s.len()).sum::<usize>() <= Self::MAX_COPIED_JOIN_LEN
+    }
+
+    /// Make `self` the string `self + other`. Two 8-bit strings link into a
+    /// rope, so `other` has the same Store/arena requirement as
+    /// [`EString::push`]. With a UTF-16 operand both sides are copied into
+    /// one flat UTF-16 buffer in `bump`; check [`EString::can_join`] first.
+    pub fn append(&mut self, other: &mut EString, bump: &Bump) {
+        if self.is_utf8() && other.is_utf8() {
+            self.push(other);
+            return;
+        }
+        let mut units: Vec<u16> = Vec::with_capacity(self.len() + other.len());
+        self.write_utf16(&mut units);
+        other.write_utf16(&mut units);
+        let joined = EString::init_utf16(bump.alloc_slice_copy(&units));
+        *self = EString {
+            prefer_template: self.prefer_template,
+            ..joined
+        };
+    }
+
+    /// Every segment as UTF-16 code units; 8-bit segments are WTF-8.
+    fn write_utf16(&self, out: &mut Vec<u16>) {
+        if self.is_utf16 {
+            out.extend_from_slice(self.slice16());
+            return;
+        }
+        let mut segment: Option<&EString> = Some(self);
+        while let Some(s) = segment {
+            match strings::wtf8_to_utf16_alloc(&s.data) {
+                Some(utf16) => out.extend_from_slice(&utf16),
+                None => out.extend(s.data.iter().map(|&b| u16::from(b))),
+            }
+            segment = s.next.as_deref();
+        }
+    }
 }
 
 fn array_sorter_is_less_than(lhs: &Expr, rhs: &Expr) -> Ordering {
@@ -2151,10 +2200,6 @@ pub enum TemplateContents {
     Raw(Str),
 }
 impl TemplateContents {
-    pub(crate) fn is_utf8(&self) -> bool {
-        matches!(self, TemplateContents::Cooked(c) if c.is_utf8())
-    }
-
     bun_core::enum_unwrap!(pub TemplateContents, Cooked => fn cooked / cooked_mut -> EString);
 }
 
@@ -2173,10 +2218,7 @@ impl TemplateContents {
 impl Template {
     /// "`a${'b'}c`" => "`abc`"
     pub fn fold(&mut self, bump: &Bump, loc: crate::Loc) -> Expr {
-        if self.tag.is_some()
-            || (matches!(self.head, TemplateContents::Cooked(_)) && !self.head.cooked().is_utf8())
-        {
-            // we only fold utf-8/ascii for now
+        if self.tag.is_some() {
             // `self` is Store/arena-allocated, so capturing its address as a
             // `StoreRef` is sound.
             return Expr {
@@ -2232,98 +2274,39 @@ impl Template {
                 _ => {}
             }
 
-            if matches!(part.value.data, crate::expr::Data::EString(_))
-                && part.tail.cooked().is_utf8()
-                && part
-                    .value
-                    .data
-                    .e_string()
-                    .expect("infallible: variant checked")
-                    .is_utf8()
-            {
-                if parts.is_empty() {
-                    if part
-                        .value
+            // "`${'b'}c`": append the value and then the tail to the string
+            // before them (the head, or the previous part's tail).
+            if let crate::expr::Data::EString(value) = part.value.data {
+                let prev: &mut EString = match parts.last_mut() {
+                    None => head
                         .data
-                        .e_string()
-                        .expect("infallible: variant checked")
-                        .len()
-                        > 0
-                    {
-                        head.data
-                            .e_string_mut()
-                            .expect("infallible: variant checked")
-                            .push(
-                                Expr::init(
-                                    part.value
-                                        .data
-                                        .e_string()
-                                        .expect("infallible: variant checked")
-                                        .shallow_clone(),
-                                    crate::Loc::EMPTY,
-                                )
+                        .e_string_mut()
+                        .expect("infallible: variant checked"),
+                    Some(prev_part) => prev_part.tail.cooked_mut(),
+                };
+                if EString::can_join(&[&*prev, value.get(), part.tail.cooked()]) {
+                    if value.len() > 0 {
+                        prev.append(
+                            Expr::init(value.shallow_clone(), crate::Loc::EMPTY)
                                 .data
                                 .e_string_mut()
                                 .unwrap(),
-                            );
+                            bump,
+                        );
                     }
-
                     if part.tail.cooked().len() > 0 {
-                        head.data
-                            .e_string_mut()
-                            .expect("infallible: variant checked")
-                            .push(
-                                Expr::init(core::mem::take(part.tail.cooked_mut()), part.tail_loc)
-                                    .data
-                                    .e_string_mut()
-                                    .unwrap(),
-                            );
-                    }
-
-                    continue;
-                } else {
-                    let prev_part = parts.last_mut().unwrap();
-                    debug_assert!(matches!(prev_part.tail, TemplateContents::Cooked(_)));
-
-                    if prev_part.tail.cooked().is_utf8() {
-                        if part
-                            .value
-                            .data
-                            .e_string()
-                            .expect("infallible: variant checked")
-                            .len()
-                            > 0
-                        {
-                            prev_part.tail.cooked_mut().push(
-                                Expr::init(
-                                    part.value
-                                        .data
-                                        .e_string()
-                                        .expect("infallible: variant checked")
-                                        .shallow_clone(),
-                                    crate::Loc::EMPTY,
-                                )
+                        prev.append(
+                            Expr::init(core::mem::take(part.tail.cooked_mut()), part.tail_loc)
                                 .data
                                 .e_string_mut()
                                 .unwrap(),
-                            );
-                        }
-
-                        if part.tail.cooked().len() > 0 {
-                            prev_part.tail.cooked_mut().push(
-                                Expr::init(core::mem::take(part.tail.cooked_mut()), part.tail_loc)
-                                    .data
-                                    .e_string_mut()
-                                    .unwrap(),
-                            );
-                        }
-                    } else {
-                        parts.push(part);
+                            bump,
+                        );
                     }
+                    continue;
                 }
-            } else {
-                parts.push(part);
             }
+            parts.push(part);
         }
 
         if parts.is_empty() {

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1807,13 +1807,8 @@ impl EString {
             ..Default::default()
         }
     }
-    /// For string values that enter the JS AST from outside the lexer (enum
-    /// member names, TOML, `--define`/env values, macro `Response` bodies,
-    /// inlined `import.meta.dir`/`module.filename` paths).
-    /// The visit pass folds `"x"[0]`, `` `${x}`.length ``, `+x`, ... on an
-    /// 8-bit string one byte per character. The lexer makes that correct by
-    /// storing every non-ASCII literal as UTF-16, so do the same here.
-    /// WTF-8 surrogates in `wtf8` (JSON `"\ud800"`) are kept as code units.
+    /// For a string that enters the AST without the lexer: like the lexer, store
+    /// non-ASCII text as UTF-16, because folding reads 8-bit strings bytewise.
     pub fn init_re_encode_utf8(wtf8: &[u8], bump: &Bump) -> EString {
         match strings::wtf8_to_utf16_alloc(wtf8) {
             Some(utf16) => Self::init_utf16(bump.alloc_slice_copy(&utf16)),
@@ -2069,24 +2064,18 @@ impl EString {
         }
     }
 
-    /// Longest result, in UTF-16 code units, that [`EString::append`] builds
-    /// by copying. Two 8-bit strings join as a rope in O(1), but ropes are
-    /// 8-bit only, so a UTF-16 operand makes the join copy both sides. The
-    /// visit pass joins `a + b + c + ...` one literal at a time, so without
-    /// a bound a long chain of non-ASCII literals copies quadratically.
+    /// A join with a UTF-16 operand copies (ropes are 8-bit only); the cap keeps
+    /// a long `a + b + ...` chain of non-ASCII literals from copying quadratically.
     pub const MAX_COPIED_JOIN_LEN: usize = 4096;
 
-    /// Whether [`EString::append`] can join `strings`: always when all are
-    /// 8-bit (a rope), else only up to [`MAX_COPIED_JOIN_LEN`](Self::MAX_COPIED_JOIN_LEN).
+    /// Always for 8-bit strings (a rope), else up to [`Self::MAX_COPIED_JOIN_LEN`] units.
     pub fn can_join(strings: &[&EString]) -> bool {
         strings.iter().all(|s| s.is_utf8())
             || strings.iter().map(|s| s.len()).sum::<usize>() <= Self::MAX_COPIED_JOIN_LEN
     }
 
-    /// Make `self` the string `self + other`. Two 8-bit strings link into a
-    /// rope, so `other` has the same Store/arena requirement as
-    /// [`EString::push`]. With a UTF-16 operand both sides are copied into
-    /// one flat UTF-16 buffer in `bump`; check [`EString::can_join`] first.
+    /// `self += other`: a rope link for two 8-bit strings (`other` must live in
+    /// the Store, see [`Self::push`]), else one UTF-16 copy in `bump`. See [`Self::can_join`].
     pub fn append(&mut self, other: &mut EString, bump: &Bump) {
         if self.is_utf8() && other.is_utf8() {
             self.push(other);
@@ -2274,8 +2263,7 @@ impl Template {
                 _ => {}
             }
 
-            // "`${'b'}c`": append the value and then the tail to the string
-            // before them (the head, or the previous part's tail).
+            // "`a${'b'}c`": join 'b' and then "c" onto the string before them.
             if let crate::expr::Data::EString(value) = part.value.data {
                 let prev: &mut EString = match parts.last_mut() {
                     None => head

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1807,8 +1807,7 @@ impl EString {
             ..Default::default()
         }
     }
-    /// For a string that enters the AST without the lexer: like the lexer, store
-    /// non-ASCII text as UTF-16, because folding reads 8-bit strings bytewise.
+    /// A non-lexer string, stored like the lexer would: UTF-16 unless ASCII (folds read 8-bit bytewise).
     pub fn init_re_encode_utf8(wtf8: &[u8], bump: &Bump) -> EString {
         match strings::wtf8_to_utf16_alloc(wtf8) {
             Some(utf16) => Self::init_utf16(bump.alloc_slice_copy(&utf16)),
@@ -2064,8 +2063,7 @@ impl EString {
         }
     }
 
-    /// A join with a UTF-16 operand copies (ropes are 8-bit only); the cap keeps
-    /// a long `a + b + ...` chain of non-ASCII literals from copying quadratically.
+    /// Cap on a join that copies (any UTF-16 operand, ropes are 8-bit only) so long chains stay linear.
     pub const MAX_COPIED_JOIN_LEN: usize = 4096;
 
     /// Always for 8-bit strings (a rope), else up to [`Self::MAX_COPIED_JOIN_LEN`] units.
@@ -2074,8 +2072,7 @@ impl EString {
             || strings.iter().map(|s| s.len()).sum::<usize>() <= Self::MAX_COPIED_JOIN_LEN
     }
 
-    /// `self += other`: a rope link for two 8-bit strings (`other` must live in
-    /// the Store, see [`Self::push`]), else one UTF-16 copy in `bump`. See [`Self::can_join`].
+    /// `self += other`: a rope link for two 8-bit strings (see [`Self::push`]), else one UTF-16 copy.
     pub fn append(&mut self, other: &mut EString, bump: &Bump) {
         if self.is_utf8() && other.is_utf8() {
             self.push(other);

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1807,19 +1807,17 @@ impl EString {
             ..Default::default()
         }
     }
-    /// E.String containing non-ascii characters may not fully work.
-    /// https://github.com/oven-sh/bun/issues/11963
-    /// More investigation is needed.
-    pub fn init_re_encode_utf8(utf8: &[u8], bump: &Bump) -> EString {
-        if strings::first_non_ascii(utf8).is_none() {
-            Self::init(utf8)
-        } else {
-            // PERF: transcodes to a heap Vec then copies into the bump
-            // arena — profile.
-            // `fail_if_invalid = false` means the only possible error is `OutOfMemory`.
-            let utf16 = bun_core::handle_oom(strings::to_utf16_alloc_for_real(utf8, false, false));
-            let arena_slice: &mut [u16] = bump.alloc_slice_copy(&utf16);
-            Self::init_utf16(arena_slice)
+    /// For string values that enter the JS AST from outside the lexer (enum
+    /// member names, TOML, `--define`/env values, macro `Response` bodies,
+    /// inlined `import.meta.dir`/`module.filename` paths).
+    /// The visit pass folds `"x"[0]`, `` `${x}`.length ``, `+x`, ... on an
+    /// 8-bit string one byte per character. The lexer makes that correct by
+    /// storing every non-ASCII literal as UTF-16, so do the same here.
+    /// WTF-8 surrogates in `wtf8` (JSON `"\ud800"`) are kept as code units.
+    pub fn init_re_encode_utf8(wtf8: &[u8], bump: &Bump) -> EString {
+        match strings::wtf8_to_utf16_alloc(wtf8) {
+            Some(utf16) => Self::init_utf16(bump.alloc_slice_copy(&utf16)),
+            None => Self::init(wtf8),
         }
     }
     /// Ensure `data` is UTF-8 (transcode from UTF-16 rope if needed).

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1379,15 +1379,8 @@ impl Expr {
             }
             _ => None,
         };
-        slice.map(|s| {
-            Expr::init(
-                E::String {
-                    data: s.into(),
-                    ..Default::default()
-                },
-                expr.loc,
-            )
-        })
+        // A regexp source can be non-ASCII.
+        slice.map(|s| Expr::init(E::EString::init_re_encode_utf8(s, bump), expr.loc))
     }
 
     #[inline]

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2151,10 +2151,8 @@ impl Data {
         }
     }
 
-    /// [`E::EString::init_re_encode_utf8`] applied to every string of a
-    /// literal tree that an interchange parser built (a JSON `--define`
-    /// value, a macro's JSON `Response` body), so the tree can be handed to
-    /// the visit pass. Only the node kinds JSON produces are walked.
+    /// [`E::EString::init_re_encode_utf8`] over every string of a JSON-shaped
+    /// literal tree (object, array, string) before the visit pass sees it.
     pub fn re_encode_utf8_strings(&mut self, bump: &Bump) {
         match self {
             Data::EString(s) => {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2157,6 +2157,37 @@ impl Data {
             _ => Ok(this),
         }
     }
+
+    /// [`E::EString::init_re_encode_utf8`] applied to every string of a
+    /// literal tree that an interchange parser built (a JSON `--define`
+    /// value, a macro's JSON `Response` body), so the tree can be handed to
+    /// the visit pass. Only the node kinds JSON produces are walked.
+    pub fn re_encode_utf8_strings(&mut self, bump: &Bump) {
+        match self {
+            Data::EString(s) => {
+                if s.is_utf8() && s.next.is_none() {
+                    let data = s.data;
+                    **s = E::EString::init_re_encode_utf8(data.slice(), bump);
+                }
+            }
+            Data::EObject(obj) => {
+                for property in obj.properties.slice_mut() {
+                    if let Some(key) = property.key.as_mut() {
+                        key.data.re_encode_utf8_strings(bump);
+                    }
+                    if let Some(value) = property.value.as_mut() {
+                        value.data.re_encode_utf8_strings(bump);
+                    }
+                }
+            }
+            Data::EArray(arr) => {
+                for item in arr.items.slice_mut() {
+                    item.data.re_encode_utf8_strings(bump);
+                }
+            }
+            _ => {}
+        }
+    }
 } // end `impl Data` (deep_clone)
 
 impl Data {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2151,8 +2151,7 @@ impl Data {
         }
     }
 
-    /// [`E::EString::init_re_encode_utf8`] over every string of a JSON-shaped
-    /// literal tree (object, array, string) before the visit pass sees it.
+    /// [`E::EString::init_re_encode_utf8`] over every string of a JSON-shaped literal tree.
     pub fn re_encode_utf8_strings(&mut self, bump: &Bump) {
         match self {
             Data::EString(s) => {

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -28,8 +28,8 @@ fn clone_rope_nodes(s: &E::EString) -> E::EString {
     root
 }
 
-/// Concatenate two `E::String`s (`None` if [`E::EString::can_join`] refuses),
-/// mutating BOTH inputs unless `has_inlined_enum_poison` is set.
+/// Concatenate two `E::String`s, mutating BOTH inputs
+/// unless `has_inlined_enum_poison` is set.
 ///
 /// Currently inlined enum poison refers to where mutation would cause output
 /// bugs due to inlined enum values sharing `E::String`s. If a new use case
@@ -196,9 +196,7 @@ pub fn fold_string_addition(
                 rhs = str;
             }
 
-            // An untagged template only has cooked contents, and nothing else
-            // shares it (enums only inline templates that folded to a string),
-            // so `rhs` joins in place onto its last string: the tail, or the head.
+            // Untagged: every part is cooked and unshared, so `rhs` joins onto the last one in place.
             if left.tag.is_none() {
                 let last: &mut E::EString = match left.parts().len() {
                     0 => left.head.cooked_mut(),

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -28,9 +28,8 @@ fn clone_rope_nodes(s: &E::EString) -> E::EString {
     root
 }
 
-/// Concatenate two `E::String`s, mutating BOTH inputs
-/// unless `has_inlined_enum_poison` is set. `None` when the join would copy
-/// more than [`E::EString::can_join`] allows.
+/// Concatenate two `E::String`s (`None` if [`E::EString::can_join`] refuses),
+/// mutating BOTH inputs unless `has_inlined_enum_poison` is set.
 ///
 /// Currently inlined enum poison refers to where mutation would cause output
 /// bugs due to inlined enum values sharing `E::String`s. If a new use case
@@ -197,15 +196,10 @@ pub fn fold_string_addition(
                 rhs = str;
             }
 
-            // An untagged template only has cooked contents.
+            // An untagged template only has cooked contents, and nothing else
+            // shares it (enums only inline templates that folded to a string),
+            // so `rhs` joins in place onto its last string: the tail, or the head.
             if left.tag.is_none() {
-                // The string that `rhs` is appended to: the last part's tail,
-                // or the head when there are no parts. Mutation of this node
-                // is fine because it will be not be shared by other places.
-                // Note that e_template will be treated by enums as strings,
-                // but will not be inlined unless they could be converted into
-                // .e_string. `parts` is `StoreSlice<T>` (arena-owned, mutable
-                // provenance) — write through `parts_mut()`.
                 let last: &mut E::EString = match left.parts().len() {
                     0 => left.head.cooked_mut(),
                     n => left.parts_mut()[n - 1].tail.cooked_mut(),

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -2,42 +2,9 @@ use crate::expr::{Data, PrimitiveType, data};
 use crate::{E, Expr, StoreRef, e};
 use bun_alloc::Arena; // bumpalo::Bump re-export
 
-// ── local rope helpers ─────────────────────────────────────────────────────
-// `EString` has no `push` / `clone_rope_nodes` inherent methods yet;
-// provide the minimal surface here.
-
 #[inline]
 fn store_append_string(s: E::EString) -> StoreRef<E::EString> {
     data::Store::append(s)
-}
-
-/// Link `other` onto `lhs`'s rope tail.
-fn estring_push(lhs: &mut E::EString, mut other: StoreRef<E::EString>) {
-    debug_assert!(lhs.is_utf8());
-    debug_assert!(other.is_utf8());
-
-    // `other` is a freshly Store-appended node; mutate via `StoreRef::DerefMut`.
-    if other.rope_len == 0 {
-        other.rope_len = other.data.len() as u32;
-    }
-    if lhs.rope_len == 0 {
-        lhs.rope_len = lhs.data.len() as u32;
-    }
-    lhs.rope_len += other.rope_len;
-
-    if lhs.next.is_none() {
-        lhs.next = Some(other);
-        lhs.end = Some(other);
-    } else {
-        let mut end = lhs.end.unwrap();
-        while end.get().next.is_some() {
-            end = end.get().end.unwrap();
-        }
-        // `end` points into the live Store; rope nodes are mutated in place
-        // via `StoreRef::DerefMut` (single-threaded visitor).
-        end.next = Some(other);
-        lhs.end = Some(other);
-    }
 }
 
 /// Deep-copy the `next` chain into fresh Store nodes so mutating the result
@@ -62,7 +29,8 @@ fn clone_rope_nodes(s: &E::EString) -> E::EString {
 }
 
 /// Concatenate two `E::String`s, mutating BOTH inputs
-/// unless `has_inlined_enum_poison` is set.
+/// unless `has_inlined_enum_poison` is set. `None` when the join would copy
+/// more than [`E::EString::can_join`] allows.
 ///
 /// Currently inlined enum poison refers to where mutation would cause output
 /// bugs due to inlined enum values sharing `E::String`s. If a new use case
@@ -72,7 +40,12 @@ fn join_strings(
     left: &E::EString,
     right: &E::EString,
     has_inlined_enum_poison: bool,
-) -> E::EString {
+    bump: &Arena,
+) -> Option<E::EString> {
+    if !E::EString::can_join(&[left, right]) {
+        return None;
+    }
+
     let mut new = if has_inlined_enum_poison {
         // Inlined enums can be shared by multiple call sites. In
         // this case, we need to ensure that the ENTIRE rope is
@@ -98,16 +71,16 @@ fn join_strings(
     //     C = ("3" + B) + "4",
     //   };
     //   console.log(A.B, A.C);
-    let rhs_clone = store_append_string(if has_inlined_enum_poison {
+    let mut rhs_clone = store_append_string(if has_inlined_enum_poison {
         clone_rope_nodes(right)
     } else {
         right.shallow_clone()
     });
 
-    estring_push(&mut new, rhs_clone);
+    new.append(&mut rhs_clone, bump);
     new.prefer_template = new.prefer_template || rhs_clone.get().prefer_template;
 
-    new
+    Some(new)
 }
 
 /// Concat two `TemplatePart` slices into the bump arena.
@@ -174,47 +147,40 @@ pub fn fold_string_addition(
                 rhs = str;
             }
 
-            if left.is_utf8() {
-                match rhs.data {
-                    // "bar" + "baz" => "barbaz"
-                    Data::EString(right) => {
-                        if right.is_utf8() {
-                            let has_inlined_enum_poison = matches!(l.data, Data::EInlinedEnum(_))
-                                || matches!(r.data, Data::EInlinedEnum(_));
+            match rhs.data {
+                // "bar" + "baz" => "barbaz"
+                Data::EString(right) => {
+                    let has_inlined_enum_poison = matches!(l.data, Data::EInlinedEnum(_))
+                        || matches!(r.data, Data::EInlinedEnum(_));
 
-                            return Some(Expr::init(
-                                join_strings(left.get(), right.get(), has_inlined_enum_poison),
-                                lhs.loc,
-                            ));
-                        }
-                    }
-                    // "bar" + `baz${bar}` => `barbaz${bar}`
-                    Data::ETemplate(right) => {
-                        if right.head.is_utf8() {
-                            return Some(Expr::init(
-                                E::Template {
-                                    tag: None,
-                                    parts: right.parts,
-                                    head: e::TemplateContents::Cooked(join_strings(
-                                        left.get(),
-                                        right.head.cooked(),
-                                        matches!(l.data, Data::EInlinedEnum(_)),
-                                    )),
-                                },
-                                l.loc,
-                            ));
-                        }
-                    }
-                    _ => {
-                        // other constant-foldable ast nodes would have been converted to .e_string
+                    if let Some(joined) =
+                        join_strings(left.get(), right.get(), has_inlined_enum_poison, bump)
+                    {
+                        return Some(Expr::init(joined, lhs.loc));
                     }
                 }
-
-                // "'x' + `y${z}`" => "`xy${z}`"
-                if let Data::ETemplate(t) = rhs.data {
-                    if t.tag.is_none() {
-                        // (intentionally empty)
+                // "bar" + `baz${bar}` => `barbaz${bar}`
+                Data::ETemplate(right) => {
+                    if let (None, e::TemplateContents::Cooked(head)) = (&right.tag, &right.head)
+                        && let Some(joined) = join_strings(
+                            left.get(),
+                            head,
+                            matches!(l.data, Data::EInlinedEnum(_)),
+                            bump,
+                        )
+                    {
+                        return Some(Expr::init(
+                            E::Template {
+                                tag: None,
+                                parts: right.parts,
+                                head: e::TemplateContents::Cooked(joined),
+                            },
+                            l.loc,
+                        ));
                     }
+                }
+                _ => {
+                    // other constant-foldable ast nodes would have been converted to .e_string
                 }
             }
 
@@ -231,73 +197,52 @@ pub fn fold_string_addition(
                 rhs = str;
             }
 
+            // An untagged template only has cooked contents.
             if left.tag.is_none() {
+                // The string that `rhs` is appended to: the last part's tail,
+                // or the head when there are no parts. Mutation of this node
+                // is fine because it will be not be shared by other places.
+                // Note that e_template will be treated by enums as strings,
+                // but will not be inlined unless they could be converted into
+                // .e_string. `parts` is `StoreSlice<T>` (arena-owned, mutable
+                // provenance) — write through `parts_mut()`.
+                let last: &mut E::EString = match left.parts().len() {
+                    0 => left.head.cooked_mut(),
+                    n => left.parts_mut()[n - 1].tail.cooked_mut(),
+                };
                 match rhs.data {
                     // `foo${bar}` + "baz" => `foo${bar}baz`
                     Data::EString(right) => {
-                        if right.is_utf8() {
-                            // Mutation of this node is fine because it will be not
-                            // be shared by other places. Note that e_template will
-                            // be treated by enums as strings, but will not be
-                            // inlined unless they could be converted into
-                            // .e_string.
-                            // `parts` is `StoreSlice<T>` (arena-owned, mutable
-                            // provenance) — write through `parts_mut()`.
-                            if !left.parts().is_empty() {
-                                let i = left.parts().len() - 1;
-                                let last_tail = &left.parts()[i].tail;
-                                if last_tail.is_utf8() {
-                                    let new_tail = e::TemplateContents::Cooked(join_strings(
-                                        last_tail.cooked(),
-                                        right.get(),
-                                        matches!(r.data, Data::EInlinedEnum(_)),
-                                    ));
-                                    left.parts_mut()[i].tail = new_tail;
-                                    return Some(lhs);
-                                }
-                            } else if left.head.is_utf8() {
-                                let new_head = join_strings(
-                                    left.head.cooked(),
-                                    right.get(),
-                                    matches!(r.data, Data::EInlinedEnum(_)),
-                                );
-                                left.head = e::TemplateContents::Cooked(new_head);
-                                return Some(lhs);
-                            }
+                        if let Some(joined) = join_strings(
+                            last,
+                            right.get(),
+                            matches!(r.data, Data::EInlinedEnum(_)),
+                            bump,
+                        ) {
+                            *last = joined;
+                            return Some(lhs);
                         }
                     }
                     // `foo${bar}` + `a${hi}b` => `foo${bar}a${hi}b`
                     Data::ETemplate(right) => {
-                        if right.tag.is_none() && right.head.is_utf8() {
-                            if !left.parts().is_empty() {
-                                let i = left.parts().len() - 1;
-                                let last_tail = &left.parts()[i].tail;
-                                if last_tail.is_utf8() && right.head.is_utf8() {
-                                    let new_tail = e::TemplateContents::Cooked(join_strings(
-                                        last_tail.cooked(),
-                                        right.head.cooked(),
-                                        matches!(r.data, Data::EInlinedEnum(_)),
-                                    ));
-                                    left.parts_mut()[i].tail = new_tail;
-
-                                    let new_parts = if right.parts().is_empty() {
-                                        left.parts
-                                    } else {
-                                        concat_parts(bump, left.parts(), right.parts())
-                                    };
-                                    left.parts = new_parts;
-                                    return Some(lhs);
-                                }
-                            } else if left.head.is_utf8() && right.head.is_utf8() {
-                                let new_head = join_strings(
-                                    left.head.cooked(),
-                                    right.head.cooked(),
-                                    matches!(r.data, Data::EInlinedEnum(_)),
-                                );
-                                left.head = e::TemplateContents::Cooked(new_head);
-                                left.parts = right.parts;
-                                return Some(lhs);
+                        if let (None, e::TemplateContents::Cooked(right_head)) =
+                            (&right.tag, &right.head)
+                            && let Some(joined) = join_strings(
+                                last,
+                                right_head,
+                                matches!(r.data, Data::EInlinedEnum(_)),
+                                bump,
+                            )
+                        {
+                            *last = joined;
+                            if !right.parts().is_empty() {
+                                left.parts = if left.parts().is_empty() {
+                                    right.parts
+                                } else {
+                                    concat_parts(bump, left.parts(), right.parts())
+                                };
                             }
+                            return Some(lhs);
                         }
                     }
                     _ => {

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -51,12 +51,9 @@ fn env_string_store_put(
     key: &[u8],
     value: &[u8],
 ) -> Result<(), crate::Error> {
-    // The `E.String` slab must NOT live in the thread-local
-    // `Expr.Data.Store` — `configureDefines` resets that store on return, so
-    // the env-define payloads must outlive it. Allocate from `bump` (the
-    // transpiler arena) so the slab is bulk-freed with the `Define` table
-    // instead of leaking a `Box` per env var. The value bytes are copied too:
-    // the env map frees an entry that a later `process.env` write replaces.
+    // Node and bytes live in `bump` (freed with the `Define` table): the Expr
+    // store is reset after `configure_defines`, and the env map frees an entry
+    // that a later `process.env` write replaces.
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(bump.alloc(
         bun_ast::E::EString::init_re_encode_utf8(bump.alloc_slice_copy(value), bump),
     )));

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -55,11 +55,11 @@ fn env_string_store_put(
     // `Expr.Data.Store` — `configureDefines` resets that store on return, so
     // the env-define payloads must outlive it. Allocate from `bump` (the
     // transpiler arena) so the slab is bulk-freed with the `Define` table
-    // instead of leaking a `Box` per env var. ASCII value bytes alias the
-    // long-lived env-map storage; non-ASCII values are re-encoded into `bump`.
-    let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
-        bump.alloc(bun_ast::E::EString::init_re_encode_utf8(value, bump)),
-    ));
+    // instead of leaking a `Box` per env var. The value bytes are copied too:
+    // the env map frees an entry that a later `process.env` write replaces.
+    let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(bump.alloc(
+        bun_ast::E::EString::init_re_encode_utf8(bump.alloc_slice_copy(value), bump),
+    )));
     let data = DefineData::init(Options {
         value,
         can_be_removed_if_unused: true,

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -51,9 +51,7 @@ fn env_string_store_put(
     key: &[u8],
     value: &[u8],
 ) -> Result<(), crate::Error> {
-    // Node and bytes live in `bump` (freed with the `Define` table): the Expr
-    // store is reset after `configure_defines`, and the env map frees an entry
-    // that a later `process.env` write replaces.
+    // All in `bump`: the Expr store resets after `configure_defines`, and the env map can free `value`.
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(bump.alloc(
         bun_ast::E::EString::init_re_encode_utf8(bump.alloc_slice_copy(value), bump),
     )));

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -55,10 +55,10 @@ fn env_string_store_put(
     // `Expr.Data.Store` — `configureDefines` resets that store on return, so
     // the env-define payloads must outlive it. Allocate from `bump` (the
     // transpiler arena) so the slab is bulk-freed with the `Define` table
-    // instead of leaking a `Box` per env var. Value bytes alias the long-lived
-    // env-map storage.
+    // instead of leaking a `Box` per env var. ASCII value bytes alias the
+    // long-lived env-map storage; non-ASCII values are re-encoded into `bump`.
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
-        bump.alloc(bun_ast::E::EString::init(value)),
+        bump.alloc(bun_ast::E::EString::init_re_encode_utf8(value, bump)),
     ));
     let data = DefineData::init(Options {
         value,
@@ -443,7 +443,8 @@ impl DefineDataExt for DefineData {
         // `.into()` deep-walking T2→T4 and re-boxing the payload; now `.into()`
         // is identity, so without `deep_clone` the `DefineData.value` dangles
         // into a freed slab and `process.env.NODE_ENV` reads garbage.
-        let data: ExprData = expr.data.deep_clone(bump)?;
+        let mut data: ExprData = expr.data.deep_clone(bump)?;
+        data.re_encode_utf8_strings(bump);
         let can_be_removed_if_unused = bun_ast::expr::Tag::is_primitive_literal(data.tag());
         Ok(DefineData {
             value: data,

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -957,7 +957,7 @@ pub(crate) fn defines_from_transform_options(
             .iter()
             .zip(environment_defines.values().iter())
             .filter_map(|(k, v)| match &v.value {
-                defines::DefineValue::EString(s) if s.is_utf8() => Some((k.as_ref(), s.slice8())),
+                defines::DefineValue::EString(s) => Some((k.as_ref(), s.get())),
                 _ => None,
             }),
         drop.iter().copied(),

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -439,23 +439,33 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         {
                             // inline module.id
                             p.ignore_usage(p.module_ref);
-                            return Some(p.new_expr(e_string_init(p.source.path.pretty), name_loc));
+                            return Some(p.new_expr(
+                                E::EString::init_re_encode_utf8(p.source.path.pretty, p.arena),
+                                name_loc,
+                            ));
                         } else if p.options.bundle
                             && name == b"filename"
                             && identifier_opts.assign_target() == js_ast::AssignTarget::None
                         {
                             // inline module.filename
                             p.ignore_usage(p.module_ref);
-                            return Some(
-                                p.new_expr(e_string_init(p.source.path.name().filename), name_loc),
-                            );
+                            return Some(p.new_expr(
+                                E::EString::init_re_encode_utf8(
+                                    p.source.path.name().filename,
+                                    p.arena,
+                                ),
+                                name_loc,
+                            ));
                         } else if p.options.bundle
                             && name == b"path"
                             && identifier_opts.assign_target() == js_ast::AssignTarget::None
                         {
                             // inline module.path
                             p.ignore_usage(p.module_ref);
-                            return Some(p.new_expr(e_string_init(p.source.path.pretty), name_loc));
+                            return Some(p.new_expr(
+                                E::EString::init_re_encode_utf8(p.source.path.pretty, p.arena),
+                                name_loc,
+                            ));
                         }
                     }
 
@@ -606,17 +616,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     {
                         if name == b"dir" || name == b"dirname" {
                             // Inline import.meta.dir
-                            return Some(
-                                p.new_expr(e_string_init(p.source.path.name().dir), name_loc),
-                            );
+                            return Some(p.new_expr(
+                                E::EString::init_re_encode_utf8(p.source.path.name().dir, p.arena),
+                                name_loc,
+                            ));
                         } else if name == b"file" {
                             // Inline import.meta.file (filename only)
-                            return Some(
-                                p.new_expr(e_string_init(p.source.path.name().filename), name_loc),
-                            );
+                            return Some(p.new_expr(
+                                E::EString::init_re_encode_utf8(
+                                    p.source.path.name().filename,
+                                    p.arena,
+                                ),
+                                name_loc,
+                            ));
                         } else if name == b"path" {
                             // Inline import.meta.path (full path)
-                            return Some(p.new_expr(e_string_init(p.source.path.text), name_loc));
+                            return Some(p.new_expr(
+                                E::EString::init_re_encode_utf8(p.source.path.text, p.arena),
+                                name_loc,
+                            ));
                         } else if name == b"url" {
                             // Inline import.meta.url as file:// URL
                             let bunstr = bun_core::String::from_bytes(p.source.path.text);

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -2311,7 +2311,7 @@ impl<'a> Lexer<'a> {
                     return Err(e);
                 }
                 let first_non_ascii = strings::first_non_ascii16(&tmp);
-                // prefer to store an ascii e.string rather than a utf-16 one. ascii takes less memory, and `+` folding is not yet supported on utf-16.
+                // prefer to store an ascii e.string rather than a utf-16 one. ascii takes less memory, and `+` folding joins two ascii strings as a rope instead of a copy.
                 let out = if first_non_ascii.is_some() {
                     let dup = self.arena.alloc_slice_copy(&tmp);
                     js_ast::E::String::init_utf16(dup)

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -545,19 +545,20 @@ pub mod defines {
         }
 
         /// Order-independent, length-prefixed hash of the three inputs. `None` when all are empty.
+        /// `env_defines` keys are unique (they come from a map).
         pub fn hash_user_inputs<'i>(
             defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
-            env_defines: impl IntoIterator<Item = (&'i [u8], &'i [u8])>,
+            env_defines: impl IntoIterator<Item = (&'i [u8], &'i E::EString)>,
             drop: impl IntoIterator<Item = &'i [u8]>,
         ) -> Option<u64> {
             let mut defines: Vec<(&[u8], &[u8])> = defines.into_iter().collect();
-            let mut env_defines: Vec<(&[u8], &[u8])> = env_defines.into_iter().collect();
+            let mut env_defines: Vec<(&[u8], &E::EString)> = env_defines.into_iter().collect();
             let mut drop: Vec<&[u8]> = drop.into_iter().filter(|item| !item.is_empty()).collect();
             if defines.is_empty() && env_defines.is_empty() && drop.is_empty() {
                 return None;
             }
             defines.sort_unstable();
-            env_defines.sort_unstable();
+            env_defines.sort_unstable_by_key(|(key, _)| *key);
             drop.sort_unstable();
             drop.dedup();
 
@@ -567,11 +568,21 @@ pub mod defines {
                 hasher.update(bytes);
             };
             // Separate sections: `init` lets a later env pair override a user pair.
-            for pairs in [defines, env_defines] {
-                update(&(pairs.len() as u64).to_le_bytes());
-                for (key, value) in pairs {
-                    update(key);
-                    update(value);
+            update(&(defines.len() as u64).to_le_bytes());
+            for (key, value) in defines {
+                update(key);
+                update(value);
+            }
+            update(&(env_defines.len() as u64).to_le_bytes());
+            for (key, value) in env_defines {
+                update(key);
+                // Tag the encoding: the UTF-16 bytes of `"中"` are the 8-bit bytes of `"-N"`.
+                if value.is_utf8() {
+                    update(&[0]);
+                    update(value.slice8());
+                } else {
+                    update(&[1]);
+                    update(bytemuck::cast_slice::<u16, u8>(value.slice16()));
                 }
             }
             update(&(drop.len() as u64).to_le_bytes());

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7169,6 +7169,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 );
             }
             js_ast::ExprData::EString(str_) => {
+                // Constant folding reads an 8-bit string one byte per character.
+                debug_assert!(str_.is_utf16 || strings::is_all_ascii(&str_.data));
                 return self.new_expr(&*str_, loc);
             }
             _ => {}

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1069,14 +1069,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 {
                     // "foo"[2] -> "o"
                     if let Some(str_) = target.data.as_e_string() {
-                        if !str_.is_utf16 {
+                        // One byte is one character only in an ASCII string.
+                        if !str_.is_utf16 && strings::is_all_ascii(&str_.data) {
                             let literal = str_.data;
                             let num: usize = index
                                 .data
                                 .e_number()
                                 .expect("infallible: variant checked")
                                 .to_usize();
-                            debug_assert!(strings::is_all_ascii(&literal));
                             if num < literal.len() {
                                 *e = p.new_expr(
                                     E::String {
@@ -2458,7 +2458,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if e_.args.len_u32() == 1 {
             if let Some(dot) = e_.target.data.e_dot() {
                 if let Some(target_str) = dot.target.data.e_string() {
-                    if !target_str.is_utf16 && dot.name == b"charCodeAt" {
+                    // Byte offsets are code unit offsets only in an ASCII string.
+                    if !target_str.is_utf16
+                        && dot.name == b"charCodeAt"
+                        && strings::is_all_ascii(&target_str.data)
+                    {
                         let str_ = target_str.data;
                         let arg1 = e_.args.at(0).unwrap_inlined();
                         if let Data::ENumber(n) = &arg1.data {

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -1104,8 +1104,7 @@ fn expr_from_blob(
         );
 
     if is_text_like {
-        // `E.String` data is the unescaped text (the printer escapes it),
-        // copied into `bump` so it does not borrow the blob's store.
+        // The text itself (the printer escapes it), copied out of the blob's store.
         return Ok(Expr::init(
             E::String::init_re_encode_utf8(bump.alloc_slice_copy(bytes), bump),
             loc,

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -1085,6 +1085,7 @@ fn expr_from_blob(
             Err(_) => return Err(crate::Error::MacroFailed),
         };
         out_expr.loc = loc;
+        out_expr.data.re_encode_utf8_strings(bump);
         match &mut out_expr.data {
             ExprData::EObject(obj) => obj.was_originally_macro = true,
             ExprData::EArray(arr) => arr.was_originally_macro = true,
@@ -1103,22 +1104,10 @@ fn expr_from_blob(
         );
 
     if is_text_like {
-        let mut output = bun_core::MutableString::init_empty();
-        bun_core::quote_for_json(bytes, &mut output, true)?;
-        let owned = output.to_owned_slice();
-        // strip the surrounding quotes; copy into the bump arena so the
-        // `E.String` data outlives `owned`.
-        let unquoted: &[u8] = if owned.len() >= 2 {
-            &owned[1..owned.len() - 1]
-        } else {
-            &owned[..]
-        };
-        let data = Str::new(bump.alloc_slice_copy(unquoted));
+        // `E.String` data is the unescaped text (the printer escapes it),
+        // copied into `bump` so it does not borrow the blob's store.
         return Ok(Expr::init(
-            E::String {
-                data,
-                ..Default::default()
-            },
+            E::String::init_re_encode_utf8(bump.alloc_slice_copy(bytes), bump),
             loc,
         ));
     }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,9 +57,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-/// Version 30: non-ASCII `--define` and env values are UTF-16 strings, so `U[0]`,
-/// `` `${U}`.length `` and `+U` no longer fold over their UTF-8 bytes; `+` and
-/// template literals fold non-ASCII (UTF-16) strings.
+/// Version 30: non-ASCII define/env strings are UTF-16 and fold per code unit; `+` folds UTF-16 strings.
 const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: non-ASCII `--define` and env values are UTF-16 strings, so `U[0]`,
+/// `` `${U}`.length `` and `+U` no longer fold over their UTF-8 bytes.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -58,7 +58,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: non-ASCII `--define` and env values are UTF-16 strings, so `U[0]`,
-/// `` `${U}`.length `` and `+U` no longer fold over their UTF-8 bytes.
+/// `` `${U}`.length `` and `+U` no longer fold over their UTF-8 bytes; `+` and
+/// template literals fold non-ASCII (UTF-16) strings.
 const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -917,7 +917,7 @@ fn export_replacement_value(
         // crate's `Str` convention (see ast/E.rs).
         let data = arena.alloc_slice_copy(utf8.slice());
         return Ok(Some(Expr::init(
-            bun_ast::E::EString::init(data),
+            bun_ast::E::EString::init_re_encode_utf8(data, arena),
             bun_ast::Loc::EMPTY,
         )));
     }

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -451,17 +451,17 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "50b3e5192dd86a205c73583d585884c1b414467b14db54d03c77d3026bf236ff",
+          "js": "2937248d36358716a09034348758a5934d049f654da8223dd47b69f181bf9838",
           "jsc": {
-            "bytes": 1997464,
-            "sha256": "cf47f5e069b3f20c112160c430a3b18c5ce2d501f1c52525d34dfbd054273cfb",
+            "bytes": 1997600,
+            "sha256": "4827b467caf47c9d2128c2805f855467649838278d87068ee03330f4a1ad121a",
           },
         },
         "bun build --bytecode --minify features.js": {
-          "js": "d30a5febed53e316cc2dd2b076502079e809bb0c201ef1671e9a190ecdcf093d",
+          "js": "9a9cfce86572d5074294bcdb9acb29b5c546f56b8ed14b849ecfbacc7a3556e8",
           "jsc": {
-            "bytes": 46152,
-            "sha256": "7dc5fe8fbfaed3c41d424d2f172efb0efa1be60524ecefcc9d77dfc8088b32af",
+            "bytes": 46136,
+            "sha256": "3360683eee77f9b0a9efb8cbb19e9ce517ee1c67efa1547041c4bf9f915b5862",
           },
         },
         "bun build --bytecode --minify records.js": {

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
 
 for (let backend of ["api", "cli"] as const) {
@@ -28,12 +28,14 @@ for (let backend of ["api", "cli"] as const) {
       });
 
     // Inlined values are raw environment bytes. A non-ASCII value has to fold like a source string literal under
-    // --minify-syntax: per UTF-16 code unit (`[0]`, template `.length`), with U+2028 as numeric whitespace (`+x`).
+    // --minify-syntax: per UTF-16 code unit (`[0]`, template `.length`), with U+2028 as numeric whitespace (`+x`),
+    // and still join with a literal so that `require(process.env.DIR + "/m.js")` resolves at build time.
     if (backend === "cli")
       itBundled("env/inline non-ascii", {
         env: {
           INLINE_NON_ASCII: "é😀",
           INLINE_LS_NUMBER: "\u2028 12 ",
+          INLINE_DIR: "./dér",
         },
         backend: backend,
         dotenv: "inline",
@@ -41,15 +43,20 @@ for (let backend of ["api", "cli"] as const) {
         files: {
           "/a.js": `
         const v = process.env.INLINE_NON_ASCII;
-        console.log(JSON.stringify([v, process.env.INLINE_NON_ASCII[0], process.env.INLINE_NON_ASCII?.[1], \`\${process.env.INLINE_NON_ASCII}\`.length, process.env.INLINE_NON_ASCII === "é😀", +process.env.INLINE_LS_NUMBER, ~process.env.INLINE_LS_NUMBER]));
+        const m = require(process.env.INLINE_DIR + "/m.js");
+        console.log(JSON.stringify([v, process.env.INLINE_NON_ASCII[0], process.env.INLINE_NON_ASCII?.[1], \`\${process.env.INLINE_NON_ASCII}\`.length, process.env.INLINE_NON_ASCII === "é😀", +process.env.INLINE_LS_NUMBER, ~process.env.INLINE_LS_NUMBER, m]));
       `,
+          "/dér/m.js": `module.exports = "from m";`,
+        },
+        onAfterBundle(api) {
+          expect(api.readFile("/out.js")).toContain("from m");
         },
         run: {
           env: {
             INLINE_NON_ASCII: "the run-time value, which inlining should have replaced",
             INLINE_LS_NUMBER: "0",
           },
-          stdout: '["é😀","é","\\ud83d",3,true,12,-13]',
+          stdout: '["é😀","é","\\ud83d",3,true,12,-13,"from m"]',
         },
       });
 

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -27,6 +27,32 @@ for (let backend of ["api", "cli"] as const) {
         },
       });
 
+    // Inlined values are raw environment bytes. A non-ASCII value has to fold like a source string literal under
+    // --minify-syntax: per UTF-16 code unit (`[0]`, template `.length`), with U+2028 as numeric whitespace (`+x`).
+    if (backend === "cli")
+      itBundled("env/inline non-ascii", {
+        env: {
+          INLINE_NON_ASCII: "é😀",
+          INLINE_LS_NUMBER: "\u2028 12 ",
+        },
+        backend: backend,
+        dotenv: "inline",
+        minifySyntax: true,
+        files: {
+          "/a.js": `
+        const v = process.env.INLINE_NON_ASCII;
+        console.log(JSON.stringify([v, process.env.INLINE_NON_ASCII[0], process.env.INLINE_NON_ASCII?.[1], \`\${process.env.INLINE_NON_ASCII}\`.length, process.env.INLINE_NON_ASCII === "é😀", +process.env.INLINE_LS_NUMBER, ~process.env.INLINE_LS_NUMBER]));
+      `,
+        },
+        run: {
+          env: {
+            INLINE_NON_ASCII: "the run-time value, which inlining should have replaced",
+            INLINE_LS_NUMBER: "0",
+          },
+          stdout: '["é😀","é","\\ud83d",3,true,12,-13]',
+        },
+      });
+
     // A variable from the process environment (not a .env file) is inlined at build time. It has to be one this
     // process started with (the api backend builds in-process), spelled as the environment spells it (on Windows the
     // inlined name is case-sensitive even though process.env is not: `Path`, not `PATH`).

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -138,6 +138,7 @@ describe("bundler", () => {
   }
   // A join with a non-ASCII (UTF-16) string literal copies both sides into one
   // UTF-16 string, so it is capped at 4096 code units; an ASCII join is a rope.
+  const eAcute = (count: number) => Buffer.alloc(count * Buffer.byteLength("é"), "é").toString();
   itBundled("minify/StringAdditionFoldingNonAscii", {
     files: {
       "/entry.js": /* js */ `
@@ -146,8 +147,8 @@ describe("bundler", () => {
           \`a\${"é"}b\${1}😀\` + "x",
           ("a" + "é" + "😀x").length,
           (/é/ + "x")[1],
-          ("${"é".repeat(4095)}" + "x").length,
-          ("${"é".repeat(4096)}" + "y").length,
+          ("${eAcute(4095)}" + "x").length,
+          ("${eAcute(4096)}" + "y").length,
         ]));
       `,
     },

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -90,6 +90,75 @@ describe("bundler", () => {
     ],
     minifySyntax: true,
   });
+  // `--define` values are parsed as JSON, outside the lexer. A non-ASCII string
+  // value must fold per UTF-16 code unit like a source literal does, not per
+  // UTF-8 byte (`U[0]`, `` `${U}`.length ``, `+D`, `case` DCE).
+  for (const backend of ["cli", "api"] as const) {
+    itBundled(`minify/DefineNonAsciiStringFolding${backend === "cli" ? "Cli" : "Api"}`, {
+      files: {
+        "/entry.ts": /* ts */ `
+          declare const U: string, E: string, D: string, S: string, A: { s: string; n: string[] };
+          console.log(JSON.stringify([U, U[0], U[1], U[3], \`\${U}\`.length, U.length, (U + "")[0], U + "!", U === "é😀", U.charCodeAt(0)]));
+          console.log(JSON.stringify([E === U, E[0], \`\${E}\`.length]));
+          console.log(JSON.stringify([+D, -D, ~D]));
+          console.log(JSON.stringify([S.length, S.charCodeAt(0), \`\${S}\`.length]));
+          console.log(JSON.stringify([A.s[0], A.n[0][0], \`\${A.n[0]}\`.length]));
+          switch (U[0]) {
+            case "é":
+              console.log("case é");
+              break;
+            default:
+              console.log("default");
+          }
+        `,
+      },
+      define: {
+        U: '"é😀"',
+        // the same value spelled in ASCII
+        E: '"\\u00e9\\ud83d\\ude00"',
+        // U+2028 is StrWhiteSpace for ToNumber
+        D: '"\u2028 12 "',
+        // a lone surrogate survives as one code unit
+        S: '"\\ud800"',
+        A: '{"s":"ü!","n":["中文"]}',
+      },
+      minifySyntax: true,
+      backend,
+      run: {
+        stdout: [
+          '["é😀","é","\\ud83d",null,3,3,"é","é😀!",true,233]',
+          '[true,"é",3]',
+          "[12,-12,-13]",
+          "[1,55296,1]",
+          '["ü","中",2]',
+          "case é",
+        ].join("\n"),
+      },
+    });
+  }
+  // `import.meta.file`/`dir` (cjs output) and `module.filename` are inlined from the
+  // file path. A non-ASCII path must fold like a source literal, not per UTF-8 byte.
+  itBundled("minify/InlinedImportMetaPathNonAscii", {
+    files: {
+      "/dér/filé.js": /* js */ `
+        console.log(JSON.stringify([import.meta.file, import.meta.file[3], import.meta.file[4], \`\${import.meta.file}\`.length, \`\${import.meta.dir}\`.length === import.meta.dir.length]));
+      `,
+    },
+    format: "cjs",
+    target: "bun",
+    minifySyntax: true,
+    run: { stdout: '["filé.js","é",".",7,true]' },
+  });
+  itBundled("minify/InlinedModuleFilenameNonAscii", {
+    files: {
+      "/dér/cjé.cjs": /* js */ `
+        console.log(JSON.stringify([module.filename, module.filename[2], module.filename[3], \`\${module.filename}\`.length]));
+      `,
+    },
+    target: "bun",
+    minifySyntax: true,
+    run: { stdout: '["cjé.cjs","é",".",7]' },
+  });
   itBundled("minify/FunctionExpressionRemoveName", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -136,18 +136,52 @@ describe("bundler", () => {
       },
     });
   }
+  // A join with a non-ASCII (UTF-16) string literal copies both sides into one
+  // UTF-16 string, so it is capped at 4096 code units; an ASCII join is a rope.
+  itBundled("minify/StringAdditionFoldingNonAscii", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(JSON.stringify([
+          "é" + "x",
+          \`a\${"é"}b\${1}😀\` + "x",
+          ("a" + "é" + "😀x").length,
+          (/é/ + "x")[1],
+          ("${"é".repeat(4095)}" + "x").length,
+          ("${"é".repeat(4096)}" + "y").length,
+        ]));
+      `,
+    },
+    minifySyntax: true,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).not.toContain('"x"');
+      expect(code).toContain('+ "y"');
+      expect(code).toContain("4096,");
+    },
+    run: { stdout: '["éx","aéb1😀x",5,"é",4096,4097]' },
+  });
   // `import.meta.file`/`dir` (cjs output) and `module.filename` are inlined from the
-  // file path. A non-ASCII path must fold like a source literal, not per UTF-8 byte.
+  // file path. A non-ASCII path must fold like a source literal, not per UTF-8 byte,
+  // and still join with a literal so that `require(import.meta.dir + "/m.js")` resolves.
   itBundled("minify/InlinedImportMetaPathNonAscii", {
     files: {
       "/dér/filé.js": /* js */ `
-        console.log(JSON.stringify([import.meta.file, import.meta.file[3], import.meta.file[4], \`\${import.meta.file}\`.length, \`\${import.meta.dir}\`.length === import.meta.dir.length]));
+        const m = require(import.meta.dir + "/m.js");
+        const t = require(\`\${import.meta.dir}/t.js\`);
+        console.log(JSON.stringify([import.meta.file, import.meta.file[3], import.meta.file[4], \`\${import.meta.file}\`.length, \`\${import.meta.dir}\`.length === import.meta.dir.length, m.x, t.y]));
       `,
+      "/dér/m.js": `module.exports.x = "from m";`,
+      "/dér/t.js": `module.exports.y = "from t";`,
     },
     format: "cjs",
     target: "bun",
     minifySyntax: true,
-    run: { stdout: '["filé.js","é",".",7,true]' },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("from m");
+      expect(code).toContain("from t");
+    },
+    run: { stdout: '["filé.js","é",".",7,true,"from m","from t"]' },
   });
   itBundled("minify/InlinedModuleFilenameNonAscii", {
     files: {

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -237,6 +237,41 @@ test("a macro that returns a JSON or text Response or Blob is inlined by its con
   expect(exitCode).toBe(0);
 });
 
+// The body bytes are inlined as the text they encode: a JSON string with non-ASCII characters folds per
+// UTF-16 code unit like a source literal (not per UTF-8 byte), and a text body keeps its quotes,
+// backslashes, newlines and non-ASCII characters instead of their JSON escapes.
+test("non-ASCII and escaped text in a macro's JSON or text Response is inlined verbatim", async () => {
+  using dir = tempDir("macro-response-non-ascii", {
+    "m.ts": [
+      `export function json() {`,
+      `  return Response.json(["é😀", { "clé": "ü\\n\\"" }]);`,
+      `}`,
+      `export function text() {`,
+      `  return new Response('é😀 "q" \\\\ \\n end', { headers: { "content-type": "text/plain" } });`,
+      `}`,
+    ].join("\n"),
+    "index.ts": [
+      `import { json, text } from "./m.ts" with { type: "macro" };`,
+      `console.log(JSON.stringify([json()[0], json()[0][0], json()[0][1], \`\${json()[0]}\`.length, json()[1], text(), text()[0], text().length]));`,
+      ``,
+    ].join("\n"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Debug builds print "[macro] call <name>" to stdout before the script's own output.
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({
+    lastLine: JSON.stringify(["é😀", "é", "\ud83d", 3, { "clé": 'ü\n"' }, 'é😀 "q" \\ \n end', "é", 15]),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 // The classification follows the MIME essence, not the category table the runtime uses for blob types:
 // any `+json` suffix or `/json` subtype is JSON, and the JavaScript and XML `application/*` types are text.
 // The data URL keeps the raw content type, parameters included.

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -15,6 +15,38 @@ test("non-ascii regexp literals", () => {
   expect(str.replace(/[🔵🔴,]+/g, "")).toBe("11 54 / 10000");
 });
 
+// A `--define` value is parsed as JSON outside the lexer. The runtime transpiler
+// folds `U[0]`, `` `${U}`.length `` and `+D`; a non-ASCII value has to fold per
+// UTF-16 code unit like a source literal, not per UTF-8 byte.
+test("non-ascii --define values fold like string literals", async () => {
+  using dir = tempDir("define-non-ascii", {
+    "index.ts": `
+      declare const U: string, D: string;
+      console.log(JSON.stringify([U, U[0], U[1], U[3], \`\${U}\`.length, U.length, (U + "")[0], U === "é😀", +D, -D, ~D]));
+      switch (U[0]) {
+        case "é":
+          console.log("case é");
+          break;
+        default:
+          console.log("default");
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "--define", 'U="é😀"', "--define", 'D="\u2028 12 "', "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr }).toEqual({
+    stdout: '["é😀","é","\\ud83d",null,3,3,"é",true,12,-12,-13]\ncase é\n',
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 test("ascii regex with escapes", () => {
   expect(/^[-#!$@£%^&*()_+|~=`{}\[\]:";'<>?,.\/ ]$/).toBeInstanceOf(RegExp);
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2395,6 +2395,35 @@ export default <>hi</>
     expect(exitCode).toBe(0);
   });
 
+  // A define value is parsed as JSON outside the lexer; a non-ASCII string must fold per UTF-16
+  // code unit like a source literal (`U[0]`, template `.length`, `+D`), not per UTF-8 byte. Run in
+  // a subprocess: a debug build asserts on the byte-wise fold instead of printing a wrong string.
+  it("non-ascii define values fold like string literals", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const t = new Bun.Transpiler({
+            loader: "ts",
+            target: "bun",
+            define: { U: JSON.stringify("é😀"), E: '"\\\\u00e9"', D: JSON.stringify("\\u2028 12 ") },
+          });
+          const code = t.transformSync("globalThis.out = [U, U[0], U[1], \`\${U}\`.length, U.length, (U + '')[0], E, E[0], +D, ~D];");
+          (0, eval)(code);
+          process.stdout.write(JSON.stringify(globalThis.out));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('["é😀","é","\\ud83d",3,3,"é","é","é",12,-13]');
+    expect(exitCode).toBe(0);
+  });
+
   it("JSX keys", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3071,7 +3071,10 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_(`console.log("\\u{10334}" === "\\uD800\\uDF34")`, "console.log(true)");
       expectPrinted_(`console.log("\\u{10334}" === "\\uDF34\\uD800")`, "console.log(false)");
       expectPrintedMin_(`console.log("abc" + "def")`, 'console.log("abcdef")');
-      expectPrintedMin_(`console.log("\\uD800" + "\\uDF34")`, 'console.log("\\uD800" + "\\uDF34")');
+      // Two lone surrogates join into the code unit sequence of the pair, as at run time.
+      expectPrintedMin_(`console.log("\\uD800" + "\\uDF34")`, 'console.log("\\uD800\\uDF34")');
+      expectPrintedMin_(`console.log(("\\uD800" + "\\uDF34").length)`, "console.log(2)");
+      expectPrintedMin_(`console.log("a" + "é" + "😀")`, 'console.log("aé\\uD83D\\uDE00")');
     });
 
     it("fold string addition", () => {
@@ -3221,8 +3224,10 @@ export const { dead } = { dead: "hello world!" };
         `export const foo = "😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌".length;`,
         `export const foo = 52`,
       );
-      // no rope string for non-ascii
-      expectBunPrinted_(`export const foo = ("æ" + "™").length;`, `export const foo = ("æ" + "™").length`);
+      // non-ascii strings join into one UTF-16 string, whose length is its code unit count
+      expectBunPrinted_(`export const foo = ("æ" + "™").length;`, `export const foo = 2`);
+      expectBunPrinted_(`export const foo = ("a" + "é" + "😀").length;`, `export const foo = 4`);
+      expectBunPrinted_("export const foo = `a${'é'}b${1}😀`.length;", `export const foo = 6`);
     });
 
     describe("Bun.js", () => {


### PR DESCRIPTION
### Problem
- A non-ASCII `--define` string folds over its UTF-8 bytes: with `U="é😀"`, `U[0]` is `"\0"`, `` `${U}`.length `` is `6`, and `case "é":` on `U[0]` is eliminated. 1.3.14 was correct. Debug builds hit `assertion failed: strings::is_all_ascii(&literal)`.
- Same for the other strings that skip the lexer: inlined `process.env.*`, macro `Response`/`Blob` bodies, inlined `import.meta.dir`/`module.filename`, a regexp coerced by `+`.
- Cause: the lexer stores a non-ASCII literal as UTF-16, and the string folds read an 8-bit `E.String` bytewise. `DefineData::parse` (`src/bundler/defines.rs`) uses the JSON parser, which emits WTF-8 since the 1.4 port. The other producers always stored raw bytes.

### Fix
- Build these strings with `EString::init_re_encode_utf8`: non-ASCII becomes UTF-16, lone surrogates are kept. A macro text body is stored as its text, not a JSON-escaped form that got escaped twice.
- `+` and template folding join a UTF-16 operand by copying into one UTF-16 string, capped at 4096 code units. Otherwise `require(import.meta.dir + "/m.js")` under a non-ASCII directory stopped resolving at build time. `"é" + "x"` folds now too.
- The index and `charCodeAt` folds check for ASCII in release builds. The env define hash tags the encoding. Transpiler cache version 30.
- Verified: new cases in `bundler_minify`, `bundler_env`, `transpiler.test.js`, `runtime-transpiler` and `macro-test` fail on canary and pass here.

### Background
- `E.String` is 8-bit bytes or UTF-16 code units. The printer handles WTF-8 bytes, but the folders assume 8-bit means ASCII, which the lexer guarantees.
- A rope (`E.String.next`) links 8-bit strings so `"a" + "b" + ...` folds without a copy. Ropes are 8-bit only, so a UTF-16 join copies, hence the cap.
- A define swaps an identifier for a pre-built expression during the visit pass, so its strings fold like source literals.

<details><summary>Notes</summary>

- Full runs: the five files above, `bundler_string`, `template-literal`, `transpiler-cache`, `bundler_edgecase`, `bun-build-api`, the TOML suites, and esbuild `default`/`ts`/`dce`.
- #38989 and #39072 make two folders (`.length` of a rope, `to_number`) decline on 8-bit non-ASCII strings. They stay useful as defense. This PR fixes the producers, so equality folds and `case` elimination also see the right value.
- `env_string_store_put` now copies the value bytes into the define arena. #37784 does the same copy for a use-after-free when a proxy env var is written after the table is built; its tests still apply.
- `hash_user_inputs` (`src/js_parser/lib.rs`) hashes an encoding tag before each env value: the UTF-16LE bytes of `"中"` are the 8-bit bytes of `"-N"`.
- `JSTranspiler` `exports.replace` string values go through the same helper.
- Two existing expectations in `transpiler.test.js` encoded the old limit: `"\uD800" + "\uDF34"` now folds to `"\uD800\uDF34"` (the same code units as at run time) and `("æ" + "™").length` folds to `2`.
- `import.meta.url` is inlined percent-encoded (ASCII) and is unchanged. JSON and TOML module imports are not visited, so their 8-bit strings never reach a folder.
- Bun prints the regexp `/é/` as `/\u00E9/`, so `String(/é/)` differs from node at run time (#33866). The fold of `/é/ + "x"` uses the source text, as node does.
- Repro matrix from the report with `U="é😀"`: `[U[0], U[1], `${U}`.length, U.length, (U + "")[0]]` was `["\0","©",6,3,"\0"]`, now `["é","\ud83d",3,3,"é"]`, same as node and 1.3.14.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->