### PR TITLE
Free the heap members of ImportMetaObject, v8 InternalFieldObject and JSHTTPParser when the GC collects them

### DIFF
--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -380,10 +380,26 @@ inline constexpr SubspaceForInit subspaceForInit {
     static_cast<void (*)(JSC::JSCell*, JSC::SlotVisitor&)>(T::visitOutputConstraints) != static_cast<void (*)(JSC::JSCell*, JSC::SlotVisitor&)>(JSC::JSCell::visitOutputConstraints),
 };
 
+// Whether `T::destroy` is still `JSC::JSCell::destroy`, which runs no C++
+// destructor. A `destroy` that is not accessible from here was declared by
+// `T` or one of its bases, so it counts as defined.
+template<typename T>
+inline constexpr bool inheritsJSCellDestroy = [] {
+    if constexpr (requires { static_cast<void (*)(JSC::JSCell*)>(&T::destroy); })
+        return static_cast<void (*)(JSC::JSCell*)>(&T::destroy) == static_cast<void (*)(JSC::JSCell*)>(&JSC::JSCell::destroy);
+    else
+        return false;
+}();
+
 template<typename T, UseCustomHeapCellType useCustomHeapCellType>
 ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, SubspaceSlots slots, JSC::HeapCellType& (*getCustomHeapCellType)(JSHeapData&) = nullptr)
 {
     static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || T::needsDestruction == JSC::DoesNotNeedDestruction);
+    // The GC calls `methodTable.destroy` when it sweeps a destructible cell.
+    // If that is still JSCell::destroy, the destructors of T's members never
+    // run and whatever they own leaks with every collected instance.
+    static_assert(T::needsDestruction == JSC::DoesNotNeedDestruction || std::is_trivially_destructible_v<T> || !inheritsJSCellDestroy<T>,
+        "this cell type has data members with destructors but no `static void destroy(JSC::JSCell*)` that runs them");
     auto& clientData = *downcast<JSVMClientData>(vm.clientData);
     auto* clientSpace = *reinterpret_cast<JSC::GCClient::IsoSubspace**>(reinterpret_cast<uint8_t*>(&clientData.clientSubspaces()) + slots.clientOffset);
     if (clientSpace)

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -380,8 +380,7 @@ inline constexpr SubspaceForInit subspaceForInit {
     static_cast<void (*)(JSC::JSCell*, JSC::SlotVisitor&)>(T::visitOutputConstraints) != static_cast<void (*)(JSC::JSCell*, JSC::SlotVisitor&)>(JSC::JSCell::visitOutputConstraints),
 };
 
-// `T::destroy` is still `JSC::JSCell::destroy`, which runs no destructor. An
-// inaccessible `destroy` was declared below JSCell, so it does not count.
+// True when T::destroy is JSCell::destroy, which runs no destructor. A non-public destroy can only be an override.
 template<typename T>
 inline constexpr bool inheritsJSCellDestroy = [] {
     if constexpr (requires { static_cast<void (*)(JSC::JSCell*)>(&T::destroy); })

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -380,9 +380,8 @@ inline constexpr SubspaceForInit subspaceForInit {
     static_cast<void (*)(JSC::JSCell*, JSC::SlotVisitor&)>(T::visitOutputConstraints) != static_cast<void (*)(JSC::JSCell*, JSC::SlotVisitor&)>(JSC::JSCell::visitOutputConstraints),
 };
 
-// Whether `T::destroy` is still `JSC::JSCell::destroy`, which runs no C++
-// destructor. A `destroy` that is not accessible from here was declared by
-// `T` or one of its bases, so it counts as defined.
+// `T::destroy` is still `JSC::JSCell::destroy`, which runs no destructor. An
+// inaccessible `destroy` was declared below JSCell, so it does not count.
 template<typename T>
 inline constexpr bool inheritsJSCellDestroy = [] {
     if constexpr (requires { static_cast<void (*)(JSC::JSCell*)>(&T::destroy); })
@@ -395,11 +394,8 @@ template<typename T, UseCustomHeapCellType useCustomHeapCellType>
 ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, SubspaceSlots slots, JSC::HeapCellType& (*getCustomHeapCellType)(JSHeapData&) = nullptr)
 {
     static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || T::needsDestruction == JSC::DoesNotNeedDestruction);
-    // The GC calls `methodTable.destroy` when it sweeps a destructible cell.
-    // If that is still JSCell::destroy, the destructors of T's members never
-    // run and whatever they own leaks with every collected instance.
     static_assert(T::needsDestruction == JSC::DoesNotNeedDestruction || std::is_trivially_destructible_v<T> || !inheritsJSCellDestroy<T>,
-        "this cell type has data members with destructors but no `static void destroy(JSC::JSCell*)` that runs them");
+        "the GC sweeps this cell type with JSCell::destroy, so its members' destructors never run; define `static void destroy(JSC::JSCell*)`");
     auto& clientData = *downcast<JSVMClientData>(vm.clientData);
     auto* clientSpace = *reinterpret_cast<JSC::GCClient::IsoSubspace**>(reinterpret_cast<uint8_t*>(&clientData.clientSubspaces()) + slots.clientOffset);
     if (clientSpace)

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -20,11 +20,16 @@ namespace Zig {
 using namespace JSC;
 using namespace WebCore;
 
-class ImportMetaObject final : public JSC::JSNonFinalObject {
+class ImportMetaObject final : public JSC::JSDestructibleObject {
 public:
-    using Base = JSC::JSNonFinalObject;
+    using Base = JSC::JSDestructibleObject;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetPrototype;
+
+    static void destroy(JSC::JSCell* cell)
+    {
+        static_cast<ImportMetaObject*>(cell)->ImportMetaObject::~ImportMetaObject();
+    }
 
     /// Must be called with a valid url string (for `import.meta.url`)
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, const String& url);

--- a/src/jsc/bindings/node/http/JSHTTPParser.h
+++ b/src/jsc/bindings/node/http/JSHTTPParser.h
@@ -36,15 +36,16 @@ public:
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
 
+    static void destroy(JSC::JSCell* cell)
+    {
+        static_cast<JSHTTPParser*>(cell)->~JSHTTPParser();
+    }
+
     void finishCreation(JSC::VM&);
 
     JSHTTPParser(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
         : Base(vm, structure)
         , m_impl(globalObject)
-    {
-    }
-
-    ~JSHTTPParser()
     {
     }
 

--- a/src/jsc/bindings/v8/shim/InternalFieldObject.h
+++ b/src/jsc/bindings/v8/shim/InternalFieldObject.h
@@ -14,6 +14,11 @@ public:
 
     DECLARE_INFO;
 
+    static void destroy(JSC::JSCell* cell)
+    {
+        static_cast<InternalFieldObject*>(cell)->~InternalFieldObject();
+    }
+
     template<typename, JSC::SubspaceAccess mode>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/test/js/bun/resolve/import-meta-url-leak-fixture.mjs
+++ b/test/js/bun/resolve/import-meta-url-leak-fixture.mjs
@@ -1,0 +1,39 @@
+// Loads and drops one ES module over and over and prints how much RSS grew.
+//
+// Every module record gets an import.meta object whose native part owns the
+// module's URL string. The module here is virtual and its specifier is 512 KB
+// long, so each collected import.meta object that does not release its URL
+// costs 512 KB.
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const iterations = parseInt(process.argv[2] ?? "200");
+const specifier = "import-meta-url-leak-" + Buffer.alloc(512 * 1024, "m").toString() + ".mjs";
+
+Bun.plugin({
+  name: "import-meta-url-leak",
+  setup(build) {
+    build.module(specifier, () => ({ contents: "export const urlLength = import.meta.url.length;", loader: "js" }));
+  },
+});
+
+async function load() {
+  // Deleting the cache entry removes the module from the registry, so the next
+  // import() creates a new module record (and a new import.meta object).
+  delete require.cache[specifier];
+  const { urlLength } = await import(specifier);
+  if (urlLength < specifier.length) throw new Error("unexpected import.meta.url length " + urlLength);
+}
+
+for (let i = 0; i < 8; i++) await load();
+Bun.gc(true);
+const before = process.memoryUsage.rss();
+
+for (let i = 0; i < iterations; i++) {
+  await load();
+  if (i % 16 === 15) Bun.gc(true);
+}
+Bun.gc(true);
+const after = process.memoryUsage.rss();
+
+console.log(JSON.stringify({ deltaMiB: (after - before) / 1024 / 1024 }));

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { isModuleResolveFilenameSlowPathEnabled } from "bun:internal-for-testing";
 import { expect, it, mock } from "bun:test";
-import { bunEnv, bunExe, ospath, tempDir } from "harness";
+import { bunEnv, bunExe, expectRssDeltaBelow, ospath, tempDir } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import Module from "node:module";
 import { tmpdir } from "node:os";
@@ -346,3 +346,11 @@ it("import.meta is correct in a module that was required with a query param", as
   expect(cjs.dir).toBe(import.meta.dir);
   expect(cjs.file).toBe("other-cjs.js");
 });
+
+it("import.meta of a collected module does not leak its url", async () => {
+  // 200 module records with a 512 KB url each: 100 MiB when every one leaks.
+  await expectRssDeltaBelow(["--smol", join(import.meta.dir, "import-meta-url-leak-fixture.mjs"), "200"], {
+    release: 40,
+    debug: 55,
+  });
+}, 90_000);

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -32,7 +32,6 @@ leak:_tlv_get_addr
 # `bun build` tears down its macro VM on exit or the box is LSAN-ignored where
 # it is allocated.
 leak:^Bun::generateInternalModule(
-leak:Zig::ImportMetaObject::createFromSpecifier
 leak:Zig::GlobalObject::moduleLoaderResolve
 leak:JSModuleLoader__import
 leak:dyld::ThreadLocalVariables
@@ -62,7 +61,6 @@ leak:JSC::moduleLoaderModuleDeclarationInstantiation
 leak:JSC::arrayProtoFuncSort
 leak:bindgen_Fmt_jsFmtString
 leak:runtime.dns_jsc.dns.GetAddrInfoRequest.run
-leak:Zig::ImportMetaObject::finishCreation
 leak:uws_add_server_name_with_options
 leak:runtime.webcore.Body.Value.fromJS
 leak:sys_jsc.error_jsc.errorToSystemError

--- a/test/v8/v8-module/main.cpp
+++ b/test/v8/v8-module/main.cpp
@@ -383,6 +383,26 @@ void test_v8_object_template(const FunctionCallbackInfo<Value> &info) {
   LOG_EXPR(obj2->GetInternalField(1).As<Number>()->Value());
 }
 
+// create_objects_with_internal_fields(count, fieldCount): creates `count`
+// instances of an ObjectTemplate with `fieldCount` internal fields and drops
+// them all, so the caller can check that collecting them releases their
+// internal field storage.
+void create_objects_with_internal_fields(
+    const FunctionCallbackInfo<Value> &info) {
+  Isolate *isolate = info.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  uint32_t count = info[0]->Uint32Value(context).FromJust();
+  int field_count = static_cast<int>(info[1]->Uint32Value(context).FromJust());
+
+  Local<ObjectTemplate> obj_template = ObjectTemplate::New(isolate);
+  obj_template->SetInternalFieldCount(field_count);
+  for (uint32_t i = 0; i < count; i++) {
+    HandleScope handle_scope(isolate);
+    obj_template->NewInstance(context).ToLocalChecked();
+  }
+  return ok(info);
+}
+
 void return_data_callback(const FunctionCallbackInfo<Value> &info) {
   info.GetReturnValue().Set(info.Data());
 }
@@ -2085,6 +2105,8 @@ void initialize(Local<Object> exports, Local<Value> module,
   NODE_SET_METHOD(exports, "return_this", return_this);
   NODE_SET_METHOD(exports, "create_object_with_holder_accessor",
                   create_object_with_holder_accessor);
+  NODE_SET_METHOD(exports, "create_objects_with_internal_fields",
+                  create_objects_with_internal_fields);
   NODE_SET_METHOD(exports, "global_get", GlobalTestWrapper::get);
   NODE_SET_METHOD(exports, "global_set", GlobalTestWrapper::set);
   NODE_SET_METHOD(exports, "test_many_v8_locals", test_many_v8_locals);

--- a/test/v8/v8-module/module.js
+++ b/test/v8/v8-module/module.js
@@ -3,6 +3,20 @@ module.exports = debugMode => {
   return {
     ...nativeModule,
 
+    // Bun only: 48k collected instances with 128 internal fields each. Their
+    // field storage is about 2 KB per instance, 100 MiB if none of it is freed.
+    test_v8_internal_field_object_leak() {
+      nativeModule.create_objects_with_internal_fields(256, 128);
+      Bun.gc(true);
+      const before = process.memoryUsage.rss();
+      for (let i = 0; i < 24; i++) {
+        nativeModule.create_objects_with_internal_fields(2000, 128);
+        Bun.gc(true);
+      }
+      const after = process.memoryUsage.rss();
+      console.log(JSON.stringify({ deltaMiB: (after - before) / 1024 / 1024 }));
+    },
+
     test_v8_global() {
       console.log("global initial value =", nativeModule.global_get());
 

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -5,6 +5,7 @@ import {
   bunEnv,
   bunExe,
   canBuildNodeAddons,
+  expectRssDeltaBelow,
   isASAN,
   isBroken,
   isMusl,
@@ -272,6 +273,12 @@ describe.skipIf(!canBuildNodeAddons()).todoIf(isBroken && isMusl)("node:v8", () 
   describe("ObjectTemplate", () => {
     it("creates objects with internal fields", async () => {
       await checkSameOutput("test_v8_object_template");
+    });
+    it("frees the internal fields of collected instances", async () => {
+      await expectRssDeltaBelow(
+        ["--smol", join(directories.bunRelease, "main.js"), "test_v8_internal_field_object_leak", "[]", "null"],
+        { release: 40, debug: 55 },
+      );
     });
   });
 


### PR DESCRIPTION
### Problem
- `Zig::ImportMetaObject` (`src/jsc/bindings/ImportMetaObject.h:23`) is a `JSNonFinalObject` that owns `WTF::String url`. The GC sweeps it without a destructor, so every collected module record leaks its URL: re-imports after `delete require.cache[...]`, hot reloads, and every module of a terminated Worker. `test/leaksan.supp` hid it as `leak:Zig::ImportMetaObject::createFromSpecifier`.
- `v8::shim::InternalFieldObject` and `Bun::JSHTTPParser` derive `JSDestructibleObject` but never declared `destroy()`. Their method table points at `JSCell::destroy`, which runs nothing, so the two `FixedVector`s of every `ObjectTemplate` instance and the parser's `StringPtr` copies leak too.

### Fix
- `ImportMetaObject` derives `JSDestructibleObject`, and all three classes define a `destroy()` that runs the destructor. Same shape as #41904.
- `subspaceForImpl` gets a `static_assert`: a cell type that needs destruction and has members with destructors must not use `JSCell::destroy`. It rejects the last two classes as they are on main.
- Correct because the three destructors only free plain heap memory. None reads the cell's `Structure` or another cell, so sweep order does not matter.
- Verified: new RSS tests in `test/js/bun/resolve/import-meta.test.js` (106 MiB before, 12 MiB after) and `test/v8/v8.test.ts` (119 MiB before, 5 MiB after). `v8`, `napi`, `node:http` parser, worker, `node:vm` and resolve suites pass on debug ASAN. Self-reviewed: 5 concerns, 4 addressed (scope trimmed, see Notes), 1 kept (the test timeout, see Notes).

### Background
- A block's `HeapCellType` decides whether sweeping calls `destroy()` at all. `subspaceForImpl` picks the destructible one for `JSDestructibleObject` subclasses. The function called is `ClassInfo::methodTable.destroy`, which `CREATE_METHOD_TABLE` takes from the nearest class that declares `destroy`. Nothing between `JSCell` and `JSDestructibleObject` does.
- `Heap::lastChanceToFinalize` at VM teardown follows the same rules, so Worker exit leaked the same members.
- JSC creates one `import.meta` object per module record at link time, whether or not the module reads it.

<details><summary>Notes</summary>

- Four v8 shim cells have the same defect as plain `JSCell` or `InternalFunction` subclasses with containers: `FunctionTemplate` and `ObjectTemplate` (`Vector<TemplateProperty>`), `GlobalInternals` (`HashMap`/`Vector`s) and `HandleScopeBuffer` (never cleared when it backs `GlobalInternals::globalHandles()`). They need `needsDestruction` plus an `IsoHeapCellType` each, or GC-managed storage. Left out here: #39805 rewrites `HandleScopeBuffer` and `GlobalInternals` and edits the same `JSHeapData` hunks, and what they leak is per template or per global, not per instance. A first version of this branch included them and passed the same suites.
- A stricter assert (every cell in a non-destructible subspace must be trivially destructible) compiles for everything on main except `Bun::JSMockFunction`, which #40382 covers. It can replace the `needsDestruction == DoesNotNeedDestruction` escape once that lands. Checked by compiling every bindings translation unit with that form.
- LSan only sees these allocations with `Malloc=1` (they live in libpas memory), which CI does not set, so the two `Zig::ImportMetaObject` entries in `leaksan.supp` were not what kept CI green. With `Malloc=1 BUN_DESTRUCT_VM_ON_EXIT=1` and `detect_leaks=1`, re-importing a virtual module 30 times reported `Direct leak of 31110 byte(s) in 30 object(s)` from `ImportMetaObject::createFromSpecifier` before this change and nothing after.
- The import.meta test passes an explicit `90_000` timeout: a debug ASAN build spends about 140 ms per `import()` of a 512 KB specifier, so the 200 iterations that make the leak 100 MiB take about 30 s there (0.4 s in release). The v8 test takes 2 s in debug.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/v8/v8.test.ts

<!-- robobun:evidence:end -->