### PR TITLE
URLPattern: keep # and ? in pattern fixed text, reject a trailing ()

### DIFF
--- a/src/jsc/bindings/webcore/URLPattern.cpp
+++ b/src/jsc/bindings/webcore/URLPattern.cpp
@@ -137,8 +137,13 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
         }
     }
 
+    // https://urlpattern.spec.whatwg.org/#process-protocol-for-init
     if (!init.protocol.isNull()) {
-        auto protocolResult = canonicalizeProtocol(init.protocol, type);
+        StringView strippedValue { init.protocol };
+        if (strippedValue.endsWith(':'))
+            strippedValue = strippedValue.left(strippedValue.length() - 1);
+
+        auto protocolResult = canonicalizeProtocol(strippedValue, type);
 
         if (protocolResult.hasException())
             return protocolResult.releaseException();
@@ -188,8 +193,13 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
         result.pathname = pathResult.releaseReturnValue();
     }
 
+    // https://urlpattern.spec.whatwg.org/#process-search-for-init
     if (!init.search.isNull()) {
-        auto queryResult = canonicalizeSearch(init.search, type);
+        StringView strippedValue { init.search };
+        if (strippedValue.startsWith('?'))
+            strippedValue = strippedValue.substring(1);
+
+        auto queryResult = canonicalizeSearch(strippedValue, type);
 
         if (queryResult.hasException())
             return queryResult.releaseException();
@@ -197,8 +207,13 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
         result.search = queryResult.releaseReturnValue();
     }
 
+    // https://urlpattern.spec.whatwg.org/#process-hash-for-init
     if (!init.hash.isNull()) {
-        auto fragmentResult = canonicalizeHash(init.hash, type);
+        StringView strippedValue { init.hash };
+        if (strippedValue.startsWith('#'))
+            strippedValue = strippedValue.substring(1);
+
+        auto fragmentResult = canonicalizeHash(strippedValue, type);
 
         if (fragmentResult.hasException())
             return fragmentResult.releaseException();

--- a/src/jsc/bindings/webcore/URLPatternCanonical.cpp
+++ b/src/jsc/bindings/webcore/URLPatternCanonical.cpp
@@ -67,18 +67,17 @@ bool isAbsolutePathname(StringView input, BaseURLStringType inputType)
     return false;
 }
 
-// https://urlpattern.spec.whatwg.org/#canonicalize-a-protocol, combined with https://urlpattern.spec.whatwg.org/#process-protocol-for-init
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-protocol
+// The trailing ':' removal from https://urlpattern.spec.whatwg.org/#process-protocol-for-init is done by the caller.
 ExceptionOr<String> canonicalizeProtocol(StringView value, BaseURLStringType valueType)
 {
     if (value.isEmpty())
         return value.toString();
 
-    auto strippedValue = value.endsWith(':') ? value.left(value.length() - 1) : value;
-
     if (valueType == BaseURLStringType::Pattern)
-        return strippedValue.toString();
+        return value.toString();
 
-    URL dummyURL(makeString(strippedValue, "://w/"_s));
+    URL dummyURL(makeString(value, "://w/"_s));
 
     if (!dummyURL.isValid())
         return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL protocol string."_s };
@@ -221,37 +220,37 @@ ExceptionOr<String> processPathname(StringView pathnameValue, const StringView p
     return canonicalizeOpaquePathname(pathnameValue);
 }
 
-// https://urlpattern.spec.whatwg.org/#canonicalize-a-search, combined with https://urlpattern.spec.whatwg.org/#process-search-for-init
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-search
+// The leading '?' removal from https://urlpattern.spec.whatwg.org/#process-search-for-init is done by the caller.
 ExceptionOr<String> canonicalizeSearch(StringView value, BaseURLStringType valueType)
 {
     if (value.isEmpty())
         return value.toString();
 
-    auto strippedValue = value[0] == '?' ? value.substring(1) : value;
-
     if (valueType == BaseURLStringType::Pattern)
-        return strippedValue.toString();
+        return value.toString();
 
+    // The spec parses value with the query state as the state override: a '?' stays as is and a '#' is
+    // percent-encoded. URL::setQuery instead treats a leading '?' as the delimiter and a '#' as the fragment.
     URL dummyURL(dummyURLCharacters);
-    dummyURL.setQuery(strippedValue);
+    dummyURL.setQuery(makeString('?', makeStringByReplacingAll(value.toString(), '#', "%23"_s)));
     ASSERT(dummyURL.isValid());
 
     return dummyURL.query().toString();
 }
 
-// https://urlpattern.spec.whatwg.org/#canonicalize-a-hash, combined with https://urlpattern.spec.whatwg.org/#process-hash-for-init
+// https://urlpattern.spec.whatwg.org/#canonicalize-a-hash
+// The leading '#' removal from https://urlpattern.spec.whatwg.org/#process-hash-for-init is done by the caller.
 ExceptionOr<String> canonicalizeHash(StringView value, BaseURLStringType valueType)
 {
     if (value.isEmpty())
         return value.toString();
 
-    auto strippedValue = value[0] == '#' ? value.substring(1) : value;
-
     if (valueType == BaseURLStringType::Pattern)
-        return strippedValue.toString();
+        return value.toString();
 
     URL dummyURL(dummyURLCharacters);
-    dummyURL.setFragmentIdentifier(strippedValue);
+    dummyURL.setFragmentIdentifier(value);
     ASSERT(dummyURL.isValid());
 
     return dummyURL.fragmentIdentifier().toString();

--- a/src/jsc/bindings/webcore/URLPatternTokenizer.cpp
+++ b/src/jsc/bindings/webcore/URLPatternTokenizer.cpp
@@ -255,8 +255,10 @@ ExceptionOr<Vector<Token>> Tokenizer::tokenize()
 
             auto regexLength = regexPosition - regexStart - 1;
 
-            if (!regexLength)
+            if (!regexLength) {
                 maybeException = processTokenizingError(regexStart, m_index, "Regex length is zero."_s);
+                continue;
+            }
 
             addToken(TokenType::Regexp, regexPosition, regexStart, regexLength);
             continue;

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -206,4 +206,76 @@ describe("URLPattern", () => {
       expect(new URLPattern({ pathname: "/a/:foo/:baz([a-z]+)?/b/*" }).hasRegExpGroups).toBe(true);
     });
   });
+
+  // The encoding callbacks are https://urlpattern.spec.whatwg.org/#canonicalize-a-hash and
+  // #canonicalize-a-search. Only #process-hash-for-init and #process-search-for-init remove a
+  // single leading "#" or "?" from the whole component, never from fixed text inside the pattern.
+  describe("fixed text that follows a token keeps a leading # or ?", () => {
+    test("hash", () => {
+      expect(new URLPattern("https://h/#a*#b").hash).toBe("a*#b");
+      expect(new URLPattern("https://h/#:x#b").hash).toBe(":x#b");
+
+      const p = new URLPattern("https://h/#v-*#end");
+      expect(p.hash).toBe("v-*#end");
+      expect(p.test("https://h/#v-1#end")).toBe(true);
+      expect(p.test("https://h/#v-1")).toBe(false);
+      expect(p.test("https://h/#v-1xend")).toBe(false);
+      expect(new URLPattern({ hash: p.hash }).hash).toBe(p.hash);
+      expect(new URLPattern({ hash: p.hash }).test("https://h/#v-1xend")).toBe(false);
+
+      expect(new URLPattern({ hash: "\\#\\#b" }).hash).toBe("##b");
+      // process hash for init removes one leading "#" from the component as a whole.
+      expect(new URLPattern({ hash: "##b" }).hash).toBe("#b");
+      expect(new URLPattern("https://h/#a#b").hash).toBe("a#b");
+      expect(new URLPattern({ hash: "a#b" }).hash).toBe("a#b");
+
+      const any = new URLPattern({ hash: "*" });
+      expect(any.exec({ hash: "#b" })!.hash.input).toBe("b");
+      expect(any.exec({ hash: "##b" })!.hash.input).toBe("#b");
+    });
+
+    // Chromium 152 drops one leading "?" from such fixed text because its callback goes through the
+    // URL search setter. The spec's canonicalize a search runs the query state, which keeps it.
+    test("search", () => {
+      const p = new URLPattern({ search: "a:x\\?b" });
+      expect(p.search).toBe("a:x\\?b");
+      expect(p.test({ search: "av?b" })).toBe(true);
+      expect(p.test("https://h/?av?b")).toBe(true);
+      expect(p.test({ search: "avb" })).toBe(false);
+      expect(new URLPattern({ search: p.search }).test({ search: "avb" })).toBe(false);
+
+      expect(new URLPattern({ search: "\\?\\?b" }).search).toBe("\\?\\?b");
+      // process search for init removes one leading "?" from the component as a whole.
+      expect(new URLPattern({ search: "?\\?b" }).search).toBe("\\?b");
+      expect(new URLPattern("https://h/x?\\?b").search).toBe("\\?b");
+
+      const any = new URLPattern({ search: "*" });
+      expect(any.exec({ search: "?b" })!.search.input).toBe("b");
+      expect(any.exec({ search: "??b" })!.search.input).toBe("?b");
+      expect(any.exec("https://h/??b")!.search.input).toBe("?b");
+    });
+
+    // With the query state override a "#" is part of the query and gets percent-encoded,
+    // like the URL search setter does.
+    test("# in a search pattern or dictionary input is percent-encoded", () => {
+      const p = new URLPattern({ search: "q=a#b" });
+      expect(p.search).toBe("q=a%23b");
+      expect(p.test({ search: "q=a#b" })).toBe(true);
+      expect(p.test("https://h/?q=a%23b")).toBe(true);
+      expect(p.test("https://h/?q=a#b")).toBe(false);
+      expect(new URLPattern({ search: "*" }).exec({ search: "q=a#b" })!.search.input).toBe("q=a%23b");
+    });
+  });
+
+  // https://urlpattern.spec.whatwg.org/#tokenize treats a zero-length regexp group as a
+  // tokenizing error regardless of where it appears in the input.
+  test("empty regexp group is rejected wherever it appears", () => {
+    for (const pathname of ["/()", "/:y()", "/x/()", "/a()", "()", "(\\d)()", "/a()b", "/()b"]) {
+      expect(() => new URLPattern({ pathname })).toThrow(TypeError);
+    }
+    expect(() => new URLPattern({ hash: "a()" })).toThrow(TypeError);
+    expect(() => new URLPattern("https://h/()")).toThrow(TypeError);
+    expect(() => new URLPattern("https://h/x#()")).toThrow(TypeError);
+    expect(new URLPattern({ pathname: "/\\(\\)" }).test({ pathname: "/()" })).toBe(true);
+  });
 });


### PR DESCRIPTION
### Problem
- `new URLPattern('https://h/#a*#b').hash` is `a*b`, and `new URLPattern('https://h/#v-*#end')` matches `#v-1xend` (Chromium: `a*#b`, no match). `search` loses an escaped `?` the same way. `callEncodingCallback` (`URLPatternCanonical.cpp:260`) reused the process-for-init helpers, which strip one leading `#` or `?`.
- `new URLPattern({pathname:'/()'})` is accepted when `()` ends the input. The tokenizer stored the "Regex length is zero." error but still added the token, and the loop ended before its error check.

### Fix
- Move the `:` / `?` / `#` removal into `processInit`, where the spec does it. `canonicalizeSearch` keeps a leading `?` and percent-encodes `#`, as the query state does.
- `continue` after the zero-length regexp error, as upstream WebKit does.
- Self-reviewed: one concern, addressed. A first draft also changed non-special pathnames, which #42007 owns.
- Verified: `test/js/web/urlpattern/urlpattern.test.ts` (4 new blocks fail on 1.4.3, the 349 WPT cases pass) and Node's `test-urlpattern.js`. The hash, `#`-in-search and `()` rows match Chrome 152.

### Background
- Fixed text in a pattern runs through an "encoding callback": the spec's `canonicalize a <component>`, a URL parse with a state override. Only `process <component> for init` strips a delimiter, once, from the whole component.
- WTF's `URLParser` has no state override, so these helpers parse a dummy URL. `URL::setQuery` eats a leading `?` and stops at `#`, hence `'?' + value` with `#` pre-encoded.
- One deliberate difference from Chrome 152: it drops one leading `?` from search fixed text, because its callback uses the URL search setter. This PR follows the spec, like ada-url/ada#1171.

<details><summary>Notes</summary>

- Source: a differential run against Chromium native URLPattern (ledger items 44584 and 44585). Upstream WebKit `main` still has the delimiter bug, so Safari behaves like bun did; it already has the tokenizer `continue`. Node 26.3 ships an Ada from before ada-url/ada#1171 and still shows the delimiter bug.
- Chrome 152.0.7977.82, headless, same assertions as the new tests: every `hash` expectation, every `()` expectation, `{search:'q=a#b'}.search === 'q=a%23b'` and `exec({search:'q=a#b'}).search.input === 'q=a%23b'` agree. The `?` rows differ as said above: Chrome gives `a{:x}b` for `{search:'a:x\\?b'}`, `\?b` for `{search:'\\?\\?b'}`, and `b` for `{search:'?\\?b'}` and for the dictionary input `{search:'??b'}`.
- Local differential, 1.4.3 vs this build, 17,550 constructions with up to 4 inputs each: 854 differ, all in the hash/search delimiter class or the `()` class. `{search:'a#b'}` is now `a%23b` instead of `a`, for patterns and dictionary inputs alike, like the URL `search` setter.
- Ledger item 44583 (dot segments in non-special pathnames) has the same root as 44582 and is the either/or already written up in #42007: resolve behind a dummy host (Deno, denoland/rust-urlpattern#62) or keep the opaque path state literal (spec text, Chromium). Not touched here.
- Pre-existing and not touched: `'` in a search pattern is encoded as `%27` because the dummy URL is special (`https://w/`), while a non-special URL input keeps `'`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen cpp.rs (cppbind)
[2/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocatio
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [0.94ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [0.09ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [0.06ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [0.09ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [0.38ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [0.11ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [0.11ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] [0.08ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [32.50ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [6.87ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [6.47ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [6.59ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [12.60ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [7.71ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [42.68ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     83081b656a
  features     baseline

23 deps, 131 codegen, 1172 objects in 741ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [15.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] fetch zlib
[zlib] up to date
[5/1244] gen bindgenv2
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen .bind.ts → GeneratedBindings.cpp
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1216] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 83ms
[11/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/URLPattern.cpp          | 21 ++++++-
 src/jsc/bindings/webcore/URLPatternCanonical.cpp | 29 +++++-----
 src/jsc/bindings/webcore/URLPatternTokenizer.cpp |  4 +-
 test/js/web/urlpattern/urlpattern.test.ts        | 72 ++++++++++++++++++++++++
 4 files changed, 107 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/bindings/webcore/URLPattern.cpp               1      2     12
src/jsc/bindings/webcore/URLPatternCanonical.cpp      2      4     12
src/jsc/bindings/webcore/URLPatternTokenizer.cpp      1      1     12
test/js/web/urlpattern/urlpattern.test.ts             2      4     12
```

</details>

<!-- robobun:evidence:end -->