### PR TITLE
bundler: run CommonJS and lazily-initialized <script src> files of an HTML entry point

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -934,13 +934,15 @@ impl<'a> LinkerContext<'a> {
                 Vec::with_capacity(parts_col.len());
             for (i, parts) in parts_col.iter().enumerate() {
                 let mut bits = bun_collections::AutoBitSet::init_empty(parts.len())?;
-                // The HTML loader's `ParseTask` builds its synthetic part 1 already
-                // live (so the JS-chunk visitor follows every embedded import record).
                 // `mark_file_live_for_tree_shaking` short-circuits for HTML and never
-                // walks its parts, so seed the bit here to preserve the old
-                // `Part::is_live = true` initializer.
-                if loaders.get(i).is_some_and(|l| *l == Loader::Html) && parts.len() > 1 {
-                    bits.set(1);
+                // walks its parts. The HTML loader's `ParseTask` builds one
+                // statement-less part per import record (so the JS-chunk visitor
+                // follows every embedded `<script src>` in document order), and all
+                // of them are live.
+                if loaders.get(i).is_some_and(|l| *l == Loader::Html) {
+                    for part_index in 1..parts.len() {
+                        bits.set(part_index);
+                    }
                 }
                 parts_live.push(bits);
             }
@@ -2311,6 +2313,65 @@ impl<'a> LinkerContext<'a> {
         }
 
         Ok(true)
+    }
+
+    /// The HTML loader gives each `<script src>` its own statement-less part
+    /// that holds only the import record. A script that resolved to a wrapped
+    /// module runs nothing until its wrapper is called, so print that call where
+    /// the tag was, like `should_remove_import_export_stmt` does for a bare
+    /// `import "./script"`: `require_foo()`, `init_foo()`, or `await init_foo()`.
+    /// Nothing observes the namespace, so the result is not passed to `__toESM`.
+    pub(crate) fn append_html_script_wrapper_calls(
+        &self,
+        stmts: &mut StmtList,
+        part: &Part,
+        ast: &JSAst<'_>,
+    ) -> Result<(), AllocError> {
+        for &import_record_index in part.import_record_indices.slice() {
+            let record = &ast.import_records[import_record_index as usize];
+            if record.kind != ImportKind::Stmt
+                || !record.source_index.is_valid()
+                || record.flags.contains(bun_ast::ImportRecordFlags::IS_UNUSED)
+            {
+                continue;
+            }
+            let other_source_index = record.source_index.get() as usize;
+            let other_flags = self.graph.meta.items_flags()[other_source_index];
+            match other_flags.wrap {
+                WrapKind::None => continue,
+                WrapKind::Cjs => {}
+                WrapKind::Esm => {
+                    if !self.graph.files_live.is_set(other_source_index) {
+                        continue;
+                    }
+                }
+            }
+            let wrapper_ref = self.graph.ast.items_wrapper_ref()[other_source_index];
+            if wrapper_ref.is_empty() {
+                continue;
+            }
+
+            let mut call = Expr::init(
+                E::Call {
+                    target: Expr::init_identifier(wrapper_ref, Loc::EMPTY),
+                    ..Default::default()
+                },
+                Loc::EMPTY,
+            );
+            if other_flags.wrap == WrapKind::Esm && other_flags.is_async_or_has_async_dependency {
+                call = Expr::init(E::Await { value: call }, Loc::EMPTY);
+            }
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(Stmt::alloc(
+                    S::SExpr {
+                        value: call,
+                        ..Default::default()
+                    },
+                    Loc::EMPTY,
+                ))?;
+        }
+        Ok(())
     }
 
     pub(crate) fn print_code_for_file_in_chunk_js(

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1231,23 +1231,24 @@ pub mod parse_worker {
                 // gave up on figuring out how to fix it so that
                 // this feature could ship.
                 ast.has_lazy_export = false;
-                // Liveness for this synthetic part is seeded in
-                // `tree_shaking_and_code_splitting` (the per-part bitset
-                // does not exist at parse time).
-                ast.parts.as_mut_slice()[1] = Part {
-                    stmts: ast::StoreSlice::EMPTY,
-                    import_record_indices: {
-                        // Generate a single part that depends on all the import records.
-                        // This is to ensure that we generate a JavaScript bundle containing all the user's code.
-                        let mut import_record_indices = ast::PartImportRecordIndices::init_capacity(
-                            import_records_len as usize,
-                        );
-                        import_record_indices
-                            .extend(0..u32::try_from(import_records_len).expect("int cast"));
-                        import_record_indices
-                    },
-                    ..Default::default()
-                };
+                // One statement-less part per import record, in document order.
+                // The linker prints a part after the files it imports, so a
+                // `<script src>` that resolves to a wrapped module gets its
+                // `require_foo()` / `init_foo()` call at the tag's position
+                // (see `append_html_script_wrapper_calls`). Liveness for these
+                // parts is seeded in `tree_shaking_and_code_splitting` (the
+                // per-part bitset does not exist at parse time).
+                ast.parts.truncate(1);
+                ast.parts.reserve(import_records_len);
+                for import_record_index in 0..u32::try_from(import_records_len).expect("int cast") {
+                    let mut import_record_indices = ast::PartImportRecordIndices::init_capacity(1);
+                    import_record_indices.push(import_record_index);
+                    ast.parts.push(Part {
+                        stmts: ast::StoreSlice::EMPTY,
+                        import_record_indices,
+                        ..Default::default()
+                    });
+                }
 
                 // Try to avoid generating unnecessary ESM <> CJS wrapper code.
                 if output_format == js_parser::options::Format::Esm

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -10,7 +10,7 @@ use bun_js_printer::{self as js_printer, PrintResult, PrintResultSuccess};
 use crate::analyze_transpiled_module::ModuleInfo;
 use crate::generic_path_with_pretty_initialized;
 use crate::linker_context_mod::{StmtList, StmtListWhich};
-use crate::options::Format as OutputFormat;
+use crate::options::{Format as OutputFormat, Loader};
 use crate::{Chunk, Index, LinkerContext, Part, PartRange, WrapKind};
 
 use bun_ast::StoreRef;
@@ -237,6 +237,8 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
 
     let namespace_export_part_index = bun_ast::NAMESPACE_EXPORT_PART_INDEX;
 
+    let is_html = c.parse_graph().input_files.items_loader()[source_index] == Loader::Html;
+
     stmts.reset();
 
     let part_index_for_lazy_default_export: u32 = 'brk: {
@@ -351,6 +353,13 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         if index == wrapper_part_index.get() {
             // Skip the wrapper part because we already handled it above
             needs_wrapper = true;
+            continue;
+        }
+
+        if is_html {
+            if let Err(err) = c.append_html_script_wrapper_calls(stmts, part, &ast) {
+                return PrintResult::Err(err.into());
+            }
             continue;
         }
 

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -680,7 +680,12 @@ pub(crate) fn post_process_js_chunk(
         }
 
         // TODO: metafile
-        newline_before_comment = !compile_result.code().is_empty();
+
+        // Put a newline before the next file path comment. An empty result (a
+        // part range that printed nothing) must not take it away again.
+        if !compile_result.code().is_empty() {
+            newline_before_comment = true;
+        }
     }
     // An entry chunk whose code all lives in shared chunks has no compile results of its own.
     if !preload_registration.is_empty() {

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -732,6 +732,9 @@ pub(crate) fn scan_imports_and_exports(
             let wrap = flag.wrap;
             let export_kind = col_ref!(exports_kind)[id];
             let source: &Source = &col_ref!(input_files)[id];
+            // An HTML file's `<script src>` records print as bare wrapper calls
+            // (`append_html_script_wrapper_calls`); nothing reads the namespace.
+            let is_html = col_ref!(loaders)[id] == Loader::Html;
 
             let exports_ref = col_ref!(exports_refs)[id];
             let module_ref = col_ref!(module_refs)[id];
@@ -1212,6 +1215,7 @@ pub(crate) fn scan_imports_and_exports(
                         // A same-chunk `import()` of a lifted CommonJS module needs it
                         // too, so that `default` is `module.exports` (the namespace).
                         if kind != ImportKind::Require
+                            && !is_html
                             && (other_export_kind == ExportsKind::Cjs
                                 || (kind == ImportKind::Dynamic
                                     && other_flags.wrap == WrapKind::Esm

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -249,6 +249,135 @@ export const padZero = (num) => String(num).padStart(2, '0');`,
     },
   });
 
+  // A `<script src>` that bun classifies as CommonJS (a `.cjs` file, a file
+  // that calls `require()`, top-level `this` in a UMD header, `module.exports`
+  // behind a `typeof module` guard) is wrapped in `__commonJS`. The page must
+  // still run it, in document order.
+  itBundled("html/script-src-commonjs", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="./umd.js"></script>
+    <script src="./guarded.js"></script>
+    <script src="./ext.cjs"></script>
+    <script src="./requires.js"></script>
+    <script src="./plain.js"></script>
+  </body>
+</html>`,
+      "/umd.js": `
+(function (root, factory) {
+  root.LIB = factory();
+})(this, function () {
+  return { v: 1 };
+});
+console.log("umd");`,
+      "/guarded.js": `
+console.log("guarded");
+if (typeof module === "object") module.exports = { guarded: true };`,
+      "/ext.cjs": `console.log("cjs extension");`,
+      "/requires.js": `
+const dep = require("./dep.js");
+console.log("requires " + dep);`,
+      "/dep.js": `module.exports = 7;`,
+      "/plain.js": `console.log("plain");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.writeFile("out/run.mjs", `import "./${js}";`);
+    },
+    run: { file: "out/run.mjs", stdout: "umd\nguarded\ncjs extension\nrequires 7\nplain" },
+  });
+
+  // Every `.js` file of a `"type": "commonjs"` package (the `npm init` default)
+  // is classified as CommonJS, so even a plain `console.log` script is wrapped.
+  itBundled("html/script-src-type-commonjs-package", {
+    outdir: "out/",
+    files: {
+      "/package.json": `{ "name": "app", "version": "1.0.0", "type": "commonjs" }`,
+      "/index.html": `<!DOCTYPE html><html><body><script src="./first.js"></script><script src="./second.js"></script></body></html>`,
+      "/first.js": `console.log("first");`,
+      "/second.js": `console.log("second");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.writeFile("out/run.mjs", `import "./${js}";`);
+    },
+    run: { file: "out/run.mjs", stdout: "first\nsecond" },
+  });
+
+  // Same, when the script resolved to a lazily-initialized ES module (here
+  // because another script also `import()`s it): the page calls `init_foo()`,
+  // with `await` when the module uses top-level await.
+  itBundled("html/script-src-lazy-esm", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="./sync.js"></script>
+    <script src="./tla.js"></script>
+    <script src="./main.js"></script>
+  </body>
+</html>`,
+      "/sync.js": `
+export const sync = "sync";
+console.log(sync);`,
+      "/tla.js": `
+export const tla = await Promise.resolve("tla");
+console.log(tla);`,
+      "/main.js": `
+console.log("main");
+const { sync } = await import("./sync.js");
+const { tla } = await import("./tla.js");
+console.log("lazy " + sync + " " + tla);`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.expectFile("out/" + js).toMatch(/init_sync\(\);\s*await init_tla\(\);/);
+      api.writeFile("out/run.mjs", `import "./${js}";`);
+    },
+    run: { file: "out/run.mjs", stdout: "sync\ntla\nmain\nlazy sync tla" },
+  });
+
+  // With code splitting the CommonJS script shared by two pages moves to its
+  // own chunk. Each page imports `require_lib` from it and still calls it. The
+  // page itself never reads the namespace, so it does not import `__toESM`
+  // (two.js does, for its own `import * as`).
+  itBundled("html/script-src-commonjs-splitting", {
+    outdir: "out/",
+    splitting: true,
+    files: {
+      "/one.html": `<!DOCTYPE html><html><body><script src="./lib.js"></script><script src="./one.js"></script></body></html>`,
+      "/two.html": `<!DOCTYPE html><html><body><script src="./lib.js"></script><script src="./two.js"></script></body></html>`,
+      "/lib.js": `
+console.log("lib");
+module.exports = { lib: true };`,
+      "/one.js": `console.log("one");`,
+      "/two.js": `
+import * as ns from "./lib.js";
+console.log("two", ns.default.lib);`,
+    },
+    entryPoints: ["/one.html", "/two.html"],
+    onAfterBundle(api) {
+      for (const page of ["one", "two"]) {
+        const js = api.readFile(`out/${page}.html`).match(/src="\.\/([^"]+\.js)"/)![1];
+        if (page === "one") api.expectFile("out/" + js).not.toContain("__toESM");
+        api.writeFile(`out/run-${page}.mjs`, `import "./${js}";`);
+      }
+    },
+    run: [
+      { file: "out/run-one.mjs", stdout: "lib\none" },
+      { file: "out/run-two.mjs", stdout: "lib\ntwo true" },
+    ],
+  });
+
   // Test CSS imports
   itBundled("html/css-imports", {
     outdir: "out/",

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -310,6 +310,41 @@ console.log("requires " + dep);`,
     run: { file: "out/run.mjs", stdout: "first\nsecond" },
   });
 
+  // The chunk prints wrapped files ahead of the flat ones, so the call for a
+  // CommonJS script that sits between two plain scripts must come from the
+  // tag's own part to keep document order, not from next to the wrapper.
+  itBundled("html/script-src-commonjs-between-plain-scripts", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="./first.js"></script>
+    <script src="./umd-badge.js"></script>
+    <script src="./last.js"></script>
+  </body>
+</html>`,
+      "/first.js": `console.log("first");`,
+      "/umd-badge.js": `
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) module.exports = factory();
+  else root.Badge = factory();
+})(globalThis, function () {
+  console.log("umd badge");
+  return {};
+});`,
+      "/last.js": `console.log("last");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.expectFile("out/" + js).not.toContain("__toESM");
+      api.writeFile("out/run.mjs", `import "./${js}";`);
+    },
+    run: { file: "out/run.mjs", stdout: "first\numd badge\nlast" },
+  });
+
   // Same, when the script resolved to a lazily-initialized ES module (here
   // because another script also `import()`s it): the page calls `init_foo()`,
   // with `await` when the module uses top-level await.

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -141,11 +141,11 @@ console.log(favicon);
             "files": [
               {
                 "input": "client.html",
-                "path": "./client-qjznw47b.js",
+                "path": "./client-c9kjeh05.js",
                 "loader": "js",
                 "isEntry": true,
                 "headers": {
-                  "etag": "l5IfNVyE54s",
+                  "etag": "7GmzUg4RQCU",
                   "content-type": "text/javascript;charset=utf-8"
                 }
               },
@@ -155,7 +155,7 @@ console.log(favicon);
                 "loader": "html",
                 "isEntry": true,
                 "headers": {
-                  "etag": "xh1kdn7wbmI",
+                  "etag": "L1NGVitZslc",
                   "content-type": "text/html;charset=utf-8"
                 }
               },
@@ -325,17 +325,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "Dl7kT6q7eY4",
+                  "etag": "Vr91Jdsy4Zc",
                 },
                 "input": "home.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./home-ey4favse.js",
+                "path": "./home-pzn5vj1q.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "IhvRaM9jGDU",
+                  "etag": "bO9UOC8tMwQ",
                 },
                 "input": "home.html",
                 "isEntry": true,
@@ -360,17 +360,17 @@ console.log("About manifest:", aboutHtml);
               {
                 "headers": {
                   "content-type": "text/javascript;charset=utf-8",
-                  "etag": "RCRrF1EbBvo",
+                  "etag": "xjiS27vgDE0",
                 },
                 "input": "about.html",
                 "isEntry": true,
                 "loader": "js",
-                "path": "./about-44bqhv6t.js",
+                "path": "./about-6rjvv0cd.js",
               },
               {
                 "headers": {
                   "content-type": "text/html;charset=utf-8",
-                  "etag": "2OGqRD6vx54",
+                  "etag": "yq0KRVKuKEY",
                 },
                 "input": "about.html",
                 "isEntry": true,

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -74,6 +74,42 @@ console.log(data);`,
     expect(html).toContain("await");
   });
 
+  // A script that bun classifies as CommonJS (UMD header with top-level `this`,
+  // or a guarded `module.exports`) is wrapped in `__commonJS`. The inlined
+  // module must still run it, in document order.
+  test("runs CommonJS scripts in document order", async () => {
+    using dir = tempDir("compile-browser-cjs-script", {
+      "index.html": `<!DOCTYPE html><html><body><script src="./umd.js"></script><script src="./guarded.js"></script><script src="./plain.js"></script></body></html>`,
+      "umd.js": `(function (root, factory) { root.LIB = factory(); })(this, function () { return { v: 1 }; });
+console.log("umd");`,
+      "guarded.js": `console.log("guarded");
+if (typeof module === "object") module.exports = { guarded: true };`,
+      "plain.js": `console.log("plain");`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/index.html`],
+      compile: true,
+      target: "browser",
+    });
+
+    expect(result.success).toBe(true);
+    const html = await result.outputs[0].text();
+    const script = html.match(/<script type="module">([\s\S]*)<\/script>/)![1];
+    await Bun.write(`${dir}/inlined.mjs`, script);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), `${dir}/inlined.mjs`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("umd\nguarded\nplain\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   test("escapes </script> in inlined JS", async () => {
     using dir = tempDir("compile-browser-escape-script", {
       "index.html": `<!DOCTYPE html><html><body><script src="./app.js"></script></body></html>`,

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -224,7 +224,7 @@ console.log("How...dashing?");
   "content-length": "316",
   "content-type": "text/javascript;charset=utf-8",
   "date": "<date>",
-  "etag": ""f862dbeedf9b72bc"",
+  "etag": ""c2050d7cfe555369"",
   "sourcemap": "/chunk-HASH.js.map",
 }
 `);


### PR DESCRIPTION
### Problem
- An HTML entry point (`bun build ./index.html`, also `--compile --target=browser`) never runs a `<script src>` that the bundler classifies as CommonJS. The chunk has `var require_a = __commonJS(...)` and nothing calls `require_a()`. Exit 0, no diagnostic. Triggers: any `.js` in a `"type": "commonjs"` package (the `npm init` default), a `.cjs` file, a `require()` call, a UMD header passing `this`, a guarded `module.exports`. A script wrapped in `__esm` is dropped too.
- Cause: the HTML loader built one statement-less part holding all import records (`src/bundler/ParseTask.rs:1234`). The linker prints a wrapped import only from an `import` statement, so that part printed nothing.

### Fix
- One part per import record in the HTML AST. The chunk visitor prints a part after the files it imports, so each tag keeps its position.
- `append_html_script_wrapper_calls` prints `require_a()`, `init_a()`, or `await init_a()` for an HTML part whose record resolved to a wrapped file. No `__toESM`: nothing reads the namespace.
- Not changed: a classic script still runs as module code, so a UMD global set through `this` lands on `exports` (#18770 family).
- Verified: 5 new cases in `test/bundler/bundler_html.test.ts`, 1 in `test/bundler/standalone.test.ts`. Each runs the emitted module and fails on 1.4.3.

### Background
- An HTML entry point yields the rewritten HTML plus one JS chunk that merges every `<script src>`, as if a module imported each in turn.
- A file the linker cannot inline is wrapped: CommonJS in `__commonJS` (run by `require_x()`), a lazy ES module in `__esm` (run by `init_x()`). An importer prints that call at its `import` statement.
- The chunk hash mixes in part ranges: HTML entry chunks get new hashes, same bytes. That is the snapshot churn.

<details><summary>Notes</summary>

- Found by a fuzz corpus that compares built pages against Chromium: 0 of 114 pages with such a script ran it after `bun build`, 81 of 114 did unbundled. No linked user report.
- Output for the original repro (UMD `a.js`, guarded `m.js`, plain `b.js`) now reads:
  ```js
  // index.html
  require_a();
  require_m();

  // b.js
  document.documentElement.setAttribute("data-b", typeof LIB);
  ```
- Related PRs that touched the same `Loader::Html` block: #41999 (top-level await ordering between scripts, closed in favor of this PR) and #41982 (per-script error boundary, a draft stacked on this commit). #41999 made the same per-tag part change with synthesized `import` statements instead of statement-less parts. Its `html/script-src-commonjs-between-plain-scripts` case (a CommonJS script between two plain scripts) was carried over here. Its top-level-await rule was not: it changes when later scripts run, and #41982 covers that question (`__scriptAsync`) pending a direction call.
- `post_process_js_chunk` now keeps the blank line between two files when an empty part range sits between them. esbuild only ever sets that flag; bun also cleared it, and the per-tag HTML parts made that visible.
- `scan_imports_and_exports` step 6 no longer registers a `__toESM` use for an HTML importer. It used to surface as an unused `import { __toESM }` in the page's entry chunk under `--splitting`.
- `find_imported_parts_in_js_order` emits a file part by part, each part after the files its records import. One part per tag is what lets the call land between the scripts around it.
- The dev server (`bun ./index.html`) was not affected: its HTML module lists the scripts as imports and the HMR runtime loads CommonJS modules on import.
- Why not synthesize real `import` statements in the HTML AST: that prints `var import_a = __toESM(require_a())`, which needs a namespace symbol per tag and the `__toESM` runtime, and tree shaking never walks an HTML file's part dependencies, so the helper would not be included.
- `link[as=worker][href]` is also an `ImportKind::Stmt` record today and is merged into the page chunk like a script; a CommonJS target now runs there too, consistent with an unwrapped one.
- Also checked by hand: `--splitting` with a shared CommonJS script (the page chunk imports `require_lib` and calls it), `--minify`, `--format=cjs`, `--format=iife`, `--sourcemap` (mappings of the other files unchanged, the HTML file adds none), a CommonJS script that is also its own entry point, external `https://` scripts (left in the HTML as before), pages with no scripts.
- Suites run locally: bundler_html, standalone, html-import-manifest, bun-serve-html, bun-serve-html-manifest, bundler_html_server, bundler_splitting, bundler_compile, bundler_compile_splitting, bun-build-api, esbuild/default, esbuild/splitting, esbuild/importstar, esbuild/dce, esbuild/loader, bundler_edgecase, bundler_minify, bundler_jsx, bundler_banner, bundler_footer, bundler_cjs, bundler_cjs2esm, bundler_regressions, bundler_browser, bundler_loader, cli, bake dev html/bundle/production, dev-and-prod.
- Self-reviewed: 2 concerns raised, 2 addressed (body leads with the common triggers and a `"type": "commonjs"` test was added; relationship to #41999 and #41982 stated).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/standalone.test.ts

<!-- robobun:evidence:end -->
