### PR TITLE
Bun.serve: do not re-derive a Content-Type the handler deleted from the Response

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -165,13 +165,10 @@ impl FileRoute {
                     "expected blob not to be heap-allocated"
                 );
                 *body_value = BodyValue::Blob(blob.dupe());
-                // See `Response::headers_own_content_type`: a Content-Type missing
-                // from such a header list was deleted by the user.
-                let headers = if response.headers_own_content_type() {
-                    bun_http_jsc::headers_jsc::from_fetch_headers(response.get_init_headers(), None)
-                } else {
-                    headers_from(response.get_init_headers(), &blob)
-                };
+                let headers = bun_http_jsc::headers_jsc::from_fetch_headers(
+                    response.get_init_headers(),
+                    response.body_content_type(blob_content_type(&blob)),
+                );
                 let status_code = response.status_code();
 
                 return Ok(Some(RefPtr::new(FileRoute::new(

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -165,7 +165,13 @@ impl FileRoute {
                     "expected blob not to be heap-allocated"
                 );
                 *body_value = BodyValue::Blob(blob.dupe());
-                let headers = headers_from(response.get_init_headers(), &blob);
+                // See `Response::headers_own_content_type`: a Content-Type missing
+                // from such a header list was deleted by the user.
+                let headers = if response.headers_own_content_type() {
+                    bun_http_jsc::headers_jsc::from_fetch_headers(response.get_init_headers(), None)
+                } else {
+                    headers_from(response.get_init_headers(), &blob)
+                };
                 let status_code = response.status_code();
 
                 return Ok(Some(RefPtr::new(FileRoute::new(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3799,8 +3799,12 @@ where
             blob.size()
         };
 
-        let (content_type, needs_content_type, content_type_needs_free) =
-            get_content_type(response.get_init_headers_mut(), blob);
+        let headers_own_content_type = response.headers_own_content_type();
+        let (content_type, needs_content_type, content_type_needs_free) = get_content_type(
+            response.get_init_headers_mut(),
+            headers_own_content_type,
+            blob,
+        );
         // NOTE: `MimeType` owns a `Cow<'static, [u8]>`; Drop handles the owned case.
         // Hold the value past all reads below, then let it drop at scope end.
         let _ct_guard = scopeguard::guard(content_type_needs_free, |_needs| {
@@ -4788,7 +4792,15 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
     }
 }
 
-fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (MimeType, bool, bool) {
+/// `headers_own_content_type` is [`Response::headers_own_content_type`]: the
+/// header list is the only source of the Content-Type, so when it has none the
+/// handler removed it and none is sent. The returned `MimeType` still describes
+/// the body (for `autoset_filename`).
+fn get_content_type(
+    headers: Option<&mut FetchHeaders>,
+    headers_own_content_type: bool,
+    blob: &AnyBlob,
+) -> (MimeType, bool, bool) {
     let mut needs_content_type = true;
     let mut content_type_needs_free = false;
 
@@ -4807,6 +4819,9 @@ fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (Mime
                 );
                 drop(content_slice);
                 break 'brk mt;
+            }
+            if headers_own_content_type {
+                needs_content_type = false;
             }
         }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3799,12 +3799,8 @@ where
             blob.size()
         };
 
-        let headers_own_content_type = response.headers_own_content_type();
-        let (content_type, needs_content_type, content_type_needs_free) = get_content_type(
-            response.get_init_headers_mut(),
-            headers_own_content_type,
-            blob,
-        );
+        let (content_type, needs_content_type, content_type_needs_free) =
+            get_content_type(response, blob);
         // NOTE: `MimeType` owns a `Cow<'static, [u8]>`; Drop handles the owned case.
         // Hold the value past all reads below, then let it drop at scope end.
         let _ct_guard = scopeguard::guard(content_type_needs_free, |_needs| {
@@ -4792,20 +4788,18 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
     }
 }
 
-/// `headers_own_content_type` is [`Response::headers_own_content_type`]: the
-/// header list is the only source of the Content-Type, so when it has none the
-/// handler removed it and none is sent. The returned `MimeType` still describes
-/// the body (for `autoset_filename`).
-fn get_content_type(
-    headers: Option<&mut FetchHeaders>,
-    headers_own_content_type: bool,
-    blob: &AnyBlob,
-) -> (MimeType, bool, bool) {
+/// `(content_type, needs_content_type, content_type_needs_free)` for framing
+/// `blob`, the body already moved out of `response`. `needs_content_type` is
+/// `false` when `do_write_headers` sends the handler's own Content-Type, and
+/// when the handler deleted it ([`Response::headers_own_content_type`]): then
+/// none is sent, but `content_type` still describes the body for
+/// `autoset_filename`.
+fn get_content_type(response: &Response, blob: &AnyBlob) -> (MimeType, bool, bool) {
     let mut needs_content_type = true;
     let mut content_type_needs_free = false;
 
     let content_type: MimeType = 'brk: {
-        if let Some(headers_) = headers {
+        if let Some(headers_) = response.get_init_headers_mut() {
             if let Some(content) = headers_.fast_get(jsc::HTTPHeaderName::ContentType) {
                 needs_content_type = false;
 
@@ -4820,7 +4814,7 @@ fn get_content_type(
                 drop(content_slice);
                 break 'brk mt;
             }
-            if headers_own_content_type {
+            if response.headers_own_content_type() {
                 needs_content_type = false;
             }
         }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4788,12 +4788,7 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
     }
 }
 
-/// `(content_type, needs_content_type, content_type_needs_free)` for framing
-/// `blob`, the body already moved out of `response`. `needs_content_type` is
-/// `false` when `do_write_headers` sends the handler's own Content-Type, and
-/// when the handler deleted it ([`Response::headers_own_content_type`]): then
-/// none is sent, but `content_type` still describes the body for
-/// `autoset_filename`.
+/// `needs_content_type` is false when the headers carry one or the handler deleted it; the `MimeType` always describes `blob`.
 fn get_content_type(response: &Response, blob: &AnyBlob) -> (MimeType, bool, bool) {
     let mut needs_content_type = true;
     let mut content_type_needs_free = false;

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -214,18 +214,23 @@ impl StaticRoute {
             // Consuming the body left a plain `Blob` behind, which no longer implies
             // the `text/plain` a string body carried. Record it on the response's own
             // headers so re-registering the same `Response` serves the same type.
-            if was_string {
-                let text_mime = bun_http_types::MimeType::TEXT;
-                response.get_or_create_headers(global_this)?.put_default(
-                    HTTPHeaderName::ContentType,
-                    &bun_core::String::ascii(text_mime.value.as_ref()),
+            if was_string && !response.headers_own_content_type() {
+                response.put_default_content_type(
                     global_this,
+                    bun_http_types::MimeType::TEXT.value.as_ref(),
                 )?;
             }
 
+            // See `Response::headers_own_content_type`: a Content-Type missing
+            // from such a header list was deleted by the user.
+            let body_content_type = if response.headers_own_content_type() {
+                None
+            } else {
+                any_blob_content_type(&blob)
+            };
             let mut headers: Headers = bun_http_jsc::headers_jsc::from_fetch_headers(
                 response.get_init_headers(),
-                any_blob_content_type(&blob),
+                body_content_type,
             );
 
             // Generate ETag if not already present

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -221,16 +221,9 @@ impl StaticRoute {
                 )?;
             }
 
-            // See `Response::headers_own_content_type`: a Content-Type missing
-            // from such a header list was deleted by the user.
-            let body_content_type = if response.headers_own_content_type() {
-                None
-            } else {
-                any_blob_content_type(&blob)
-            };
             let mut headers: Headers = bun_http_jsc::headers_jsc::from_fetch_headers(
                 response.get_init_headers(),
-                body_content_type,
+                response.body_content_type(any_blob_content_type(&blob)),
             );
 
             // Generate ETag if not already present

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -629,17 +629,33 @@ impl Response {
         Ok(())
     }
 
-    /// Whether a server must take this response's Content-Type from the header
-    /// list alone. `true` once the list has held one: supplied in the init,
-    /// copied from a typed body (`Blob` with a `type`, `FormData`,
-    /// `URLSearchParams`, `Bun.file()`), or set by `Response.json()`. If the
-    /// list then has no Content-Type the user deleted it, so deriving one from
-    /// the body again would undo that. While `false` (a string or untyped body,
-    /// or headers never materialized) the server may still default one from
-    /// the body.
+    /// Whether this response's Content-Type comes from the header list alone.
+    /// `true` once the list has held one: supplied in the init, copied from a
+    /// typed body (`Blob` with a `type`, `FormData`, `URLSearchParams`,
+    /// `Bun.file()`), or set by `Response.json()`. If the list then has no
+    /// Content-Type the user deleted it, and deriving one from the body again
+    /// would undo that. While `false` (a string or untyped body, or headers
+    /// never materialized) the body may still supply one. Every reader of the
+    /// Content-Type (the `Bun.serve` send paths, `formData()`,
+    /// `WebAssembly.compileStreaming`) goes through [`body_content_type`] or
+    /// [`get_content_type`] so they agree.
     #[inline]
     pub(crate) fn headers_own_content_type(&self) -> bool {
         self.init.get().headers_own_content_type
+    }
+
+    /// The Content-Type that `body` (this response's body, which a server may
+    /// already have moved out) still contributes: `None` once the header list
+    /// owns the Content-Type, else `body_content_type` unless it is empty.
+    #[inline]
+    pub(crate) fn body_content_type<'b>(
+        &self,
+        body_content_type: Option<&'b [u8]>,
+    ) -> Option<&'b [u8]> {
+        if self.headers_own_content_type() {
+            return None;
+        }
+        body_content_type.filter(|content_type| !content_type.is_empty())
     }
 
     pub(crate) fn get_headers(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
@@ -655,14 +671,11 @@ impl Response {
             }
         }
 
-        if let BodyValue::Blob(blob) = self.body.get().value.get() {
-            let content_type = blob.content_type_slice();
-            if !content_type.is_empty() {
-                return Ok(Some(Utf8Bytes::Borrowed(content_type)));
-            }
-        }
-
-        Ok(None)
+        let from_body = match self.body.get().value.get() {
+            BodyValue::Blob(blob) => Some(blob.content_type_slice()),
+            _ => None,
+        };
+        Ok(self.body_content_type(from_body).map(Utf8Bytes::Borrowed))
     }
 }
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -367,9 +367,8 @@ impl Response {
     }
 
     /// R-2 `JsCell` escape hatch — single-JS-thread invariant. Centralises the
-    /// `unsafe { self.init.get_mut() }` deref so the call sites
-    /// ([`get_init_headers_mut`], [`clone_init_headers`],
-    /// [`get_or_create_headers`], [`put_default_content_type`],
+    /// `unsafe { self.init.get_mut() }` deref so the four call sites
+    /// ([`get_init_headers_mut`], [`header`], [`get_or_create_headers`],
     /// [`get_content_type`]) read it as a plain `&mut Init`.
     ///
     /// # Safety (encapsulated)
@@ -613,8 +612,7 @@ impl Response {
         Ok(init.headers.as_mut().unwrap())
     }
 
-    /// `put_default` a Content-Type on the (created if needed) header list and
-    /// hand ownership of the Content-Type to it.
+    /// `put_default` a Content-Type, after which the header list owns the Content-Type.
     pub(crate) fn put_default_content_type(
         &self,
         global_this: &JSGlobalObject,
@@ -629,24 +627,13 @@ impl Response {
         Ok(())
     }
 
-    /// Whether this response's Content-Type comes from the header list alone.
-    /// `true` once the list has held one: supplied in the init, copied from a
-    /// typed body (`Blob` with a `type`, `FormData`, `URLSearchParams`,
-    /// `Bun.file()`), or set by `Response.json()`. If the list then has no
-    /// Content-Type the user deleted it, and deriving one from the body again
-    /// would undo that. While `false` (a string or untyped body, or headers
-    /// never materialized) the body may still supply one. Every reader of the
-    /// Content-Type (the `Bun.serve` send paths, `formData()`,
-    /// `WebAssembly.compileStreaming`) goes through [`body_content_type`] or
-    /// [`get_content_type`] so they agree.
+    /// See [`Init::headers_own_content_type`]: when `true`, a missing Content-Type header was deleted by the user.
     #[inline]
     pub(crate) fn headers_own_content_type(&self) -> bool {
         self.init.get().headers_own_content_type
     }
 
-    /// The Content-Type that `body` (this response's body, which a server may
-    /// already have moved out) still contributes: `None` once the header list
-    /// owns the Content-Type, else `body_content_type` unless it is empty.
+    /// `body_content_type` (the body may already be moved out) unless the header list owns the Content-Type.
     #[inline]
     pub(crate) fn body_content_type<'b>(
         &self,
@@ -1239,11 +1226,7 @@ pub struct Init {
     pub(crate) status_code: u16,
     pub(crate) status_text: BunString,
     pub method: Method,
-    /// `headers` held a Content-Type when it was attached (the init supplied
-    /// one) or Bun has since put the body's type into it. From then on the
-    /// header list is the only source of this response's Content-Type: when a
-    /// server finds none there the user removed it, and the body's type must
-    /// not be derived again. See [`Response::headers_own_content_type`].
+    /// `headers` has held a Content-Type (init, typed body, `Response.json`): never derive one from the body again.
     pub(crate) headers_own_content_type: bool,
 }
 
@@ -1318,8 +1301,7 @@ impl Init {
                 // JS wrapper cell; rooted by `response_init` for this call.
                 let resp = unsafe { &*resp };
                 let mut init = resp.init.get().clone(global_this)?;
-                // The donor's flag describes the donor's body, not the one this
-                // init is about to be paired with.
+                // The donor's flag describes the donor's body; the constructor recomputes it.
                 init.headers_own_content_type = false;
                 return Ok(Some(init));
             }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -367,8 +367,9 @@ impl Response {
     }
 
     /// R-2 `JsCell` escape hatch — single-JS-thread invariant. Centralises the
-    /// `unsafe { self.init.get_mut() }` deref so the four call sites
-    /// ([`get_init_headers_mut`], [`header`], [`get_or_create_headers`],
+    /// `unsafe { self.init.get_mut() }` deref so the call sites
+    /// ([`get_init_headers_mut`], [`clone_init_headers`],
+    /// [`get_or_create_headers`], [`put_default_content_type`],
     /// [`get_content_type`]) read it as a plain `&mut Init`.
     ///
     /// # Safety (encapsulated)
@@ -604,11 +605,41 @@ impl Response {
                         &BunString::ascii(content_type),
                         global_this,
                     )?;
+                    init.headers_own_content_type = true;
                 }
             }
         }
 
         Ok(init.headers.as_mut().unwrap())
+    }
+
+    /// `put_default` a Content-Type on the (created if needed) header list and
+    /// hand ownership of the Content-Type to it.
+    pub(crate) fn put_default_content_type(
+        &self,
+        global_this: &JSGlobalObject,
+        content_type: &[u8],
+    ) -> JsResult<()> {
+        self.get_or_create_headers(global_this)?.put_default(
+            HTTPHeaderName::ContentType,
+            &BunString::ascii(content_type),
+            global_this,
+        )?;
+        self.init_mut().headers_own_content_type = true;
+        Ok(())
+    }
+
+    /// Whether a server must take this response's Content-Type from the header
+    /// list alone. `true` once the list has held one: supplied in the init,
+    /// copied from a typed body (`Blob` with a `type`, `FormData`,
+    /// `URLSearchParams`, `Bun.file()`), or set by `Response.json()`. If the
+    /// list then has no Content-Type the user deleted it, so deriving one from
+    /// the body again would undo that. While `false` (a string or untyped body,
+    /// or headers never materialized) the server may still default one from
+    /// the body.
+    #[inline]
+    pub(crate) fn headers_own_content_type(&self) -> bool {
+        self.init.get().headers_own_content_type
     }
 
     pub(crate) fn get_headers(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
@@ -927,13 +958,8 @@ impl Response {
             }
         }
 
-        let headers_ref = response.get_or_create_headers(global_this)?;
-        let json_mime = bun_http_types::MimeType::JSON;
-        headers_ref.put_default(
-            HTTPHeaderName::ContentType,
-            &BunString::ascii(json_mime.value.as_ref()),
-            global_this,
-        )?;
+        response
+            .put_default_content_type(global_this, bun_http_types::MimeType::JSON.value.as_ref())?;
         // Disarm the body-reset guard: all fallible ops have succeeded.
         let response = scopeguard::ScopeGuard::into_inner(response);
         // Ownership transfers to the JSC wrapper (freed via `finalize`).
@@ -1154,17 +1180,20 @@ impl Response {
         // Perform the only remaining fallible op BEFORE heap-allocating:
         // doing it on stack locals lets `?` trigger the scopeguard and
         // `init`'s drop glue and avoids leaking the heap allocation entirely.
-        if let BodyValue::Blob(blob) = body.value.get() {
-            if let Some(headers) = init.headers.as_deref_mut() {
+        if let Some(headers) = init.headers.as_deref_mut() {
+            let mut owns_content_type = headers.fast_has(HTTPHeaderName::ContentType);
+            if !owns_content_type && let BodyValue::Blob(blob) = body.value.get() {
                 let content_type = blob.content_type_slice();
-                if !content_type.is_empty() && !headers.fast_has(HTTPHeaderName::ContentType) {
+                if !content_type.is_empty() {
                     headers.put(
                         HTTPHeaderName::ContentType,
                         &BunString::ascii(content_type),
                         global_this,
                     )?;
+                    owns_content_type = true;
                 }
             }
+            init.headers_own_content_type = owns_content_type;
         }
 
         // Disarm: all fallible ops have succeeded.
@@ -1197,6 +1226,12 @@ pub struct Init {
     pub(crate) status_code: u16,
     pub(crate) status_text: BunString,
     pub method: Method,
+    /// `headers` held a Content-Type when it was attached (the init supplied
+    /// one) or Bun has since put the body's type into it. From then on the
+    /// header list is the only source of this response's Content-Type: when a
+    /// server finds none there the user removed it, and the body's type must
+    /// not be derived again. See [`Response::headers_own_content_type`].
+    pub(crate) headers_own_content_type: bool,
 }
 
 impl Default for Init {
@@ -1206,6 +1241,7 @@ impl Default for Init {
             status_code: 0,
             status_text: BunString::EMPTY,
             method: Method::GET,
+            headers_own_content_type: false,
         }
     }
 }
@@ -1224,6 +1260,7 @@ impl Init {
             status_code: self.status_code,
             status_text: self.status_text.clone(),
             method: self.method,
+            headers_own_content_type: self.headers_own_content_type,
         })
     }
 
@@ -1267,7 +1304,11 @@ impl Init {
                 // SAFETY: `as_direct` returned a live `*mut Response` owned by the
                 // JS wrapper cell; rooted by `response_init` for this call.
                 let resp = unsafe { &*resp };
-                return Ok(Some(resp.init.get().clone(global_this)?));
+                let mut init = resp.init.get().clone(global_this)?;
+                // The donor's flag describes the donor's body, not the one this
+                // init is about to be paired with.
+                init.headers_own_content_type = false;
+                return Ok(Some(init));
             }
         }
 

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -467,21 +467,20 @@ describe("Bun.serve does not re-derive a Content-Type the handler deleted", () =
     return value?.startsWith("multipart/form-data;") ? "multipart/form-data" : value;
   };
 
-  for (const [name, c] of Object.entries(cases)) {
-    test(name, async () => {
-      const path = encodeURIComponent(name);
-      const expected: Record<string, unknown> = { inProcess: c.inProcess, "GET dynamic": c.wire };
-      const actual: Record<string, unknown> = {
-        inProcess: inProcess(c.make()),
-        "GET dynamic": await contentTypes("GET", "/dynamic/" + path),
-      };
-      if (c.static) {
-        expected["GET static"] = c.wire;
-        expected["HEAD static"] = c.wire;
-        actual["GET static"] = await contentTypes("GET", "/static/" + path);
-        actual["HEAD static"] = await contentTypes("HEAD", "/static/" + path);
-      }
-      expect(actual).toEqual(expected);
-    });
-  }
+  test.each(Object.keys(cases))("%s", async name => {
+    const c = cases[name];
+    const path = encodeURIComponent(name);
+    const expected: Record<string, unknown> = { inProcess: c.inProcess, "GET dynamic": c.wire };
+    const actual: Record<string, unknown> = {
+      inProcess: inProcess(c.make()),
+      "GET dynamic": await contentTypes("GET", "/dynamic/" + path),
+    };
+    if (c.static) {
+      expected["GET static"] = c.wire;
+      expected["HEAD static"] = c.wire;
+      actual["GET static"] = await contentTypes("GET", "/static/" + path);
+      actual["HEAD static"] = await contentTypes("HEAD", "/static/" + path);
+    }
+    expect(actual).toEqual(expected);
+  });
 });

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -320,6 +320,16 @@ describe("Bun.serve does not re-derive a Content-Type the handler deleted", () =
       inProcess: null,
       static: true,
     };
+    cases[`${name}: content-type set then deleted`] = {
+      make: () => {
+        const r = new Response(body.make(), { headers: { "x-a": "b" } });
+        r.headers.set("content-type", "text/x-set");
+        return del(r);
+      },
+      wire: [],
+      inProcess: null,
+      static: true,
+    };
     // Controls that keep sending a Content-Type.
     cases[`${name}: headers never touched`] = {
       make: () => new Response(body.make()),

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import * as net from "node:net";
+import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {
@@ -264,4 +265,213 @@ describe("response Connection: close closes the socket", () => {
       socket.destroy();
     }
   });
+});
+
+// The Response constructor and the `headers` getter copy a typed body's
+// Content-Type (URLSearchParams, FormData, a Blob with a `type`, Bun.file())
+// into the header list, so from then on the header list is the only source of
+// it, as in the Fetch spec. A handler that deletes it must get no Content-Type
+// on the wire; the server used to derive the body's type a second time at send.
+describe("Bun.serve does not re-derive a Content-Type the handler deleted", () => {
+  const jsFile = join(import.meta.dir, "bun-serve.fixture.js");
+  const typedBodies = {
+    URLSearchParams: {
+      make: () => new URLSearchParams("a=1"),
+      type: "application/x-www-form-urlencoded;charset=UTF-8",
+    },
+    FormData: {
+      make: () => {
+        const fd = new FormData();
+        fd.append("a", "1");
+        return fd;
+      },
+      // The boundary differs per body; `contentTypes()` normalizes it away.
+      type: "multipart/form-data",
+    },
+    "typed Blob": { make: () => new Blob(["hi"], { type: "text/x-blob" }), type: "text/x-blob" },
+    "Bun.file()": { make: () => Bun.file(jsFile), type: "text/javascript;charset=utf-8" },
+  } satisfies Record<string, { make: () => BodyInit; type: string }>;
+
+  const del = (r: Response) => {
+    r.headers.delete("content-type");
+    return r;
+  };
+  type Case = {
+    make: () => Response;
+    /** Content-Type values expected on the wire (empty: no such header). */
+    wire: string[];
+    /** `headers.get("content-type")` on the Response the handler returns. */
+    inProcess: string | null;
+    /** Also register the Response in `routes` (static / file route). */
+    static?: boolean;
+  };
+  const cases: Record<string, Case> = {};
+  for (const [name, body] of Object.entries(typedBodies)) {
+    // The fix: once deleted, it stays deleted.
+    cases[`${name}: body type deleted`] = {
+      make: () => del(new Response(body.make())),
+      wire: [],
+      inProcess: null,
+      static: true,
+    };
+    cases[`${name}: init content-type deleted`] = {
+      make: () => del(new Response(body.make(), { headers: { "Content-Type": "text/x-init" } })),
+      wire: [],
+      inProcess: null,
+      static: true,
+    };
+    // Controls that keep sending a Content-Type.
+    cases[`${name}: headers never touched`] = {
+      make: () => new Response(body.make()),
+      wire: [body.type],
+      inProcess: body.type,
+      static: true,
+    };
+    cases[`${name}: headers read`] = {
+      make: () => {
+        const r = new Response(body.make(), { headers: { "x-a": "b" } });
+        r.headers.get("x-a");
+        return r;
+      },
+      wire: [body.type],
+      inProcess: body.type,
+      static: true,
+    };
+    cases[`${name}: init content-type kept`] = {
+      make: () => new Response(body.make(), { headers: { "Content-Type": "text/x-init" } }),
+      wire: ["text/x-init"],
+      inProcess: "text/x-init",
+      static: true,
+    };
+    cases[`${name}: content-type replaced`] = {
+      make: () => {
+        const r = new Response(body.make());
+        r.headers.set("content-type", "text/x-set");
+        return r;
+      },
+      wire: ["text/x-set"],
+      inProcess: "text/x-set",
+      static: true,
+    };
+  }
+  Object.assign(cases, {
+    "string: init content-type deleted": {
+      make: () => del(new Response("hello", { headers: { "Content-Type": "text/x-init" } })),
+      wire: [],
+      inProcess: null,
+      static: true,
+    },
+    "Response.json(): content-type deleted": {
+      make: () => del(Response.json({ a: 1 })),
+      wire: [],
+      inProcess: null,
+      static: true,
+    },
+    "clone() of a Response whose content-type was deleted": {
+      make: () => del(new Response(new URLSearchParams("a=1"))).clone(),
+      wire: [],
+      inProcess: null,
+      static: true,
+    },
+    // The deleted-from Response only donates its (now empty) header list; the
+    // new Response pairs it with its own body, whose type goes in again.
+    "typed body with a content-type-deleted Response as init": {
+      make: () => new Response(new URLSearchParams("a=1"), del(new Response(new Blob(["x"], { type: "text/x-b" })))),
+      wire: [typedBodies.URLSearchParams.type],
+      inProcess: typedBodies.URLSearchParams.type,
+      static: true,
+    },
+    // Bodies whose type Bun never puts in the header list keep their defaults.
+    "string: other init headers": {
+      make: () => new Response("hello", { headers: { "x-a": "b" } }),
+      wire: ["text/plain;charset=utf-8"],
+      inProcess: null,
+      static: true,
+    },
+    "string: headers read": {
+      make: () => {
+        const r = new Response("hello");
+        r.headers.get("x-a");
+        return r;
+      },
+      wire: ["text/plain;charset=utf-8"],
+      inProcess: null,
+      static: true,
+    },
+    "Response.json()": {
+      make: () => Response.json({ a: 1 }, { headers: { "x-a": "b" } }),
+      wire: ["application/json;charset=utf-8"],
+      inProcess: "application/json;charset=utf-8",
+      static: true,
+    },
+    "Bun.file().stream() with init headers": {
+      make: () => new Response(Bun.file(jsFile).stream(), { headers: { "x-a": "b" } }),
+      wire: ["text/javascript;charset=utf-8"],
+      inProcess: null,
+    },
+  } satisfies Record<string, Case>);
+
+  let server: ReturnType<typeof Bun.serve>;
+  beforeAll(() => {
+    const routes: Record<string, Response> = {};
+    for (const [name, c] of Object.entries(cases)) {
+      if (c.static) routes["/static/" + encodeURIComponent(name)] = c.make();
+    }
+    server = Bun.serve({
+      port: 0,
+      development: false,
+      routes,
+      fetch(req) {
+        const name = decodeURIComponent(new URL(req.url).pathname.slice("/dynamic/".length));
+        return cases[name]?.make() ?? new Response("no such case", { status: 404 });
+      },
+    });
+  });
+  afterAll(() => server?.stop(true));
+
+  /** The Content-Type header values in the raw response to `method path`. */
+  async function contentTypes(method: string, path: string): Promise<string[]> {
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write(`${method} ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+      let raw = "";
+      await new Promise<void>(resolve => {
+        socket.on("data", chunk => (raw += chunk.toString("latin1")));
+        socket.on("close", resolve);
+      });
+      expect(raw).toStartWith("HTTP/1.1 200 ");
+      return raw
+        .split("\r\n\r\n")[0]
+        .split("\r\n")
+        .filter(line => line.toLowerCase().startsWith("content-type:"))
+        .map(line => line.slice("content-type:".length).trim())
+        .map(value => (value.startsWith("multipart/form-data;") ? "multipart/form-data" : value));
+    } finally {
+      socket.destroy();
+    }
+  }
+  const inProcess = (r: Response) => {
+    const value = r.headers.get("content-type");
+    return value?.startsWith("multipart/form-data;") ? "multipart/form-data" : value;
+  };
+
+  for (const [name, c] of Object.entries(cases)) {
+    test(name, async () => {
+      const path = encodeURIComponent(name);
+      const expected: Record<string, unknown> = { inProcess: c.inProcess, "GET dynamic": c.wire };
+      const actual: Record<string, unknown> = {
+        inProcess: inProcess(c.make()),
+        "GET dynamic": await contentTypes("GET", "/dynamic/" + path),
+      };
+      if (c.static) {
+        expected["GET static"] = c.wire;
+        expected["HEAD static"] = c.wire;
+        actual["GET static"] = await contentTypes("GET", "/static/" + path);
+        actual["HEAD static"] = await contentTypes("HEAD", "/static/" + path);
+      }
+      expect(actual).toEqual(expected);
+    });
+  }
 });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -872,6 +872,41 @@ describe("Content-Type header propagation", () => {
       expect(res.status).toBe(200);
     });
   });
+
+  // The Response constructor / `headers` getter copy the body's Content-Type into
+  // the header list; from then on the header list is the only source (Fetch spec),
+  // so deleting it there also hides it from formData(), not only from the wire.
+  test("Response.formData() does not fall back to a Content-Type deleted from the headers", async () => {
+    const bodies = {
+      FormData: () => {
+        const fd = new FormData();
+        fd.append("a", "1");
+        return fd;
+      },
+      URLSearchParams: () => new URLSearchParams("a=1"),
+    };
+    for (const [name, make] of Object.entries(bodies)) {
+      const intact = new Response(make());
+      expect([...(await intact.formData()).keys()], name).toEqual(["a"]);
+
+      const deleted = new Response(make());
+      deleted.headers.delete("content-type");
+      expect(deleted.headers.get("content-type"), name).toBeNull();
+      expect(async () => await deleted.formData(), name).toThrow(TypeError);
+
+      // clone() carries the deletion.
+      const cloned = deleted.clone();
+      expect(cloned.headers.get("content-type"), name).toBeNull();
+      expect(async () => await cloned.formData(), name).toThrow(TypeError);
+
+      // Putting the Content-Type back makes it parse again.
+      const restored = new Response(make());
+      const contentType = restored.headers.get("content-type")!;
+      restored.headers.delete("content-type");
+      restored.headers.set("content-type", contentType);
+      expect([...(await restored.formData()).keys()], name).toEqual(["a"]);
+    }
+  });
 });
 
 it("drops multipart part Content-Type values containing control characters", async () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -876,37 +876,39 @@ describe("Content-Type header propagation", () => {
   // The Response constructor / `headers` getter copy the body's Content-Type into
   // the header list; from then on the header list is the only source (Fetch spec),
   // so deleting it there also hides it from formData(), not only from the wire.
-  test("Response.formData() does not fall back to a Content-Type deleted from the headers", async () => {
-    const bodies = {
-      FormData: () => {
-        const fd = new FormData();
-        fd.append("a", "1");
-        return fd;
-      },
-      URLSearchParams: () => new URLSearchParams("a=1"),
-    };
-    for (const [name, make] of Object.entries(bodies)) {
+  const formBodies: Record<string, () => BodyInit> = {
+    FormData: () => {
+      const fd = new FormData();
+      fd.append("a", "1");
+      return fd;
+    },
+    URLSearchParams: () => new URLSearchParams("a=1"),
+  };
+  test.each(Object.keys(formBodies))(
+    "Response.formData() does not fall back to a Content-Type deleted from the headers (%s body)",
+    async name => {
+      const make = formBodies[name];
       const intact = new Response(make());
-      expect([...(await intact.formData()).keys()], name).toEqual(["a"]);
+      expect([...(await intact.formData()).keys()]).toEqual(["a"]);
 
       const deleted = new Response(make());
       deleted.headers.delete("content-type");
-      expect(deleted.headers.get("content-type"), name).toBeNull();
-      expect(async () => await deleted.formData(), name).toThrow(TypeError);
+      expect(deleted.headers.get("content-type")).toBeNull();
+      expect(async () => await deleted.formData()).toThrow(TypeError);
 
       // clone() carries the deletion.
       const cloned = deleted.clone();
-      expect(cloned.headers.get("content-type"), name).toBeNull();
-      expect(async () => await cloned.formData(), name).toThrow(TypeError);
+      expect(cloned.headers.get("content-type")).toBeNull();
+      expect(async () => await cloned.formData()).toThrow(TypeError);
 
       // Putting the Content-Type back makes it parse again.
       const restored = new Response(make());
       const contentType = restored.headers.get("content-type")!;
       restored.headers.delete("content-type");
       restored.headers.set("content-type", contentType);
-      expect([...(await restored.formData()).keys()], name).toEqual(["a"]);
-    }
-  });
+      expect([...(await restored.formData()).keys()]).toEqual(["a"]);
+    },
+  );
 });
 
 it("drops multipart part Content-Type values containing control characters", async () => {


### PR DESCRIPTION
### Problem
- `Bun.serve` sends a Content-Type the handler deleted. `const r = new Response(new URLSearchParams("q=1")); r.headers.delete("content-type"); return r;` has no Content-Type in-process, but the client gets `application/x-www-form-urlencoded;charset=UTF-8`. Same for `FormData`, a typed `Blob`, `Bun.file()`, a deleted init Content-Type, and `routes`.
- The constructor and the `headers` getter copy the body's type into the header list (`Response.rs`). The send paths (`get_content_type` in `RequestContext.rs`, `StaticRoute::from_js`, `FileRoute::from_js`) and `formData()` then derive it from the body again when the list has none.

### Fix
- `Response` `Init` gets `headers_own_content_type`: the header list has held a Content-Type (from the init, copied from the body, or `Response.json()`). `clone()` copies it. `new Response(body, otherResponse)` recomputes it.
- Every Content-Type reader asks the `Response`. With the flag set and no Content-Type in the list, the send paths send none and `formData()` rejects, as in undici and Deno. The header list is then the single source.
- A `Response` whose headers were never materialized keeps the allocation-free send-time derivation (`new Response("str")` is unchanged). String and untyped bodies keep their defaults.
- Verified: `test/js/bun/http/bun-serve-headers.test.ts` (36 new raw-socket cases, 15 fail on 1.4.3), `test/js/web/html/FormData.test.ts` (1 new, fails on 1.4.3). Other suites in Notes.

### Background
- Per Fetch, `new Response(body)` appends the body's type to the header list at construction, and undici and Deno serialize that list.
- Bun defers it: with no `headers` init it allocates no `FetchHeaders` and derives the Content-Type at send time. The first `response.headers` access materializes the list and copies the type in.
- `routes: { "/x": response }` snapshots the headers in `StaticRoute::from_js` / `FileRoute::from_js` with the same fallback.

<details><summary>Notes</summary>

- Why a flag and not "a header list exists, so never derive": `new Response(Bun.file(p).stream(), { headers: {...} })` has a header list from the start, but its body is a stream with no type. At send time `to_blob_if_possible()` turns the lazy file stream back into a file `Blob` whose type comes from the extension, and the wire gets `text/javascript` etc. today. A stateless rule drops that. The flag records whether the Content-Type decision actually reached the header list. The stateless rule becomes possible if a maintainer decides that a string body should put `text/plain;charset=utf-8` into the header list the way undici does (the question #8530 asks). That is a separate, visible change (`new Response("x").headers.get("content-type")` is `null` today), so it is not made here. Question for a maintainer: is that materialization wanted? If yes, this flag can go.
- `render_metadata` still computes the body's `MimeType` when the flag suppresses the header, because the `Content-Disposition` filename rule (`autoset_filename`) keys on its category. Only the `content-type` write is skipped.
- The send-time fallback order in `get_content_type` is unchanged: header list, else `blob.content_type()`, else image sniff, else `text/plain` for strings, else `application/octet-stream`. The flag only stops it after step one.
- Self-reviewed: 5 concerns raised, 2 addressed in code (`formData()`/`compileStreaming` read the same rule, the send paths ask the `Response` instead of taking a bare flag), 3 answered here:
  - String bodies: `new Response("str", { headers: { "content-type": x } })` plus delete now sends none, but `new Response("str")` plus `headers.set` plus `headers.delete` still sends `text/plain`, because Bun never records a string body's default type in the header list (see the first note). Only a Content-Type that was in the header list is tracked.
  - `new Response(r.body, r)` after deleting from `r` gets the type again when `r`'s body was an in-memory typed `Blob`: Bun turns a blob-backed stream body back into the typed `Blob` at construction (`Body.rs`, kept for #14988), so the new `Response` pairs a typed body with a header list that has no Content-Type, and copies it in. In-process and wire agree there. Left as is.
  - #32913 and #42015 (both open) touch the same functions for the other face of this gap (Content-Type lost when the body is read before the headers) and add their own `Init` field. They do not fix the delete case: after the header list is materialized they fall back to the body's type at send time like main does. Whichever lands second rebases, the fields compose. #30997 rewrites the detached-body condition 50 lines below the call changed here, no textual overlap.
- Unchanged on purpose: untyped `Blob`/`ArrayBuffer` bodies keep the image sniff and `application/octet-stream` fallback. A `fetch()`-created `Response` whose own headers are edited is not flagged (`new Response(res.body, res)` is, it goes through the constructor). The client side (`fetch(request)` after `request.headers.delete("content-type")`) is a separate path in `fetch.rs`.
- HEAD through the `fetch` handler already sends no Content-Type for these bodies (it renders metadata from an empty blob, #41585 and #33427 are about that). The test pins GET dynamic, GET static and HEAD static.
- Cost: one `bool` in `Init`, one extra `fast_has(ContentType)` (a scan of the common-header vector) in `new Response(body, { headers })`. No new `FetchHeaders` allocation anywhere.
- Suites run with the debug build: `serve.test.ts` (2 pre-existing environment failures, same on stock bun: root port, loopback dev mode), `bun-serve-static`, `bun-serve-file`, `bun-serve-routes`, `bun-serve-html`, `bun-server`, `web/fetch/body`, `body-clone`, `response`, `wasm-streaming`, `fetch.test.ts` (environment-only failures: ipv6, public internet, root permissions, ASAN timeouts), `web/html/FormData`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 17 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-headers.test.ts test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [505.72ms]
(pass) response header values are isomorphic-encoded on the wire > Response headers [613.20ms]
(pass) response header values are isomorphic-encoded on the wire > Set-Cookie headers [103.94ms]
(pass) response header values are isomorphic-encoded on the wire > long values and values that start with a non-ASCII char [251.93ms]
(pass) response Connection: close closes the socket > string body [83.66ms]
(pass) response Connection: close closes the socket > case-insensitive value [49.89ms]
(pass) response Connection: close closes the socket > token list [54.97ms]
(pass) response Connection: close closes the socket > streaming body [65.72ms]
(pass) response Connection: close closes the socket > keep-alive still the default [76.55ms]
479 |       expected["GET static"] = c.wire;
480 |       expected["HEAD static"] = c.wire;
481 |       actual["GET static"] = await co
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (8de054b85)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [9.15ms]
(pass) response header values are isomorphic-encoded on the wire > Response headers [8.68ms]
(pass) response header values are isomorphic-encoded on the wire > Set-Cookie headers [3.25ms]
(pass) response header values are isomorphic-encoded on the wire > long values and values that start with a non-ASCII char [7.44ms]
(pass) response Connection: close closes the socket > string body [3.02ms]
(pass) response Connection: close closes the socket > case-insensitive value [1.89ms]
(pass) response Connection: close closes the socket > token list [1.99ms]
(pass) response Connection: close closes the socket > streaming body [1.81ms]
(pass) response Connection: close closes the socket > keep-alive still the default [2.25ms]
(pass) Bun.serve does not re-derive a Content-Type the handler deleted > URLSearchParams: body type deleted [3.95ms]
(pass) Bun.serve does not re-derive a Content-Type the handler deleted > URLSearchParams: init content-type deleted [1.57ms]
(pass) Bun.serve does not re-derive a Content-Type the handler deleted > URLSearchParams: content-type se
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-headers.test.ts test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [452.66ms]
(pass) response header values are isomorphic-encoded on the wire > Response headers [501.47ms]
(pass) response header values are isomorphic-encoded on the wire > Set-Cookie headers [82.44ms]
(pass) response header values are isomorphic-encoded on the wire > long values and values that start with a non-ASCII char [286.05ms]
(pass) response Connection: close closes the socket > string body [86.73ms]
(pass) response Connection: close closes the socket > case-insensitive value [52.91ms]
(pass) response Connection: close closes the socket > token list [41.80ms]
(pass) response Connection: close closes the socket > streaming body [56.40ms]
(pass) response Connection: close closes the socket > keep-alive still the default [45.69ms]
(pass) Bun.serve does not re-derive a Content-Type the handler deleted > URLSearchParams: body type deleted [104.85ms]
(pass) Bun.serve
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 823ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 41s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+c31617e1e
[build] done
bun test v1.4.3-canary.1 (c31617e1e)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [10.90ms]
(pass) response header values are isomorphic-encoded on the wire > Response headers [8.53ms]
(pass) response header values are isomorphic-encoded on the wire > Set-Cookie headers [3.34ms]
(pass) response header values are isomorphic-encoded on the wire > long values and values that start with a non-ASCII char [8.16ms]
(pass) response Connection: close closes the socket > string body [2.68ms]
(pass) response Connection: close closes the socket > cas
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/FileRoute.rs            |   5 +-
 src/runtime/server/RequestContext.rs       |  10 +-
 src/runtime/server/StaticRoute.rs          |  10 +-
 src/runtime/webcore/Response.rs            |  74 +++++++---
 test/js/bun/http/bun-serve-headers.test.ts | 221 ++++++++++++++++++++++++++++-
 test/js/web/html/FormData.test.ts          |  37 +++++
 6 files changed, 327 insertions(+), 30 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/server/FileRoute.rs                 3      2     16
src/runtime/server/RequestContext.rs            5      5     16
src/runtime/server/StaticRoute.rs               3      3     16
src/runtime/webcore/Response.rs                 9     14     16
test/js/bun/http/bun-serve-headers.test.ts      3      2     12
test/js/web/html/FormData.test.ts               2      2      9
```

</details>

<!-- robobun:evidence:end -->