### PR TITLE
bun build --no-bundle: reject or report bundler-only flags instead of ignoring them

### DIFF
--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -122,7 +122,12 @@ bun build <entry points>
 </ParamField>
 
 <ParamField path="--no-bundle" type="boolean">
-  Transpile only — do not bundle
+  Transpile only — do not bundle. Each entry point is emitted as its own file with its imports left as written.
+  <code>--format</code> other than <code>esm</code>, <code>--bytecode</code>, <code>--metafile</code>,
+  <code>--server-components</code> and <code>--compile</code> are rejected in this mode. <code>--banner</code>,
+  <code>--footer</code> and <code>--react-fast-refresh</code> are not supported yet and are ignored with a warning, and
+  flags that only affect resolving or chunking (such as <code>--external</code> or <code>--splitting</code>) have no
+  effect.
 </ParamField>
 
 <ParamField path="--css-chunking" type="boolean">

--- a/docs/snippets/cli/build.mdx
+++ b/docs/snippets/cli/build.mdx
@@ -123,11 +123,10 @@ bun build <entry points>
 
 <ParamField path="--no-bundle" type="boolean">
   Transpile only — do not bundle. Each entry point is emitted as its own file with its imports left as written.
-  <code>--format</code> other than <code>esm</code>, <code>--bytecode</code>, <code>--metafile</code>,
-  <code>--server-components</code> and <code>--compile</code> are rejected in this mode. <code>--banner</code>,
-  <code>--footer</code> and <code>--react-fast-refresh</code> are not supported yet and are ignored with a warning, and
-  flags that only affect resolving or chunking (such as <code>--external</code> or <code>--splitting</code>) have no
-  effect.
+  <code>--metafile</code>, <code>--server-components</code> and <code>--compile</code> are rejected in this mode.
+  <code>--banner</code>, <code>--footer</code> and <code>--react-fast-refresh</code> are not supported yet and are
+  ignored with a warning, and flags that only affect resolving or chunking (such as <code>--external</code> or
+  <code>--splitting</code>) have no effect.
 </ParamField>
 
 <ParamField path="--css-chunking" type="boolean">

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1638,6 +1638,14 @@ impl<'a> Transpiler<'a> {
 
                 opts.features.inlining = self.options.inlining;
                 opts.features.auto_import_jsx = self.options.auto_import_jsx;
+                opts.features.react_compiler = if self.options.react_compiler.is_enabled()
+                    && loader.is_jsx()
+                    && !path.is_node_module()
+                {
+                    self.options.react_compiler
+                } else {
+                    bun_ast::runtime::ReactCompilerMode::Disabled
+                };
                 // JavaScriptCore implements `using` / `await using` natively, so
                 // when targeting Bun there is no need to lower them.
                 opts.features.lower_using = !target.is_bun();

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2659,7 +2659,7 @@ fn parse_build_command_options(
     }
 
     if ctx.bundler_options.transform_only {
-        check_no_bundle_flags(args, ctx.bundler_options.output_format);
+        check_no_bundle_flags(args);
         // Reported as ignored or without effect above; keep it that way
         // further down (`--splitting` would otherwise demand --outdir).
         ctx.bundler_options.code_splitting = false;
@@ -2675,27 +2675,13 @@ fn parse_build_command_options(
 /// only tunes resolving, chunking or linking, is reported and ignored.
 #[cold]
 #[inline(never)]
-fn check_no_bundle_flags(args: &clap::Args<clap::Help>, output_format: options::Format) {
-    let mut failed = false;
-    if let Some(format) = args.option(b"--format") {
-        if output_format != options::Format::Esm {
-            Output::err_generic(
-                "--format={} is not supported with --no-bundle (see https://github.com/oven-sh/bun/issues/29187)",
-                (BStr::new(format),),
-            );
-            bun_core::note!(
-                "to emit one file in that format, bundle it with every import external: bun build ./file.ts --format={} --external '*'",
-                BStr::new(format)
-            );
-            failed = true;
-        }
-    }
-    let unsupported: [(&[u8], bool); 4] = [
-        (b"--bytecode", args.flag(b"--bytecode")),
+fn check_no_bundle_flags(args: &clap::Args<clap::Help>) {
+    let unsupported: [(&[u8], bool); 3] = [
         (b"--server-components", args.flag(b"--server-components")),
         (b"--metafile", args.option(b"--metafile").is_some()),
         (b"--metafile-md", args.option(b"--metafile-md").is_some()),
     ];
+    let mut failed = false;
     for (flag, passed) in unsupported {
         if passed {
             Output::err_generic("{} is not supported with --no-bundle", (BStr::new(flag),));

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2660,8 +2660,7 @@ fn parse_build_command_options(
 
     if ctx.bundler_options.transform_only {
         check_no_bundle_flags(args);
-        // Reported as ignored or without effect above; keep it that way
-        // further down (`--splitting` would otherwise demand --outdir).
+        // Warned about above; cleared so nothing downstream acts on them.
         ctx.bundler_options.code_splitting = false;
         ctx.bundler_options.react_fast_refresh = false;
         ctx.bundler_options.banner = Box::default();
@@ -2669,10 +2668,8 @@ fn parse_build_command_options(
     }
 }
 
-/// `--no-bundle` transpiles each entry point on its own and never resolves or
-/// links its imports. A flag that asks for output this mode cannot produce
-/// fails the build; a per-file transform it does not run yet, or a flag that
-/// only tunes resolving, chunking or linking, is reported and ignored.
+/// `--no-bundle` never runs the linker: reject flags that need its output,
+/// warn about flags it would merely have consulted.
 #[cold]
 #[inline(never)]
 fn check_no_bundle_flags(args: &clap::Args<clap::Help>) {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2668,8 +2668,7 @@ fn parse_build_command_options(
     }
 }
 
-/// `--no-bundle` never runs the linker: reject flags that need its output,
-/// warn about flags it would merely have consulted.
+/// `--no-bundle` never runs the linker: reject flags that need it, warn about the rest.
 #[cold]
 #[inline(never)]
 fn check_no_bundle_flags(args: &clap::Args<clap::Help>) {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2657,4 +2657,96 @@ fn parse_build_command_options(
         // produces an executable or a standalone HTML file (browsers do read
         // the comment, so standalone HTML keeps the user's choice).
     }
+
+    if ctx.bundler_options.transform_only {
+        check_no_bundle_flags(args, ctx.bundler_options.output_format);
+        // Reported as ignored or without effect above; keep it that way
+        // further down (`--splitting` would otherwise demand --outdir).
+        ctx.bundler_options.code_splitting = false;
+        ctx.bundler_options.react_fast_refresh = false;
+        ctx.bundler_options.banner = Box::default();
+        ctx.bundler_options.footer = Box::default();
+    }
+}
+
+/// `--no-bundle` transpiles each entry point on its own and never resolves or
+/// links its imports. A flag that asks for output this mode cannot produce
+/// fails the build; a per-file transform it does not run yet, or a flag that
+/// only tunes resolving, chunking or linking, is reported and ignored.
+#[cold]
+#[inline(never)]
+fn check_no_bundle_flags(args: &clap::Args<clap::Help>, output_format: options::Format) {
+    let mut failed = false;
+    if let Some(format) = args.option(b"--format") {
+        if output_format != options::Format::Esm {
+            Output::err_generic(
+                "--format={} is not supported with --no-bundle (see https://github.com/oven-sh/bun/issues/29187)",
+                (BStr::new(format),),
+            );
+            bun_core::note!(
+                "to emit one file in that format, bundle it with every import external: bun build ./file.ts --format={} --external '*'",
+                BStr::new(format)
+            );
+            failed = true;
+        }
+    }
+    let unsupported: [(&[u8], bool); 4] = [
+        (b"--bytecode", args.flag(b"--bytecode")),
+        (b"--server-components", args.flag(b"--server-components")),
+        (b"--metafile", args.option(b"--metafile").is_some()),
+        (b"--metafile-md", args.option(b"--metafile-md").is_some()),
+    ];
+    for (flag, passed) in unsupported {
+        if passed {
+            Output::err_generic("{} is not supported with --no-bundle", (BStr::new(flag),));
+            failed = true;
+        }
+    }
+    if failed {
+        Global::exit(1);
+    }
+
+    let not_yet: [(&[u8], bool); 3] = [
+        (b"--banner", args.option(b"--banner").is_some()),
+        (b"--footer", args.option(b"--footer").is_some()),
+        (b"--react-fast-refresh", args.flag(b"--react-fast-refresh")),
+    ];
+    for (flag, passed) in not_yet {
+        if passed {
+            bun_core::warn!(
+                "{} is not supported with --no-bundle yet and has been ignored",
+                BStr::new(flag)
+            );
+        }
+    }
+
+    let no_effect: [(&[u8], bool); 13] = [
+        (b"--splitting", args.flag(b"--splitting")),
+        (b"--external", !args.options(b"--external").is_empty()),
+        (b"--packages", args.option(b"--packages").is_some()),
+        (b"--public-path", args.option(b"--public-path").is_some()),
+        (b"--chunk-naming", args.option(b"--chunk-naming").is_some()),
+        (b"--asset-naming", args.option(b"--asset-naming").is_some()),
+        (b"--css-chunking", args.flag(b"--css-chunking")),
+        (b"--no-split-require", args.flag(b"--no-split-require")),
+        (b"--no-module-preload", args.flag(b"--no-module-preload")),
+        (
+            b"--min-chunk-size",
+            args.option(b"--min-chunk-size").is_some(),
+        ),
+        (
+            b"--allow-unresolved",
+            !args.options(b"--allow-unresolved").is_empty(),
+        ),
+        (b"--reject-unresolved", args.flag(b"--reject-unresolved")),
+        (
+            b"--no-deprecated-namespace-object-setters",
+            args.flag(b"--no-deprecated-namespace-object-setters"),
+        ),
+    ];
+    for (flag, passed) in no_effect {
+        if passed {
+            bun_core::warn!("{} has no effect with --no-bundle", BStr::new(flag));
+        }
+    }
 }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -799,6 +799,137 @@ describe.concurrent("--no-bundle with --outdir", () => {
   });
 });
 
+describe.concurrent("--no-bundle with flags that need the bundler", () => {
+  async function buildNoBundle(files: Record<string, string>, args: string[]) {
+    using dir = tempDir("no-bundle-flags", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, entries: fs.readdirSync(String(dir)).sort() };
+  }
+
+  // These ask for output that transpiling one file at a time cannot produce:
+  // the build fails before anything is written.
+  test.each([
+    [
+      "--format=cjs",
+      "error: --format=cjs is not supported with --no-bundle (see https://github.com/oven-sh/bun/issues/29187)\n" +
+        "note: to emit one file in that format, bundle it with every import external: bun build ./file.ts --format=cjs --external '*'\n",
+    ],
+    [
+      "--format=iife",
+      "error: --format=iife is not supported with --no-bundle (see https://github.com/oven-sh/bun/issues/29187)\n" +
+        "note: to emit one file in that format, bundle it with every import external: bun build ./file.ts --format=iife --external '*'\n",
+    ],
+    ["--bytecode", "error: --bytecode is not supported with --no-bundle\n"],
+    ["--metafile=meta.json", "error: --metafile is not supported with --no-bundle\n"],
+    ["--metafile-md=meta.md", "error: --metafile-md is not supported with --no-bundle\n"],
+    ["--server-components", "error: --server-components is not supported with --no-bundle\n"],
+  ])("%s fails the build", async (flag, expectedStderr) => {
+    const { stdout, stderr, exitCode, entries } = await buildNoBundle({ "a.ts": `export const a: number = 1;\n` }, [
+      "./a.ts",
+      "--outdir=dist",
+      flag,
+    ]);
+    expect(stderr).toBe(expectedStderr);
+    expect(stdout).toBe("");
+    expect(entries).toEqual(["a.ts"]);
+    expect(exitCode).toBe(1);
+  });
+
+  test("--format=esm is the format --no-bundle emits and is accepted", async () => {
+    const { stdout, stderr, exitCode } = await buildNoBundle({ "a.ts": `export const a: number = 1;\n` }, [
+      "./a.ts",
+      "--format=esm",
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("export const a = 1;\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Per-file transforms this mode does not run yet: the build says it ignored
+  // them and carries on.
+  test.each([
+    [[`--banner="use client";`], ["--banner"]],
+    [["--footer=// built with bun"], ["--footer"]],
+    [
+      [`--banner=// top`, "--footer=// bottom"],
+      ["--banner", "--footer"],
+    ],
+  ])("%j is reported as ignored", async (args, reported) => {
+    const { stdout, stderr, exitCode } = await buildNoBundle({ "a.ts": `export const a: number = 1;\n` }, [
+      "./a.ts",
+      ...args,
+    ]);
+    expect(stderr).toBe(
+      reported.map(flag => `warn: ${flag} is not supported with --no-bundle yet and has been ignored\n`).join(""),
+    );
+    expect(stdout).toBe("export const a = 1;\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(["App.jsx", "App.tsx"])("--react-fast-refresh is reported as ignored for %s", async file => {
+    const { stdout, stderr, exitCode } = await buildNoBundle(
+      {
+        [file]: `import { useState } from "react";\nexport function App() {\n  const [n] = useState(0);\n  return <b>{n}</b>;\n}\n`,
+      },
+      [`./${file}`, "--react-fast-refresh"],
+    );
+    expect(stderr).toBe("warn: --react-fast-refresh is not supported with --no-bundle yet and has been ignored\n");
+    expect(stdout).not.toContain("$RefreshReg$");
+    expect(stdout).not.toContain("$RefreshSig$");
+    expect(stdout).toContain("useState(0)");
+    expect(exitCode).toBe(0);
+  });
+
+  // These only tune resolving, chunking or linking, which --no-bundle skips:
+  // the build says so and carries on.
+  test.each([
+    [["--splitting"], ["--splitting"]],
+    [
+      ["--splitting", "--min-chunk-size=1024"],
+      ["--splitting", "--min-chunk-size"],
+    ],
+    [["--external", "react"], ["--external"]],
+    [["--external", "./a.ts"], ["--external"]],
+    [["--packages=external"], ["--packages"]],
+    [["--public-path=/static/"], ["--public-path"]],
+    [["--chunk-naming=[name]-[hash].[ext]"], ["--chunk-naming"]],
+    [["--asset-naming=[name]-[hash].[ext]"], ["--asset-naming"]],
+    [["--css-chunking"], ["--css-chunking"]],
+    [["--no-split-require"], ["--no-split-require"]],
+    [["--no-module-preload"], ["--no-module-preload"]],
+    [["--allow-unresolved", "*"], ["--allow-unresolved"]],
+    [["--reject-unresolved"], ["--reject-unresolved"]],
+    [["--no-deprecated-namespace-object-setters"], ["--no-deprecated-namespace-object-setters"]],
+  ])("%j is reported as having no effect", async (args, reported) => {
+    const { stdout, stderr, exitCode } = await buildNoBundle({ "a.ts": `export const a: number = 1;\n` }, [
+      "./a.ts",
+      ...args,
+    ]);
+    expect(stderr).toBe(reported.map(flag => `warn: ${flag} has no effect with --no-bundle\n`).join(""));
+    expect(stdout).toBe("export const a = 1;\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.each(["App.jsx", "App.tsx"])("--react-compiler memoizes components in %s", async file => {
+    const { stdout, stderr, exitCode } = await buildNoBundle(
+      {
+        [file]: `export function App({ name }) {\n  return <b>{name.toUpperCase()}</b>;\n}\n`,
+      },
+      [`./${file}`, "--react-compiler"],
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/import \{\s*c as (\w+)\s*\} from "react\/compiler-runtime";/);
+    expect(exitCode).toBe(0);
+  });
+});
+
 test.concurrent("bun build names every input that maps to a shared output path", async () => {
   using dir = tempDir("bundle-outdir-collision", {
     "a.ts": `export const a = 1;\n`,

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -816,40 +816,19 @@ describe.concurrent("--no-bundle with flags that need the bundler", () => {
   // These ask for output that transpiling one file at a time cannot produce:
   // the build fails before anything is written.
   test.each([
-    [
-      "--format=cjs",
-      "error: --format=cjs is not supported with --no-bundle (see https://github.com/oven-sh/bun/issues/29187)\n" +
-        "note: to emit one file in that format, bundle it with every import external: bun build ./file.ts --format=cjs --external '*'\n",
-    ],
-    [
-      "--format=iife",
-      "error: --format=iife is not supported with --no-bundle (see https://github.com/oven-sh/bun/issues/29187)\n" +
-        "note: to emit one file in that format, bundle it with every import external: bun build ./file.ts --format=iife --external '*'\n",
-    ],
-    ["--bytecode", "error: --bytecode is not supported with --no-bundle\n"],
-    ["--metafile=meta.json", "error: --metafile is not supported with --no-bundle\n"],
-    ["--metafile-md=meta.md", "error: --metafile-md is not supported with --no-bundle\n"],
-    ["--server-components", "error: --server-components is not supported with --no-bundle\n"],
-  ])("%s fails the build", async (flag, expectedStderr) => {
+    ["--metafile=meta.json", "--metafile"],
+    ["--metafile-md=meta.md", "--metafile-md"],
+    ["--server-components", "--server-components"],
+  ])("%s fails the build", async (flag, name) => {
     const { stdout, stderr, exitCode, entries } = await buildNoBundle({ "a.ts": `export const a: number = 1;\n` }, [
       "./a.ts",
       "--outdir=dist",
       flag,
     ]);
-    expect(stderr).toBe(expectedStderr);
+    expect(stderr).toBe(`error: ${name} is not supported with --no-bundle\n`);
     expect(stdout).toBe("");
     expect(entries).toEqual(["a.ts"]);
     expect(exitCode).toBe(1);
-  });
-
-  test("--format=esm is the format --no-bundle emits and is accepted", async () => {
-    const { stdout, stderr, exitCode } = await buildNoBundle({ "a.ts": `export const a: number = 1;\n` }, [
-      "./a.ts",
-      "--format=esm",
-    ]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("export const a = 1;\n");
-    expect(exitCode).toBe(0);
   });
 
   // Per-file transforms this mode does not run yet: the build says it ignored

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -826,6 +826,8 @@ describe.concurrent("bundler", () => {
       stdout: "c",
     },
   });
+  // esbuild runs these two with format "cjs"; `bun build --no-bundle` only
+  // emits ESM and rejects --format=cjs, and the assertions hold either way.
   itBundled("default/DynamicImportWithExpressionCJS", {
     files: {
       "/a.js": /* js */ `
@@ -833,7 +835,6 @@ describe.concurrent("bundler", () => {
         import(foo())
       `,
     },
-    format: "cjs",
     bundling: false,
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain('import("foo")');
@@ -847,7 +848,6 @@ describe.concurrent("bundler", () => {
         import(foo())
       `,
     },
-    format: "cjs",
     bundling: false,
     minifyWhitespace: true,
     onAfterBundle(api) {
@@ -2064,7 +2064,9 @@ describe.concurrent("bundler", () => {
         })()
       `,
     },
-    format: "iife",
+    // esbuild uses format "iife" to keep `with` out of strict mode; `bun build
+    // --no-bundle` rejects --format=iife, but its output for this file has no
+    // import/export, so node still runs it as a sloppy script.
     minifyIdentifiers: true,
     bundling: false,
     run: {
@@ -2145,7 +2147,6 @@ describe.concurrent("bundler", () => {
     },
     minifyIdentifiers: true,
     bundling: false,
-    format: "cjs",
     onAfterBundle(api) {
       const text = api.readFile("/out.js");
       assert(text.includes("shouldNotBeRenamed2"), "Should not have renamed `shouldNotBeRenamed2`");

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -826,8 +826,6 @@ describe.concurrent("bundler", () => {
       stdout: "c",
     },
   });
-  // esbuild runs these two with format "cjs"; `bun build --no-bundle` only
-  // emits ESM and rejects --format=cjs, and the assertions hold either way.
   itBundled("default/DynamicImportWithExpressionCJS", {
     files: {
       "/a.js": /* js */ `
@@ -835,6 +833,7 @@ describe.concurrent("bundler", () => {
         import(foo())
       `,
     },
+    format: "cjs",
     bundling: false,
     onAfterBundle(api) {
       api.expectFile("/out.js").toContain('import("foo")');
@@ -848,6 +847,7 @@ describe.concurrent("bundler", () => {
         import(foo())
       `,
     },
+    format: "cjs",
     bundling: false,
     minifyWhitespace: true,
     onAfterBundle(api) {
@@ -2064,9 +2064,7 @@ describe.concurrent("bundler", () => {
         })()
       `,
     },
-    // esbuild uses format "iife" to keep `with` out of strict mode; `bun build
-    // --no-bundle` rejects --format=iife, but its output for this file has no
-    // import/export, so node still runs it as a sloppy script.
+    format: "iife",
     minifyIdentifiers: true,
     bundling: false,
     run: {
@@ -2147,6 +2145,7 @@ describe.concurrent("bundler", () => {
     },
     minifyIdentifiers: true,
     bundling: false,
+    format: "cjs",
     onAfterBundle(api) {
       const text = api.readFile("/out.js");
       assert(text.includes("shouldNotBeRenamed2"), "Should not have renamed `shouldNotBeRenamed2`");

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -622,10 +622,7 @@ function expectBundled(
       "bundling:false with more than one entry point is not implemented in this harness",
     );
   }
-  // `bun build --no-bundle` emits one ES module per entry and rejects these.
-  if (!ESBUILD && bundling === false && format !== "esm") {
-    throw new UnsupportedOptionError(`format: "${format}" with bundling: false is not implemented in bun build`);
-  }
+  // `bun build --no-bundle` has no module graph to describe and rejects --metafile.
   if (!ESBUILD && bundling === false && metafile) {
     throw new UnsupportedOptionError("metafile with bundling: false is not implemented in bun build");
   }

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -622,6 +622,13 @@ function expectBundled(
       "bundling:false with more than one entry point is not implemented in this harness",
     );
   }
+  // `bun build --no-bundle` emits one ES module per entry and rejects these.
+  if (!ESBUILD && bundling === false && format !== "esm") {
+    throw new UnsupportedOptionError(`format: "${format}" with bundling: false is not implemented in bun build`);
+  }
+  if (!ESBUILD && bundling === false && metafile) {
+    throw new UnsupportedOptionError("metafile with bundling: false is not implemented in bun build");
+  }
 
   if (!ESBUILD && legalComments) {
     throw new UnsupportedOptionError("legalComments not implemented in bun build");


### PR DESCRIPTION
### Problem
- `bun build --no-bundle` silently ignores most bundler flags and exits 0: `--metafile` writes no file, `--server-components` does nothing, `--banner`/`--footer` never appear, `--react-fast-refresh`/`--react-compiler` do not run, `--splitting`/`--external`/`--packages` say nothing.
- Cause: `--no-bundle` takes the transform-only path (`Transpiler::transform`, `src/bundler/transpiler.rs`), which never reaches the linker, and `src/runtime/cli/Arguments.rs` accepts every flag anyway.

### Fix
- `Arguments.rs`, `check_no_bundle_flags`: flags whose output this mode cannot produce fail the build (`--metafile`, `--metafile-md`, `--server-components`), as `--compile` already does. Per-file transforms not run yet (`--banner`, `--footer`, `--react-fast-refresh`) warn that they were ignored. Flags that only tune resolving, chunking or linking (`--splitting`, `--external`, ...) warn that they have no effect. Output and exit code stay unchanged for both warning groups.
- `--react-compiler` is a per-file transform this path can run: `Transpiler::parse` now passes it to the parser with the gating `ParseTask` uses.
- `--format` and `--bytecode` are left as they are on purpose: #41988 honours `--format=cjs` and `--bytecode` per file and rejects `--format=iife`. The two PRs compose in either order.
- Verified: `test/bundler/cli.test.ts`, block `--no-bundle with flags that need the bundler` (24 tests, all fail on 1.4.3-canary), plus the suites in the notes. Self-reviewed: two parts split out (see notes).

### Background
- `--no-bundle` transpiles each entry point on its own and leaves imports as written. The linker never runs: no module graph, no chunks, no metafile.
- This is one member of a `--no-bundle` flag audit. `--format`/`--bytecode` (#41988), `--watch` (#35633), `--sourcemap` (#41939), the unresolved-entry exit code (#38752) and copied entries such as `.wasm` (#38123) have their own PRs.

<details><summary>Notes</summary>

Flag by flag under `--no-bundle` after this change:

| | |
|---|---|
| honoured (unchanged) | `--target`, `--define`, `--drop`, `--env`, `--feature`, `--loader`, `--jsx-*`, `--tsconfig-override`, `--minify*`, `--keep-names`, `--production`, `--outfile`, `--outdir`, `--root`, `--entry-naming`, `--emit-dce-annotations`, `--ignore-dce-annotations`, `--conditions` (entry point resolution) |
| honoured (new) | `--react-compiler` |
| error (unchanged) | `--compile`, `.html` entry points, `--asset`/`--compile-*`/`--windows-*` (require `--compile`) |
| error (new) | `--metafile`, `--metafile-md`, `--server-components` |
| warning, ignored (new) | `--banner`, `--footer`, `--react-fast-refresh` |
| warning, no effect (new) | `--splitting`, `--external`, `--packages`, `--public-path`, `--chunk-naming`, `--asset-naming`, `--css-chunking`, `--no-split-require`, `--no-module-preload`, `--min-chunk-size`, `--allow-unresolved`, `--reject-unresolved`, `--no-deprecated-namespace-object-setters` |
| not touched here, open PRs | `--format=cjs` / `--format=iife` / `--bytecode` (#41988), `--watch` (#35633), `--sourcemap` (#41939), unresolved entry exit code (#38752), copied entries such as `.wasm` (#38123) |

Error versus warning: an error where the requested artifact cannot be produced (a metafile, the server-components transform), because exit 0 without what was asked for misleads whatever consumes the build. A warning where the output is still usable: a per-file transform that is skipped, or a flag that tunes a step that does not run.

`--format` / `--bytecode`: an earlier revision here rejected `--format=cjs|iife` and `--bytecode` under `--no-bundle`. #41988 instead honours `--format=cjs` and `--bytecode` per file through the linker (what #29187 asked for) and rejects only `--format=iife`, so those arms were dropped to let that PR decide the flag pair. Nothing needs reconciling whichever lands first. If #41988 is not taken, re-adding the three error rows is a small follow-up.

Split out after review:
- An earlier revision also honoured `--banner`/`--footer` by wrapping the printed file. That collides with `--no-bundle --sourcemap` (#41939), where a banner must shift the mappings, so it is left for that PR or a follow-up on top of it; until then the flags warn.
- `--react-fast-refresh` per file needs the `Transpiler::parse` wiring from #32951 and the `.tsx` import fix from #42010 (today a `.tsx` file loses the `react-refresh/runtime` import). Until both land it warns; the warning and the `react_fast_refresh = false` reset in `Arguments.rs` go away with that follow-up.

`itBundled` (`test/bundler/expectBundled.ts`) registers a test as `todo` when the backend lacks an option. `bundling: false` with a metafile is now such a case for `bun build`.

`--target` is honoured in transform-only mode. It only shows on non-ASCII input (`--target=bun` prints `"h\xE9llo"`), on `using` lowering, and on the JSX dev/prod choice.

`--splitting` is also cleared after the warning. Otherwise `bun build --no-bundle a.ts --splitting` would still stop with `Must use --outdir when code splitting is enabled`.

`--public-path`: #41939 uses it for the `//# sourceMappingURL` of `--no-bundle --sourcemap=linked`. Whichever lands second should skip the `--public-path` warning when a linked source map is requested.

With #41988, `--no-bundle --format=cjs` goes through the linker, which does apply `--banner`, `--metafile` and the rest. The checks here still run first for that combination; whichever lands second can gate them on the ESM path (`output_format == esm`) in one line.

Also run with the debug build: the rest of `cli.test.ts`, `esbuild/default.test.ts`, the other `bundling: false` itBundled suites, `transpiler/transpiler.test.js`, regression 29242, 31401, 23569, 25716.

Before, on 1.4.3-canary:

```
$ bun build --no-bundle m.ts --metafile=meta.json --outdir out; echo rc=$?; ls meta.json
Transpiled file in 1ms

  m.js  19 bytes  (chunk)

rc=0
ls: cannot access 'meta.json': No such file or directory
$ bun build --no-bundle m.ts --banner='// B' --splitting --outdir out
(same, no banner in out/m.js, no message)
$ bun build --no-bundle App.tsx --react-compiler | grep -c compiler-runtime
0
```

After:

```
$ bun build --no-bundle m.ts --metafile=meta.json --outdir out; echo rc=$?
error: --metafile is not supported with --no-bundle
rc=1
$ bun build --no-bundle m.ts --banner='// B' --splitting
warn: --banner is not supported with --no-bundle yet and has been ignored
warn: --splitting has no effect with --no-bundle
export const x = 1;
$ bun build --no-bundle App.tsx --react-compiler | head -2
import { jsxDEV as jsxDEV_7x81h0kn } from "react/jsx-dev-runtime";
import { c as _c } from "react/compiler-runtime";
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->
