### PR TITLE
worker_threads: report uncaught errors raised in a worker's last loop turn

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -405,6 +405,7 @@ unsafe extern "C" {
 
     safe fn Process__dispatchOnBeforeExit(global: &JSGlobalObject, code: u8);
     safe fn Process__dispatchOnExit(global: &JSGlobalObject, code: u8);
+    safe fn Bun__Process__isExiting(global: &JSGlobalObject) -> bool;
     safe fn Bun__closeAllSQLiteDatabasesForTermination(global: &JSGlobalObject);
     safe fn Bun__closeAllNodeSqliteDatabasesForTermination(global: &JSGlobalObject);
     safe fn Bun__WebView__closeAllForTermination();
@@ -702,6 +703,10 @@ impl ExitHandler {
         let _ = jsc::from_js_host_call_generic(global, || {
             Process__dispatchOnBeforeExit(global, exit_code)
         });
+        // Ticks-and-rejections checkpoint for the listeners, before the caller's loop-alive check.
+        if vm.event_loop_mut().drain_microtasks().is_ok() {
+            let _ = global.handle_rejected_promises();
+        }
     }
 }
 
@@ -1675,7 +1680,7 @@ impl VirtualMachine {
                 // code 7). Report it to the parent + arm termination via the
                 // normal path; process_exit() RETURNS on a worker, so the
                 // main-thread process_exit(7)+panic below would crash.
-                self.exit_handler.exit_code = 1;
+                self.fail_exit_code();
                 (self.on_unhandled_rejection)(self, global_object, err);
                 return false;
             }
@@ -1709,7 +1714,7 @@ impl VirtualMachine {
             }
             // TODO maybe we want a separate code path for uncaught exceptions
             self.unhandled_error_counter += 1;
-            self.exit_handler.exit_code = 1;
+            self.fail_exit_code();
             (self.on_unhandled_rejection)(self, global_object, err);
         }
         // Note: this reset must cover BOTH the FFI call and the
@@ -2224,9 +2229,9 @@ pub struct RuntimeHooks {
     pub auto_tick: unsafe fn(vm: *mut VirtualMachine),
     /// `eventLoop().autoTickActive()` — like `auto_tick` but only sleeps in
     /// the uSockets loop while it has active handles.
-    /// Separate slot because the body skips `runImminentGCTimer` /
-    /// `handleRejectedPromises` and falls through to `tickWithoutIdle` when
-    /// idle — folding it into `auto_tick` would change shutdown semantics.
+    /// Separate slot because the body skips `runImminentGCTimer` and falls
+    /// through to `tickWithoutIdle` when idle — folding it into `auto_tick`
+    /// would change shutdown semantics.
     pub auto_tick_active: unsafe fn(vm: *mut VirtualMachine),
     /// `printException` / `printErrorlikeObject` — formats `value` (or its
     /// wrapped `JSC::Exception`) to stderr via `ConsoleObject::Formatter`.
@@ -3863,7 +3868,16 @@ impl VirtualMachine {
             }
         }
         self.unhandled_error_counter += 1;
+        self.fail_exit_code();
         (self.on_unhandled_rejection)(self, global_object, reason);
+    }
+
+    /// Exit code 1, unless 'exit' is already being emitted (Node's `process._exiting` check).
+    fn fail_exit_code(&mut self) {
+        // The VM's own global: the reporting global may be a node:vm context's.
+        if !Bun__Process__isExiting(self.global()) {
+            self.exit_handler.exit_code = 1;
+        }
     }
 
     /// After a hot reload, surfaces the entry-point promise's rejection (if any) and re-arms the watcher.

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -881,6 +881,12 @@ extern "C" void Process__dispatchOnExit(Zig::GlobalObject* globalObject, uint8_t
     dispatchExitInternal(globalObject, process, exitCode);
 }
 
+// `process._exiting`: the 'exit' listeners have started (or reallyExit ran).
+extern "C" bool Bun__Process__isExiting(Zig::GlobalObject* globalObject)
+{
+    return globalObject->hasProcessObject() && globalObject->processObject()->m_isExiting;
+}
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionUptime, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     double now = static_cast<double>(Bun__readOriginTimer(bunVM(lexicalGlobalObject)));

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -116,7 +116,7 @@ pub struct WebWorker {
     /// Cloned env for the worker VM; boxed on the global heap because the arena
     /// does not run `Drop`. Reclaimed in `shutdown()`.
     worker_env_loader: Cell<*mut bun_dotenv::Loader>,
-    /// `process.exit(code)` ran; later error paths must not overwrite its code.
+    /// Exiting on its own (`process.exit()` or an uncaught error): the exit code is decided.
     exit_called: AtomicBool,
     /// The parent asked this thread to stop (`worker.terminate()` or an exiting
     /// parent) while its VM was live — as opposed to the thread stopping itself,
@@ -1013,12 +1013,12 @@ impl WebWorker {
         let vm_ptr = self.vm.replace(core::ptr::null_mut());
 
         // ---- 2. User exit handlers -----------------------------------------
+        // A throw from an 'exit' listener is still reported: `on_exit` marks shutdown after them.
         let mut exit_code: i32 = 0;
         if !vm_ptr.is_null() {
             // SAFETY: vm_ptr valid; no other thread holds a pointer to it (they
             // only ever held its handle) — `&mut` is exclusive.
             let vm = unsafe { &mut *vm_ptr };
-            vm.is_shutting_down = true;
             vm.on_exit();
             exit_code = i32::from(vm.exit_handler.exit_code);
             log!(
@@ -1246,7 +1246,6 @@ fn on_unhandled_rejection(
     // termination exception makes dispatchExitInternal skip 'exit' (as terminate() should),
     // and its processIsExiting guard stops shutdown() from running them twice.
     virtual_machine::ExitHandler::dispatch_on_exit(vm);
-    let _ = worker.set_requested_terminate();
     // Do NOT call `worker.shutdown()` here —
     // `shutdown()` RETURNS, so calling it here would destroy
     // the `JSC::VM`, free the Bun `VirtualMachine` + arena, and report
@@ -1258,8 +1257,8 @@ fn on_unhandled_rejection(
     // second time (a second `workerGlobalScopeDestroyed` → double deref of
     // the proxy's thread-held reference).
     //
-    // Instead, request the stop as `exit()` does and unwind to `spin()`'s `shutdown()`.
-    vm.handle_ref().request_termination();
+    // Instead end as `process.exit()` does: request the stop and unwind to `spin()`'s `shutdown()`.
+    worker.exit();
 }
 
 /// Resolve a worker entry-point specifier to a path the module loader can

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -978,10 +978,11 @@ impl WebWorker {
             // TODO: is this able to allow the event loop to continue?
             vm.as_mut().on_before_exit();
             // Drained with the entry still pending: an unsettled top-level await,
-            // Node's exit 13 (unless the user chose a nonzero exit code).
+            // Node's exit 13, unless the user chose a code or stopped the worker from 'beforeExit'.
             // SAFETY: rooted by `entry_promise`.
             if unsafe { (*promise).status() } == jsc::js_promise::Status::Pending
                 && vm.exit_handler.exit_code == 0
+                && !self.has_requested_terminate()
             {
                 vm.as_mut().exit_handler.exit_code = 13;
             }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1121,10 +1121,9 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
 }
 
 /// `eventLoop().autoTickActive()`. Same shape as
-/// [`auto_tick`] but: no `runImminentGCTimer`, no `handleRejectedPromises` at
-/// the tail, and no debug sleep-timer logging. Used by `bun_main` /
-/// `on_before_exit` drain loops where blocking when the loop is idle would
-/// hang shutdown.
+/// [`auto_tick`] but: no `runImminentGCTimer` and no debug sleep-timer logging.
+/// Used by `bun_main` / `on_before_exit` drain loops where blocking when the
+/// loop is idle would hang shutdown.
 ///
 /// # Safety
 /// `vm` is the live per-thread VM.
@@ -1175,6 +1174,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         unsafe { (*loop_).tick_without_idle() };
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
+        // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
+        let _ = unsafe { (*(*vm).global).handle_rejected_promises() };
         return;
     }
 
@@ -1238,6 +1239,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
+    // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
+    let _ = unsafe { (*(*vm).global).handle_rejected_promises() };
 }
 
 /// `printException` / `printErrorlikeObject` — formats `value` to stderr via

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -959,6 +959,17 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("-e reports a rejection left by the last timer callback", async () => {
+      const { stdout, stderr, exitCode } = await runReplWith([
+        "-e",
+        "process.on('unhandledRejection', e => console.log('unhandledRejection', e.message));" +
+          "setTimeout(() => Promise.reject(new Error('late')), 1)",
+      ]);
+      expect(stdout).toBe("unhandledRejection late\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
     test("-p drains event loop before printing", async () => {
       // Result should be printed after the timer output, since we drain
       // the event loop before printing the final result.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -998,6 +998,79 @@ describe.concurrent(() => {
       expect(exitCode).toBe(1);
     });
 
+    it("fires after the work an unhandledRejection listener scheduled from the last callback", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("unhandledRejection", e => {
+             console.log("unhandledRejection", e.message);
+             setTimeout(() => console.log("late work"), 1);
+           });
+           process.on("beforeExit", () => console.log("beforeExit"));
+           setImmediate(() => Promise.reject(new Error("boom")));`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("unhandledRejection boom\nlate work\nbeforeExit\n");
+      expect(stderr).not.toInclude("error: boom");
+      expect(exitCode).toBe(0);
+    });
+
+    it("a rejection from work scheduled inside beforeExit is reported before beforeExit is re-emitted", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("unhandledRejection", e => console.log("unhandledRejection", e.message));
+           let scheduled = false;
+           process.on("beforeExit", () => {
+             console.log("beforeExit");
+             if (scheduled) return;
+             scheduled = true;
+             setImmediate(() => Promise.reject(new Error("late")));
+           });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("beforeExit\nunhandledRejection late\nbeforeExit\n");
+      expect(stderr).not.toInclude("error: late");
+      expect(exitCode).toBe(0);
+    });
+
+    it("a listener recovers from a rejection a beforeExit listener made, after a microtask hop", async () => {
+      // The 'unhandledRejection' listener reaches setTimeout only after a
+      // microtask (what an await compiles to); that checkpoint has to run before
+      // the loop is judged dead, and 'beforeExit' then fires a second time.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `let n = 0;
+           process.on("beforeExit", () => {
+             console.log("beforeExit#" + ++n);
+             if (n === 1) Promise.reject(new Error("from beforeExit"));
+           });
+           process.on("unhandledRejection", () => {
+             console.log("handler");
+             Promise.resolve().then(() => setTimeout(() => console.log("recovered"), 1));
+           });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "beforeExit#1\nhandler\nrecovered\nbeforeExit#2\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
     it("still fires when an uncaughtException listener handled the throw", async () => {
       await using proc = Bun.spawn({
         cmd: [

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -959,6 +959,45 @@ describe.concurrent(() => {
       expect(exitCode).toBe(1);
     });
 
+    it("is skipped after a fatal unhandled rejection from the last timer", async () => {
+      // The rejection is processed when the timers phase ends (Node's
+      // processTicksAndRejections), so the run is already failing when the loop
+      // is found drained: no 'beforeExit', and 'exit' listeners see code 1.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("beforeExit", () => console.log("beforeExit"));
+           process.on("exit", c => console.log("exit", c, process.exitCode));
+           setTimeout(() => Promise.reject(new Error("boom")), 1);`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("exit 1 1\n");
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it("an async listener's continuation runs, and a throw from it is fatal", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `let n = 0;
+           process.on("beforeExit", async () => { if (n++) return; await null; console.log("continued"); throw new Error("late"); });
+           process.on("exit", c => console.log("exit", c));`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("continued\nexit 1\n");
+      expect(stderr).toInclude("error: late");
+      expect(exitCode).toBe(1);
+    });
+
     it("still fires when an uncaughtException listener handled the throw", async () => {
       await using proc = Bun.spawn({
         cmd: [

--- a/test/js/node/worker_threads/worker-error-exit-code.test.ts
+++ b/test/js/node/worker_threads/worker-error-exit-code.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Spawned: isBunTest short-circuits VirtualMachine::unhandled_rejection so the
+// in-process path is not the one users observe.
+async function run(workerSrc: string, expected: { err: string | null; code: number }) {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { Worker } = require("node:worker_threads");
+       const w = new Worker(${JSON.stringify(workerSrc)}, { eval: true });
+       let err = null;
+       w.on("error", e => { err = e?.name + ": " + e?.message; });
+       w.on("exit", code => { console.log(JSON.stringify({ err, code })); });
+       w.postMessage("go");`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+    stdout: JSON.stringify(expected),
+    stderr: "",
+    exitCode: 0,
+  });
+}
+
+describe.concurrent("exit code when a worker dies from an error", () => {
+  // The error escapes either a parentPort 'message' listener or a timer callback;
+  // in both the worker's loop is still alive (the port, the interval) when it dies.
+  const sites = {
+    "message handler": (body: string) => `require("node:worker_threads").parentPort.on("message", () => { ${body} });`,
+    "timer callback": (body: string) => `setInterval(() => {}, 1000); setTimeout(() => { ${body} }, 20);`,
+  };
+  for (const [site, wrap] of Object.entries(sites)) {
+    test(`unhandled promise rejection in a ${site} exits 1`, async () => {
+      await run(wrap(`Promise.reject(new Error("task-reject"));`), { err: "Error: task-reject", code: 1 });
+    });
+
+    test(`synchronous throw in a ${site} exits 1`, async () => {
+      await run(wrap(`throw new Error("task-throw");`), { err: "Error: task-throw", code: 1 });
+    });
+  }
+
+  test("unhandled rejection runs the worker's process.on('exit') with code 1", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(
+           'process.on("exit", c => require("node:worker_threads").parentPort.postMessage(c));' +
+           'require("node:worker_threads").parentPort.on("message", () => { Promise.reject(new Error("r")); });',
+           { eval: true },
+         );
+         let workerExitArg = null;
+         w.on("error", () => {});
+         w.on("message", c => { workerExitArg = c; });
+         w.on("exit", code => { console.log(JSON.stringify({ workerExitArg, code })); });
+         w.postMessage("go");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ workerExitArg: 1, code: 1 }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("process.on('unhandledRejection') handler suppresses the nonzero exit", async () => {
+    await run(
+      `const { parentPort } = require("node:worker_threads");
+       process.on("unhandledRejection", () => parentPort.close());
+       parentPort.once("message", () => { Promise.reject(new Error("handled")); });`,
+      { err: null, code: 0 },
+    );
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2232,6 +2232,26 @@ describe("an uncaught error at the end of a worker's life", () => {
       ["message:UR:R"],
       0,
     ],
+    // With the entry module's top-level await still pending the worker waits in
+    // the same loop; the rejection decides the exit, not the unsettled await (13).
+    [
+      "rejection in the last immediate while a top-level await is pending",
+      `setImmediate(() => Promise.reject(new Error("R"))); await new Promise(() => {})`,
+      ["error:R"],
+      1,
+    ],
+    [
+      "the worker's listener takes it and the unsettled top-level await still exits 13",
+      `process.on("unhandledRejection", e => parentPort.postMessage("UR:" + e.message)); setImmediate(() => Promise.reject(new Error("R"))); await new Promise(() => {})`,
+      ["message:UR:R"],
+      13,
+    ],
+    [
+      "process.exit(0) from 'beforeExit' is not turned into 13 by a pending top-level await",
+      `process.on("beforeExit", () => process.exit(0)); await new Promise(() => {})`,
+      [],
+      0,
+    ],
     [
       "an 'exit' listener throwing on a natural exit",
       `process.on("exit", () => { throw new Error("T"); })`,
@@ -2270,6 +2290,37 @@ describe("an uncaught error at the end of a worker's life", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: JSON.stringify({ events, code }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Node reports the rejection right after the macrotask that left it, before
+  // a task that macrotask queued (here a MessagePort delivery) runs.
+  test.concurrent("the rejection is reported before tasks the same turn queued", async () => {
+    const workerSrc = `const { parentPort } = require("node:worker_threads");
+      const { port1, port2 } = new MessageChannel();
+      port2.on("message", () => { parentPort.postMessage("task"); port2.close(); });
+      process.on("unhandledRejection", e => parentPort.postMessage("UR:" + e.message));
+      setImmediate(() => { port1.postMessage(0); Promise.reject(new Error("R")); });`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(${JSON.stringify(workerSrc)}, { eval: true });
+         const messages = [];
+         w.on("message", m => messages.push(m));
+         w.on("error", e => messages.push("error:" + e.message));
+         w.on("exit", code => console.log(JSON.stringify({ messages, code })));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ messages: ["UR:R", "task"], code: 0 }) + "\n",
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2171,6 +2171,111 @@ test("a top-level await rejecting while the loop is alive fails the worker then"
   expect(exitCode).toBe(0);
 });
 
+// An uncaught error in the worker's last loop turn (nothing keeps the loop alive
+// once the callback returns) is the worker's 'error' and exit code 1, whichever
+// phase dispatched the callback. Node processes ticks and rejections after every
+// callback; the worker used to decide "loop drained, exit 0" first and drop a
+// rejection raised from a timer, an immediate, a child 'exit' or a 'beforeExit'
+// listener without reporting it anywhere. An error while 'exit' listeners run
+// is reported too, and leaves the exit code as it stands (Node).
+// (Subprocess: inside `bun test` a worker's uncaught error counts as handled.)
+describe("an uncaught error at the end of a worker's life", () => {
+  test.concurrent.each([
+    ["rejection in the last timer", `setTimeout(() => Promise.reject(new Error("R")), 5)`, ["error:R"], 1],
+    ["rejection in the last immediate", `setImmediate(() => Promise.reject(new Error("R")))`, ["error:R"], 1],
+    [
+      "rejection in a nextTick queued by the last timer",
+      `setTimeout(() => process.nextTick(() => Promise.reject(new Error("R"))), 5)`,
+      ["error:R"],
+      1,
+    ],
+    [
+      "async function throwing after its last await",
+      `(async () => { await new Promise(r => setTimeout(r, 5)); throw new Error("R"); })()`,
+      ["error:R"],
+      1,
+    ],
+    ["Bun.sleep().then() throwing", `Bun.sleep(5).then(() => { throw new Error("R"); })`, ["error:R"], 1],
+    [
+      "rejection in a child process 'exit' listener",
+      `require("node:child_process").spawn(process.execPath, ["--version"]).on("exit", () => Promise.reject(new Error("R")))`,
+      ["error:R"],
+      1,
+    ],
+    [
+      "rejection in a 'beforeExit' listener",
+      `let n = 0; process.on("beforeExit", () => { if (!n++) Promise.reject(new Error("R")); })`,
+      ["error:R"],
+      1,
+    ],
+    [
+      "async 'beforeExit' listener throwing after an await",
+      `let n = 0; process.on("beforeExit", async () => { if (n++) return; await null; throw new Error("R"); })`,
+      ["error:R"],
+      1,
+    ],
+    [
+      "rejection in a timer while an interval keeps the loop alive",
+      `setInterval(() => {}, 1000); setTimeout(() => Promise.reject(new Error("R")), 5)`,
+      ["error:R"],
+      1,
+    ],
+    [
+      "the worker's 'exit' listeners see code 1",
+      `process.on("exit", c => parentPort.postMessage("exit:" + c + ":" + process.exitCode)); setTimeout(() => Promise.reject(new Error("R")), 5)`,
+      ["error:R", "message:exit:1:1"],
+      1,
+    ],
+    [
+      "the worker's own 'unhandledRejection' listener takes it",
+      `process.on("unhandledRejection", e => parentPort.postMessage("UR:" + e.message)); setTimeout(() => Promise.reject(new Error("R")), 5)`,
+      ["message:UR:R"],
+      0,
+    ],
+    [
+      "an 'exit' listener throwing on a natural exit",
+      `process.on("exit", () => { throw new Error("T"); })`,
+      ["error:T"],
+      0,
+    ],
+    [
+      "an 'exit' listener throwing under process.exit(4)",
+      `process.on("exit", () => { throw new Error("T"); }); process.exit(4)`,
+      ["error:T"],
+      4,
+    ],
+    [
+      "an 'uncaughtException' listener throwing for a throwing 'exit' listener",
+      `process.exitCode = 4; process.on("uncaughtException", () => { throw new Error("h"); }); process.on("exit", () => { throw new Error("T"); })`,
+      ["error:h"],
+      4,
+    ],
+  ])("%s", async (_label, body, events, code) => {
+    const workerSrc = `const { parentPort } = require("node:worker_threads"); ${body};`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const w = new Worker(${JSON.stringify(workerSrc)}, { eval: true });
+         const events = [];
+         w.on("message", m => events.push("message:" + m));
+         w.on("error", e => events.push("error:" + e.message));
+         w.on("exit", code => console.log(JSON.stringify({ events: events.sort(), code })));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ events, code }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 // Static imports that are still being read/transpiled are loading, not a
 // top-level await: message delivery waits for the graph to execute.
 test("a file worker's static imports load before it counts as started", async () => {


### PR DESCRIPTION
### Problem
- In a `node:worker_threads` Worker, an unhandled rejection from the callback that let the loop drain (a timer, an immediate, a child `'exit'`, a `'beforeExit'` listener) was dropped: no `'error'` event, exit code 0, and the worker's own `unhandledRejection` listener never ran. Node reports `'error'` and exits 1.
- Cause: `auto_tick_active` (`src/runtime/jsc_hooks.rs`) fires those callbacks but, unlike `auto_tick` and `EventLoop::tick`, never ran `handleRejectedPromises`. The worker's `spin()` then saw a dead loop and tore the VM down. Two more gaps: `unhandled_rejection()` never set the exit code, and the worker marked its VM shutting down before the `'exit'` listeners ran, which hid a throw from them.

### Fix
- `auto_tick_active` ends with `handleRejectedPromises`. `dispatch_on_before_exit` drains microtasks and rejections after the listeners ran, as Node does. This covers the main thread too.
- `unhandled_rejection()` sets exit code 1 as `uncaught_exception()` does. Neither changes the code once `'exit'` is being emitted, as in Node.
- The worker runs its `'exit'` listeners before it marks the VM shutting down. Its error handler ends through `WebWorker::exit()`, so a `process.exit(n)` whose listener threw keeps `n`.
- Verified: 13 new cases in `worker_threads.test.ts` and 2 in `process.test.js`, all red on 1.4.3.

### Background
- JSC reports a promise rejected with no handler to the global, which queues it. `handleRejectedPromises` later passes each still-unhandled one to `VirtualMachine::unhandled_rejection`.
- The run loops are `while alive { tick(); auto_tick_active(); }`. A rejection from `auto_tick_active` was only seen by the next `tick()`. There is none once the loop is idle.
- A worker's fatal-error handler posts `'error'` to the parent, runs the `'exit'` listeners and requests termination.

<details><summary>Notes</summary>

Stacked on #42031 (base branch `robobun/ccb1615d/events-capture-rejections`). That PR makes `node:events` `captureRejections` and the post-`'unhandledRejection'` drain match Node; without it, the end-of-turn rejection pass added here lets `test/js/node/test/parallel/test-event-capture-rejections.js` run past the stage where it used to stall and into those gaps. Once #42031 merges this PR's base becomes `main`.

Door matrix (worker body, events seen by the parent, exit code), bun 1.4.3 vs this branch vs node 26:

```
door                      bun 1.4.3                 this branch               node
timer                     (no event)        exit 0  error:R           exit 1  error:R           exit 1
queueMicrotask tail       (no event)        exit 0  error:R           exit 1  error:R           exit 1
nextTick tail             (no event)        exit 0  error:R           exit 1  error:R           exit 1
beforeExit                (no event)        exit 0  error:R           exit 1  error:R           exit 1
beforeExit async          (no event)        exit 0  error:R           exit 1  error:R           exit 1
child 'exit'              (no event)        exit 0  error:R           exit 1  error:R           exit 1
Bun.sleep().then          (no event)        exit 0  error:R           exit 1  error:R           exit 1
setImmediate              (no event)        exit 0  error:R           exit 1  error:R           exit 1
fs.readFile cb            error:R           exit 0/1 (racy)  error:R  exit 1  error:R           exit 1
kept alive (setInterval)  error:R           exit 0  error:R           exit 1  error:R           exit 1
'exit' listener sees      exit:0:undefined  exit 0  exit:1:1          exit 1  exit:1:1          exit 1
own unhandledRejection    (no event)        exit 0  message:UR:x      exit 0  message:UR:x      exit 0
'exit' listener throws    (no event)        exit 0  error:T           exit 0  error:T           exit 0
same, under exit(4)       error:T           exit 1  error:T           exit 4  error:T           exit 4
exitCode=4, listener thr. (no event)        exit 4  error:T           exit 4  error:T           exit 4
top-level reject (ctl)    error:R           exit 1  error:R           exit 1  error:R           exit 1
```

The racy `fs.readFile` row: the completion sometimes landed inside `load_entry_point_for_web_worker`, whose failure path set code 1, and sometimes in the run loop, where nothing did.

One known remaining difference: when a rejection ends the worker, Bun posts `'error'` before it runs the worker's `'exit'` listeners, so a message posted from an `'exit'` listener arrives after `'error'` (Node: before). Unchanged by this PR.

Suites run locally (Linux x64 debug+ASAN, and Windows x64 debug): `test/js/node/worker_threads/` (all files), `test/js/web/workers/worker.test.ts`, `worker-late-completion.test.ts`, `worker_destruction.test.ts`, the `process.onBeforeExit` / `process.onExit` blocks of `process.test.js`, `test/js/bun/test/test-test.test.ts`, `test/cli/hot/hot.test.ts`, and node's `test-promise-unhandled-*`, `test-promises-unhandled-*`, `test-process-beforeexit*`, `test-process-exit-*`, `test-next-tick-errors`, `test-timers-unrefed-in-beforeexit`, `test-worker-beforeexit-throw-exit`, `test-worker-exit-code`, `test-unhandled-exception-with-worker-inuse`.

Older open PRs that each address one face of this and would be superseded: #37981 (the `auto_tick_active` tail plus a pass after the worker's `'beforeExit'`, conflicting since August), #34193 (exit code 1 set in the worker's error handler), and the exit-code half of #38116 (main-thread `'exit'` listeners see 1). #40132 changes `WebWorker::exit()`'s signature; whichever lands second needs a one-line rebase.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js, test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->