### PR TITLE
FileReader: release the event loop while a pipe reader is stopped at its highwater mark

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -4,7 +4,7 @@ use core::ptr::NonNull;
 
 use bun_sys::{self as sys, Fd};
 
-use crate::{EventLoopHandle, FilePollFlag, FilePollKind, FilePollRef, Owner, PollTag};
+use crate::{EventLoopHandle, FilePollKind, FilePollRef, Owner, PollTag};
 // `bun.Async.Loop` — on POSIX the uws `us_loop_t`, on Windows the embedded
 // `uv_loop_t` (`bun_io::Loop` is the cfg-aliased nominal that picks the
 // right one). `BufferedReaderParent::loop_` returns this so callers in T3+
@@ -239,6 +239,12 @@ impl PosixBufferedReader {
         let Some(poll) = self.handle.get_poll() else {
             return;
         };
+        // A ref'd reader holds the loop only while its poll is armed: an
+        // unarmed poll delivers nothing, and `try_register_poll` re-applies
+        // KEEP_ALIVE when it arms again.
+        if value && !poll.is_watching() {
+            return;
+        }
         poll.set_keeping_process_alive(self.vtable.event_loop(), value);
     }
 
@@ -529,9 +535,8 @@ impl PosixBufferedReader {
         };
         poll.set_owner(Owner::new(PollTag::BufferedReader, owner_ptr.cast()));
 
-        if !poll.has_flag(FilePollFlag::WasEverRegistered)
-            && self.flags.contains(PosixFlags::KEEP_ALIVE)
-        {
+        // Re-applied on every arm: `pause()` unregisters, which drops it.
+        if self.flags.contains(PosixFlags::KEEP_ALIVE) {
             poll.enable_keeping_process_alive(ev);
         }
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -239,9 +239,7 @@ impl PosixBufferedReader {
         let Some(poll) = self.handle.get_poll() else {
             return;
         };
-        // A ref'd reader holds the loop only while its poll is armed: an
-        // unarmed poll delivers nothing, and `try_register_poll` re-applies
-        // KEEP_ALIVE when it arms again.
+        // An unarmed poll delivers nothing; `try_register_poll` applies KEEP_ALIVE when it arms.
         if value && !poll.is_watching() {
             return;
         }

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -908,8 +908,7 @@ impl FilePoll {
             || self.flags.contains(Flags::PollProcess)
             || self.flags.contains(Flags::PollMachport)
             || self.flags.contains(Flags::PollMemoryPressure);
-        // The `needs_rearm` skip below keeps the disarmed registration in the kernel; teardown still has to delete
-        // it (the fd may outlive this poll), by fd on epoll and for both filters on kqueue.
+        // The `needs_rearm` skip below keeps the disarmed kernel registration, so teardown must still delete it.
         let disarmed_only = !registered && self.flags.contains(Flags::NeedsRearm);
         if !registered && !(disarmed_only && force_unregister) {
             return sys::Result::Ok(());

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -903,22 +903,28 @@ impl FilePoll {
     ) -> sys::Result<()> {
         debug_assert!(fd.native() >= 0 && fd != INVALID_FD);
 
-        if !(self.flags.contains(Flags::PollReadable)
+        let registered = self.flags.contains(Flags::PollReadable)
             || self.flags.contains(Flags::PollWritable)
             || self.flags.contains(Flags::PollProcess)
             || self.flags.contains(Flags::PollMachport)
-            || self.flags.contains(Flags::PollMemoryPressure))
-        {
-            // no-op
+            || self.flags.contains(Flags::PollMemoryPressure);
+        // The `needs_rearm` skip below leaves a fired one-shot poll's disarmed
+        // registration in the kernel. The fd can outlive this poll (stdio, a
+        // borrowed fd), and the next EPOLL_CTL_ADD for it then fails with
+        // EEXIST, so a forced unregister (teardown) deletes it after all. Its
+        // direction is no longer recorded: epoll deletes by fd; kqueue gets a
+        // delete for both filters and tolerates the missing one.
+        let disarmed_only = !registered && self.flags.contains(Flags::NeedsRearm);
+        if !registered && !(disarmed_only && force_unregister) {
             return sys::Result::Ok(());
         }
 
-        debug_assert!(fd != INVALID_FD);
         let watcher_fd = loop_.fd;
-        let both_directions =
-            self.flags.contains(Flags::PollReadable) && self.flags.contains(Flags::PollWritable);
+        let both_directions = disarmed_only
+            || (self.flags.contains(Flags::PollReadable)
+                && self.flags.contains(Flags::PollWritable));
         let flag: Flags = 'brk: {
-            if self.flags.contains(Flags::PollReadable) {
+            if disarmed_only || self.flags.contains(Flags::PollReadable) {
                 break 'brk Flags::Readable;
             }
             if self.flags.contains(Flags::PollWritable) {

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -908,12 +908,8 @@ impl FilePoll {
             || self.flags.contains(Flags::PollProcess)
             || self.flags.contains(Flags::PollMachport)
             || self.flags.contains(Flags::PollMemoryPressure);
-        // The `needs_rearm` skip below leaves a fired one-shot poll's disarmed
-        // registration in the kernel. The fd can outlive this poll (stdio, a
-        // borrowed fd), and the next EPOLL_CTL_ADD for it then fails with
-        // EEXIST, so a forced unregister (teardown) deletes it after all. Its
-        // direction is no longer recorded: epoll deletes by fd; kqueue gets a
-        // delete for both filters and tolerates the missing one.
+        // The `needs_rearm` skip below keeps the disarmed registration in the kernel; teardown still has to delete
+        // it (the fd may outlive this poll), by fd on epoll and for both filters on kqueue.
         let disarmed_only = !registered && self.flags.contains(Flags::NeedsRearm);
         if !registered && !(disarmed_only && force_unregister) {
             return sys::Result::Ok(());

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -655,9 +655,7 @@ impl FileReader {
             // No JS read is waiting; stop at the highwater mark and let onPull restart. `started` gates it: a non-lazy `Bun.spawn` pipe is already reading before any consumer attaches, and throttling then deadlocks a child alternating stdout/stderr writes.
             let keep_going = !self.started.get()
                 || (self.flowing.get() && self.buffered.get().len() < self.highwater_mark);
-            // Returning `false` only ends this read loop. `pause()` is what stops the reader: it cancels the next
-            // completion read (Windows) or unregisters the poll, which also releases its hold on the event loop
-            // (POSIX; an unarmed poll could not even observe the peer closing). `on_pull` unpauses.
+            // `false` only ends this read loop; `pause()` stops the reader and releases its hold on the event loop until `on_pull`.
             if !keep_going {
                 self.reader().pause();
             }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -655,8 +655,9 @@ impl FileReader {
             // No JS read is waiting; stop at the highwater mark and let onPull restart. `started` gates it: a non-lazy `Bun.spawn` pipe is already reading before any consumer attaches, and throttling then deadlocks a child alternating stdout/stderr writes.
             let keep_going = !self.started.get()
                 || (self.flowing.get() && self.buffered.get().len() < self.highwater_mark);
-            // A completion-driven reader keeps issuing reads unless stopped; `on_pull` restarts it.
-            #[cfg(windows)]
+            // Returning `false` only ends this read loop. `pause()` is what stops the reader: it cancels the next
+            // completion read (Windows) or unregisters the poll, which also releases its hold on the event loop
+            // (POSIX; an unarmed poll could not even observe the peer closing). `on_pull` unpauses.
             if !keep_going {
                 self.reader().pause();
             }
@@ -809,6 +810,8 @@ impl FileReader {
         }
 
         if !self.reader().has_pending_read() && self.flowing.get() {
+            // A consumer is pulling again: undo the highwater pause from `on_read_chunk`.
+            self.reader().unpause();
             // SAFETY: the reader cell is live for `self`'s lifetime; `read_into` is the raw re-entrancy-safe entry (EOF/error dispatch runs user JS).
             let (amount_read, state) = unsafe { IOReader::read_into(self.reader.get(), buffer) };
             bun_core::scoped_log!(FileReader, "onPull({}) = {}", buffer.len(), amount_read);

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -807,6 +807,79 @@ describe("should not hang", () => {
   }
 });
 
+// What keeps a process alive whose only handle is a child's stdout reader (the
+// child itself is unref'd): a read that can still deliver something does, a
+// reader stopped at its highwater mark does not. Stopped, the pipe reader's
+// poll is unregistered until the next pull, so it could not even observe the
+// child going away. Node: readStop() at the highWaterMark leaves the handle
+// inactive, and a pending read keeps it active.
+describe.skipIf(isWindows)("stdout reader of an unref'd child and process lifetime", () => {
+  async function run(script: string) {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return stdout;
+  }
+
+  // "saturating" fills the pipe faster than the parent reads it; "trickling"
+  // lets most parent reads end in EAGAIN, the path that used to re-arm the
+  // poll regardless of the highwater stop.
+  const producers = {
+    saturating: `const chunk = Buffer.alloc(8192, 120); for (;;) require("fs").writeSync(1, chunk);`,
+    trickling: `const chunk = Buffer.alloc(2048, 120); setInterval(() => require("fs").writeSync(1, chunk), 1);`,
+  };
+  for (const [kind, producer] of Object.entries(producers)) {
+    it.concurrent(`an idle reader stopped at the highwater mark does not keep the process alive (${kind} writer)`, async () => {
+      const stdout = await run(`
+        const producer = Bun.spawn({
+          cmd: [process.execPath, "-e", ${JSON.stringify(producer)}],
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "inherit",
+        });
+        const reader = producer.stdout.getReader();
+        // The running child no longer counts; only its stdout reader can keep this process alive now.
+        producer.unref();
+        let firstLength = -1;
+        process.on("exit", () => {
+          console.log(JSON.stringify({ gotFirstChunk: firstLength > 0, producerExitCode: producer.exitCode }));
+          producer.kill("SIGKILL");
+        });
+        firstLength = (await reader.read()).value.length;
+        // The reader stays locked and idle while the child keeps writing: the pipe
+        // reader fills to its highwater mark and stops, and then nothing is pending.
+      `);
+      expect(JSON.parse(stdout)).toEqual({ gotFirstChunk: true, producerExitCode: null });
+    });
+  }
+
+  it.concurrent("a pending read keeps the process alive until the child writes", async () => {
+    const child = `const fs = require("fs"); fs.readSync(0, Buffer.alloc(4)); fs.writeSync(1, "pong");`;
+    const stdout = await run(`
+      const child = Bun.spawn({
+        cmd: [process.execPath, "-e", ${JSON.stringify(child)}],
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const reader = child.stdout.getReader();
+      child.unref();
+      child.stdin.write("ping");
+      child.stdin.end();
+      // Only this read is left to wait for. It must hold the process until "pong" arrives.
+      const { value } = await reader.read();
+      console.log(new TextDecoder().decode(value));
+    `);
+    expect(stdout).toBe("pong\n");
+  });
+});
+
 describe("unref() + .exited with nothing else ref'd (Windows)", () => {
   // Windows: with only an unref'd uv_process_t left, uv_run() used to skip its
   // body and never dequeue the IOCP exit packet, so these children busy-spun

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -835,8 +835,10 @@ describe.skipIf(isWindows)("stdout reader of an unref'd child and process lifeti
     trickling: `const chunk = Buffer.alloc(2048, 120); setInterval(() => require("fs").writeSync(1, chunk), 1);`,
   };
   for (const [kind, producer] of Object.entries(producers)) {
-    it.concurrent(`an idle reader stopped at the highwater mark does not keep the process alive (${kind} writer)`, async () => {
-      const stdout = await run(`
+    it.concurrent(
+      `an idle reader stopped at the highwater mark does not keep the process alive (${kind} writer)`,
+      async () => {
+        const stdout = await run(`
         const producer = Bun.spawn({
           cmd: [process.execPath, "-e", ${JSON.stringify(producer)}],
           stdin: "ignore",
@@ -855,8 +857,9 @@ describe.skipIf(isWindows)("stdout reader of an unref'd child and process lifeti
         // The reader stays locked and idle while the child keeps writing: the pipe
         // reader fills to its highwater mark and stops, and then nothing is pending.
       `);
-      expect(JSON.parse(stdout)).toEqual({ gotFirstChunk: true, producerExitCode: null });
-    });
+        expect(JSON.parse(stdout)).toEqual({ gotFirstChunk: true, producerExitCode: null });
+      },
+    );
   }
 
   it.concurrent("a pending read keeps the process alive until the child writes", async () => {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -864,6 +864,8 @@ describe.skipIf(isWindows)("stdout reader of an unref'd child and process lifeti
 
   it.concurrent("a pending read keeps the process alive until the child writes", async () => {
     const child = `const fs = require("fs"); fs.readSync(0, Buffer.alloc(4)); fs.writeSync(1, "pong");`;
+    // Not top-level await: an unsettled entry-module promise keeps the process
+    // running on its own and would hide a read that does not.
     const stdout = await run(`
       const child = Bun.spawn({
         cmd: [process.execPath, "-e", ${JSON.stringify(child)}],
@@ -873,13 +875,63 @@ describe.skipIf(isWindows)("stdout reader of an unref'd child and process lifeti
       });
       const reader = child.stdout.getReader();
       child.unref();
-      child.stdin.write("ping");
-      child.stdin.end();
-      // Only this read is left to wait for. It must hold the process until "pong" arrives.
-      const { value } = await reader.read();
-      console.log(new TextDecoder().decode(value));
+      (async () => {
+        const pending = reader.read();
+        child.stdin.write("ping");
+        child.stdin.end();
+        // Only this read is left to wait for. It must hold the process until "pong" arrives.
+        const { value } = await pending;
+        console.log(new TextDecoder().decode(value));
+      })();
     `);
     expect(stdout).toBe("pong\n");
+  });
+
+  // node:child_process pause() stops the pipe reader (the poll is unregistered)
+  // and resume() arms it again; the re-armed poll must hold the loop like the
+  // first one did. The writer starts only once the parent is reading ("s"),
+  // overfills the paused Readable, and sends "END" after a pause the parent has
+  // to sit through idle on the pipe with nothing else pending.
+  it.concurrent("a child_process stdout resumed after pause() keeps the process alive again", async () => {
+    const writer = `
+      const fs = require("fs");
+      const chunk = Buffer.alloc(65536, "x");
+      const waitForParent = () => fs.readSync(0, Buffer.alloc(1), 0, 1, null);
+      waitForParent();
+      for (let i = 0; i < 16; i++) fs.writeSync(1, chunk);
+      waitForParent();
+      setTimeout(() => fs.writeSync(1, "END"), 100);
+    `;
+    const stdout = await run(`
+      const { spawn } = require("node:child_process");
+      const child = spawn(process.execPath, ["-e", ${JSON.stringify(writer)}], { stdio: ["pipe", "pipe", "inherit"] });
+      child.unref();
+      let received = 0;
+      let paused = false;
+      let drained = false;
+      child.stdout.on("data", chunk => {
+        received += chunk.length;
+        if (!paused) {
+          paused = true;
+          child.stdout.pause();
+          const resumeWhenFull = () => {
+            if (child.stdout.readableLength >= child.stdout.readableHighWaterMark) {
+              console.log("resume");
+              child.stdout.resume();
+            } else {
+              setImmediate(resumeWhenFull);
+            }
+          };
+          setImmediate(resumeWhenFull);
+        } else if (!drained && received >= 16 * 65536) {
+          drained = true;
+          child.stdin.end("g");
+        }
+      });
+      child.stdout.on("end", () => console.log("end " + received));
+      setImmediate(() => child.stdin.write("s"));
+    `);
+    expect(stdout).toBe("resume\nend " + (16 * 65536 + 3) + "\n");
   });
 });
 

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -564,6 +564,56 @@ describe.skipIf(isWindows)("pipe backpressure", () => {
     expect(first).toBe(true);
   });
 
+  // The same over an anonymous pipe (the blocking-pipe read path; Bun.spawn
+  // stdio above is a socketpair). The writer keeps the pipe full until the
+  // reader is gone, so EOF can never be what lets the reader exit.
+  test.concurrent("over a shell pipe, a reader stopped at the backstop does not keep the process alive", async () => {
+    using dir = tempDir("stdin-backstop-pipe", {
+      "writer.js": `
+        const chunk = Buffer.alloc(65536, 0x78);
+        process.stdout.on("error", () => process.exit(0));
+        (function pump() {
+          while (process.stdout.write(chunk)) {}
+          process.stdout.once("drain", pump);
+        })();
+      `,
+      "reader.js": `
+        const reader = Bun.stdin.stream().getReader();
+        const { value } = await reader.read();
+        process.on("exit", () => console.log("EXIT"));
+        console.log("FIRST " + (value.byteLength > 0));
+      `,
+    });
+    const { promise, resolve } = Promise.withResolvers<{ err: Error | null; stdout: string; stderr: string }>();
+    exec(
+      `"${bunExe()}" writer.js | "${bunExe()}" reader.js`,
+      { cwd: String(dir), env: bunEnv },
+      (err, stdout, stderr) => resolve({ err, stdout, stderr }),
+    );
+    expect(await promise).toEqual({ err: null, stdout: "FIRST true\nEXIT\n", stderr: "" });
+  });
+
+  // Stopping unregisters a fired one-shot poll without a syscall, which leaves
+  // its disarmed registration in the kernel. Cancelling the stream must still
+  // take it out: fd 0 stays open, and the next poll on it would hit EEXIST.
+  test.concurrent("a reader cancelled at the highwater backstop frees fd 0 for the next reader", async () => {
+    const { second } = await run(`
+      const { getEventLoopStats } = require("bun:internal-for-testing");
+      // Not top-level await: an unsettled entry-module promise would keep the process alive by itself.
+      (async () => {
+        const reader = Bun.stdin.stream().getReader();
+        await reader.read();
+        // The parent keeps the pipe full, so the reader soon stops and lets go of the loop.
+        while (getEventLoopStats().loopActive) await new Promise(resolve => setImmediate(resolve));
+        await reader.cancel();
+        const next = await Bun.file(0).stream().getReader().read();
+        process.stdout.write(JSON.stringify({ second: (next.value?.length ?? 0) > 0 }));
+        process.exit(0);
+      })();
+    `);
+    expect(second).toBe(true);
+  });
+
   test.concurrent("reading resumes after the highwater backstop", async () => {
     // Stop reading long enough for the backstop to engage, then drain to EOF
     // and make sure every byte written by the parent is delivered.

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -305,6 +305,58 @@ test.concurrent("stdin should not allow process to exit when not paused", async 
   expect(await proc.stderr.text()).toMatchInlineSnapshot(`""`);
 });
 
+// unref() drops stdin's hold on the event loop and ref() takes it back: after
+// the pair the child has nothing else pending and must still receive every
+// later byte up to EOF.
+test.concurrent("stdin.ref() after unref() keeps the process alive until EOF", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      let total = 0;
+      process.stdin.on("data", chunk => {
+        if (total === 0) {
+          process.stdin.unref();
+          process.stdin.ref();
+          process.stdout.write("ready\\n");
+        }
+        total += chunk.length;
+      });
+      process.stdin.on("end", () => {
+        process.stdout.write("TOTAL " + total + "\\n");
+      });
+      `,
+    ],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let stdout = "";
+  proc.stdin.write("x");
+  while (!stdout.includes("ready\n")) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    stdout += decoder.decode(value);
+  }
+  // The child is idle again with only stdin to wait for; these bytes must still reach it.
+  const rest = Buffer.alloc(64 * 1024, "y");
+  proc.stdin.write(rest);
+  await proc.stdin.end();
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    stdout += decoder.decode(value);
+  }
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(`ready\nTOTAL ${1 + rest.length}\n`);
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("a throw from a 'data' listener is an uncaughtException, and stdin keeps reading", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -496,6 +548,20 @@ describe.skipIf(isWindows)("pipe backpressure", () => {
     `);
     expect(bytesAfter).toBeLessThan(feedMB * 1024 * 1024);
     expect(deltaMB).toBeLessThan(maxDeltaMB);
+  });
+
+  // Stopped at the backstop, the reader's one-shot poll is left unarmed until
+  // the next read, so it can observe nothing (not even the writer going away)
+  // and must not keep the event loop alive on its own. Node behaves the same:
+  // readStop() at the highWaterMark leaves the handle inactive.
+  test.concurrent("a reader stopped at the highwater backstop does not keep the process alive", async () => {
+    const { first } = await run(`
+      const rd = Bun.stdin.stream().getReader();
+      const c = await rd.read();
+      process.stdout.write(JSON.stringify({ first: (c.value?.length ?? 0) > 0 }));
+      // No further read and no exit(): once the backstop engages nothing is pending.
+    `);
+    expect(first).toBe(true);
   });
 
   test.concurrent("reading resumes after the highwater backstop", async () => {


### PR DESCRIPTION
### Problem
- A locked, idle reader on `Bun.spawn` stdout or `Bun.stdin.stream()` pins the process once the peer goes away. Repro on 1.4.2: read one chunk of a child's stdout, SIGKILL the child, `await proc.exited`. The process never exits. Node exits.
- `FileReader::on_read_chunk` stops reading at its 16 KB highwater mark when no JS read waits. On POSIX it only returned `false`: the read loop ends, but the fired one-shot poll stays unarmed yet still counts as active on the loop. Unarmed, it cannot see the peer close, so the count never drops.
- The reverse too: `child.stdout.pause()` then `resume()` re-armed the poll without its hold, so an unref'd child's parent exited mid-stream.

### Fix
- `on_read_chunk` calls `reader.pause()` on every platform (it was Windows-only). That unregisters the poll and drops its hold. `on_pull` unpauses.
- `try_register_poll()` re-applies `KEEP_ALIVE` on every arm (before: first registration only), and `update_ref(true)` takes the hold only while armed. A ref'd reader holds the loop exactly while it can deliver something, as in Node (`readStop()` leaves the handle inactive).
- A forced `FilePoll` unregister (teardown) also deletes the kernel entry that a fired, softly unregistered poll leaves behind. Without it, cancelling a stopped stdin reader left fd 0 registered and the next reader got EEXIST.
- Verified: new rows in `spawn.test.ts` and `process-stdin.test.ts`. Six fail on 1.4.2 and pass now, two guard holds that must survive.

### Background
- `PosixBufferedReader` arms its fd with `EPOLLONESHOT` / `EV_DISPATCH`: each wakeup disarms the poll until `register_poll` re-arms it. The poll adds one to the loop's active count while it "keeps the process alive". That count keeps the loop running.
- `FileReader` is the `ReadableStream` source for pipes, sockets and FIFOs. With no pending JS read it buffers up to `highwater_mark`, then stops until the next `pull`.

<details><summary>Notes</summary>

- Second behavior change, on purpose: pausing at the mark also turns the EAGAIN re-arm in `read_loop` into a no-op. Before, when the read that crossed the mark ended in EAGAIN, the poll was re-armed despite the stop, so an idle reader kept draining a trickling writer into `buffered` between pulls (a FIFO trace showed 50+ consecutive 8 KB chunks with no pull, far past 16 KB). Now a stopped POSIX reader reads nothing until the next pull, which is what Windows already did. The "trickling writer" row covers it.
- Node ground truth (v26.3.0): `process.stdin.once("data", () => process.stdin.pause())` and `Readable.toWeb(process.stdin).getReader().read()` both exit 1 to 2 ms after the first chunk with `readableLength=65536, reading=false` while the writer is still alive. `uv_ref` on an inactive handle does not hold the loop either, which is what the `update_ref(true)` gate mirrors (`process.stdin.ref()` while stopped at the mark does not re-pin, the next read does).
- Alternative considered: keep HUP/ERR interest while stopped. epoll can wait for `EPOLLHUP` without `EPOLLIN`, but kqueue's `EVFILT_READ` is level-triggered on available bytes and a stopped reader always has unread bytes in the pipe, so there is no portable HUP-only wait. Releasing the loop is uniform across platforms and is what Node does. In a long-lived process the stopped stream stays open (and GC-rooted through `waiting_for_on_reader_done`) until it is read or cancelled, as before.
- `PipeReader`'s contract says returning `false` from `on_read_chunk` "ends only the current read loop. To stop the reader, call `pause()`". The sink-backpressure path and `setFlowing(false)` already did. The highwater stop now does too. #41244's notes recorded the missing half: "pause() unregisters the poll, and that also releases the poll's hold on the event loop. unpause() does not take it back". Re-applying `KEEP_ALIVE` on every arm is that fix, and the `child_process` pause/resume row is its test.
- The teardown hole: `pause()` on a fired poll takes the `needs_rearm` shortcut in `unregister_with_fd_impl` (no syscall, `Poll*` flags cleared, disarmed entry kept so the next arm is a `CTL_MOD`). `PollOrFd::close` then called `deinit_force_unregister`, which saw no `Poll*` flag and skipped the delete. For an fd that outlives the reader (stdin) the next `EPOLL_CTL_ADD` returned EEXIST. On 1.4.2 the cancel usually happened while the flags were still set, so the delete ran. Stopping through `pause()` made the hole reachable. Found by a parallel investigation of the same report (branches `robobun/392a1a11/idle-pipe-reader-loop-ref` and `robobun/e37efcfc/pipe-reader-keepalive-while-armed`, whose fd-0 reuse, shell-pipe and pause/resume rows are adapted here).
- Windows: `on_read_chunk` already paused there and `read_into` is `unpause()`, so the added `unpause()` before it is a no-op. No behavior change intended.
- Test mechanics: the spawn rows unref the still-running child after taking the reader, so only the stdout reader can hold the parent. Rows that wait inside the child avoid top-level await, since an unsettled entry-module promise keeps a Bun process alive by itself. The fd-0 row waits for `getEventLoopStats().loopActive` to drop instead of sleeping.
- Suites run locally (debug+ASAN): spawn.test.ts, spawn-stdin-readable-stream, spawn-streaming-*, readablestream-helpers, spawn leak/GC/stale-fd tests, process-stdin, child_process, streams.test.js, native-source-onclose-leak, bun-serve-file, serve-body-leak, fetch-backpressure, filesink, bunshell, shell file-io/pipeline/hang, terminal.
- Pre-existing in this container with or without the change (debug+ASAN timing or environment): `spawn-pipe-leak.test.ts` (todo on ASAN CI), `shell/leak.test.ts` memleak rows, `child_process.test.ts` "default shell" and "extra stdio pipes are not double-closed on GC", the S3 rows of `fetch-backpressure.test.ts`. `bun-serve-file.test.ts` "resumes when the client reads" runs 3.7 to 4.3 s here and occasionally crosses 5 s.
- Open PRs in the same functions: #41632 adds the same `unpause()` before `read_into` and force-unregisters in `pause()`. Both compose with this.
- Self-reviewed: 3 concerns raised, 3 addressed (route the stop through `pause()` instead of a new io-layer state, close the EAGAIN re-arm hole, add the must-still-hold tests).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process-stdin.test.ts, test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->