### PR TITLE
html dev server: keep an explicit port, warn when the default port moves

### DIFF
--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -268,18 +268,22 @@ yourself with Bun.serve().
       if (error?.syscall !== "listen") throw error;
 
       let message: string = error.message;
-      if (error.code === "EADDRINUSE" && typeof error.port === "number" && !portIsPinned(error.port)) {
-        const refusedPort: number = error.port;
+      const { code, port: refusedPort } = error;
+      if (code === "EADDRINUSE" && typeof refusedPort === "number" && !portIsPinned(refusedPort)) {
         const lastCandidate = Math.min(refusedPort + 10, 65535);
         portInUse = refusedPort;
+        message = `Ports ${refusedPort} to ${lastCandidate} are all in use.`;
         for (let candidate = refusedPort + 1; candidate <= lastCandidate; candidate++) {
           try {
             return serve(candidate);
           } catch (error: any) {
-            if (error?.code !== "EADDRINUSE") throw error;
+            if (error?.syscall !== "listen") throw error;
+            if (error.code !== "EADDRINUSE") {
+              message = error.message;
+              break;
+            }
           }
         }
-        message = `Ports ${refusedPort} to ${lastCandidate} are all in use.`;
       }
 
       console.error(enableANSIColors ? `\x1b[31merror\x1b[0m\x1b[2m:\x1b[0m ${message}` : `error: ${message}`);

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -219,69 +219,85 @@ yourself with Bun.serve().
     },
     {} as Record<string, HTMLBundle>,
   );
-  var server: Server;
-  getServer: {
-    try {
-      server = Bun.serve({
-        static: staticRoutes,
-        development:
-          env.NODE_ENV !== "production"
-            ? {
-                console: enableConsoleLog,
-                hmr: undefined,
-              }
-            : false,
+  const enableANSIColors = Bun.enableANSIColors;
 
-        hostname,
-        port,
+  // A port named by a flag or an environment variable stays fixed: a proxy,
+  // a test runner or a container mapping may have been given the same number.
+  // Only a default port (3000, or `serve.port` in bunfig.toml) moves to the
+  // next free one when it is taken.
+  function portIsPinned(refusedPort: number) {
+    return (
+      // --port, --host=<host>:<port> after the entry point
+      port !== undefined ||
+      // bun --port=<port> ./index.html
+      process.execArgv.some(arg => arg === "--port" || arg.startsWith("--port=")) ||
+      // the variables Bun.serve() reads, when one of them is where the port came from
+      [env.BUN_PORT, env.PORT, env.NODE_PORT].some(value => value !== undefined && Number(value) === refusedPort)
+    );
+  }
 
-        // use the default port via existing port detection code.
-        // port: 3000,
-
-        fetch(_req: Request) {
-          return new Response("Not found", { status: 404 });
-        },
-      });
-      break getServer;
-    } catch (error: any) {
-      if (error?.code === "EADDRINUSE") {
-        let defaultPort = port || parseInt(env.PORT || env.BUN_PORT || env.NODE_PORT || "3000", 10);
-        for (let remainingTries = 5; remainingTries > 0; remainingTries--) {
-          try {
-            server = Bun.serve({
-              static: staticRoutes,
-              development:
-                env.NODE_ENV !== "production"
-                  ? {
-                      console: enableConsoleLog,
-                      hmr: undefined,
-                    }
-                  : false,
-
-              hostname,
-
-              // Retry with a different port up to 4 times.
-              port: defaultPort++,
-
-              fetch(_req: Request) {
-                return new Response("Not found", { status: 404 });
-              },
-            });
-            break getServer;
-          } catch (error: any) {
-            if (error?.code === "EADDRINUSE") {
-              continue;
+  function serve(port: number | undefined) {
+    return Bun.serve({
+      static: staticRoutes,
+      development:
+        env.NODE_ENV !== "production"
+          ? {
+              console: enableConsoleLog,
+              hmr: undefined,
             }
-            throw error;
+          : false,
+
+      hostname,
+
+      // When undefined, Bun.serve() picks the port: BUN_PORT/PORT/NODE_PORT,
+      // `bun --port`, `serve.port` in bunfig.toml, else 3000.
+      port,
+
+      fetch(_req: Request) {
+        return new Response("Not found", { status: 404 });
+      },
+    });
+  }
+
+  let portInUse: number | undefined;
+  function listen(): Server | undefined {
+    try {
+      return serve(port);
+    } catch (error: any) {
+      // Anything but a refused bind is a bug worth a stack trace.
+      if (error?.syscall !== "listen") throw error;
+
+      let message: string = error.message;
+      if (error.code === "EADDRINUSE" && typeof error.port === "number" && !portIsPinned(error.port)) {
+        const refusedPort: number = error.port;
+        const lastCandidate = Math.min(refusedPort + 10, 65535);
+        portInUse = refusedPort;
+        for (let candidate = refusedPort + 1; candidate <= lastCandidate; candidate++) {
+          try {
+            return serve(candidate);
+          } catch (error: any) {
+            if (error?.code !== "EADDRINUSE") throw error;
           }
         }
+        message = `Ports ${refusedPort} to ${lastCandidate} are all in use.`;
       }
 
-      throw error;
+      console.error(enableANSIColors ? `\x1b[31merror\x1b[0m\x1b[2m:\x1b[0m ${message}` : `error: ${message}`);
+      // Not process.exit(): under --watch/--hot the process stays up and the
+      // next reload tries again, like any other entry point that fails.
+      process.exitCode = 1;
+      return undefined;
     }
   }
+  const server = listen();
+  if (!server) return;
+
+  if (portInUse !== undefined) {
+    const message = `Port ${portInUse} is in use, using port ${server.port} instead.`;
+    console.warn(enableANSIColors ? `\x1b[33mwarn\x1b[0m\x1b[2m:\x1b[0m ${message}` : `warn: ${message}`);
+  }
+
   const elapsed = (performance.now() - initial).toFixed(2);
-  const enableANSIColors = Bun.enableANSIColors;
   function printInitialMessage(isFirst: boolean) {
     let pathnameToPrint;
     if (servePaths.length === 1) {

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -221,10 +221,7 @@ yourself with Bun.serve().
   );
   const enableANSIColors = Bun.enableANSIColors;
 
-  // A port named by a flag or an environment variable stays fixed: a proxy,
-  // a test runner or a container mapping may have been given the same number.
-  // Only a default port (3000, or `serve.port` in bunfig.toml) moves to the
-  // next free one when it is taken.
+  // A port somebody asked for stays fixed. Only a default (3000, bunfig `serve.port`) may move.
   function portIsPinned(refusedPort: number) {
     return (
       // --port, --host=<host>:<port> after the entry point
@@ -249,8 +246,7 @@ yourself with Bun.serve().
 
       hostname,
 
-      // When undefined, Bun.serve() picks the port: BUN_PORT/PORT/NODE_PORT,
-      // `bun --port`, `serve.port` in bunfig.toml, else 3000.
+      // undefined: Bun.serve() resolves BUN_PORT/PORT/NODE_PORT, `bun --port`, bunfig `serve.port`, else 3000
       port,
 
       fetch(_req: Request) {
@@ -287,8 +283,7 @@ yourself with Bun.serve().
       }
 
       console.error(enableANSIColors ? `\x1b[31merror\x1b[0m\x1b[2m:\x1b[0m ${message}` : `error: ${message}`);
-      // Not process.exit(): under --watch/--hot the process stays up and the
-      // next reload tries again, like any other entry point that fails.
+      // No process.exit(): --watch/--hot keep the process up for the next reload.
       process.exitCode = 1;
       return undefined;
     }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1991,8 +1991,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 port,
                 hostname: _hostname,
             } => {
-                // Same own property as node's listen errors, so a caller that let
-                // Bun.serve() pick the port can tell which one was refused.
+                // `err.port`, as on node's listen errors.
                 let with_port = |error_instance: JSValue| {
                     if *port != 0 {
                         error_instance.put(

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1991,6 +1991,18 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 port,
                 hostname: _hostname,
             } => {
+                // Same own property as node's listen errors, so a caller that let
+                // Bun.serve() pick the port can tell which one was refused.
+                let with_port = |error_instance: JSValue| {
+                    if *port != 0 {
+                        error_instance.put(
+                            global,
+                            b"port",
+                            JSValue::js_number_from_int32(i32::from(*port)),
+                        );
+                    }
+                    error_instance
+                };
                 // Rust's `target_os = "linux"` excludes
                 // Android, so match both explicitly.
                 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -2011,7 +2023,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             syscall: bun_core::String::static_("listen"),
                             ..Default::default()
                         };
-                        let _ = global.throw_value(err.to_error_instance(global));
+                        let _ = global.throw_value(with_port(err.to_error_instance(global)));
                         return;
                     }
                     // e.g. ENOSPC from epoll_ctl(EPOLL_CTL_ADD). Linux-only because
@@ -2022,20 +2034,22 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             bun_sys::Error::from_code(errno, bun_sys::Tag::listen)
                                 .to_system_error(),
                         );
-                        let _ = global.throw_value(err.to_error_instance(global));
+                        let _ = global.throw_value(with_port(err.to_error_instance(global)));
                         return;
                     }
                 }
-                jsc::SystemError {
-                    message: bun_core::String::create_format(format_args!(
-                        "Failed to start server. Is port {} in use?",
-                        port
-                    )),
-                    code: bun_core::String::static_("EADDRINUSE"),
-                    syscall: bun_core::String::static_("listen"),
-                    ..Default::default()
-                }
-                .to_error_instance(global)
+                with_port(
+                    jsc::SystemError {
+                        message: bun_core::String::create_format(format_args!(
+                            "Failed to start server. Is port {} in use?",
+                            port
+                        )),
+                        code: bun_core::String::static_("EADDRINUSE"),
+                        syscall: bun_core::String::static_("listen"),
+                        ..Default::default()
+                    }
+                    .to_error_instance(global),
+                )
             }
             server_config::Address::Unix(unix) => {
                 let unix = unix.as_bytes();

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,5 +1,5 @@
 import type { Subprocess } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
@@ -714,4 +714,107 @@ test.concurrent("subdirectory routes use forward slashes on Windows", async () =
   const buttons = await fetch(new URL("/components/buttons", serverUrl));
   expect(buttons.status).toBe(200);
   expect(await buttons.text()).toContain("<title>Buttons</title>");
+});
+
+describe("when the port is in use", () => {
+  // No PORT-like variable may leak in from the environment: each test picks
+  // exactly one way to name (or not name) the port.
+  const { PORT: _1, BUN_PORT: _2, NODE_PORT: _3, ...cleanEnv } = bunEnv;
+  const env = { ...cleanEnv, NODE_ENV: "production", NO_COLOR: "1" };
+  const files = { "index.html": `<!DOCTYPE html><html><body><h1>Hello</h1></body></html>` };
+
+  // Holds a port that still has room above it: the fallback walks upward and
+  // stops at 65535.
+  function takePort() {
+    for (;;) {
+      const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("taken") });
+      if (server.port <= 65500) return server;
+      server.stop(true);
+    }
+  }
+
+  // Reads stdout until the dev server prints its URL or exits. The unfixed
+  // behaviour (serving on another port) shows up as a URL here instead of
+  // as a test timeout.
+  async function urlOrExit(proc: Subprocess<"ignore", "pipe", "pipe">) {
+    const decoder = new TextDecoder();
+    let stdout = "";
+    for await (const chunk of proc.stdout) {
+      stdout += decoder.decode(chunk, { stream: true });
+      const match = stdout.match(/http:\/\/\S+/);
+      if (match && URL.canParse(match[0])) return { stdout, url: new URL(match[0]) };
+    }
+    return { stdout, url: undefined };
+  }
+
+  test.concurrent("an explicit --port fails instead of moving to another port", async () => {
+    using taken = takePort();
+    await using dir = tempDir("html-port-taken-flag", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.html", `--port=${taken.port}`, "--hostname=127.0.0.1"],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const { url } = await urlOrExit(proc);
+    if (url) proc.kill();
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(url?.href).toBeUndefined();
+    expect(stderr.trim()).toBe(`error: Failed to start server. Is port ${taken.port} in use?`);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("an explicit PORT fails instead of moving to another port", async () => {
+    using taken = takePort();
+    await using dir = tempDir("html-port-taken-env", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.html", "--hostname=127.0.0.1"],
+      env: { ...env, PORT: String(taken.port) },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const { url } = await urlOrExit(proc);
+    if (url) proc.kill();
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(url?.href).toBeUndefined();
+    expect(stderr.trim()).toBe(`error: Failed to start server. Is port ${taken.port} in use?`);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("a default port moves to the next free one and says so", async () => {
+    using taken = takePort();
+    // `serve.port` replaces the built-in default of 3000, so this exercises the
+    // same path as a taken port 3000 without depending on that port in CI.
+    await using dir = tempDir("html-port-taken-default", {
+      ...files,
+      "bunfig.toml": `[serve]\nport = ${taken.port}\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.html", "--hostname=127.0.0.1"],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const { url, stdout } = await urlOrExit(proc);
+    expect(url?.href, stdout).toBeDefined();
+    try {
+      const response = await fetch(url!);
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("<h1>Hello</h1>");
+    } finally {
+      proc.kill();
+    }
+    const stderr = await proc.stderr.text();
+
+    expect(Number(url!.port)).not.toBe(taken.port);
+    expect(stderr.trim()).toBe(`warn: Port ${taken.port} is in use, using port ${url!.port} instead.`);
+  });
 });

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
 async function getServerUrl(process: Subprocess) {
@@ -741,7 +741,8 @@ describe("when the port is in use", () => {
     let stdout = "";
     for await (const chunk of proc.stdout) {
       stdout += decoder.decode(chunk, { stream: true });
-      const match = stdout.match(/http:\/\/\S+/);
+      // only a whole line, so a chunk boundary cannot cut the port short
+      const match = stdout.match(/http:\/\/\S+(?=\n)/);
       if (match && URL.canParse(match[0])) return { stdout, url: new URL(match[0]) };
     }
     return { stdout, url: undefined };
@@ -806,9 +807,16 @@ describe("when the port is in use", () => {
     const { url, stdout } = await urlOrExit(proc);
     expect(url?.href, stdout).toBeDefined();
     try {
-      const response = await fetch(url!);
-      expect(response.status).toBe(200);
-      expect(await response.text()).toContain("<h1>Hello</h1>");
+      // Not on Windows: `taken` sits in the dynamic port range there, and Windows
+      // can hand the child's explicitly bound fallback port to a concurrent
+      // `port: 0` listener in another process as well (netstat then shows two
+      // LISTENING rows for 127.0.0.1:<port>), so a fetch may reach the wrong
+      // server. Real default ports (3000) are outside that range.
+      if (!isWindows) {
+        const response = await fetch(url!);
+        expect(response.status).toBe(200);
+        expect(await response.text()).toContain("<h1>Hello</h1>");
+      }
     } finally {
       proc.kill();
     }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2673,6 +2673,29 @@ it("should support promise returned from error", async () => {
   subprocess.kill();
 });
 
+it("EADDRINUSE error names the port that was refused", () => {
+  using first = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: () => new Response("first"),
+  });
+  let error: any;
+  try {
+    using second = Bun.serve({
+      port: first.port,
+      hostname: "127.0.0.1",
+      fetch: () => new Response("second"),
+    });
+  } catch (e) {
+    error = e;
+  }
+  expect({ code: error?.code, syscall: error?.syscall, port: error?.port }).toEqual({
+    code: "EADDRINUSE",
+    syscall: "listen",
+    port: first.port,
+  });
+});
+
 if (process.platform === "linux")
   it("should use correct error when using a root range port(#7187)", () => {
     expect(() => {


### PR DESCRIPTION
### Problem
- `bun ./index.html --port=N` serves on N+1 when N is in use, with no notice. `PORT=N` does the same, and `bun --port=N ./index.html` falls back to 3000. `Bun.serve({ port: N })` throws `EADDRINUSE`. Anything that was told N talks to the wrong server.
- The cause is the retry loop in `src/js/internal/html.ts:246`. It retried `port + 1` five times whatever named the port. Its fallback came from its own argv/env parse, which never saw `bun --port`.

### Fix
- A port named by `--port`, `--host=h:N`, `bun --port`, `PORT`, `BUN_PORT` or `NODE_PORT` stays fixed. On `EADDRINUSE` it prints `error: Failed to start server. Is port N in use?` and exits 1, as `next dev` does.
- Only a default port moves: 3000, or bunfig `serve.port`. It tries the next 10 ports and prints `warn: Port N is in use, using port M instead.` to stderr.
- The TCP listen errors from `Bun.serve()` gain a `port` own property, like node's listen errors. The wrapper reads it instead of repeating the port lookup.
- Verified: `test/js/bun/http/bun-serve-html-entry.test.ts` (3 new tests, all fail on stock bun) and one in `serve.test.ts`. Self-reviewed: 4 concerns, 3 addressed, 1 deferred (Notes).

### Background
- `bun ./index.html` runs `src/js/internal/html.ts`, a wrapper that imports the HTML files as `HTMLBundle`s and calls `Bun.serve({ static })`. Flags after the entry are in `process.argv`, those before it in `process.execArgv`.
- With `port` undefined, `Bun.serve()` picks it: the env vars, then `bun --port` or bunfig `serve.port`, else 3000. The wrapper cannot see the bunfig value, hence `port` on the error.

<details><summary>Notes</summary>

- Found by an automated browser-execution differential of the HTML bundler, not by a user report. Reproduced on bun 1.4.3 (canary f42e98025), Linux x64, with the port held by a plain `socket.listen()`:
  - `bun ./index.html --port=41321` -> `url: http://127.0.0.1:41322/`, exit 0
  - `PORT=41321 bun ./index.html` -> 41322, same for `--host=127.0.0.1:41321` and `BUN_PORT`
  - `bun --port=41321 ./index.html` -> `url: http://127.0.0.1:3000/`
  - bunfig `[serve] port = 41321` -> 3000
- After the change (debug build): the explicit forms print the one-line error and exit 1. A taken default 3000 serves on 3001 with `warn: Port 3000 is in use, using port 3001 instead.` A taken bunfig `serve.port` walks up from that port. `--hostname=h:N` counts as explicit too.
- The port lookup lives in `src/runtime/server/ServerConfig.rs:647` (`BUN_PORT`, `PORT`, `NODE_PORT`, then `transform_options.port`, which both `bun --port` and bunfig `serve.port` set). An environment variable pins the port only when its value is the port that was refused, so `PORT=abc` (which `Bun.serve()` ignores) still gets the default-port fallback instead of a confusing error about port 3000.
- bunfig `serve.port` is documented as "the default port for `Bun.serve`", so it is treated as a movable default, not a pinned port.
- Any other listen failure (`EACCES` on a privileged port, for example) now prints its message on one line and exits 1 too, instead of a stack trace into `internal:html`. This also holds for a fallback candidate during the walk. Errors that are not listen failures are still thrown.
- The fallback test does not fetch the fallback server on Windows. The held port comes from `port: 0` and so sits in the Windows dynamic range, and Windows can hand the child's explicitly bound fallback port to a concurrent `port: 0` listener in another process as well (`netstat` showed two LISTENING rows for `127.0.0.1:<port>` from two PIDs on the CI image). A fetch can then reach the other server. Real default ports such as 3000 are outside that range. The warn line and the banner port are still asserted there.
- The warn line goes to stderr so it survives a piped stdout (the harness that found this ran `bun ./index.html | grep url:`).
- The fallback test sets bunfig `serve.port` to a port the test holds, so it exercises the default-port path without touching port 3000 in CI.
- The old loop retried the refused port once more before moving on (`defaultPort++` started at the same number). The new loop starts at N+1 and stops at 65535.
- Under `--watch`/`--hot` a pinned port that is in use leaves the process up for the next reload, as for any failing entry point.
- Review concerns: (1) `process.exit(1)` killed `--watch`/`--hot` sessions that used to stay alive on a failing entry: addressed, the wrapper now sets `process.exitCode` and returns. (2) `port` was only on the `EADDRINUSE` branch: addressed, all three TCP branches carry it. (3) An invalid or late-set `PORT` made the wrapper report a port it never asked for: addressed by the value match above. (4) The new stderr lines key their styling on `Bun.enableANSIColors` (stdout or stderr is a TTY), like the rest of this file. #41887 adds per-fd flags for built-in JS. Whichever lands second should key these two lines on the stderr flag. Deferred to that sequencing.
- Not addressed here: `address` on the listen error (node has it). `Bun.serve()` may bind several addresses for one hostname, so there is no single obvious value. Left for a follow-up if wanted.
- This does not fix #18132 (dual-stack `localhost` binds that hide a conflict). #36710 is the complementary usockets change. The new tests pass `--hostname=127.0.0.1` for that reason.
- Under `--hot`, if the process that held a default port goes away and the HTML file is edited, the reload binds the original port and the fallback listener stays open. Stock bun does the same. Out of scope.
- Both touched test files pass in full with the debug build (the pre-existing root-port EACCES test needs a non-root user).
- Out of scope, tracked separately: an error thrown by `html.ts`'s `start()` after its first `await` is reported twice (visible with `bun ./index.html --port=99999`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts, test/js/bun/http/bun-serve-html-entry.test.ts

<!-- robobun:evidence:end -->