### PR TITLE
css: stop emitting :-webkit-any() copies of :is() that outrank the original rule

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -493,46 +493,37 @@ The `:is()` pseudo-class function (formerly `:matches()`) takes a selector list 
 }
 
 /* Complex example with multiple groups */
-:is(header, main, footer) :is(h1, h2, .title) {
+:is(.card, .panel) :is(h2, .title) {
   font-family: "Heading Font", sans-serif;
 }
 ```
 
-For browsers that don't support `:is()`, Bun's CSS bundler provides fallbacks using vendor-prefixed alternatives:
+For browsers that don't support `:is()`, Bun's CSS bundler provides fallbacks using the vendor-prefixed `:-webkit-any()` and `:-moz-any()`:
 
 ```css
 /* Fallback using -webkit-any */
-.article :-webkit-any(h1, h2, h3) {
-  margin-top: 1.5em;
+:-webkit-any(.card, .panel) :-webkit-any(h2, .title) {
+  font-family: "Heading Font", sans-serif;
 }
 
 /* Fallback using -moz-any */
-.article :-moz-any(h1, h2, h3) {
-  margin-top: 1.5em;
+:-moz-any(.card, .panel) :-moz-any(h2, .title) {
+  font-family: "Heading Font", sans-serif;
 }
 
 /* Original preserved for modern browsers */
-.article :is(h1, h2, h3) {
-  margin-top: 1.5em;
-}
-
-/* Complex example with fallbacks */
-:-webkit-any(header, main, footer) :-webkit-any(h1, h2, .title) {
-  font-family: "Heading Font", sans-serif;
-}
-
-:-moz-any(header, main, footer) :-moz-any(h1, h2, .title) {
-  font-family: "Heading Font", sans-serif;
-}
-
-:is(header, main, footer) :is(h1, h2, .title) {
+:is(.card, .panel) :is(h2, .title) {
   font-family: "Heading Font", sans-serif;
 }
 ```
 
 <Warning>
-  The vendor-prefixed versions have limitations compared to the standardized `:is()` selector, particularly with complex
-  selectors. Bun only uses the prefixed versions when they work correctly.
+  The prefixed forms are more limited than `:is()`. They accept compound selectors only, and browsers give them the
+  specificity of a single class no matter what is inside, while `:is()` takes the specificity of its most specific
+  argument. Bun only emits the prefixed fallbacks when every `:is()` in the rule uses no combinators and has at least
+  one argument with a class, attribute, pseudo-class, or ID. A rule like `.article :is(h1, h2, h3)` stays `:is()` only:
+  a `:-webkit-any(h1, h2, h3)` copy would be more specific than the original in current browsers and could override
+  rules it should not.
 </Warning>
 
 ### :not() selector

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -128,17 +128,9 @@ fn downlevel_component<'bump>(
             let mut necessary_prefixes = downlevel_selectors(bump, selectors, targets);
 
             // Convert :is to :-webkit-any/:-moz-any if needed.
-            // All selectors must be simple, no combinators are supported.
             if targets.should_compile_same(Feature::IsSelector)
                 && !should_unwrap_is(selectors)
-                && 'brk: {
-                    for selector in selectors.iter() {
-                        if selector.has_combinator() {
-                            break 'brk false;
-                        }
-                    }
-                    break 'brk true;
-                }
+                && can_downlevel_is_to_any(selectors)
             {
                 necessary_prefixes.insert(
                     targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo),
@@ -156,6 +148,16 @@ fn downlevel_component<'bump>(
             // We need to use :is() / :-webkit-any() rather than :not(.a):not(.b) to ensure the specificity is equivalent.
             // https://drafts.csswg.org/selectors/#specificity-rules
             if selectors.len() > 1 && targets.should_compile_same(Feature::NotSelectorList) {
+                if targets.should_compile_same(Feature::IsSelector)
+                    && can_downlevel_is_to_any(selectors)
+                {
+                    necessary_prefixes.insert(
+                        targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo),
+                    );
+                } else {
+                    necessary_prefixes.insert(VendorPrefix::NONE);
+                }
+
                 let is: Selector = Selector::from_component(Component::Is({
                     // `Component::Is` carries `Box<[Selector]>` (heap, not arena);
                     // could re-thread `&'bump [Selector]` once the arena lifetime is plumbed.
@@ -166,14 +168,6 @@ fn downlevel_component<'bump>(
                     new_selectors.into_boxed_slice()
                 }));
                 *component = Component::Negation(vec![is].into_boxed_slice());
-
-                if targets.should_compile_same(Feature::IsSelector) {
-                    necessary_prefixes.insert(
-                        targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo),
-                    );
-                } else {
-                    necessary_prefixes.insert(VendorPrefix::NONE);
-                }
             }
 
             necessary_prefixes
@@ -867,7 +861,9 @@ pub(crate) mod serialize {
                         }
 
                         let vp = dest.vendor_prefix;
-                        if vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MOZ) {
+                        if (vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MOZ))
+                            && can_downlevel_is_to_any(selectors)
+                        {
                             dest.write_char(b':')?;
                             vp.to_css(dest)?;
                             dest.write_str(b"any(")?;
@@ -1668,6 +1664,29 @@ pub(crate) fn should_unwrap_is(selectors: &[parser::Selector]) -> bool {
     }
 
     false
+}
+
+/// Whether `:is(selectors)` can be written as the legacy `:-webkit-any()` /
+/// `:-moz-any()` for old browsers without changing the cascade in new ones.
+///
+/// The legacy forms take compound selectors only, and Blink and WebKit still
+/// parse `:-webkit-any()` today with the specificity of one pseudo-class,
+/// (0,1,0), whatever its arguments are. `:is()` takes the specificity of its
+/// most specific argument. When that is below (0,1,0), for example
+/// `:is(span, p)` or `:is(*)`, the prefixed copy of the rule outranks the
+/// `:is()` copy in every browser that supports both, and wins cascades that
+/// the authored selector loses. At or above (0,1,0) the prefixed copy can
+/// never outrank the `:is()` copy, so it is a safe fallback.
+pub(crate) fn can_downlevel_is_to_any(selectors: &[parser::Selector]) -> bool {
+    let mut max: u32 = 0;
+    for selector in selectors {
+        if selector.has_combinator() {
+            return false;
+        }
+        max = max.max(selector.specificity());
+    }
+    let max = parser::Specificity::from_u32(max);
+    max.id_selectors > 0 || max.class_like_selectors > 0
 }
 
 fn has_type_selector(selector: &parser::Selector) -> bool {

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -86,10 +86,48 @@ pub(crate) fn downlevel_selectors<'bump>(
     selectors: &mut [Selector],
     targets: &Targets,
 ) -> VendorPrefix {
+    let mut any = AnyLowering::default();
+    let mut necessary_prefixes = downlevel_selector_list(bump, selectors, targets, &mut any);
+    if !any.blocked {
+        necessary_prefixes.insert(any.prefixes);
+    }
+    necessary_prefixes
+}
+
+/// How the `:is()` lists of one style rule lower to `:-webkit-any()` /
+/// `:-moz-any()`, collected across the whole selector list (nested lists
+/// included) because the prefixed copy repeats the whole rule.
+#[derive(Default)]
+struct AnyLowering {
+    /// Prefixes requested by the `:is()` lists that can be lowered.
+    prefixes: VendorPrefix,
+    /// Some `:is()` list has to stay `:is()` (see `can_downlevel_is_to_any`).
+    /// A prefixed copy of the rule would still contain it, and every browser
+    /// that needs the copy drops the whole rule, so none is emitted.
+    blocked: bool,
+}
+
+impl AnyLowering {
+    fn request(&mut self, selectors: &[Selector], targets: &Targets) {
+        if can_downlevel_is_to_any(selectors) {
+            self.prefixes
+                .insert(targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo));
+        } else {
+            self.blocked = true;
+        }
+    }
+}
+
+fn downlevel_selector_list<'bump>(
+    bump: &'bump Bump,
+    selectors: &mut [Selector],
+    targets: &Targets,
+    any: &mut AnyLowering,
+) -> VendorPrefix {
     let mut necessary_prefixes = VendorPrefix::empty();
     for selector in selectors.iter_mut() {
         for component in selector.components.iter_mut() {
-            necessary_prefixes.insert(downlevel_component(bump, component, targets));
+            necessary_prefixes.insert(downlevel_component(bump, component, targets, any));
         }
     }
     necessary_prefixes
@@ -99,6 +137,7 @@ fn downlevel_component<'bump>(
     bump: &'bump Bump,
     component: &mut Component,
     targets: &Targets,
+    any: &mut AnyLowering,
 ) -> VendorPrefix {
     match component {
         Component::NonTsPseudoClass(pc) => {
@@ -106,7 +145,7 @@ fn downlevel_component<'bump>(
                 PseudoClass::Dir { direction } => {
                     if targets.should_compile_same(Feature::DirSelector) {
                         *component = downlevel_dir(bump, *direction, targets);
-                        return downlevel_component(bump, component, targets);
+                        return downlevel_component(bump, component, targets, any);
                     }
                     VendorPrefix::empty()
                 }
@@ -116,7 +155,7 @@ fn downlevel_component<'bump>(
                     if languages.len() > 1 && targets.should_compile_same(Feature::LangSelectorList)
                     {
                         *component = Component::Is(lang_list_to_selectors(bump, languages));
-                        return downlevel_component(bump, component, targets);
+                        return downlevel_component(bump, component, targets, any);
                     }
                     VendorPrefix::empty()
                 }
@@ -125,37 +164,26 @@ fn downlevel_component<'bump>(
         }
         Component::PseudoElement(pe) => pe.get_necessary_prefixes(targets),
         Component::Is(selectors) => {
-            let mut necessary_prefixes = downlevel_selectors(bump, selectors, targets);
+            let mut necessary_prefixes = downlevel_selector_list(bump, selectors, targets, any);
+            necessary_prefixes.insert(VendorPrefix::NONE);
 
             // Convert :is to :-webkit-any/:-moz-any if needed.
-            if targets.should_compile_same(Feature::IsSelector)
-                && !should_unwrap_is(selectors)
-                && can_downlevel_is_to_any(selectors)
-            {
-                necessary_prefixes.insert(
-                    targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo),
-                );
-            } else {
-                necessary_prefixes.insert(VendorPrefix::NONE);
+            if targets.should_compile_same(Feature::IsSelector) && !should_unwrap_is(selectors) {
+                any.request(selectors, targets);
             }
 
             necessary_prefixes
         }
         Component::Negation(selectors) => {
-            let mut necessary_prefixes = downlevel_selectors(bump, selectors, targets);
+            let mut necessary_prefixes = downlevel_selector_list(bump, selectors, targets, any);
 
             // Downlevel :not(.a, .b) -> :not(:is(.a, .b)) if not list is unsupported.
-            // We need to use :is() / :-webkit-any() rather than :not(.a):not(.b) to ensure the specificity is equivalent.
+            // We need to use :is() rather than :not(.a):not(.b) to ensure the specificity is equivalent.
             // https://drafts.csswg.org/selectors/#specificity-rules
             if selectors.len() > 1 && targets.should_compile_same(Feature::NotSelectorList) {
-                if targets.should_compile_same(Feature::IsSelector)
-                    && can_downlevel_is_to_any(selectors)
-                {
-                    necessary_prefixes.insert(
-                        targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo),
-                    );
-                } else {
-                    necessary_prefixes.insert(VendorPrefix::NONE);
+                necessary_prefixes.insert(VendorPrefix::NONE);
+                if targets.should_compile_same(Feature::IsSelector) {
+                    any.request(selectors, targets);
                 }
 
                 let is: Selector = Selector::from_component(Component::Is({
@@ -172,8 +200,8 @@ fn downlevel_component<'bump>(
 
             necessary_prefixes
         }
-        Component::Where(s) | Component::Has(s) => downlevel_selectors(bump, s, targets),
-        Component::Any { selectors, .. } => downlevel_selectors(bump, selectors, targets),
+        Component::Where(s) | Component::Has(s) => downlevel_selector_list(bump, s, targets, any),
+        Component::Any { selectors, .. } => downlevel_selector_list(bump, selectors, targets, any),
         _ => VendorPrefix::empty(),
     }
 }

--- a/test/bundler/css/is-selector-21169.test.ts
+++ b/test/bundler/css/is-selector-21169.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect } from "bun:test";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -27,6 +28,30 @@ describe("css", () => {
         }
         "
       `);
+    },
+  });
+
+  // `:-webkit-any()` always counts as one pseudo-class, (0,1,0), in Blink and
+  // WebKit. For `:is()` / `:not()` lists whose arguments are all below that, a
+  // prefixed copy would outrank the standard rule in current browsers and flip
+  // cascades the authored CSS loses, so no prefixed copy is emitted for them.
+  itBundled("css/is-selector-no-any-below-class-specificity", {
+    files: {
+      "index.css": /* css */ `
+        .d .e { color: blue }
+        :not(span, p) .e { color: red }
+        .b:is(*) { color: blue }
+        :is(section, div) .q { color: green }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out/index.css");
+      expect(out).not.toContain("-webkit-any");
+      expect(out).not.toContain("-moz-any");
+      expect(out).toContain(".b:is(*)");
+      expect(out).toContain(":is(section, div) .q");
     },
   });
 });

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5602,6 +5602,64 @@ describe("css tests", () => {
         chrome: 50 << 16,
       },
     );
+    // When one `:is()` in the rule has to stay `:is()`, a prefixed copy of the
+    // rule would still contain it and be dropped by the browsers it is for, so
+    // no copy is emitted.
+    prefix_test(
+      ":is(header, main) :is(h1, .title) {color:red}",
+      `
+      :is(header, main) :is(h1, .title) {
+        color: red;
+      }
+      `,
+      {
+        safari: 11 << 16,
+        firefox: 50 << 16,
+      },
+    );
+    prefix_test(
+      ":is(.a .b) :is(.c, .d) {color:red}",
+      `
+      :is(.a .b) :is(.c, .d) {
+        color: red;
+      }
+      `,
+      {
+        safari: 11 << 16,
+        firefox: 50 << 16,
+      },
+    );
+    prefix_test(
+      ".x:not(.a, :is(span, p)) {color:red}",
+      `
+      .x:not(:is(.a, :is(span, p))) {
+        color: red;
+      }
+      `,
+      {
+        safari: 8 << 16,
+      },
+    );
+    prefix_test(
+      ":is(header, .main) :is(h1, .title) {color:red}",
+      `
+      :-webkit-any(header, .main) :-webkit-any(h1, .title) {
+        color: red;
+      }
+
+      :-moz-any(header, .main) :-moz-any(h1, .title) {
+        color: red;
+      }
+
+      :is(header, .main) :is(h1, .title) {
+        color: red;
+      }
+      `,
+      {
+        safari: 11 << 16,
+        firefox: 50 << 16,
+      },
+    );
 
     prefix_test(
       "a:lang(en, fr) {color:red}",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5483,6 +5483,126 @@ describe("css tests", () => {
       },
     );
 
+    // `:-webkit-any()` is still parsed by Blink and WebKit, with the specificity
+    // of one pseudo-class whatever its arguments are. When the most specific
+    // `:is()` argument is below that (type selectors, `*`), the prefixed copy
+    // would outrank the `:is()` rule in current browsers, so it is not emitted.
+    prefix_test(
+      "a:is(span, p) {color:red}",
+      `
+      a:is(span, p) {
+        color: red;
+      }
+      `,
+      {
+        safari: 11 << 16,
+        firefox: 50 << 16,
+      },
+    );
+    prefix_test(
+      ".a:is(*) {color:red}",
+      `
+      .a:is(*) {
+        color: red;
+      }
+      `,
+      {
+        safari: 11 << 16,
+        firefox: 50 << 16,
+      },
+    );
+    prefix_test(
+      ":is(section, div) .a {color:red}",
+      `
+      :is(section, div) .a {
+        color: red;
+      }
+      `,
+      {
+        chrome: 80 << 16,
+      },
+    );
+    prefix_test(
+      ".a:not(span, p) {color:red}",
+      `
+      .a:not(:is(span, p)) {
+        color: red;
+      }
+      `,
+      {
+        safari: 8 << 16,
+      },
+    );
+    // One class-level argument is enough: the prefixed copy is then at most as
+    // specific as the `:is()` copy and cannot change which rule wins.
+    prefix_test(
+      "a:is(.foo, p) {color:red}",
+      `
+      a:-webkit-any(.foo, p) {
+        color: red;
+      }
+
+      a:-moz-any(.foo, p) {
+        color: red;
+      }
+
+      a:is(.foo, p) {
+        color: red;
+      }
+      `,
+      {
+        safari: 11 << 16,
+        firefox: 50 << 16,
+      },
+    );
+    prefix_test(
+      "a:is([href], p) {color:red}",
+      `
+      a:-webkit-any([href], p) {
+        color: red;
+      }
+
+      a:is([href], p) {
+        color: red;
+      }
+      `,
+      {
+        chrome: 80 << 16,
+      },
+    );
+    // A prefix pass requested by another component in the selector does not
+    // turn such an `:is()` into `:-webkit-any()` either.
+    prefix_test(
+      ":is(span, p) input::placeholder {color:red}",
+      `
+      :is(span, p) input::-webkit-input-placeholder {
+        color: red;
+      }
+
+      :is(span, p) input::placeholder {
+        color: red;
+      }
+      `,
+      {
+        chrome: 50 << 16,
+      },
+    );
+    prefix_test(
+      ":is(.a > .b, .c) input::placeholder {color:red}",
+      `
+      :is(.a > .b, .c) input::-webkit-input-placeholder {
+        color: red;
+      }
+
+      :is(.a > .b, .c) input::placeholder {
+        color: red;
+      }
+      `,
+      {
+        chrome: 50 << 16,
+      },
+    );
+
     prefix_test(
       "a:lang(en, fr) {color:red}",
       `


### PR DESCRIPTION
### Problem
- For targets without `:is()` (Chrome < 88), the minifier emits each `:is()` rule as a `:-webkit-any(…)` + `:-moz-any(…)` + `:is(…)` triplet. Bun's default bundler targets (chrome 80) are in that range, so every default `bun build` does this.
- Blink and WebKit still parse `:-webkit-any()`, with specificity (0,1,0) whatever its arguments are. For `:is(span, p)`, `:is(*)` or `:not(span, p)` the prefixed copy outranks the original and wins cascades the authored selector loses: `.d .e { color: blue } :not(span, p) .e { color: red }` paints `.e` red (Chromium 148).

### Fix
- `downlevel_selectors` (`src/css/selectors/selector.rs`) requests the prefixed copies only when every `:is()` list in the rule passes `can_downlevel_is_to_any`: no argument has a combinator (as before), and the most specific argument has an id or class-like component (new). If one list fails, the rule gets no prefixed copy, since that copy would still contain `:is()` and be dropped by the browsers it is for. The serializer applies the same check in a prefix pass that another component requested.
- Correct because a (0,1,0) copy then never outranks the `:is()` copy, which matches the same elements and comes later. `:is(.a, .b)`, `:lang()` lists and `:dir()` keep their fallback.
- Verified: `test/js/bun/css/css.test.ts` (12 new cases, 9 fail on stock bun) and `test/bundler/css/is-selector-21169.test.ts` (new case, fails on stock bun). Other suites in Notes. `docs/bundler/css.mdx` showed the removed output and is updated.

### Background
- `:is(A, B)` has the specificity of its most specific argument. `:-webkit-any()` is its pre-standard spelling, which Blink and WebKit count as one pseudo-class (sources in Notes). Gecko parses `-moz-any` as plain `:is()`. `:not(a, b)`, `:lang(a, b)` and `:dir()` lower through `:is()`, so they were affected too.
- `StyleRule::to_css` prints a prefixed rule once per prefix. `serialize_component` picks each `:is()` spelling from `dest.vendor_prefix`. Hence the check in both places.
- lightningcss 1.30.2 emits the same triplet for these targets. #40369 raises bun's defaults, which hides this for default builds only.

<details><summary>Notes</summary>

- Found by differential testing of computed styles (authored CSS against `bun build` output, Chromium 148). There is no user report.
- Repro, bun 1.4.3-canary (f42e98025), `bun build --minify a.css`:

  ```css
  .d .e { color: blue }   :not(span, p) .e { color: red }
  @scope (#root) { :scope > * { color: red } }   .b:is(*) { color: blue }
  ```

  before:

  ```css
  .d .e{color:#00f}:not(:-webkit-any(span,p)) .e{color:red}:not(:-moz-any(span,p)) .e{color:red}:not(:is(span,p)) .e{color:red}@scope(#root){:scope>*{color:red}}.b:-webkit-any(*){color:#00f}.b:-moz-any(*){color:#00f}.b:is(*){color:#00f}
  ```

  after:

  ```css
  .d .e{color:#00f}:not(:is(span,p)) .e{color:red}@scope(#root){:scope>*{color:red}}.b:is(*){color:#00f}
  ```

  Case 1: authored `:not(span,p) .e` is (0,1,1) and loses to `.d .e` (0,2,0). The old `:not(:-webkit-any(span,p)) .e` copy counts as (0,2,0), comes later, and won. Case 2: authored `.b:is(*)` is (0,1,0), ties with the scoped rule and loses on proximity. `.b:-webkit-any(*)` is (0,2,0) and won outright.
- Also ran: `test/js/bun/css/` (all files), `test/bundler/css/`, `test/bundler/esbuild/css.test.ts`, `test/regression/issue/{25785,25794,27458}.test.ts`.
- Unchanged output (argument specificity at least (0,1,0)): `.y:is(.a, .b)`, `.z:is(#a, p)`, `:lang(en, de)`, `:dir(rtl)`, `.w:not(.a, .b)`, `.foo:is(input:checked)`. Old browsers now skip `:is(span, p)`-style rules instead of applying them with the wrong specificity.
- Why "at least (0,1,0)" and not "exactly": for `:is(#a, .b)` the legacy copy is less specific than the original. In a browser that supports both, the `:is()` copy matches the same elements with higher specificity and later source order, so the legacy copy never decides a computed value. In a browser with only the legacy form the rule still applies, which is the point of the fallback. Only a legacy copy that is more specific than the original can change a result in a current browser, and that is exactly the below-(0,1,0) case.
- Whole-rule gating: the prefix set is computed per rule and the prefixed copy repeats the whole selector list. `:is(header, main) :is(h1, .title)` printed `:-webkit-any(header, main) :-webkit-any(h1, .title)` on stock bun. Checking each list alone would print `:is(header, main) :-webkit-any(h1, .title)`, which no browser uses: old ones drop it for the `:is()`, new ones have the `:is()` copy. So one list that has to stay `:is()` (below class level, or with a combinator as in `:is(.a .b) :is(.c, .d)`, which stock bun printed as an invalid `:-webkit-any(.a .b)`) turns the copies off for the rule. Nested lists count too: `.x:not(.a, :is(span, p))` becomes `.x:not(:is(.a, :is(span, p)))` only.
- The serializer check matters when another component drives the prefix pass: with chrome 50 targets, `:is(span, p) input::placeholder` printed `:-webkit-any(span, p) input::-webkit-input-placeholder`, which current Chrome applies with the raised specificity. It now prints `:is(span, p) input::-webkit-input-placeholder`. The same check stops `:is(.a > .b, .c)` from printing as an invalid `:-webkit-any(.a > .b, .c)` in such a pass.
- The cached `Selector::specificity()` counts `&` as zero, so `:is(&, p)` is treated as (0,0,1) and gets no legacy copy even when the parent is a class. That errs toward fewer prefixed copies, never toward an unsafe one.
- A hand-written `:-webkit-any(…)` (`Component::Any`) prints as written. Only copies the minifier generates from `:is()` change. One visible consequence of the existing merge of prefix-equivalent adjacent rules (`merge_style_rules`, `is_equivalent`): `.x:-webkit-any(span,p){color:red}` directly followed by `.x:is(span,p){color:red}` already collapsed into one rule whose prefixes are recomputed from the targets, so with chrome 80 it now prints only `.x:is(span,p){color:red}`, the same as it already did for chrome 88+ targets.
- Docs: `docs/bundler/css.mdx` advertised `.article :-webkit-any(h1, h2, h3)` and `:-webkit-any(header, main, footer) :-webkit-any(h1, h2, .title)` as the fallback output and said "Bun only uses the prefixed versions when they work correctly". The examples now use class-bearing lists and the warning states the rule.
- #40369 interaction: if the default targets move past Chrome 88, the `itBundled` case keeps passing but stops exercising this path. The `prefix_test` cases pin old targets and are the lasting coverage.
- Engine references: Blink `third_party/blink/renderer/core/css/css_selector.cc` (`kPseudoAny` falls through to `kClassLikeSpecificity`, FIXME linking http://lists.w3.org/Archives/Public/www-style/2010Sep/0530.html); WebKit `Source/WebCore/css/CSSSelector.cpp` (`PseudoClass` default returns `ClassB`) and `Source/WebCore/css/CSSPseudoSelectors.json` ("Alias of :is() with different specificity rules"); Gecko `servo/components/style/gecko/selector_parser.rs` (`is_is_alias("-moz-any")`).
- lightningcss comparison: `transform({ targets: { chrome: 80<<16, edge: 80<<16, firefox: 78<<16, safari: 14<<16, opera: 67<<16 }, minify: true })` on the repro stylesheet matches stock bun byte for byte, so the lowering is inherited. The upstream `downlevel_component` in `src/selector.rs` has the same shape.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/css/is-selector-21169.test.ts" test/js/bun/css/css.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO
... (truncated)

release without fix: 10 failed, 67 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/css/is-selector-21169.test.ts:
(pass) css > css/is-selector [14.80ms]
46 |     },
47 |     outdir: "/out",
48 |     entryPoints: ["/index.css"],
49 |     onAfterBundle(api) {
50 |       const out = api.readFile("/out/index.css");
51 |       expect(out).not.toContain("-webkit-any");
                           ^
error: expect(received).not.toContain(expected)

Expected to not contain: "-webkit-any"
Received: "/* index.css */\n.d .e {\n  color: #00f;\n}\n\n:not(:-webkit-any(span, p)) .e {\n  color: red;\n}\n\n:not(:-moz-any(span, p)) .e {\n  color: red;\n}\n\n:not(:is(span, p)) .e {\n  color: red;\n}\n\n.b:-webkit-any(*) {\n  color: #00f;\n}\n\n.b:-moz-any(*) {\n  color: #00f;\n}\n\n.b:is(*) {\n  color: #00f;\n}\n\n:-webkit-any(section, div) .q {\n  color: green;\n}\n\n:-moz-any(section, div) .q {\n  color: green;\n}\n\n:is(section, div) .q {\n  color: green;\n}\n"

      at onAfterBundle (/workspace/bun/test/bundler/css/is-selector-21169.test.ts:51:23)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1658:13)
(fail) css > css/is-selector-no-any-below-class-specificity [4.86ms]

test/js/bun/css/css.te
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/css/is-selector-21169.test.ts" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/css/is-selector-21169.test.ts:
(pass) css > css/is-selector [484.68ms]
(pass) css > css/is-selector-no-any-below-class-specificity [108.39ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.38ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [12.33ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.16ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e25f090f47
  features     baseline

23 deps, 131 codegen, 1172 objects in 677ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [18.00ms]
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[5/1244] gen bindgenv2
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen .bind.ts → Ge
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/bundler/css.mdx                       |  35 +++---
 src/css/selectors/selector.rs              | 115 +++++++++++++------
 test/bundler/css/is-selector-21169.test.ts |  25 ++++
 test/js/bun/css/css.test.ts                | 178 +++++++++++++++++++++++++++++
 4 files changed, 297 insertions(+), 56 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
docs/bundler/css.mdx                            1      1     11
src/css/selectors/selector.rs                   6      6     11
test/bundler/css/is-selector-21169.test.ts      1      2      5
test/js/bun/css/css.test.ts                     2      2     11
```

</details>

<!-- robobun:evidence:end -->