### PR TITLE
css: keep css-wide keywords and percentage stretch out of the font and transition shorthands

### DIFF
--- a/src/css/generics.rs
+++ b/src/css/generics.rs
@@ -711,12 +711,14 @@ mod inherent_bridge {
 
     // ── properties/font ──
     use crate::properties::font::{
-        FontFamily, FontSize, FontStretch, FontStyle, FontVariantCaps, FontWeight, LineHeight,
+        FontFamily, FontSize, FontStretch, FontStretchKeyword, FontStyle, FontVariantCaps,
+        FontWeight, LineHeight,
     };
     bridge_clone_partialeq!(
         FontWeight,
         FontSize,
         FontStretch,
+        FontStretchKeyword,
         FontStyle,
         FontVariantCaps,
         LineHeight,

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -19,6 +19,7 @@ use bun_alloc::ArenaVecExt as _;
 
 use crate::values as css_values;
 use css_values::angle::Angle;
+use css_values::ident::is_reserved_custom_ident;
 use css_values::length::{LengthPercentage, LengthValue};
 use css_values::number::{CSSNumber, CSSNumberFns};
 use css_values::percentage::{DimensionPercentage, Percentage};
@@ -251,6 +252,18 @@ impl FontStretch {
         }
     }
 
+    /// The keyword with the same computed value, if there is one. The `font`
+    /// shorthand only accepts these keywords (`<font-stretch-css3>`), never a
+    /// percentage.
+    pub(crate) fn keyword(self) -> Option<FontStretchKeyword> {
+        match self {
+            FontStretch::Keyword(kw) => Some(kw),
+            FontStretch::Percentage(val) => FontStretchKeyword::ALL
+                .into_iter()
+                .find(|kw| kw.into_percentage() == val),
+        }
+    }
+
     pub(crate) fn is_compatible(self, browsers: &crate::targets::Browsers) -> bool {
         match self {
             FontStretch::Percentage(_) => Feature::FontStretchPercentage.is_compatible(browsers),
@@ -260,11 +273,6 @@ impl FontStretch {
 
     // eql → derived PartialEq
     // deepClone → derived Clone
-
-    #[inline]
-    fn default() -> FontStretch {
-        FontStretch::Keyword(FontStretchKeyword::default())
-    }
 }
 
 /// A [font stretch keyword](https://www.w3.org/TR/css-fonts-4/#font-stretch-prop),
@@ -294,6 +302,18 @@ pub enum FontStretchKeyword {
 }
 
 impl FontStretchKeyword {
+    const ALL: [FontStretchKeyword; 9] = [
+        FontStretchKeyword::Normal,
+        FontStretchKeyword::UltraCondensed,
+        FontStretchKeyword::ExtraCondensed,
+        FontStretchKeyword::Condensed,
+        FontStretchKeyword::SemiCondensed,
+        FontStretchKeyword::SemiExpanded,
+        FontStretchKeyword::Expanded,
+        FontStretchKeyword::ExtraExpanded,
+        FontStretchKeyword::UltraExpanded,
+    ];
+
     #[inline]
     fn default() -> FontStretchKeyword {
         FontStretchKeyword::Normal
@@ -344,15 +364,15 @@ impl FontFamily {
         // SAFETY: arena outlives the returned `FontFamily` (parser source/arena lives for 'bump).
         let bump: &'static bun_alloc::Arena =
             unsafe { &*std::ptr::from_ref::<bun_alloc::Arena>(input.arena()) };
-        let value: *const [u8] = std::ptr::from_ref::<[u8]>(input.expect_ident()?);
+        let location = input.current_source_location();
+        let value: &'static [u8] = input.expect_ident_cloned()?;
         // AST crate: ArrayListUnmanaged fed input.arena() (arena) → bumpalo Vec
         let mut string: Option<bun_alloc::ArenaVec<'_, u8>> = None;
         while let Ok(ident) = input.try_parse(|p| p.expect_ident().map(std::ptr::from_ref::<[u8]>))
         {
             if string.is_none() {
                 let mut s = bun_alloc::ArenaVec::<u8>::new_in(bump);
-                // SAFETY: arena-owned slice valid for 'bump.
-                s.extend_from_slice(unsafe { crate::arena_str(value) });
+                s.extend_from_slice(value);
                 string = Some(s);
             }
 
@@ -365,7 +385,14 @@ impl FontFamily {
 
         let final_value: *const [u8] = match string {
             Some(s) => std::ptr::from_ref::<[u8]>(s.into_bump_slice()),
-            None => value,
+            // A css-wide keyword or `default` is a <family-name> only when more
+            // identifiers follow it (`inherit foo`). On its own it is that keyword,
+            // which only a whole `Property::Unparsed` declaration can carry.
+            // https://drafts.csswg.org/css-fonts-4/#family-name-syntax
+            None if is_reserved_custom_ident(value) => {
+                return Err(location.new_unexpected_token_error(crate::Token::Ident(value)));
+            }
+            None => std::ptr::from_ref::<[u8]>(value),
         };
 
         Ok(FontFamily::FamilyName(final_value))
@@ -382,6 +409,7 @@ impl FontFamily {
                 // https://www.w3.org/TR/css-fonts-4/#family-name-syntax
 
                 if !val.is_empty()
+                    && !is_reserved_custom_ident(val)
                     && !css::parse_utility::parse_string::<GenericFontFamily>(
                         dest.arena,
                         val,
@@ -483,21 +511,6 @@ pub enum GenericFontFamily {
     UiSansSerif,
     UiMonospace,
     UiRounded,
-
-    // CSS wide keywords. These must be parsed as identifiers so they
-    // don't get serialized as strings.
-    // https://www.w3.org/TR/css-values-4/#common-keywords
-    Initial,
-    Inherit,
-    Unset,
-    // Default is also reserved by the <custom-ident> type.
-    // https://www.w3.org/TR/css-values-4/#custom-idents
-    Default,
-
-    // CSS defaulting keywords
-    // https://drafts.csswg.org/css-cascade-5/#defaulting-keywords
-    Revert,
-    RevertLayer,
 }
 
 impl GenericFontFamily {
@@ -684,8 +697,8 @@ pub struct Font {
     pub(crate) style: FontStyle,
     /// The font weight.
     pub(crate) weight: FontWeight,
-    /// The font stretch.
-    pub(crate) stretch: FontStretch,
+    /// The font stretch. The shorthand grammar admits only the keywords.
+    pub(crate) stretch: FontStretchKeyword,
     /// The line height.
     pub(crate) line_height: LineHeight,
     /// How the text should be capitalized. Only CSS 2.1 values are supported.
@@ -698,7 +711,7 @@ impl Font {
     pub(crate) fn parse(input: &mut css::Parser) -> CssResult<Font> {
         let mut style: Option<FontStyle> = None;
         let mut weight: Option<FontWeight> = None;
-        let mut stretch: Option<FontStretch> = None;
+        let mut stretch: Option<FontStretchKeyword> = None;
         let final_size: FontSize;
         let mut variant_caps: Option<FontVariantCaps> = None;
         let mut count: i32 = 0;
@@ -740,7 +753,7 @@ impl Font {
 
             if stretch.is_none() {
                 if let Ok(value) = input.try_parse(FontStretchKeyword::parse) {
-                    stretch = Some(FontStretch::Keyword(value));
+                    stretch = Some(value);
                     count += 1;
                     continue;
                 }
@@ -769,7 +782,7 @@ impl Font {
             size: final_size,
             style: style.unwrap_or_else(FontStyle::default),
             weight: weight.unwrap_or_else(FontWeight::default),
-            stretch: stretch.unwrap_or_else(FontStretch::default),
+            stretch: stretch.unwrap_or_else(FontStretchKeyword::default),
             line_height: line_height.unwrap_or_else(LineHeight::default),
             variant_caps: variant_caps.unwrap_or_else(FontVariantCaps::default),
         })
@@ -791,7 +804,7 @@ impl Font {
             dest.write_char(b' ')?;
         }
 
-        if self.stretch != FontStretch::default() {
+        if self.stretch != FontStretchKeyword::default() {
             self.stretch.to_css(dest)?;
             dest.write_char(b' ')?;
         }
@@ -912,11 +925,12 @@ impl FontHandler {
             Property::FontVariantCaps(val) => property_helper!(self, variant_caps, val),
             Property::LineHeight(val) => property_helper!(self, line_height, val),
             Property::Font(val) => {
+                let stretch = FontStretch::Keyword(val.stretch);
                 flush_helper!(self, family, &val.family);
                 flush_helper!(self, size, &val.size);
                 flush_helper!(self, style, &val.style);
                 flush_helper!(self, weight, &val.weight);
-                flush_helper!(self, stretch, &val.stretch);
+                flush_helper!(self, stretch, &stretch);
                 flush_helper!(self, line_height, &val.line_height);
                 flush_helper!(self, variant_caps, &val.variant_caps);
 
@@ -924,7 +938,7 @@ impl FontHandler {
                 self.size = Some(val.size.clone());
                 self.style = Some(val.style);
                 self.weight = Some(val.weight.clone());
-                self.stretch = Some(val.stretch);
+                self.stretch = Some(stretch);
                 self.line_height = Some(val.line_height.clone());
                 self.variant_caps = Some(val.variant_caps);
                 self.has_any = true;
@@ -1017,7 +1031,15 @@ impl FontHandler {
             }
         }
 
-        if let (Some(_), Some(_), Some(_), Some(_), Some(_), Some(_), Some(variant_caps_v)) = (
+        if let (
+            Some(_),
+            Some(_),
+            Some(_),
+            Some(_),
+            Some(stretch_v),
+            Some(_),
+            Some(variant_caps_v),
+        ) = (
             family.as_ref(),
             size.as_ref(),
             style.as_ref(),
@@ -1027,6 +1049,8 @@ impl FontHandler {
             variant_caps.as_ref(),
         ) {
             let caps = *variant_caps_v;
+            let stretch = *stretch_v;
+            let stretch_keyword = stretch.keyword();
             push_prop!(
                 Font,
                 Font {
@@ -1034,7 +1058,7 @@ impl FontHandler {
                     size: size.unwrap(),
                     style: style.unwrap(),
                     weight: weight.unwrap(),
-                    stretch: stretch.unwrap(),
+                    stretch: stretch_keyword.unwrap_or_else(FontStretchKeyword::default),
                     line_height: line_height.unwrap(),
                     variant_caps: if caps.is_css2() {
                         caps
@@ -1048,6 +1072,13 @@ impl FontHandler {
             // If we have a CSS 3+ value, we need to add a separate property.
             if !caps.is_css2() {
                 push_prop!(FontVariantCaps, FONT_VARIANT_CAPS, caps);
+            }
+
+            // Likewise it only accepts the font-stretch keywords. A percentage that
+            // matches none of them follows the shorthand (which resets font-stretch)
+            // as its own declaration.
+            if stretch_keyword.is_none() {
+                push_prop!(FontStretch, FONT_STRETCH, stretch);
             }
         } else {
             if let Some(val) = family {

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -742,8 +742,7 @@ impl Font {
                 }
             }
 
-            if variant_caps.is_some() {
-                // Intentionally checks `is_some()` to match upstream lightningcss (likely a bug there; should be `is_none()`)
+            if variant_caps.is_none() {
                 if let Ok(value) = input.try_parse(FontVariantCaps::parse_css2) {
                     variant_caps = Some(value);
                     count += 1;

--- a/src/css/properties/mod.rs
+++ b/src/css/properties/mod.rs
@@ -291,9 +291,35 @@ mod generic_registrations {
         animation::AnimationName,
         // ui
         ui::ColorScheme,
-        // PropertyId (used as `SmallList<PropertyId, 1>` for `transition-property`)
-        properties_generated::PropertyId,
     );
+
+    // `PropertyId` as a declaration *value* (`SmallList<PropertyId, 1>` for
+    // `transition-property`) is a `<custom-ident>`, so the generic parse goes
+    // through `parse_custom_ident`, not the name parser `PropertyId::parse`.
+    impl crate::generics::Parse for properties_generated::PropertyId {
+        #[inline]
+        fn parse(input: &mut crate::css_parser::Parser) -> crate::css_parser::CssResult<Self> {
+            properties_generated::PropertyId::parse_custom_ident(input)
+        }
+    }
+    impl crate::generics::ParseWithOptions for properties_generated::PropertyId {
+        #[inline]
+        fn parse_with_options(
+            input: &mut crate::css_parser::Parser,
+            _o: &crate::css_parser::ParserOptions,
+        ) -> crate::css_parser::CssResult<Self> {
+            properties_generated::PropertyId::parse_custom_ident(input)
+        }
+    }
+    impl crate::generics::ToCss for properties_generated::PropertyId {
+        #[inline]
+        fn to_css(
+            &self,
+            dest: &mut crate::printer::Printer,
+        ) -> ::core::result::Result<(), crate::PrintErr> {
+            properties_generated::PropertyId::to_css(self, dest)
+        }
+    }
 
     // `GenericBorder<S, P>` covers Border / BorderTop / … / Outline. The
     // inherent impl block bounds `S` on the protocol traits; mirror here.

--- a/src/css/properties/properties_impl.rs
+++ b/src/css/properties/properties_impl.rs
@@ -32,6 +32,24 @@ impl Property {
     }
 }
 
+impl PropertyId {
+    /// Parses a `<custom-ident>` that names a property inside a declaration
+    /// *value* (`transition-property`, the `transition` shorthand). Unlike
+    /// [`PropertyId::parse`], which reads a declaration name, this rejects the
+    /// css-wide keywords and `default`: `transition-property: inherit` is the
+    /// keyword applied to `transition-property`, not a property called
+    /// "inherit", and stays a `Property::Unparsed` declaration that no handler
+    /// folds into a shorthand.
+    pub(crate) fn parse_custom_ident(input: &mut css::Parser) -> css::Result<PropertyId> {
+        let location = input.current_source_location();
+        let name = input.expect_ident_cloned()?;
+        if css::css_values::ident::is_reserved_custom_ident(name) {
+            return Err(location.new_unexpected_token_error(css::Token::Ident(name)));
+        }
+        Ok(property_id_mixin::from_string(name))
+    }
+}
+
 /// Ordered single-bit prefix flags. The crate-root `VendorPrefix::FIELDS` is
 /// a `&'static [VendorPrefix]` with the same values in the same declaration
 /// order (webkit, moz, ms, o, none); kept duplicated here as a fixed-size

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -73,7 +73,7 @@ impl Transition {
             }
 
             if property.is_none() {
-                if let Ok(value) = parser.try_parse(PropertyId::parse) {
+                if let Ok(value) = parser.try_parse(PropertyId::parse_custom_ident) {
                     property = Some(value);
                     continue;
                 }

--- a/src/css/properties/ui.rs
+++ b/src/css/properties/ui.rs
@@ -22,40 +22,66 @@ bitflags::bitflags! {
 }
 
 impl ColorScheme {
+    // Consumes only the keywords it knows (`normal | [ light | dark | <custom-ident> ]+ && only?`
+    // minus the custom idents). Anything else, including a css-wide keyword, is left
+    // in the input so that `Property::parse` fails `expect_exhausted` and keeps the
+    // declaration as `Property::Unparsed` instead of collapsing it to `normal`.
     pub(crate) fn parse(input: &mut css::Parser) -> css::Result<ColorScheme> {
         let mut res = ColorScheme::empty();
-        let ident = input.expect_ident_cloned()?;
+        let mut has_any = false;
 
-        if let Some(value) = color_scheme_map_get(ident) {
-            match value {
-                ColorSchemeKeyword::Normal => return Ok(res),
-                ColorSchemeKeyword::Only => res.insert(ColorScheme::ONLY),
-                ColorSchemeKeyword::Light => res.insert(ColorScheme::LIGHT),
-                ColorSchemeKeyword::Dark => res.insert(ColorScheme::DARK),
-            }
+        if input
+            .try_parse(|input| input.expect_ident_matching(b"normal"))
+            .is_ok()
+        {
+            return Ok(res);
         }
 
-        while let Ok(i) = input.try_parse(|p| p.expect_ident_cloned()) {
-            if let Some(value) = color_scheme_map_get(i) {
-                match value {
-                    ColorSchemeKeyword::Normal => {
-                        return Err(input.new_custom_error(css::ParserError::invalid_value));
-                    }
-                    ColorSchemeKeyword::Only => {
-                        // Only must be at the start or the end, not in the middle
-                        if res.contains(ColorScheme::ONLY) {
-                            return Err(input.new_custom_error(css::ParserError::invalid_value));
-                        }
-                        res.insert(ColorScheme::ONLY);
-                        return Ok(res);
-                    }
-                    ColorSchemeKeyword::Light => res.insert(ColorScheme::LIGHT),
-                    ColorSchemeKeyword::Dark => res.insert(ColorScheme::DARK),
-                }
-            }
+        if input
+            .try_parse(|input| input.expect_ident_matching(b"only"))
+            .is_ok()
+        {
+            res.insert(ColorScheme::ONLY);
+            has_any = true;
         }
 
-        Ok(res)
+        loop {
+            if input
+                .try_parse(|input| input.expect_ident_matching(b"light"))
+                .is_ok()
+            {
+                res.insert(ColorScheme::LIGHT);
+                has_any = true;
+                continue;
+            }
+
+            if input
+                .try_parse(|input| input.expect_ident_matching(b"dark"))
+                .is_ok()
+            {
+                res.insert(ColorScheme::DARK);
+                has_any = true;
+                continue;
+            }
+
+            break;
+        }
+
+        // `only` is allowed at the start or the end.
+        if !res.contains(ColorScheme::ONLY)
+            && input
+                .try_parse(|input| input.expect_ident_matching(b"only"))
+                .is_ok()
+        {
+            res.insert(ColorScheme::ONLY);
+            has_any = true;
+        }
+
+        if has_any {
+            return Ok(res);
+        }
+
+        Err(input.new_custom_error(css::ParserError::invalid_value))
     }
 
     pub(crate) fn to_css(self, dest: &mut Printer) -> Result<(), PrintErr> {
@@ -75,29 +101,13 @@ impl ColorScheme {
         }
 
         if self.contains(ColorScheme::ONLY) {
+            if !self.intersects(ColorScheme::LIGHT | ColorScheme::DARK) {
+                return dest.write_str("only");
+            }
             dest.write_str(" only")?;
         }
 
         Ok(())
-    }
-}
-
-// ≤8 entries → plain match on bytes.
-#[derive(Clone, Copy)]
-enum ColorSchemeKeyword {
-    Normal,
-    Only,
-    Light,
-    Dark,
-}
-
-fn color_scheme_map_get(ident: &[u8]) -> Option<ColorSchemeKeyword> {
-    match ident {
-        b"normal" => Some(ColorSchemeKeyword::Normal),
-        b"only" => Some(ColorSchemeKeyword::Only),
-        b"light" => Some(ColorSchemeKeyword::Light),
-        b"dark" => Some(ColorSchemeKeyword::Dark),
-        _ => None,
     }
 }
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5027,6 +5027,14 @@ describe("css tests", () => {
     minify_test(".foo { font: normal normal 500 medium/normal Charcoal; }", ".foo{font:500 medium Charcoal}");
     minify_test(".foo { font: normal normal 400 medium Charcoal; }", ".foo{font:400 medium Charcoal}");
     minify_test(".foo { font: normal normal 500 medium/10px Charcoal; }", ".foo{font:500 medium/10px Charcoal}");
+    // The shorthand takes the css2.1 font-variant values in any position before the size.
+    minify_test(".foo { font: small-caps bold 12px serif; }", ".foo{font:small-caps 700 12px serif}");
+    minify_test(".foo { font: bold small-caps 12px serif; }", ".foo{font:small-caps 700 12px serif}");
+    minify_test(
+      ".foo { font: normal small-caps 12px serif; font-style: italic }",
+      ".foo{font:italic small-caps 12px serif}",
+    );
+    minify_test(".foo { font: all-small-caps 12px serif; }", ".foo{font:all-small-caps 12px serif}");
     minify_test(".foo { font-family: 'sans-serif'; }", '.foo{font-family:"sans-serif"}');
     minify_test(".foo { font-family: sans-serif; }", ".foo{font-family:sans-serif}");
     minify_test(".foo { font-family: 'default'; }", '.foo{font-family:"default"}');
@@ -6641,6 +6649,11 @@ describe("css tests", () => {
         `.foo{transition-property:opacity,${keyword};transition-duration:2s}`,
       );
       minify_test(`.foo { transition: ${keyword} 2s }`, `.foo{transition:${keyword} 2s}`);
+      // parcel-bundler/lightningcss#1214
+      minify_test(
+        `.foo { transition: ${keyword}; transition-property: opacity }`,
+        `.foo{transition:${keyword};transition-property:opacity}`,
+      );
     }
     cssTest(
       `
@@ -7436,8 +7449,29 @@ describe("css tests", () => {
     minify_test(".foo { color-scheme: only light; }", ".foo{color-scheme:light only}");
     minify_test(".foo { color-scheme: only dark; }", ".foo{color-scheme:dark only}");
     minify_test(".foo { color-scheme: dark light only; }", ".foo{color-scheme:light dark only}");
-    minify_test(".foo { color-scheme: foo bar light; }", ".foo{color-scheme:light}");
-    minify_test(".foo { color-scheme: only foo dark bar; }", ".foo{color-scheme:dark only}");
+    minify_test(".foo { color-scheme: light dark only; }", ".foo{color-scheme:light dark only}");
+    minify_test(".foo { color-scheme: only light dark; }", ".foo{color-scheme:light dark only}");
+    minify_test(".foo { color-scheme: only; }", ".foo{color-scheme:only}");
+    minify_test(".foo { color-scheme: LIGHT Dark; }", ".foo{color-scheme:light dark}");
+    // Identifiers other than the four keywords (custom idents, css-wide keywords)
+    // keep the declaration as written instead of collapsing it to `normal`
+    // (parcel-bundler/lightningcss#1152).
+    minify_test(".foo { color-scheme: foo bar light; }", ".foo{color-scheme:foo bar light}");
+    minify_test(".foo { color-scheme: only foo dark bar; }", ".foo{color-scheme:only foo dark bar}");
+    minify_test(".foo { color-scheme: dark foo; }", ".foo{color-scheme:dark foo}");
+    minify_test(".foo { color-scheme: normal dark; }", ".foo{color-scheme:normal dark}");
+    minify_test(".foo { color-scheme: light only dark; }", ".foo{color-scheme:light only dark}");
+    for (const keyword of ["initial", "inherit", "unset", "revert", "revert-layer", "default"]) {
+      minify_test(`.foo { color-scheme: ${keyword}; }`, `.foo{color-scheme:${keyword}}`);
+    }
+    prefix_test(
+      ".foo { color-scheme: inherit; }",
+      `.foo {
+          color-scheme: inherit;
+        }
+        `,
+      { chrome: Some(90 << 16) },
+    );
     prefix_test(
       ".foo { color-scheme: dark; }",
       `.foo {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -4912,8 +4912,56 @@ describe("css tests", () => {
         line-height: 1.2em;
       }
     `,
-      indoc`.foo{font:italic small-caps 700 125% 12px/1.2em Helvetica,Times New Roman,sans-serif}`,
+      // The `font` shorthand only takes the `<font-stretch-css3>` keywords, so
+      // `expanded` must not become `125%` there (parcel-bundler/lightningcss#1140).
+      indoc`.foo{font:italic small-caps 700 expanded 12px/1.2em Helvetica,Times New Roman,sans-serif}`,
     );
+
+    // A font-stretch that reaches the shorthand from a longhand is printed as
+    // the keyword with the same computed value, or stays a longhand after the
+    // shorthand (which resets it) when no keyword matches.
+    minify_test(".foo { font: 12px foo; font-stretch: condensed }", ".foo{font:condensed 12px foo}");
+    minify_test(".foo { font: 12px foo; font-stretch: 75% }", ".foo{font:condensed 12px foo}");
+    minify_test(".foo { font: 12px foo; font-stretch: 110% }", ".foo{font:12px foo;font-stretch:110%}");
+    minify_test(".foo { font: condensed 12px/14px foo }", ".foo{font:condensed 12px/14px foo}");
+    minify_test(".foo { font-stretch: condensed }", ".foo{font-stretch:75%}");
+    cssTest(
+      `
+      .foo {
+        font-family: foo;
+        font-size: 12px;
+        font-weight: normal;
+        font-style: normal;
+        font-stretch: 110%;
+        font-variant-caps: all-small-caps;
+        line-height: normal;
+      }
+    `,
+      indoc`
+      .foo {
+        font: 12px foo;
+        font-variant-caps: all-small-caps;
+        font-stretch: 110%;
+      }
+`,
+    );
+
+    // A css-wide keyword (or the reserved `default`) on a longhand cannot be
+    // folded into the `font` shorthand: the shorthand has no slot for it, and
+    // `font: 12px inherit` is an invalid declaration that browsers drop whole.
+    for (const keyword of ["initial", "inherit", "unset", "revert", "revert-layer", "default"]) {
+      minify_test(
+        `.foo { font: italic .875rem/normal Arial, sans-serif; font-family: ${keyword} }`,
+        `.foo{font:italic .875rem Arial,sans-serif;font-family:${keyword}}`,
+      );
+      minify_test(
+        `.foo { font: 12px serif; font-family: ${keyword}, foo }`,
+        `.foo{font:12px serif;font-family:${keyword},foo}`,
+      );
+      minify_test(`.foo { font: 12px serif; font-family: "${keyword}" }`, `.foo{font:12px "${keyword}"}`);
+      minify_test(`.foo { font: 12px serif; font-family: ${keyword} foo }`, `.foo{font:12px ${keyword} foo}`);
+      minify_test(`.foo { font: 12px ${keyword} }`, `.foo{font:12px ${keyword}}`);
+    }
 
     cssTest(
       `
@@ -6575,6 +6623,25 @@ describe("css tests", () => {
     minify_test(".foo { transition: width 2s ease 1s }", ".foo{transition:width 2s 1s}");
     minify_test(".foo { transition: ease-in 1s width 4s }", ".foo{transition:width 1s ease-in 4s}");
     minify_test(".foo { transition: opacity 0s .6s }", ".foo{transition:opacity 0s .6s}");
+    minify_test(".foo { transition: opacity 1s; transition-property: none }", ".foo{transition:none 1s}");
+    minify_test(".foo { transition: opacity 1s; transition-property: all }", ".foo{transition:all 1s}");
+    // `<single-transition-property>` is a <custom-ident>: a css-wide keyword or
+    // `default` is not a property name and cannot move into the shorthand.
+    for (const keyword of ["initial", "inherit", "unset", "revert", "revert-layer", "default"]) {
+      minify_test(
+        `.foo { transition: opacity 1.5s, color 1s; transition-property: ${keyword} }`,
+        `.foo{transition:opacity 1.5s,color 1s;transition-property:${keyword}}`,
+      );
+      minify_test(
+        `.foo { transition-property: ${keyword}; transition-duration: 2s }`,
+        `.foo{transition-property:${keyword};transition-duration:2s}`,
+      );
+      minify_test(
+        `.foo { transition-property: opacity, ${keyword}; transition-duration: 2s }`,
+        `.foo{transition-property:opacity,${keyword};transition-duration:2s}`,
+      );
+      minify_test(`.foo { transition: ${keyword} 2s }`, `.foo{transition:${keyword} 2s}`);
+    }
     cssTest(
       `
       .foo {


### PR DESCRIPTION
### Problem
- The CSS minifier folds a longhand into `font` or `transition` even when the shorthand cannot hold the value: `font: italic .875rem Arial; font-family: revert-layer` becomes `font:italic .875rem revert-layer`, and a later `transition-property: revert` becomes `transition:revert 1.5s`. Browsers drop the merged declaration whole. `color-scheme: inherit` prints as `color-scheme:normal` for the same reason.
- `font: condensed 12px foo` minifies to `font:75% 12px foo`, also dropped: the shorthand takes only the `font-stretch` keywords (parcel-bundler/lightningcss#1140).
- Cause: `FontFamily::parse` took a lone css-wide keyword or `default` as a `GenericFontFamily`, `transition-property` and `color-scheme` took any identifier, and `Font::to_css` let minify rewrite the stretch keyword to a percentage (`src/css/properties/{font,transition,ui}.rs`).

### Fix
- A lone css-wide keyword or `default` fails `FontFamily::parse` and the new `PropertyId::parse_custom_ident` (used by `transition-property` and `transition`). `ColorScheme::parse` consumes only its four keywords (port of parcel-bundler/lightningcss#1152). Such declarations stay `Property::Unparsed`.
- `Font.stretch` is a `FontStretchKeyword`. A percentage longhand maps to the keyword of equal value (`75%` to `condensed`) or follows the shorthand as its own declaration, as a css3 `font-variant-caps` already does.
- Verified: `test/js/bun/css/css.test.ts` (new cases fail on canary, three upstream expectations corrected). Also `test/js/bun/css/`, `test/bundler/css/`, `test/bundler/esbuild/css.test.ts`. Self-reviewed: 3 concerns raised, 3 addressed.

### Background
- The property handlers buffer longhands and emit one shorthand once every component is set. A value the typed parser rejects stays `Property::Unparsed` and is flushed in place, never merged (as `font-style: unset` is today).
- `<family-name>` is `<string> | <custom-ident>+` and `<single-transition-property>` is `all | <custom-ident>`. `<custom-ident>` excludes the css-wide keywords and `default`. `inherit foo` is still a valid family name.
- In the `font` grammar, `<font-stretch-css3>` is the nine keywords only.

<details><summary>Notes</summary>

- Chromium 148 with the old output: `.f{font:italic .875rem revert-layer}` computes `font-style: normal` (declaration dropped), `transition:revert 1.5s` computes durations `0s`, `font:75% 12px foo` resets stretch to `100%` and loses family, size and line-height. lightningcss 1.30.2 produces the same output for the font and transition cases, so those are shared with upstream (issues 1140 and 1214 are open with no PR). The color-scheme case was fixed upstream in 1152 and is ported here.
- `transition: inherit; transition-property: bar` used to print `transition: bar` (parcel-bundler/lightningcss#1214). It now keeps both declarations.
- `Font::parse` tested `variant_caps.is_some()` where upstream has `is_none()`, with a comment that blamed upstream for it. So `font: small-caps 12px serif` never parsed as a shorthand and passed through unminified. Restored to `is_none()` with tests.
- `GenericFontFamily` no longer lists `initial`, `inherit`, `unset`, `default`, `revert`, `revert-layer`. Upstream kept them there so that `font-family: inherit` would not serialize as a quoted string. That case now never reaches `FamilyName` (it stays unparsed), and a quoted `"inherit"` is still re-quoted on output through `is_reserved_custom_ident`.
- `PropertyId::parse` (a declaration name, used by `@supports` and `@container`) is unchanged. Only the value position goes through `parse_custom_ident`.
- `font-family: revert; font: 12px serif` used to minify to `font:12px serif` and now keeps the unparsed `font-family:revert` in front of it. Both are correct. The shorter form would need the handler to drop unparsed longhands that a later shorthand overrides, which it does not do for any property today (`font-style: unset; font: 12px serif` already behaves this way).
- `@font-palette-values --x { font-family: inherit }` used to print an empty block and now passes the (invalid) declaration through, the same as any other declaration the typed parser rejects.
- A percentage that equals a keyword value (50, 62.5, 75, 87.5, 100, 112.5, 125, 150, 200) is folded as that keyword. All nine are exact in `f32`, so the comparison is exact. Any other percentage stays a longhand after the shorthand.
- `ColorScheme::parse` matched its keywords case-sensitively before, so `color-scheme: LIGHT Dark` also printed `normal`. The port matches them case-insensitively like every other keyword parser.
- Not changed: the `font-stretch` longhand still minifies a keyword to its percentage regardless of targets, as upstream does. Percentages in the longhand are supported since Chrome 62, Firefox 61 and Safari 11.1.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static
... (truncated)

release without fix: 51 failed, 67 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.20ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.63ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.13ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.06ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e9895096bd
  features     baseline

23 deps, 131 codegen, 1172 objects in 664ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [19.00ms]
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] fetch zlib
[zlib] up to date
[7/1243] gen bindgenv2
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codege
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/generics.rs                   |   4 +-
 src/css/properties/font.rs            | 102 ++++++++++++++++++++------------
 src/css/properties/mod.rs             |  30 +++++++++-
 src/css/properties/properties_impl.rs |  18 ++++++
 src/css/properties/transition.rs      |   2 +-
 src/css/properties/ui.rs              | 102 +++++++++++++++++---------------
 test/js/bun/css/css.test.ts           | 107 +++++++++++++++++++++++++++++++++-
 7 files changed, 276 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/css/generics.rs                        3      1     16
src/css/properties/font.rs                 6     16     16
src/css/properties/mod.rs                  1      1     16
src/css/properties/properties_impl.rs      1      1     16
src/css/properties/transition.rs           1      1     16
src/css/properties/ui.rs                   2      1     16
test/js/bun/css/css.test.ts                7      9     16
```

</details>

<!-- robobun:evidence:end -->