### PR TITLE
events: captureRejections for thenables and constructor-less emitters, run what an unhandledRejection listener queues

### DIFF
--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -174,8 +174,7 @@ function emitUnhandledRejectionOrErr(emitter, err, type, args) {
   if (typeof emitter[kRejection] === "function") {
     emitter[kRejection](err, type, ...args);
   } else {
-    // Capture is off during the 'error' emit so a rejecting 'error' listener
-    // cannot loop; restored even if a listener throws (-> 'uncaughtException').
+    // Capture is off during the 'error' emit so a rejecting 'error' listener cannot loop.
     const prev = emitter[kCapture];
     try {
       emitter[kCapture] = false;
@@ -192,8 +191,7 @@ let captureRejectionsByDefault = false;
 const emitWithoutRejectionCapture = function emit(type, ...args) {
   $debug(`${this.constructor?.name || "EventEmitter"}.emit`, type);
 
-  // An emitter whose constructor never ran (util.inherits without the super
-  // call) has no own `emit`; it follows the global default like node.
+  // Constructor never ran (util.inherits without super call): follow the global default.
   if (captureRejectionsByDefault && this[kCapture]) {
     return emitWithRejectionCapture.$call(this, type, ...args);
   }

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -154,9 +154,7 @@ function applyHandlers(handlers, emitter, args) {
   }
 }
 
-// `result` is whatever a listener returned (not undefined/null): a thenable is
-// followed, anything else ignored. Promises/A+: `then` may be a getter, so it
-// is read once, and a getter that throws is an 'error'.
+// Promises/A+: `then` is read once; a `then` getter that throws is an 'error'.
 function addCatch(emitter, result, type, args) {
   if (!emitter[kCapture]) return;
   try {
@@ -176,10 +174,8 @@ function emitUnhandledRejectionOrErr(emitter, err, type, args) {
   if (typeof emitter[kRejection] === "function") {
     emitter[kRejection](err, type, ...args);
   } else {
-    // Capture is off while 'error' is emitted so a rejecting 'error' listener
-    // cannot loop back here. If the error handler throws, it is not catchable
-    // and it will end up in 'uncaughtException'; the previous value is
-    // restored in case that is handled.
+    // Capture is off during the 'error' emit so a rejecting 'error' listener
+    // cannot loop; restored even if a listener throws (-> 'uncaughtException').
     const prev = emitter[kCapture];
     try {
       emitter[kCapture] = false;
@@ -190,17 +186,14 @@ function emitUnhandledRejectionOrErr(emitter, err, type, args) {
   }
 }
 
-// Mirrors EventEmitter.prototype[kCapture] (the `EventEmitter.captureRejections`
-// default) so the common emit path tests a closure variable, not a property.
+// Mirrors `EventEmitter.captureRejections` so the default emit tests a local, not a property.
 let captureRejectionsByDefault = false;
 
 const emitWithoutRejectionCapture = function emit(type, ...args) {
   $debug(`${this.constructor?.name || "EventEmitter"}.emit`, type);
 
-  // The constructor installs the capturing emit per instance; an emitter whose
-  // constructor never ran (util.inherits without the super call) lands here and
-  // follows the global default through the prototype's kCapture, as node's
-  // single emit does.
+  // An emitter whose constructor never ran (util.inherits without the super
+  // call) has no own `emit`; it follows the global default like node.
   if (captureRejectionsByDefault && this[kCapture]) {
     return emitWithRejectionCapture.$call(this, type, ...args);
   }

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -154,31 +154,56 @@ function applyHandlers(handlers, emitter, args) {
   }
 }
 
-function addCatch(emitter, promise, type, args) {
-  promise.then(undefined, function (err) {
-    // The callback is called with nextTick to avoid a follow-up rejection from this promise.
-    process.nextTick(emitUnhandledRejectionOrErr, emitter, err, type, args);
-  });
+// `result` is whatever a listener returned (not undefined/null): a thenable is
+// followed, anything else ignored. Promises/A+: `then` may be a getter, so it
+// is read once, and a getter that throws is an 'error'.
+function addCatch(emitter, result, type, args) {
+  if (!emitter[kCapture]) return;
+  try {
+    const then = result.then;
+    if (typeof then === "function") {
+      then.$call(result, undefined, function (err) {
+        // The callback is called with nextTick to avoid a follow-up rejection from this promise.
+        process.nextTick(emitUnhandledRejectionOrErr, emitter, err, type, args);
+      });
+    }
+  } catch (err) {
+    emitter.emit("error", err);
+  }
 }
 
 function emitUnhandledRejectionOrErr(emitter, err, type, args) {
   if (typeof emitter[kRejection] === "function") {
     emitter[kRejection](err, type, ...args);
   } else {
-    // If the error handler throws, it is not catchable and it will end up in 'uncaughtException'.
-    // We restore the previous value of kCapture in case the uncaughtException is present
-    // and the exception is handled.
+    // Capture is off while 'error' is emitted so a rejecting 'error' listener
+    // cannot loop back here. If the error handler throws, it is not catchable
+    // and it will end up in 'uncaughtException'; the previous value is
+    // restored in case that is handled.
+    const prev = emitter[kCapture];
     try {
       emitter[kCapture] = false;
       emitter.emit("error", err);
     } finally {
-      emitter[kCapture] = true;
+      emitter[kCapture] = prev;
     }
   }
 }
 
+// Mirrors EventEmitter.prototype[kCapture] (the `EventEmitter.captureRejections`
+// default) so the common emit path tests a closure variable, not a property.
+let captureRejectionsByDefault = false;
+
 const emitWithoutRejectionCapture = function emit(type, ...args) {
   $debug(`${this.constructor?.name || "EventEmitter"}.emit`, type);
+
+  // The constructor installs the capturing emit per instance; an emitter whose
+  // constructor never ran (util.inherits without the super call) lands here and
+  // follows the global default through the prototype's kCapture, as node's
+  // single emit does.
+  if (captureRejectionsByDefault && this[kCapture]) {
+    return emitWithRejectionCapture.$call(this, type, ...args);
+  }
 
   if (type === "error") {
     return emitError(this, args);
@@ -263,7 +288,7 @@ const emitWithRejectionCapture = function emit(type, ...args) {
         result = handler.$apply(this, args);
         break;
     }
-    if (result !== undefined && $isPromise(result)) {
+    if (result !== undefined && result !== null) {
       addCatch(this, result, type, args);
     }
     return true;
@@ -291,7 +316,7 @@ const emitWithRejectionCapture = function emit(type, ...args) {
         result = listener.$apply(this, args);
         break;
     }
-    if (result !== undefined && $isPromise(result)) {
+    if (result !== undefined && result !== null) {
       addCatch(this, result, type, args);
     }
   }
@@ -954,6 +979,7 @@ Object.defineProperties(EventEmitter, {
       validateBoolean(value, "EventEmitter.captureRejections");
 
       EventEmitterPrototype[kCapture] = value;
+      captureRejectionsByDefault = value;
     },
     enumerable: true,
   },

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3805,9 +3805,7 @@ impl VirtualMachine {
         match self.unhandled_rejections_mode() {
             Mode::Bun => {
                 if handle_unhandled() {
-                    // What the listener queued runs now: Node's processTicksAndRejections
-                    // loops ticks and rejections until both are empty, and on the
-                    // loop's last turn no later checkpoint would pick it up.
+                    // Run what the listener queued; on the loop's last turn no later checkpoint would.
                     drain(self);
                     return;
                 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3805,6 +3805,10 @@ impl VirtualMachine {
         match self.unhandled_rejections_mode() {
             Mode::Bun => {
                 if handle_unhandled() {
+                    // What the listener queued runs now: Node's processTicksAndRejections
+                    // loops ticks and rejections until both are empty, and on the
+                    // loop's last turn no later checkpoint would pick it up.
+                    drain(self);
                     return;
                 }
                 // continue to default handler

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -842,8 +842,11 @@ describe("EventEmitter captureRejections", () => {
     let returned;
     plain.on("something", () => (returned = Promise.reject(new Error("not captured"))));
     plain.emit("something");
+    // Capture would run as: rejection reaction (a microtask queued before this
+    // .catch()) -> process.nextTick -> emit('error'); so it would have fired by
+    // the time a nextTick queued after that microtask runs.
     await returned.catch(() => {});
-    await sleep(5);
+    await new Promise(resolve => process.nextTick(resolve));
     expect(onError).not.toHaveBeenCalled();
   });
 

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -814,6 +814,90 @@ describe("EventEmitter captureRejections", () => {
 
     expect(handled).toEqual(null);
   });
+
+  // Node decides per call from this[kCapture], so the global default reaches an
+  // emitter whose constructor never ran (util.inherits without the super call).
+  test("EventEmitter.captureRejections applies to an emitter whose constructor never ran", async () => {
+    function NoConstructor() {}
+    Object.setPrototypeOf(NoConstructor.prototype, EventEmitter.prototype);
+    const before = EventEmitter.captureRejections;
+    EventEmitter.captureRejections = true;
+    try {
+      const ee = new (NoConstructor as any)();
+      const err = new Error("kaboom");
+      const { promise, resolve } = Promise.withResolvers();
+      ee.on("error", resolve);
+      ee.on("something", async () => {
+        throw err;
+      });
+      ee.emit("something");
+      expect(await promise).toBe(err);
+    } finally {
+      EventEmitter.captureRejections = before;
+    }
+    // ...and an emitter created while the default was off keeps not capturing.
+    const plain = new EventEmitter();
+    const onError = mock();
+    plain.on("error", onError);
+    let returned;
+    plain.on("something", () => (returned = Promise.reject(new Error("not captured"))));
+    plain.emit("something");
+    await returned.catch(() => {});
+    await sleep(5);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  // Promises/A+: any thenable a listener returns is followed; `then` is read
+  // once, and a `then` getter that throws is emitted as 'error'.
+  test("captures thenables, reading `then` once", async () => {
+    const ee = new EventEmitter({ captureRejections: true });
+    const err = new Error("kaboom");
+    let reads = 0;
+    ee.on("something", () => {
+      const obj = {};
+      Object.defineProperty(obj, "then", {
+        get() {
+          reads++;
+          return (resolve, reject) => reject(err);
+        },
+      });
+      return obj;
+    });
+    const { promise, resolve } = Promise.withResolvers();
+    ee.on("error", resolve);
+    ee.emit("something");
+    expect(await promise).toBe(err);
+    expect(reads).toBe(1);
+  });
+
+  test("a `then` getter that throws is emitted as 'error'", () => {
+    const ee = new EventEmitter({ captureRejections: true });
+    const err = new Error("kaboom");
+    ee.on("something", () => {
+      const obj = {};
+      Object.defineProperty(obj, "then", {
+        get() {
+          throw err;
+        },
+      });
+      return obj;
+    });
+    const onError = mock();
+    ee.on("error", onError);
+    ee.emit("something");
+    expect(onError.mock.calls).toEqual([[err]]);
+  });
+
+  test("non-thenable return values are ignored", () => {
+    const ee = new EventEmitter({ captureRejections: true });
+    const onError = mock();
+    ee.on("error", onError);
+    ee.on("something", () => ({ then: "not a function" }));
+    ee.on("something", () => 42);
+    ee.on("something", () => null);
+    expect(ee.emit("something")).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
 });
 
 const waysOfCreating = [

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1685,6 +1685,36 @@ describe.concurrent(() => {
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
+  // Node's processTicksAndRejections loops ticks, microtasks and rejections
+  // until all are empty, so work an 'unhandledRejection' listener queues runs
+  // even when that rejection was the loop's last activity.
+  it("runs the nextTicks and microtasks an unhandledRejection listener queues", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("unhandledRejection", e => {
+           process.nextTick(() => console.log("tick after", e.message));
+           Promise.resolve().then(() => {
+             console.log("microtask after", e.message);
+             setTimeout(() => console.log("timer after", e.message), 0);
+           });
+         });
+         process.on("exit", c => console.log("exit", c));
+         Promise.reject(new Error("a"));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "tick after a\nmicrotask after a\ntimer after a\nexit 0\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("aborts when the uncaughtException handler throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
       stderr: "pipe",


### PR DESCRIPTION
### Problem
- `node:events` `captureRejections` missed three Node behaviours: an emitter whose constructor never ran (`util.inherits` without the super call) never captured even with `EventEmitter.captureRejections = true`; only real Promises were followed (`$isPromise`), not thenables; and a `then` getter that throws was not reported as `'error'`.
- Separately, work that a `process.on('unhandledRejection')` listener queued (`process.nextTick`, a microtask, and anything those schedule) never ran when that rejection was the event loop's last activity. Node's `processTicksAndRejections` loops ticks, microtasks and rejections until all are empty.
- Together these made `test/js/node/test/parallel/test-event-capture-rejections.js` pass vacuously: its 13 stages are chained with `process.nextTick` from inside `'unhandledRejection'` listeners, so it stopped after stage 3 and exited 0.

### Fix
- `src/js/node/events.ts`: the prototype `emit` follows `EventEmitter.captureRejections` through `this[kCapture]` (a closure boolean keeps the common path to one variable test); `addCatch` is Node's: any non-nullish result, `then` read once, a throwing getter emitted as `'error'`; `emitUnhandledRejectionOrErr` restores the previous `kCapture`.
- `VirtualMachine::unhandled_rejection`: in the default mode, drain the microtask queue after a listener handled the rejection, as the other `--unhandled-rejections` modes already do.
- Verified: `test-event-capture-rejections.js` now runs all 13 stages and exits 0 (it reached 3 before). New cases in `event-emitter.test.ts` (4) and `process.test.js` (1) fail on 1.4.3 and pass here. `test/js/node/events/`, the `test-events-*` / `test-event-emitter-*` / `test-promise-unhandled-*` / `test-process-*` node tests are unchanged.

### Background
- With `captureRejections`, `emit` looks at what each listener returns and routes a rejection to `'error'` (or `[Symbol.for('nodejs.rejection')]`). Bun installs a capturing `emit` per instance from the constructor so the default `emit` never inspects return values; an instance that skipped the constructor only has the prototype `emit`.
- Bun reports unhandled rejections from `handleRejectedPromises` at the end of an event loop turn. A listener runs there, outside any microtask checkpoint, so what it queues waited for the next checkpoint, and there is none once the loop has gone idle.

<details><summary>Notes</summary>

This is the first of two PRs. The second (worker_threads: an unhandled rejection in a Worker's last loop turn is dropped) adds the missing end-of-turn rejection pass to `auto_tick_active` and the `'beforeExit'` dispatch. That change alone un-sticks `test-event-capture-rejections.js` past stage 3 and into the `events.ts` gaps fixed here, which is why this lands first.

#33356 (open since July) contains the same `events.ts` changes and the same drain; this PR is that part on current main with tests, and #33356 can be closed once both land. The prototype-swap in #33356's `captureRejections` setter is replaced by a closure flag checked in the default `emit`, so `EventEmitter.prototype.emit` keeps its identity.

Stage trace of `test-event-capture-rejections.js` (a `console.log` at the top of each stage function): 1.4.3 prints `captureRejections, captureRejectionsTwoHandlers, defaultValue` and exits 0; this branch prints all of them through `argValidation` and exits 0, as node 26 does.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->