### PR TITLE
install: stop --production from installing a devDependency that is also an optional peerDependency

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -210,6 +210,8 @@ bun install --omit dev
 bun install --omit=dev --omit=peer --omit=optional
 ```
 
+If one `package.json` lists a package under both `devDependencies` and optional `peerDependencies`, `--omit dev` and `--production` leave it out, unless an installed package still depends on it. The same name under `devDependencies` and required `peerDependencies` stays installed, because Bun installs peer dependencies by default.
+
 ---
 
 ## Dry run

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -42,7 +42,7 @@ use bun_wyhash::{Wyhash, Wyhash11};
 use crate::analytics;
 use crate::bun_bunfig::Arguments as Command;
 use crate::bun_progress::{Node as ProgressNode, Progress};
-use crate::lockfile::tree::is_filtered_dependency_or_workspace;
+use crate::lockfile::tree::{ReachedPackages, is_filtered_dependency_or_workspace};
 use crate::lockfile::{self, Lockfile};
 use crate::package_manager::{self, PackageManager, WorkspaceFilter, run_tasks};
 use crate::package_manager_real::ProgressStrings;
@@ -230,6 +230,7 @@ pub(crate) fn build_store(
     let resolutions = &lockfile.buffers.resolutions[..];
     let dependencies = &lockfile.buffers.dependencies[..];
     let string_buf = &lockfile.buffers.string_bytes[..];
+    let mut reached = ReachedPackages::default();
 
     let mut nodes: store::node::List = store::node::List::default();
 
@@ -313,6 +314,7 @@ pub(crate) fn build_store(
                     manager,
                     lockfile,
                     resolutions,
+                    &mut reached,
                 ) {
                     provides.set(pkg_id as usize, bit);
                 }
@@ -383,6 +385,7 @@ pub(crate) fn build_store(
             manager,
             lockfile,
             resolutions,
+            &mut reached,
         ) {
             continue;
         }
@@ -694,6 +697,7 @@ pub(crate) fn build_store(
                     manager,
                     lockfile,
                     resolutions,
+                    &mut reached,
                 ) {
                     continue;
                 }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1396,6 +1396,7 @@ impl Lockfile {
             late_bound_optional_peer: false,
             list: Default::default(),
             sort_buf: Default::default(),
+            reached: Default::default(),
         };
 
         Tree::default().process_subtree(tree::ROOT_DEP_ID, tree::INVALID_ID, &mut builder)?;

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -8,6 +8,7 @@ use bun_core::ZStr;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
 
 use crate::lockfile::package::PackageColumns as _;
+use crate::lockfile::reachable;
 use crate::lockfile::{DepSorter, DependencyIDList, DependencyIDSlice, Lockfile};
 use crate::package_manager::{PackageManager, WorkspaceFilter};
 use crate::{
@@ -443,6 +444,7 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
     pub(crate) packages_to_install: Option<&'a [PackageID]>,
     /// Workspace package ids that are hoisting barriers (self-contained node_modules).
     pub(crate) self_contained: Vec<PackageID>,
+    pub(crate) reached: ReachedPackages,
 }
 
 pub struct BuilderEntry {
@@ -537,6 +539,28 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 // is_filtered_dependency_or_workspace
 // ──────────────────────────────────────────────────────────────────────────
 
+/// The packages a `--production` / `--omit` install still reaches, computed the
+/// first time `is_filtered_dependency_or_workspace` needs it. One per pass over
+/// a fixed `resolutions` buffer.
+#[derive(Default)]
+pub(crate) struct ReachedPackages(Option<DynamicBitSet>);
+
+impl ReachedPackages {
+    fn contains(
+        &mut self,
+        lockfile: &Lockfile,
+        resolutions: &[PackageID],
+        manager: &PackageManager,
+        pkg_id: PackageID,
+    ) -> bool {
+        self.0
+            .get_or_insert_with(|| {
+                reachable::packages(lockfile, resolutions, reachable::Options::install(manager))
+            })
+            .is_set(pkg_id as usize)
+    }
+}
+
 // `Builder` holds a live `&mut [PackageID]` over the resolutions buffer (see
 // `Builder.lockfile` safety contract), so callers must thread `resolutions`
 // explicitly to avoid an aliasing read through the shared `&Lockfile`.
@@ -548,6 +572,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     manager: &PackageManager,
     lockfile: &Lockfile,
     resolutions: &[PackageID],
+    reached: &mut ReachedPackages,
 ) -> bool {
     let pkg_id = resolutions[dep_id as usize];
     if (pkg_id as usize) >= lockfile.packages.len() {
@@ -605,6 +630,18 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         return true;
     }
 
+    if dep.behavior.is_optional_peer() {
+        let siblings = pkgs.items_dependencies()[parent_pkg_id as usize]
+            .get(lockfile.buffers.dependencies.as_slice());
+        if optional_peer_group_enabled(dep, siblings, |behavior| behavior.is_enabled(dep_features))
+            == Some(false)
+        {
+            // The omitted group is what resolved this package. Keep the optional peer
+            // only when the install still reaches the package through other edges.
+            return !reached.contains(lockfile, resolutions, manager, pkg_id);
+        }
+    }
+
     if parent_pkg_id != 0 {
         return false;
     }
@@ -618,6 +655,32 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     }
 
     !WorkspaceFilter::is_selected(workspace_filters, pkg_id)
+}
+
+/// A package.json can list one name under `peerDependencies` and under another
+/// group, e.g. an optional peer that is also a devDependency. The optional peer
+/// row resolved only because the other row did, so it must not keep the package
+/// by itself once that group is omitted. `Some(false)` when every same-name row
+/// from another group is omitted, `None` when there is no such row.
+pub(crate) fn optional_peer_group_enabled(
+    dep: &Dependency,
+    siblings: &[Dependency],
+    enabled: impl Fn(crate::Behavior) -> bool,
+) -> Option<bool> {
+    if !dep.behavior.is_optional_peer() {
+        return None;
+    }
+    let mut found = None;
+    for sibling in siblings {
+        if sibling.name_hash != dep.name_hash || sibling.behavior.is_peer() {
+            continue;
+        }
+        if enabled(sibling.behavior) {
+            return Some(true);
+        }
+        found = Some(false);
+    }
+    found
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -716,6 +779,7 @@ impl Tree {
                     builder.manager.expect("manager set when METHOD == Filter"),
                     lockfile,
                     &*builder.resolutions,
+                    &mut builder.reached,
                 ) {
                     continue;
                 }

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -551,11 +551,39 @@ impl ReachedPackages {
         lockfile: &Lockfile,
         resolutions: &[PackageID],
         manager: &PackageManager,
+        workspace_filters: &[WorkspaceFilter],
+        install_root_dependencies: bool,
         pkg_id: PackageID,
     ) -> bool {
         self.0
             .get_or_insert_with(|| {
-                reachable::packages(lockfile, resolutions, reachable::Options::install(manager))
+                let options = reachable::Options::install(manager);
+                if workspace_filters.is_empty()
+                    && install_root_dependencies
+                    && manager.summary.pruned_workspaces.is_empty()
+                {
+                    return reachable::packages(lockfile, resolutions, options);
+                }
+                // `--filter` or a pruned checkout links only some importers: walk from
+                // those, the same ones the workspace checks below let through.
+                let deps = lockfile.buffers.dependencies.as_slice();
+                let mut roots: Vec<PackageID> = Vec::new();
+                if install_root_dependencies {
+                    roots.push(0);
+                }
+                let root_deps = lockfile.packages.items_dependencies()[0];
+                for dep_id in root_deps.begin()..root_deps.end() {
+                    let dep = &deps[dep_id as usize];
+                    let workspace = resolutions[dep_id as usize];
+                    if dep.behavior.is_workspace()
+                        && (workspace as usize) < lockfile.packages.len()
+                        && !manager.summary.pruned_workspaces.contains(&dep.name_hash)
+                        && WorkspaceFilter::is_selected(workspace_filters, workspace)
+                    {
+                        roots.push(workspace);
+                    }
+                }
+                reachable::packages_from(lockfile, resolutions, &roots, false, options)
             })
             .is_set(pkg_id as usize)
     }
@@ -638,7 +666,14 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         {
             // The omitted group is what resolved this package. Keep the optional peer
             // only when the install still reaches the package through other edges.
-            return !reached.contains(lockfile, resolutions, manager, pkg_id);
+            return !reached.contains(
+                lockfile,
+                resolutions,
+                manager,
+                workspace_filters,
+                install_root_dependencies,
+                pkg_id,
+            );
         }
     }
 

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -539,9 +539,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 // is_filtered_dependency_or_workspace
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The packages a `--production` / `--omit` install still reaches, computed the
-/// first time `is_filtered_dependency_or_workspace` needs it. One per pass over
-/// a fixed `resolutions` buffer.
+/// The packages a `--production` / `--omit` install still reaches. Computed on first use, one per `resolutions` buffer.
 #[derive(Default)]
 pub(crate) struct ReachedPackages(Option<DynamicBitSet>);
 
@@ -564,8 +562,7 @@ impl ReachedPackages {
                 {
                     return reachable::packages(lockfile, resolutions, options);
                 }
-                // `--filter` or a pruned checkout links only some importers: walk from
-                // those, the same ones the workspace checks below let through.
+                // `--filter` or a pruned checkout links only some importers, so walk from those.
                 let deps = lockfile.buffers.dependencies.as_slice();
                 let mut roots: Vec<PackageID> = Vec::new();
                 if install_root_dependencies {
@@ -664,8 +661,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         if optional_peer_group_enabled(dep, siblings, |behavior| behavior.is_enabled(dep_features))
             == Some(false)
         {
-            // The omitted group is what resolved this package. Keep the optional peer
-            // only when the install still reaches the package through other edges.
+            // The omitted group resolved this package. Keep the peer only if the install still reaches it.
             return !reached.contains(
                 lockfile,
                 resolutions,
@@ -692,11 +688,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     !WorkspaceFilter::is_selected(workspace_filters, pkg_id)
 }
 
-/// A package.json can list one name under `peerDependencies` and under another
-/// group, e.g. an optional peer that is also a devDependency. The optional peer
-/// row resolved only because the other row did, so it must not keep the package
-/// by itself once that group is omitted. `Some(false)` when every same-name row
-/// from another group is omitted, `None` when there is no such row.
+/// For an optional peer whose name the same package.json repeats in another group: is that group enabled? `None` if no such row.
 pub(crate) fn optional_peer_group_enabled(
     dep: &Dependency,
     siblings: &[Dependency],

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -658,18 +658,19 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     if dep.behavior.is_optional_peer() {
         let siblings = pkgs.items_dependencies()[parent_pkg_id as usize]
             .get(lockfile.buffers.dependencies.as_slice());
+        // The omitted group resolved this package. Drop the peer too unless the install still reaches it.
         if optional_peer_group_enabled(dep, siblings, |behavior| behavior.is_enabled(dep_features))
             == Some(false)
-        {
-            // The omitted group resolved this package. Keep the peer only if the install still reaches it.
-            return !reached.contains(
+            && !reached.contains(
                 lockfile,
                 resolutions,
                 manager,
                 workspace_filters,
                 install_root_dependencies,
                 pkg_id,
-            );
+            )
+        {
+            return true;
         }
     }
 

--- a/src/install/lockfile/reachable.rs
+++ b/src/install/lockfile/reachable.rs
@@ -1,6 +1,7 @@
 use crate::dependency::{Behavior, Dependency};
 use crate::lockfile::DependencySlice;
 use crate::lockfile::package::{Meta, PackageColumns as _};
+use crate::lockfile::tree::optional_peer_group_enabled;
 use crate::lockfile_real::Lockfile;
 use crate::npm::{Architecture, OperatingSystem};
 use crate::{PackageID, PackageManager};
@@ -196,9 +197,17 @@ impl<'a> Walk<'a> {
     fn drain(&self, seen: &mut DynamicBitSet, worklist: &mut Vec<PackageID>) {
         while let Some(parent) = worklist.pop() {
             let slice = self.dep_slices[parent as usize];
+            let siblings = slice.get(self.deps);
             for dep_id in slice.begin() as usize..slice.end() as usize {
-                if !(self.follow_all || self.follows(self.deps[dep_id].behavior)) {
-                    continue;
+                if !self.follow_all {
+                    let dep = &self.deps[dep_id];
+                    if !self.follows(dep.behavior)
+                        || optional_peer_group_enabled(dep, siblings, |behavior| {
+                            self.follows(behavior)
+                        }) == Some(false)
+                    {
+                        continue;
+                    }
                 }
                 self.admit(self.resolutions[dep_id], seen, worklist);
             }

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -1764,14 +1764,17 @@ fn store_entry_names(manager: &mut PackageManager, wanted: &DynamicBitSet) -> Ve
     names
 }
 
-fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>> {
+fn direct_aliases(
+    manager: &PackageManager,
+    pkg_id: PackageID,
+    reached: &mut ReachedPackages,
+) -> Vec<Box<[u8]>> {
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
     let resolutions = lockfile.buffers.resolutions.as_slice();
     let slice = lockfile.packages.items_dependencies()[pkg_id as usize];
     let mut direct: Vec<Box<[u8]>> = Vec::new();
-    let mut reached = ReachedPackages::default();
     for dep_id in slice.begin()..slice.end() {
         if is_filtered_dependency_or_workspace(
             dep_id,
@@ -1781,7 +1784,7 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
             manager,
             lockfile,
             resolutions,
-            &mut reached,
+            reached,
         ) {
             continue;
         }
@@ -1836,6 +1839,7 @@ fn plan_isolated(
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
+    let mut reached = ReachedPackages::default();
     for pkg_id in 0..lockfile.packages.len() {
         let res = &pkg_res[pkg_id];
         let folder_path: Box<[u8]> = match res.tag {
@@ -1858,7 +1862,7 @@ fn plan_isolated(
         let Ok(dir) = Dir::open(&folder_path) else {
             continue;
         };
-        let direct = direct_aliases(manager, pkg_id as PackageID);
+        let direct = direct_aliases(manager, pkg_id as PackageID, &mut reached);
         let folder_idx = scan_folder(
             dir,
             &folder_path,

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -13,7 +13,7 @@ use bun_sys::{self as sys, Dir, E, EntryKind, O};
 use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _, entry as store_entry};
 use crate::isolated_install::{Store, Timings, build_store};
 use crate::lockfile::package::PackageColumns as _;
-use crate::lockfile::tree::is_filtered_dependency_or_workspace;
+use crate::lockfile::tree::{ReachedPackages, is_filtered_dependency_or_workspace};
 use crate::lockfile::{LoadResult, Lockfile, reachable, tree};
 use crate::lockfile_real::package::{Diff, DiffSummary, Package};
 use crate::package_manager::Options::{Enable, LogLevel};
@@ -1771,6 +1771,7 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
     let resolutions = lockfile.buffers.resolutions.as_slice();
     let slice = lockfile.packages.items_dependencies()[pkg_id as usize];
     let mut direct: Vec<Box<[u8]>> = Vec::new();
+    let mut reached = ReachedPackages::default();
     for dep_id in slice.begin()..slice.end() {
         if is_filtered_dependency_or_workspace(
             dep_id,
@@ -1780,6 +1781,7 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
             manager,
             lockfile,
             resolutions,
+            &mut reached,
         ) {
             continue;
         }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -815,7 +815,7 @@ describe("text lockfile", () => {
       await using proc = spawn({
         cmd: [bunExe(), "install", `--linker=${linker}`, ...args],
         cwd: packageDir,
-        stdout: "pipe",
+        stdout: "ignore",
         stderr: "pipe",
         env,
       });
@@ -883,18 +883,17 @@ describe("text lockfile", () => {
     });
 
     test("--omit=dev keeps an optional peer + devDependency that the install still reaches", async () => {
-      // lib tests against both peers; only "no-deps" is also brought by its consumer
+      // root and lib test against their peers; only "no-deps" is also brought by a consumer (app)
+      const devAndOptionalPeer = {
+        devDependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" },
+        peerDependencies: { "no-deps": "^1.0.0", "a-dep": "^1.0.1" },
+        peerDependenciesMeta: { "no-deps": { optional: true }, "a-dep": { optional: true } },
+      };
       await Promise.all([
-        write(packageJson, JSON.stringify({ name: "foo", workspaces: ["packages/*"] })),
+        write(packageJson, JSON.stringify({ name: "foo", workspaces: ["packages/*"], ...devAndOptionalPeer })),
         write(
           join(packageDir, "packages", "lib", "package.json"),
-          JSON.stringify({
-            name: "lib",
-            version: "1.0.0",
-            devDependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" },
-            peerDependencies: { "no-deps": "^1.0.0", "a-dep": "^1.0.1" },
-            peerDependenciesMeta: { "no-deps": { optional: true }, "a-dep": { optional: true } },
-          }),
+          JSON.stringify({ name: "lib", version: "1.0.0", ...devAndOptionalPeer }),
         ),
         write(
           join(packageDir, "packages", "app", "package.json"),
@@ -905,21 +904,34 @@ describe("text lockfile", () => {
           }),
         ),
       ]);
+      const rmNodeModules = async () => {
+        for (const dir of ["", join("packages", "lib"), join("packages", "app")]) {
+          await rm(join(packageDir, dir, "node_modules"), { recursive: true, force: true });
+        }
+      };
 
       expect(await install("--save-text-lockfile")).toContain("Saved lockfile");
       expect(await Promise.all([installed("no-deps", "1.0.0"), installed("a-dep", "1.0.1")])).toEqual([true, true]);
       const fullLockfile = await lockfileText();
 
-      for (const dir of ["", join("packages", "lib"), join("packages", "app")]) {
-        await rm(join(packageDir, dir, "node_modules"), { recursive: true, force: true });
-      }
+      await rmNodeModules();
       await install("--frozen-lockfile", "--omit=dev");
       expect(await Promise.all([installed("no-deps", "1.0.0"), installed("a-dep", "1.0.1")])).toEqual([true, false]);
       if (linker === "isolated") {
-        // lib still gets the peer its consumer provides, as it would without the devDependency
+        // root and lib still get the peer that app provides, as they would without the devDependency
         expect(await readdirSorted(join(packageDir, "packages", "lib", "node_modules"))).toEqual(["no-deps"]);
+        expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBeTrue();
       }
       expect(await lockfileText()).toBe(fullLockfile);
+
+      // `--filter` leaves the root out: being reached through app must not link the peer into root
+      await rmNodeModules();
+      await install("--frozen-lockfile", "--omit=dev", "--filter", "app");
+      expect(await installed("no-deps", "1.0.0")).toBeTrue();
+      if (linker === "isolated") {
+        expect(await exists(join(packageDir, "packages", "app", "node_modules", "no-deps"))).toBeTrue();
+        expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBeFalse();
+      }
     });
   });
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -810,6 +810,119 @@ describe("text lockfile", () => {
     });
   }
 
+  describe.each(["hoisted", "isolated"] as const)("%s linker", linker => {
+    async function install(...args: string[]) {
+      await using proc = spawn({
+        cmd: [bunExe(), "install", `--linker=${linker}`, ...args],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      return err;
+    }
+
+    // Where a linker puts a registry package: hoisted into node_modules, isolated into the store.
+    const installed = (pkg: string, version: string) =>
+      exists(
+        linker === "hoisted"
+          ? join(packageDir, "node_modules", pkg)
+          : join(packageDir, "node_modules", ".bun", `${pkg}@${version}`),
+      );
+    const lockfileText = async () =>
+      (await file(join(packageDir, "bun.lock")).text()).replaceAll(/localhost:\d+/g, "localhost:1234");
+
+    // The plugin idiom: test against a package (devDependency) that the consumer may bring
+    // (optional peerDependency). The optional peer row must not keep the package once its
+    // other group is omitted; npm does the same. A required peer is still installed, because
+    // bun installs peerDependencies by default.
+    test("--omit omits a dev or optional dependency that is also an optional peerDependency", async () => {
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          devDependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" },
+          optionalDependencies: { "basic-1": "1.0.0" },
+          peerDependencies: { "no-deps": "^1.0.0", "a-dep": "^1.0.1", "basic-1": "^1.0.0" },
+          peerDependenciesMeta: { "no-deps": { optional: true }, "basic-1": { optional: true } },
+        }),
+      );
+      const installedNow = async () => ({
+        "no-deps": await installed("no-deps", "1.0.0"),
+        "a-dep": await installed("a-dep", "1.0.1"),
+        "basic-1": await installed("basic-1", "1.0.0"),
+      });
+
+      expect(await install("--save-text-lockfile")).toContain("Saved lockfile");
+      expect(await installedNow()).toEqual({ "no-deps": true, "a-dep": true, "basic-1": true });
+      const fullLockfile = await lockfileText();
+
+      // from the full lockfile
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await install("--frozen-lockfile", "--omit=dev");
+      expect(await installedNow()).toEqual({ "no-deps": false, "a-dep": true, "basic-1": true });
+
+      // without a lockfile: same node_modules, and the lockfile written is the full one
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, "bun.lock"));
+      expect(await install("--save-text-lockfile", "--omit=dev")).toContain("Saved lockfile");
+      expect(await installedNow()).toEqual({ "no-deps": false, "a-dep": true, "basic-1": true });
+      expect(await lockfileText()).toBe(fullLockfile);
+
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await install("--frozen-lockfile", "--omit=optional");
+      expect(await installedNow()).toEqual({ "no-deps": true, "a-dep": true, "basic-1": false });
+
+      // `--omit=peer` alone leaves the other group in charge
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await install("--frozen-lockfile", "--omit=peer");
+      expect(await installedNow()).toEqual({ "no-deps": true, "a-dep": true, "basic-1": true });
+    });
+
+    test("--omit=dev keeps an optional peer + devDependency that the install still reaches", async () => {
+      // lib tests against both peers; only "no-deps" is also brought by its consumer
+      await Promise.all([
+        write(packageJson, JSON.stringify({ name: "foo", workspaces: ["packages/*"] })),
+        write(
+          join(packageDir, "packages", "lib", "package.json"),
+          JSON.stringify({
+            name: "lib",
+            version: "1.0.0",
+            devDependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" },
+            peerDependencies: { "no-deps": "^1.0.0", "a-dep": "^1.0.1" },
+            peerDependenciesMeta: { "no-deps": { optional: true }, "a-dep": { optional: true } },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "app", "package.json"),
+          JSON.stringify({
+            name: "app",
+            version: "1.0.0",
+            dependencies: { lib: "workspace:*", "no-deps": "1.0.0" },
+          }),
+        ),
+      ]);
+
+      expect(await install("--save-text-lockfile")).toContain("Saved lockfile");
+      expect(await Promise.all([installed("no-deps", "1.0.0"), installed("a-dep", "1.0.1")])).toEqual([true, true]);
+      const fullLockfile = await lockfileText();
+
+      for (const dir of ["", join("packages", "lib"), join("packages", "app")]) {
+        await rm(join(packageDir, dir, "node_modules"), { recursive: true, force: true });
+      }
+      await install("--frozen-lockfile", "--omit=dev");
+      expect(await Promise.all([installed("no-deps", "1.0.0"), installed("a-dep", "1.0.1")])).toEqual([true, false]);
+      if (linker === "isolated") {
+        // lib still gets the peer its consumer provides, as it would without the devDependency
+        expect(await readdirSorted(join(packageDir, "packages", "lib", "node_modules"))).toEqual(["no-deps"]);
+      }
+      expect(await lockfileText()).toBe(fullLockfile);
+    });
+  });
+
   test("optionalPeers", async () => {
     await Promise.all([
       write(

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -364,6 +364,30 @@ test.concurrent.each([["--production"], ["--prod"], ["--omit=dev"]])(
   },
 );
 
+// The optional peer row cannot keep a devDependency of the same name once dev is omitted, the same
+// as `bun install --production`. A required peer stays: bun installs peerDependencies by default.
+test.concurrent.each(linkers)(
+  "%s: --production removes a devDependency that is also an optional peerDependency",
+  async linker => {
+    const dir = await setupWithLinker(linker, {
+      name: "foo",
+      devDependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" },
+      peerDependencies: { "no-deps": "^1.0.0", "a-dep": "^1.0.1" },
+      peerDependenciesMeta: { "no-deps": { optional: true } },
+    });
+    const nm = join(dir, "node_modules");
+    expect(existsSync(join(nm, "no-deps"))).toBeTrue();
+
+    // isolated counts the store entry and the node_modules link of each package
+    const checked = linker === "hoisted" ? 2 : 4;
+    const { stdout, exitCode } = await prune(dir, "--production", "--linker", linker);
+    expect(out(stdout)).toEndWith(`- no-deps@1.0.0\n${REMOVED(1, checked)}`);
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(nm, "no-deps"))).toBeFalse();
+    expect(existsSync(join(nm, "a-dep"))).toBeTrue();
+  },
+);
+
 test.concurrent("--production keeps a package that prod and dev both need", async () => {
   const pkg = {
     name: "foo",


### PR DESCRIPTION
### Problem
- `bun install --production` installs a package that the root or a workspace lists in both `devDependencies` and optional `peerDependencies`, and runs its lifecycle scripts (the shape in #18027). A lone optional peer is never installed, and `npm install --omit=dev` omits it. `bun prune --production` keeps it.
- Cause: `Package::parse_dependency` (`src/install/lockfile/Package.rs:2100`) lets `peerDependencies` repeat a name, so the package has two rows, `DEV` and `PEER|OPTIONAL`. The hoister binds the second to the dev row's package. Under `--omit=dev`, `is_filtered_dependency_or_workspace` (`src/install/lockfile/Tree.rs`) drops the `DEV` row. The other row still places the package.

### Fix
- `is_filtered_dependency_or_workspace`: when every same-name row from another group is omitted, keep the optional-peer row only if the install still reaches the package through other edges (`reachable::packages`, once per pass). This is what a lone optional peer does. Both linkers use this predicate.
- `reachable::Walk::drain` skips the same rows, so `bun prune --production` agrees. The lockfile does not change.
- Scope: `dev` + required peer stays installed (Bun installs peers by default). Transitive optional peers (#26837) are unchanged.
- Verified: `test/cli/install/bun-install-registry.test.ts` and `bun-prune.test.ts`, which fail on 1.4.3. Self-reviewed: 4 concerns, 4 addressed (Notes).

### Background
- Root and workspace manifests are parsed with every group. `--omit` acts per row when linking, through `Behavior::is_enabled(Features)`.
- Optional peers are never resolved on their own. One gets a package id from a same-name row in the hoister, or by name when `bun.lock` loads: something else installs that package.
- `reachable.rs` is the graph walk behind `bun prune --production`.

<details><summary>Notes</summary>

- Reproduction (stub registry, `trustedDependencies` set so scripts run): root `dependencies {zz-o}`, `devDependencies {zz-pod, zz-d}`, `peerDependencies {zz-pod, zz-popt}` both optional. 1.4.3 `--production`: `node_modules = zz-o zz-pod`, scripts `RAN-zz-pod RAN-zz-o`, hoisted and isolated, cold and `--frozen-lockfile`. With this change: `zz-o` only. npm 11.16 `--omit=dev`: `zz-o` only.
- A first version filtered the row outright. That broke the isolated workspace case: `packages/lib` with `devDependencies {x}` + optional peer `x`, consumed by `apps/web` which depends on `x`. Without the devDependency, lib gets `packages/lib/node_modules/x` linked from web's copy under `--production`. Filtering outright removed that link. The reachability check keeps it, and the second registry test pins it.
- The reachability walk only runs for an optional-peer row whose sibling group is omitted, at most once per linker pass (`ReachedPackages`). A default install, and packages without that overlap, pay one `is_optional_peer()` check.
- With `--filter` or a pruned checkout, the walk starts from the importers the install links (the selected, non-pruned workspaces, plus the root when its own dependencies are installed), so an unselected workspace cannot keep the peer, and a reached row still goes through the root and workspace checks, so a root that `--filter` leaves out does not get the peer linked (the second registry test runs `--omit=dev --filter app` for this). Checked by hand on a two-workspace repo with `--filter ./packages/lib --production` (nothing but `lib` is linked) and `--filter ./apps/web --production` (lib keeps the peer web provides).
- `optionalDependencies` + optional peer under `--omit=optional` changes the same way (was kept, now omitted, as in npm). The first registry test pins it, and pins that `dev` + required peer stays installed.
- npm lets a same-name `devDependencies` entry govern a required peer too ("dev wins"), so `npm install --omit=dev` drops it. Bun keeps installing it here, like a required peer that is not a devDependency. Changing that would drop packages that workspace consumers may rely on, so it is left to a maintainer decision.
- Transitive optional peers (a registry package with an optional peer on a root devDependency, #26837): `--omit=dev` keeps the package, as npm does (`devOptional`) and unlike pnpm. Unchanged by this PR.
- #18027 also reported that a lockfile install and a cold install disagreed. That part no longer reproduces. Its optional peers (`ioredis`, `jose`, `knex`, `mssql`) are what this PR stops installing under `--production`. Its `elysia` (dev + required peer) stays.
- `dependencies` + `devDependencies` with the same name still warns `Duplicate dependency` and keeps the package under `--production`.
- Self-review concerns and what changed: (1) compute the reachable set once per pass instead of per row, done with `ReachedPackages`. (2) Narrow the docs sentence that over-promised for the transitive shape, done. (3) State the required-peer and transitive scope explicitly, done above and in docs. (4) Pin the neighbouring precedence rows in tests, done.
- Suites run with the debug build: bun-install-registry (258), bun-prune (124), isolated-install, bun-workspaces, bun-workspaces-self-contained, public-hoist-pattern, test-dev-peer-dependency-priority, bun-install (only the pre-existing network-dependent git/tarball cases fail in this sandbox, same on main), bun-audit, bun-pm-licenses, lockfile-only, frozen-lockfile-pruned.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-prune.test.ts, test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->