### PR TITLE
Bump WebKit (oven-sh/WebKit#590 preview): ShadowRealm wraps a returned callable for the caller's realm

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "preview-pr-590-c7520f66";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "preview-pr-590-c7520f66";
+export const WEBKIT_VERSION = "autobuild-preview-pr-590-c7520f66";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -42,8 +42,11 @@ it("a returned wrapper does not expose the shadow realm's global object", () => 
 
   // The realm's global stays out of reach, so the two globals share no state.
   globalThis.injectedByShadowTest = { list: [] };
-  expect(realm.evaluate(`typeof globalThis.injectedByShadowTest`)).toBe("undefined");
-  delete globalThis.injectedByShadowTest;
+  try {
+    expect(realm.evaluate(`typeof globalThis.injectedByShadowTest`)).toBe("undefined");
+  } finally {
+    delete globalThis.injectedByShadowTest;
+  }
 });
 
 it("a callable returned to the shadow realm belongs to the shadow realm", () => {

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -8,3 +8,53 @@ it("shadow realm works", () => {
   expect(globalThis.someValue).toBe(1);
   expect(result).toBe(2);
 });
+
+// A callable that a wrapped function returns is wrapped for the caller's realm,
+// so its prototype is the caller's Function.prototype. The engine uses a
+// separate call path for a target that is not a plain function, so check one
+// target of each kind.
+const targets = {
+  "a plain function": `() => () => 1`,
+  "a bound function": `(() => () => 1).bind(undefined)`,
+  "the realm's Function constructor": `Function`,
+  "a callable Proxy": `new Proxy(() => () => 1, {})`,
+  "a Proxy with an apply trap": `new Proxy(() => {}, { apply: () => () => 1 })`,
+};
+
+for (const [name, source] of Object.entries(targets)) {
+  it(`a callable returned through ${name} belongs to the caller's realm`, () => {
+    const wrapped = new ShadowRealm().evaluate(source);
+    const returned = wrapped();
+    expect(typeof returned).toBe("function");
+    expect(Object.getPrototypeOf(returned)).toBe(Function.prototype);
+  });
+}
+
+it("a returned wrapper does not expose the shadow realm's global object", () => {
+  const realm = new ShadowRealm();
+  const made = realm.evaluate(`Function`)("return 1");
+
+  // Before the fix this prototype was the realm's Function.prototype, so
+  // .constructor was the realm's real Function constructor.
+  const constructor = Object.getPrototypeOf(made).constructor;
+  expect(constructor).toBe(Function);
+  expect(constructor("return globalThis")()).toBe(globalThis);
+
+  // The realm's global stays out of reach, so the two globals share no state.
+  globalThis.injectedByShadowTest = { list: [] };
+  expect(realm.evaluate(`typeof globalThis.injectedByShadowTest`)).toBe("undefined");
+  delete globalThis.injectedByShadowTest;
+});
+
+it("a callable returned to the shadow realm belongs to the shadow realm", () => {
+  const realm = new ShadowRealm();
+  const fromRealm = realm.evaluate(`(f) => {
+    const proto = Object.getPrototypeOf(f());
+    if (proto !== Function.prototype) return typeof proto.constructor("return globalThis")().Bun;
+    return "ok";
+  }`);
+
+  expect(fromRealm(new Proxy(() => () => 1, {}))).toBe("ok");
+  expect(fromRealm(() => () => 1)).toBe("ok");
+  expect(fromRealm(Function)).toBe("ok");
+});

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -13,29 +13,25 @@ it("shadow realm works", () => {
 // so its prototype is the caller's Function.prototype. The engine uses a
 // separate call path for a target that is not a plain function, so check one
 // target of each kind.
-const targets = {
-  "a plain function": `() => () => 1`,
-  "a bound function": `(() => () => 1).bind(undefined)`,
-  "the realm's Function constructor": `Function`,
-  "a callable Proxy": `new Proxy(() => () => 1, {})`,
-  "a Proxy with an apply trap": `new Proxy(() => {}, { apply: () => () => 1 })`,
-};
-
-for (const [name, source] of Object.entries(targets)) {
-  it(`a callable returned through ${name} belongs to the caller's realm`, () => {
-    const wrapped = new ShadowRealm().evaluate(source);
-    const returned = wrapped();
-    expect(typeof returned).toBe("function");
-    expect(Object.getPrototypeOf(returned)).toBe(Function.prototype);
-  });
-}
+it.each([
+  ["a plain function", `() => () => 1`],
+  ["a bound function", `(() => () => 1).bind(undefined)`],
+  ["the realm's Function constructor", `Function`],
+  ["a callable Proxy", `new Proxy(() => () => 1, {})`],
+  ["a Proxy with an apply trap", `new Proxy(() => {}, { apply: () => () => 1 })`],
+])("a callable returned through %s belongs to the caller's realm", (name, source) => {
+  const wrapped = new ShadowRealm().evaluate(source);
+  const returned = wrapped();
+  expect(typeof returned).toBe("function");
+  expect(Object.getPrototypeOf(returned)).toBe(Function.prototype);
+});
 
 it("a returned wrapper does not expose the shadow realm's global object", () => {
   const realm = new ShadowRealm();
   const made = realm.evaluate(`Function`)("return 1");
 
-  // Before the fix this prototype was the realm's Function.prototype, so
-  // .constructor was the realm's real Function constructor.
+  // The wrapper's prototype is the caller's Function.prototype, so the
+  // constructor found on it compiles code in the caller's realm.
   const constructor = Object.getPrototypeOf(made).constructor;
   expect(constructor).toBe(Function);
   expect(constructor("return globalThis")()).toBe(globalThis);


### PR DESCRIPTION
### Problem
- `ShadowRealm`: when a wrapped function's target is not a plain JS function (a callable `Proxy`, or a built-in such as the realm's `Function`) and it returns a callable, the returned wrapper was created in the *target* realm. `Object.getPrototypeOf(wrapper)` is then the other realm's `Function.prototype`, its `.constructor` is the other realm's genuine `Function`, and `F("return globalThis")()` hands out that realm's global object. The leak runs both ways.
- The cause is in JSC: `remoteFunctionCallGeneric` (`Source/JavaScriptCore/runtime/JSRemoteFunction.cpp:158`) ended with `wrapReturnValue(globalObject, targetGlobalObject, result)`. The plain-function path and the JIT thunk wrap for the caller's realm, as `OrdinaryWrappedFunctionCall` specifies. Node with `--experimental-shadow-realm` gets this right.

```js
const r = new ShadowRealm();
const made = r.evaluate(`Function`)("return 1");
Object.getPrototypeOf(made) === Function.prototype;            // was false
const g = Object.getPrototypeOf(made).constructor("return globalThis")();
g.injected = 1; r.evaluate(`globalThis.injected`);             // was 1
```

### Fix
- Engine fix in oven-sh/WebKit#590: `wrapReturnValue` takes one global object, the caller's realm, on both call paths. This PR pins `WEBKIT_VERSION` at its preview build `autobuild-preview-pr-590-c7520f66`.
- The range from `2e2aa2290fac` also contains oven-sh/WebKit#561, oven-sh/WebKit#566 and oven-sh/WebKit#568, which are already on oven-sh/WebKit `main`.
- Verified: `test/js/bun/jsc/shadow.test.js` gains 7 cases (one per target kind, the global-object probe, and the reverse direction). 5 of 8 fail on the old pin, 8 of 8 pass on the new one. The six `test/js/node/test/parallel/test-shadow-realm*.js` files and `test/regression/issue/29519.test.ts` pass.

### Background
- A value that crosses a `ShadowRealm` boundary must be a primitive or a callable. A callable is replaced by a wrapped function (`JSRemoteFunction` in JSC) that lives in the receiving realm and forwards calls to the target.
- The global object passed to `JSRemoteFunction::tryCreate` decides the wrapper's structure and `[[Prototype]]`, so it decides which realm owns the wrapper.
- JSC has two call paths for wrapped functions, chosen when the wrapper is created: a fast one for plain `JSFunction` targets (including bound functions) and a generic one for every other callable. Only the generic one had the swap, which is why test262's `wrapped-function-proto-from-caller-realm.js` (plain function target) did not catch it.

<details><summary>Notes</summary>

- The gate's fail-before step restores `src/` and `packages/` only, and the fix lives in the WebKit pin under `scripts/`, so it cannot reproduce the failing side. Fail-before was checked by hand: `USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/shadow.test.js` (bun 1.4.3) and `bun bd test` on pin `2e2aa2290fac` both give 3 pass, 5 fail.
- `test/js/bun/jsc/domjit.test.ts` million-iteration loops time out at 5 s under the local debug ASAN build. They do not touch ShadowRealm.
- Exceptions that cross the boundary were already translated into the caller's realm on both paths (checked with a throwing Proxy target).
</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/shadow.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/shadow.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/shadow.test.js:
(pass) shadow realm works [72.62ms]
(pass) a callable returned through a plain function belongs to the caller's realm [47.06ms]
(pass) a callable returned through a bound function belongs to the caller's realm [18.78ms]
(pass) a callable returned through the realm's Function constructor belongs to the caller's realm [20.42ms]
(pass) a callable returned through a callable Proxy belongs to the caller's realm [20.80ms]
(pass) a callable returned through a Proxy with an apply trap belongs to the caller's realm [20.28ms]
(pass) a returned wrapper does not expose the shadow realm's global object [21.21ms]
(pass) a callable returned to the shadow realm belongs to the shadow realm [27.72ms]

 8 pass
 0 fail
 18 expect() calls
Ran 8 tests across 1 file. [3.08s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts   |  2 +-
 test/js/bun/jsc/shadow.test.js | 49 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 50 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
scripts/build/deps/webkit.ts        2      2     14
test/js/bun/jsc/shadow.test.js      3      3     13
```

</details>

**root cause** · written by the author bot

The generic ShadowRealm call path in `JSRemoteFunction::remoteFunctionCallGeneric` passed the target realm's global object to `wrapReturnValue`, so when a wrapped function's target was not a plain JS function (a callable Proxy or a built-in constructor such as the realm's `Function` or `Object`) and it returned a callable, the wrapper was allocated with the target realm's remote function structure. That gave the caller a function whose `[[Prototype]]` was the other realm's `Function.prototype`, exposing that realm's genuine `Function` constructor and, through it, its global object in both d…

<!-- robobun:evidence:end -->