### PR TITLE
bundler: name the right target when a non-bun build imports a Bun builtin

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6577,7 +6577,12 @@ pub mod bv2_impl {
                                                 Some(source),
                                                 import_record.range,
                                                 format_args!(
-                                                    "Browser build cannot {} Bun builtin: \"{}\"{}",
+                                                    "{} build cannot {} Bun builtin: \"{}\"{}",
+                                                    if ctx.target == Target::Node {
+                                                        "Node.js"
+                                                    } else {
+                                                        "Browser"
+                                                    },
                                                     bstr::BStr::new(
                                                         import_record.kind.error_label()
                                                     ),

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -617,6 +617,20 @@ describe("bundler", () => {
       expect(contents).toBe("");
     },
   });
+  // The diagnostic names the build's actual target, not "Browser".
+  itBundled("browser/TargetNodeImportBunError", {
+    skipOnEsbuild: true,
+    files: {
+      "/entry.js": `
+        import { version } from "bun";
+        console.log(version);
+      `,
+    },
+    target: "node",
+    bundleErrors: {
+      "/entry.js": [`Node.js build cannot import Bun builtin: "bun". When bundling for Bun, set target to 'bun'`],
+    },
+  });
 
   itBundled("browser/AwaitUsingStatement", {
     files: {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -618,17 +618,47 @@ describe("bundler", () => {
     },
   });
   // The diagnostic names the build's actual target, not "Browser".
+  const targetNodeImportBunFiles = {
+    "/entry.js": `
+      import { file } from "bun";
+      const { serve } = require("bun");
+      const dynamic = import("bun");
+      console.log(file, serve, dynamic);
+    `,
+  };
+  const targetNodeImportBunErrors = {
+    "/entry.js": ["import", "require()", "import()"].map(
+      label => `Node.js build cannot ${label} Bun builtin: "bun". When bundling for Bun, set target to 'bun'`,
+    ),
+  };
   itBundled("browser/TargetNodeImportBunError", {
+    skipOnEsbuild: true,
+    files: targetNodeImportBunFiles,
+    target: "node",
+    backend: "api",
+    bundleErrors: targetNodeImportBunErrors,
+  });
+  itBundled("browser/TargetNodeImportBunErrorCLI", {
+    skipOnEsbuild: true,
+    files: targetNodeImportBunFiles,
+    target: "node",
+    backend: "cli",
+    bundleErrors: targetNodeImportBunErrors,
+  });
+  // Unlike the bare "bun" specifier, "bun:*" is left external when targeting node.
+  itBundled("browser/TargetNodeBunPrefixedBuiltinShouldBeExternal", {
     skipOnEsbuild: true,
     files: {
       "/entry.js": `
-        import { version } from "bun";
-        console.log(version);
+        import { Database } from "bun:sqlite";
+        console.log(Database);
       `,
     },
     target: "node",
-    bundleErrors: {
-      "/entry.js": [`Node.js build cannot import Bun builtin: "bun". When bundling for Bun, set target to 'bun'`],
+    onAfterBundle(api) {
+      expect(new Bun.Transpiler().scanImports(api.readFile("out.js"))).toStrictEqual([
+        { kind: "import-statement", path: "bun:sqlite" },
+      ]);
     },
   });
 


### PR DESCRIPTION
### Problem
- `bun build ./m.mjs --target=node` with `import { version } from "bun"` fails with `Browser build cannot import Bun builtin: "bun". When bundling for Bun, set target to 'bun'`. The target was node, not browser.
- The message in `resolve_import_records` (`src/bundler/bundle_v2.rs`) runs for every non-bun target but hard-codes "Browser".

### Fix
- Name the build's target: `Node.js build cannot import Bun builtin: "bun". ...` for `--target=node`; the browser wording is unchanged.
- Verified: `test/bundler/bundler_browser.test.ts` `browser/TargetNodeImportBunError` (Bun.build, covers `import`, `require()`, `import()`) and `browser/TargetNodeImportBunErrorCLI` (`bun build`), both fail before. `browser/TargetNodeBunPrefixedBuiltinShouldBeExternal` pins that `bun:sqlite` stays external under node. The existing `browser/ImportBunError` and the dev-server `importing bun on the client` test keep the browser wording.
- The extra test cases come from #38608, which is closed as a duplicate of this PR.

### Background
- Only the `"bun"` specifier reaches this error under `--target=node`. `bun:*` specifiers (`bun:sqlite`, `bun:ffi`) are left external for node today and are not changed here; whether they should error like esbuild does is a separate decision.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1416.53ms]
(pass) bundler > browser/NodeBuffer#12272 [746.05ms]
(pass) bundler > browser/NodeFS [375.38ms]
(pass) bundler > browser/NodeTTY [437.62ms]
(pass) bundler > browser/NodeEventsOnce [601.04ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [536.93ms]
(pass) bundler > browser/NodePolyfills [7382.45ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [504.52ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [526.58ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [421.57ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [528.91ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [259.33ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [222.45ms]
(pass) bundler > browser/EntryPointDisab
... (truncated)

release without fix: 2 skipped
bun test v1.4.3-canary.1 (4c40c2a3c)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [39.89ms]
(pass) bundler > browser/NodeBuffer#12272 [27.05ms]
(pass) bundler > browser/NodeFS [16.43ms]
(pass) bundler > browser/NodeTTY [20.49ms]
(pass) bundler > browser/NodeEventsOnce [24.71ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [26.04ms]
(pass) bundler > browser/NodePolyfills [179.02ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [23.95ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [29.47ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [22.19ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [22.78ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [9.19ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [8.10ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldOnlyAppliesToBrowserTarget [21.73ms]
(pass) bundler > browser/EntryPointDisabledByPackageMainBrowserField [12.99ms]
(pass) bundler > browser/EntryPointIsNodeBu
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1343.42ms]
(pass) bundler > browser/NodeBuffer#12272 [710.91ms]
(pass) bundler > browser/NodeFS [354.09ms]
(pass) bundler > browser/NodeTTY [404.71ms]
(pass) bundler > browser/NodeEventsOnce [546.34ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [488.81ms]
(pass) bundler > browser/NodePolyfills [7579.48ms]
(todo) bundler > browser/NodePolyfillExternal
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltin#4928 [409.43ms]
(pass) bundler > browser/BrowserFieldDisablesPolyfilledBuiltinNodePrefix#4928 [391.88ms]
(pass) bundler > browser/BrowserFieldRemapsPolyfilledBuiltin#4928 [408.89ms]
(pass) bundler > browser/BrowserFieldDisabledBuiltinStillPolyfillsOutsideScope [557.09ms]
(pass) bundler > browser/EntryPointDisabledByBrowserField [239.59ms]
(pass) bundler > browser/EntryPointDisabledByBrowserFieldNextToLiveEntryPoint [210.92ms]
(pass) bundler > browser/EntryPointDisab
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 705ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sql_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs             |  7 +++++-
 test/bundler/bundler_browser.test.ts | 44 ++++++++++++++++++++++++++++++++++++
 2 files changed, 50 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/bundler/bundle_v2.rs                  9      6      7
test/bundler/bundler_browser.test.ts      1      1      6
```

</details>

<!-- robobun:evidence:end -->
