### PR TITLE
css: make the `all` shorthand reset the declarations before it

### DIFF
--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -503,7 +503,8 @@ impl<'bump> DeclarationHandler<'bump> {
                 true
             }
             css::Property::Unparsed(unparsed) => match unparsed.property_id {
-                css::PropertyId::All => {
+                // Any other non-keyword value is invalid, and browsers drop the declaration.
+                css::PropertyId::All if unparsed.value.has_variable_reference() => {
                     self.reset_for_all();
                     let bump = self.decls.bump();
                     self.decls
@@ -540,6 +541,7 @@ impl<'bump> DeclarationHandler<'bump> {
                 css::Property::Custom(custom) => {
                     matches!(custom.name, CustomPropertyName::Custom(..))
                 }
+                css::Property::Direction(..) | css::Property::UnicodeBidi(..) => true,
                 css::Property::Unparsed(unparsed) => matches!(
                     unparsed.property_id,
                     css::PropertyId::Direction | css::PropertyId::UnicodeBidi

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -486,8 +486,6 @@ impl<'bump> DeclarationHandler<'bump> {
             || self.handle_all(property)
     }
 
-    /// The `all` shorthand resets every property except `direction`,
-    /// `unicode-bidi` and custom properties.
     /// https://drafts.csswg.org/css-cascade-5/#all-shorthand
     fn handle_all(&mut self, property: &css::Property) -> bool {
         match property {
@@ -512,8 +510,7 @@ impl<'bump> DeclarationHandler<'bump> {
                         .push(css::Property::Unparsed(unparsed.deep_clone(bump)));
                     true
                 }
-                // An unparsed `direction`/`unicode-bidi` is pushed in place by the
-                // caller, so emit the typed value seen before it first.
+                // Keep a buffered typed value ahead of the unparsed one the caller pushes next.
                 css::PropertyId::Direction => {
                     if let Some(direction) = self.direction.take() {
                         self.decls.push(css::Property::Direction(direction));
@@ -532,8 +529,7 @@ impl<'bump> DeclarationHandler<'bump> {
         }
     }
 
-    /// Drops what the block declared so far, except the declarations that
-    /// `all` does not reset.
+    /// Drops everything the block declared so far that `all` resets.
     fn reset_for_all(&mut self) {
         let bump: &'bump Bump = self.decls.bump();
         let previous = core::mem::replace(self, DeclarationHandler::new(bump));

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -15,7 +15,7 @@ use crate::css_properties::margin_padding::{
 };
 use crate::css_properties::prefix_handler::FallbackHandler;
 use crate::css_properties::size::SizeHandler;
-use crate::css_properties::text::Direction;
+use crate::css_properties::text::{Direction, UnicodeBidi};
 use crate::css_properties::transform::TransformHandler;
 use crate::css_properties::transition::TransitionHandler;
 use crate::css_properties::ui::ColorSchemeHandler;
@@ -404,6 +404,7 @@ pub struct DeclarationHandler<'bump> {
     pub(crate) color_scheme: ColorSchemeHandler,
     pub fallback: FallbackHandler,
     pub(crate) direction: Option<Direction>,
+    pub(crate) unicode_bidi: Option<UnicodeBidi>,
     pub(crate) decls: DeclarationList<'bump>,
 }
 
@@ -411,6 +412,9 @@ impl<'bump> DeclarationHandler<'bump> {
     pub(crate) fn finalize(&mut self, context: &mut css::PropertyHandlerContext) {
         if let Some(direction) = self.direction.take() {
             self.decls.push(css::Property::Direction(direction));
+        }
+        if let Some(unicode_bidi) = self.unicode_bidi.take() {
+            self.decls.push(css::Property::UnicodeBidi(unicode_bidi));
         }
 
         self.background.finalize(&mut self.decls, context);
@@ -435,7 +439,6 @@ impl<'bump> DeclarationHandler<'bump> {
         property: &css::Property,
         context: &mut css::PropertyHandlerContext,
     ) -> bool {
-        // return this.background.handleProperty(property, &this.decls, context);
         self.background
             .handle_property(property, &mut self.decls, context)
             || self
@@ -480,6 +483,77 @@ impl<'bump> DeclarationHandler<'bump> {
             || self
                 .fallback
                 .handle_property(property, &mut self.decls, context)
+            || self.handle_all(property)
+    }
+
+    /// The `all` shorthand resets every property except `direction`,
+    /// `unicode-bidi` and custom properties.
+    /// https://drafts.csswg.org/css-cascade-5/#all-shorthand
+    fn handle_all(&mut self, property: &css::Property) -> bool {
+        match property {
+            css::Property::Direction(direction) => {
+                self.direction = Some(*direction);
+                true
+            }
+            css::Property::UnicodeBidi(unicode_bidi) => {
+                self.unicode_bidi = Some(*unicode_bidi);
+                true
+            }
+            css::Property::All(keyword) => {
+                self.reset_for_all();
+                self.decls.push(css::Property::All(*keyword));
+                true
+            }
+            css::Property::Unparsed(unparsed) => match unparsed.property_id {
+                css::PropertyId::All => {
+                    self.reset_for_all();
+                    let bump = self.decls.bump();
+                    self.decls
+                        .push(css::Property::Unparsed(unparsed.deep_clone(bump)));
+                    true
+                }
+                // An unparsed `direction`/`unicode-bidi` is pushed in place by the
+                // caller, so emit the typed value seen before it first.
+                css::PropertyId::Direction => {
+                    if let Some(direction) = self.direction.take() {
+                        self.decls.push(css::Property::Direction(direction));
+                    }
+                    false
+                }
+                css::PropertyId::UnicodeBidi => {
+                    if let Some(unicode_bidi) = self.unicode_bidi.take() {
+                        self.decls.push(css::Property::UnicodeBidi(unicode_bidi));
+                    }
+                    false
+                }
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    /// Drops what the block declared so far, except the declarations that
+    /// `all` does not reset.
+    fn reset_for_all(&mut self) {
+        let bump: &'bump Bump = self.decls.bump();
+        let previous = core::mem::replace(self, DeclarationHandler::new(bump));
+        self.direction = previous.direction;
+        self.unicode_bidi = previous.unicode_bidi;
+        for decl in previous.decls {
+            let survives = match &decl {
+                css::Property::Custom(custom) => {
+                    matches!(custom.name, CustomPropertyName::Custom(..))
+                }
+                css::Property::Unparsed(unparsed) => matches!(
+                    unparsed.property_id,
+                    css::PropertyId::Direction | css::PropertyId::UnicodeBidi
+                ),
+                _ => false,
+            };
+            if survives {
+                self.decls.push(decl);
+            }
+        }
     }
 
     pub(crate) fn new(bump: &'bump Bump) -> Self {
@@ -500,6 +574,7 @@ impl<'bump> DeclarationHandler<'bump> {
             color_scheme: Default::default(),
             fallback: Default::default(),
             direction: None,
+            unicode_bidi: None,
             decls: DeclarationList::new_in(bump),
         }
     }

--- a/src/css/generics.rs
+++ b/src/css/generics.rs
@@ -787,9 +787,9 @@ mod inherent_bridge {
     bridge_clone_partialeq!(PositionProp);
 
     // ── properties/text ──
-    use crate::properties::text::{Direction as TextDirection, TextShadow};
-    bridge_clone_partialeq!(TextDirection);
-    // CssHash for TextDirection — via #[derive(CssHash)] on the enum (properties/text.rs).
+    use crate::properties::text::{Direction as TextDirection, TextShadow, UnicodeBidi};
+    bridge_clone_partialeq!(TextDirection, UnicodeBidi);
+    // CssHash for TextDirection/UnicodeBidi — via #[derive(CssHash)] on the enum (properties/text.rs).
     bridge_deep_clone!(TextShadow);
     bridge_eql_partialeq!(TextShadow);
 

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -299,6 +299,23 @@ pub struct TokenList {
 impl TokenList {
     // deinit(): body only freed owned `Vec` fields — handled by `Drop` on `Vec`.
 
+    /// Whether the value uses `var()` or `env()`, which makes a declaration valid at parse time.
+    pub(crate) fn has_variable_reference(&self) -> bool {
+        self.v.iter().any(|token_or_value| match token_or_value {
+            TokenOrValue::Var(_) | TokenOrValue::Env(_) => true,
+            TokenOrValue::Function(f) => f.arguments.has_variable_reference(),
+            TokenOrValue::UnresolvedColor(color) => match color {
+                UnresolvedColor::RGB { alpha, .. } | UnresolvedColor::HSL { alpha, .. } => {
+                    alpha.has_variable_reference()
+                }
+                UnresolvedColor::LightDark { light, dark } => {
+                    light.has_variable_reference() || dark.has_variable_reference()
+                }
+            },
+            _ => false,
+        })
+    }
+
     pub fn to_css(&self, dest: &mut Printer, is_custom_property: bool) -> PrintResult<()> {
         if !dest.minify && self.v.len() == 1 && self.v[0].is_whitespace() {
             return Ok(());

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -262,6 +262,7 @@ pub enum PropertyIdTag {
     TextEmphasisColor,
     TextShadow,
     Direction,
+    UnicodeBidi,
     Composes,
     MaskImage,
     MaskMode,
@@ -577,6 +578,7 @@ impl PropertyIdTag {
             PropertyIdTag::TextEmphasisColor => b"text-emphasis-color",
             PropertyIdTag::TextShadow => b"text-shadow",
             PropertyIdTag::Direction => b"direction",
+            PropertyIdTag::UnicodeBidi => b"unicode-bidi",
             PropertyIdTag::Composes => b"composes",
             PropertyIdTag::MaskImage => b"mask-image",
             PropertyIdTag::MaskMode => b"mask-mode",
@@ -845,6 +847,7 @@ pub enum PropertyId {
     TextEmphasisColor(VendorPrefix),
     TextShadow,
     Direction,
+    UnicodeBidi,
     Composes,
     MaskImage(VendorPrefix),
     MaskMode,
@@ -1130,6 +1133,7 @@ impl PropertyId {
             PropertyId::TextEmphasisColor(..) => PropertyIdTag::TextEmphasisColor,
             PropertyId::TextShadow => PropertyIdTag::TextShadow,
             PropertyId::Direction => PropertyIdTag::Direction,
+            PropertyId::UnicodeBidi => PropertyIdTag::UnicodeBidi,
             PropertyId::Composes => PropertyIdTag::Composes,
             PropertyId::MaskImage(..) => PropertyIdTag::MaskImage,
             PropertyId::MaskMode => PropertyIdTag::MaskMode,
@@ -1512,6 +1516,7 @@ impl PropertyId {
                 b"text-emphasis-color" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT), PropertyId::TextEmphasisColor),
                 b"text-shadow" => (VendorPrefix::NONE, |_| PropertyId::TextShadow),
                 b"direction" => (VendorPrefix::NONE, |_| PropertyId::Direction),
+                b"unicode-bidi" => (VendorPrefix::NONE, |_| PropertyId::UnicodeBidi),
                 b"composes" => (VendorPrefix::NONE, |_| PropertyId::Composes),
                 b"mask-image" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT), PropertyId::MaskImage),
                 b"mask-mode" => (VendorPrefix::NONE, |_| PropertyId::MaskMode),
@@ -1544,6 +1549,7 @@ impl PropertyId {
                 b"view-transition-name" => (VendorPrefix::NONE, |_| PropertyId::ViewTransitionName),
                 b"view-transition-class" => (VendorPrefix::NONE, |_| PropertyId::ViewTransitionClass),
                 b"view-transition-group" => (VendorPrefix::NONE, |_| PropertyId::ViewTransitionGroup),
+                b"all" => (VendorPrefix::NONE, |_| PropertyId::All),
             };
         }
         let &(allowed, make) = KNOWN.get_ascii_case_insensitive(name)?;
@@ -1835,6 +1841,7 @@ pub enum Property {
     TextEmphasisColor((css::css_values::color::CssColor, VendorPrefix)),
     TextShadow(SmallList<text::TextShadow, 1>),
     Direction(text::Direction),
+    UnicodeBidi(text::UnicodeBidi),
     Composes(css_modules::Composes),
     MaskImage((SmallList<css::css_values::image::Image, 1>, VendorPrefix)),
     MaskMode(SmallList<masking::MaskMode, 1>),
@@ -2115,6 +2122,7 @@ impl Property {
             Property::TextEmphasisColor(v) => PropertyId::TextEmphasisColor(v.1),
             Property::TextShadow(..) => PropertyId::TextShadow,
             Property::Direction(..) => PropertyId::Direction,
+            Property::UnicodeBidi(..) => PropertyId::UnicodeBidi,
             Property::Composes(..) => PropertyId::Composes,
             Property::MaskImage(v) => PropertyId::MaskImage(v.1),
             Property::MaskMode(..) => PropertyId::MaskMode,
@@ -2387,6 +2395,7 @@ impl Property {
             Property::TextEmphasisColor(v) => css::generic::to_css(&v.0, dest),
             Property::TextShadow(v) => css::generic::to_css(v, dest),
             Property::Direction(v) => css::generic::to_css(v, dest),
+            Property::UnicodeBidi(v) => css::generic::to_css(v, dest),
             Property::Composes(v) => css::generic::to_css(v, dest),
             Property::MaskImage(v) => css::generic::to_css(&v.0, dest),
             Property::MaskMode(v) => css::generic::to_css(v, dest),
@@ -3684,6 +3693,11 @@ impl Property {
                     return Ok(Property::Direction(c));
                 }
             }
+            PropertyId::UnicodeBidi => {
+                if let Some(c) = parse_value::<text::UnicodeBidi>(input, options) {
+                    return Ok(Property::UnicodeBidi(c));
+                }
+            }
             PropertyId::Composes => {
                 return css::generic::parse_with_options::<css_modules::Composes>(input, options)
                     .map(Property::Composes);
@@ -3874,7 +3888,11 @@ impl Property {
                     return Ok(Property::ViewTransitionGroup(c));
                 }
             }
-            PropertyId::All => return CSSWideKeyword::parse(input).map(Property::All),
+            PropertyId::All => {
+                if let Some(c) = parse_value::<CSSWideKeyword>(input, options) {
+                    return Ok(Property::All(c));
+                }
+            }
             PropertyId::Custom(name) => {
                 return CustomProperty::parse(name, input, options).map(Property::Custom);
             }
@@ -4394,6 +4412,7 @@ impl Property {
             }
             Property::TextShadow(v) => Property::TextShadow(css::generic::deep_clone(v, arena)),
             Property::Direction(v) => Property::Direction(css::generic::deep_clone(v, arena)),
+            Property::UnicodeBidi(v) => Property::UnicodeBidi(css::generic::deep_clone(v, arena)),
             Property::Composes(v) => Property::Composes(css::generic::deep_clone(v, arena)),
             Property::MaskImage(v) => {
                 Property::MaskImage((css::generic::deep_clone(&v.0, arena), v.1))
@@ -4939,6 +4958,7 @@ impl Property {
             }
             (Property::TextShadow(a), Property::TextShadow(b)) => css::generic::eql(a, b),
             (Property::Direction(a), Property::Direction(b)) => css::generic::eql(a, b),
+            (Property::UnicodeBidi(a), Property::UnicodeBidi(b)) => css::generic::eql(a, b),
             (Property::Composes(a), Property::Composes(b)) => css::generic::eql(a, b),
             (Property::MaskImage(a), Property::MaskImage(b)) => {
                 css::generic::eql(&a.0, &b.0) && a.1 == b.1
@@ -5011,7 +5031,7 @@ impl Property {
             (Property::ViewTransitionGroup(a), Property::ViewTransitionGroup(b)) => {
                 css::generic::eql(a, b)
             }
-            (Property::All(_), Property::All(_)) => true,
+            (Property::All(a), Property::All(b)) => a == b,
             (Property::Unparsed(a), Property::Unparsed(b)) => a.eql(b),
             (Property::Custom(a), Property::Custom(b)) => a.eql(b),
             _ => false,

--- a/src/css/properties/text.rs
+++ b/src/css/properties/text.rs
@@ -125,3 +125,22 @@ pub enum Direction {
     /// This value sets inline base direction (bidi directionality) to line-right-to-line-left.
     Rtl,
 }
+
+/// A value for the [unicode-bidi](https://drafts.csswg.org/css-writing-modes-3/#unicode-bidi) property.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, crate::DefineEnumProperty, crate::generics::CssHash,
+)]
+pub enum UnicodeBidi {
+    /// The box does not open an additional level of embedding.
+    Normal,
+    /// If the box is inline, this value creates a directional embedding by opening an additional level of embedding.
+    Embed,
+    /// On an inline box, this bidi-isolates its contents.
+    Isolate,
+    /// This value puts the box's immediate inline content in a directional override.
+    BidiOverride,
+    /// This combines the isolation behavior of isolate with the directional override behavior of bidi-override.
+    IsolateOverride,
+    /// This value behaves as isolate except that the base directionality is determined using a heuristic rather than the direction property.
+    Plaintext,
+}

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7735,7 +7735,12 @@ describe("css tests", () => {
     minify_test(".foo { color: red; --x: initial; all: var(--x) }", ".foo{--x:initial;all:var(--x)}");
     minify_test(".foo { all: var(--x); color: red }", ".foo{all:var(--x);color:red}");
     minify_test(".foo { all: var(--x); all: inherit }", ".foo{all:inherit}");
+    minify_test(".foo { color: red; all: foo(1px, var(--x)) }", ".foo{all:foo(1px,var(--x))}");
+    minify_test(".foo { color: red; all: env(--x) }", ".foo{all:env(--x)}");
     minify_test(".foo { ALL: Initial }", ".foo{all:initial}");
+    // Any other value is invalid. Browsers drop the declaration, so it resets nothing.
+    minify_test(".foo { color: red; all: none }", ".foo{color:red;all:none}");
+    minify_test(".foo { color: red; all: initial 0; margin: 0 }", ".foo{color:red;all:initial 0;margin:0}");
     // Rules only merge when the keywords are equal.
     minify_test(".a { all: initial } .b { all: unset }", ".a{all:initial}.b{all:unset}");
     minify_test(".a { all: initial } .b { all: initial }", ".a,.b{all:initial}");
@@ -7753,6 +7758,10 @@ describe("css tests", () => {
     minify_test(
       ".foo { direction: rtl; unicode-bidi: isolate; all: unset; color: red }",
       ".foo{all:unset;color:red;direction:rtl;unicode-bidi:isolate}",
+    );
+    minify_test(
+      ".foo { direction: rtl; direction: var(--d); unicode-bidi: embed; unicode-bidi: var(--u); all: unset }",
+      ".foo{direction:rtl;direction:var(--d);unicode-bidi:embed;unicode-bidi:var(--u);all:unset}",
     );
     // A typed `direction`/`unicode-bidi` stays ahead of a later unparsed one.
     minify_test(".foo { direction: rtl; direction: var(--d) }", ".foo{direction:rtl;direction:var(--d)}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7706,7 +7706,10 @@ describe("css tests", () => {
     minify_test(".foo { all: initial; all: initial }", ".foo{all:initial}");
     minify_test(".foo { all: initial; all: revert }", ".foo{all:revert}");
     minify_test(".foo { background: red; all: revert-layer }", ".foo{all:revert-layer}");
-    minify_test(".foo { background: red; all: revert-layer; background: green }", ".foo{all:revert-layer;background:green}");
+    minify_test(
+      ".foo { background: red; all: revert-layer; background: green }",
+      ".foo{all:revert-layer;background:green}",
+    );
     minify_test(".foo { --test: red; all: revert-layer }", ".foo{--test:red;all:revert-layer}");
     minify_test(".foo { unicode-bidi: embed; all: revert-layer }", ".foo{all:revert-layer;unicode-bidi:embed}");
     minify_test(".foo { direction: rtl; all: revert-layer }", ".foo{all:revert-layer;direction:rtl}");
@@ -7719,7 +7722,10 @@ describe("css tests", () => {
     // margin, border, ...) are reset by a later `all` too.
     minify_test(".foo { font: 12px serif; all: initial }", ".foo{all:initial}");
     minify_test(".foo { margin: 0; all: unset; color: red }", ".foo{all:unset;color:red}");
-    minify_test(".foo { border: 1px solid red; color: red; all: inherit; margin-top: 1px }", ".foo{all:inherit;margin-top:1px}");
+    minify_test(
+      ".foo { border: 1px solid red; color: red; all: inherit; margin-top: 1px }",
+      ".foo{all:inherit;margin-top:1px}",
+    );
     minify_test(".foo { color: red; all: unset } .foo { margin: 0 }", ".foo{all:unset;margin:0}");
     minify_test(".foo { margin: 0 } .foo { all: unset }", ".foo{all:unset}");
     cssTest(".foo { font: 12px serif; all: initial }", ".foo {\n  all: initial;\n}\n");
@@ -7740,12 +7746,21 @@ describe("css tests", () => {
     // Custom properties, `direction` and `unicode-bidi` survive in every form.
     minify_test(".foo { --x: 1; all: unset; --x: 2 }", ".foo{--x:1;all:unset;--x:2}");
     minify_test(".foo { --x: 1; all: unset; --y: 2 }", ".foo{--x:1;all:unset;--y:2}");
-    minify_test(".foo { direction: var(--d); unicode-bidi: var(--u); all: unset }", ".foo{direction:var(--d);unicode-bidi:var(--u);all:unset}");
-    minify_test(".foo { direction: rtl; unicode-bidi: isolate; all: unset; color: red }", ".foo{all:unset;color:red;direction:rtl;unicode-bidi:isolate}");
+    minify_test(
+      ".foo { direction: var(--d); unicode-bidi: var(--u); all: unset }",
+      ".foo{direction:var(--d);unicode-bidi:var(--u);all:unset}",
+    );
+    minify_test(
+      ".foo { direction: rtl; unicode-bidi: isolate; all: unset; color: red }",
+      ".foo{all:unset;color:red;direction:rtl;unicode-bidi:isolate}",
+    );
     // A typed `direction`/`unicode-bidi` stays ahead of a later unparsed one.
     minify_test(".foo { direction: rtl; direction: var(--d) }", ".foo{direction:rtl;direction:var(--d)}");
     minify_test(".foo { direction: var(--d); direction: rtl }", ".foo{direction:var(--d);direction:rtl}");
-    minify_test(".foo { unicode-bidi: embed; unicode-bidi: var(--u) }", ".foo{unicode-bidi:embed;unicode-bidi:var(--u)}");
+    minify_test(
+      ".foo { unicode-bidi: embed; unicode-bidi: var(--u) }",
+      ".foo{unicode-bidi:embed;unicode-bidi:var(--u)}",
+    );
     minify_test(".foo { direction: ltr; color: red; direction: rtl }", ".foo{color:red;direction:rtl}");
     minify_test(".foo { unicode-bidi: Bidi-Override }", ".foo{unicode-bidi:bidi-override}");
     minify_test(".foo { unicode-bidi: isolate-override; unicode-bidi: plaintext }", ".foo{unicode-bidi:plaintext}");

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7701,6 +7701,66 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  // https://drafts.csswg.org/css-cascade-5/#all-shorthand
+  describe("all shorthand", () => {
+    minify_test(".foo { all: initial; all: initial }", ".foo{all:initial}");
+    minify_test(".foo { all: initial; all: revert }", ".foo{all:revert}");
+    minify_test(".foo { background: red; all: revert-layer }", ".foo{all:revert-layer}");
+    minify_test(".foo { background: red; all: revert-layer; background: green }", ".foo{all:revert-layer;background:green}");
+    minify_test(".foo { --test: red; all: revert-layer }", ".foo{--test:red;all:revert-layer}");
+    minify_test(".foo { unicode-bidi: embed; all: revert-layer }", ".foo{all:revert-layer;unicode-bidi:embed}");
+    minify_test(".foo { direction: rtl; all: revert-layer }", ".foo{all:revert-layer;direction:rtl}");
+    minify_test(".foo { direction: rtl; all: revert-layer; direction: ltr }", ".foo{all:revert-layer;direction:ltr}");
+    minify_test(".foo { background: var(--foo); all: unset; }", ".foo{all:unset}");
+    minify_test(".foo { all: unset; background: var(--foo); }", ".foo{all:unset;background:var(--foo)}");
+    minify_test(".foo {--bar:currentcolor; --foo:1.1em; all:unset}", ".foo{--bar:currentcolor;--foo:1.1em;all:unset}");
+
+    // Declarations that a handler buffers until the end of the block (font,
+    // margin, border, ...) are reset by a later `all` too.
+    minify_test(".foo { font: 12px serif; all: initial }", ".foo{all:initial}");
+    minify_test(".foo { margin: 0; all: unset; color: red }", ".foo{all:unset;color:red}");
+    minify_test(".foo { border: 1px solid red; color: red; all: inherit; margin-top: 1px }", ".foo{all:inherit;margin-top:1px}");
+    minify_test(".foo { color: red; all: unset } .foo { margin: 0 }", ".foo{all:unset;margin:0}");
+    minify_test(".foo { margin: 0 } .foo { all: unset }", ".foo{all:unset}");
+    cssTest(".foo { font: 12px serif; all: initial }", ".foo {\n  all: initial;\n}\n");
+    // An unknown property is reset like any other.
+    minify_test(".foo { unknown: 1; all: unset }", ".foo{all:unset}");
+    // `all` with a value only known at runtime still overrides what precedes it.
+    minify_test(".foo { color: red; --x: initial; all: var(--x) }", ".foo{--x:initial;all:var(--x)}");
+    minify_test(".foo { all: var(--x); color: red }", ".foo{all:var(--x);color:red}");
+    minify_test(".foo { all: var(--x); all: inherit }", ".foo{all:inherit}");
+    minify_test(".foo { ALL: Initial }", ".foo{all:initial}");
+    // Rules only merge when the keywords are equal.
+    minify_test(".a { all: initial } .b { all: unset }", ".a{all:initial}.b{all:unset}");
+    minify_test(".a { all: initial } .b { all: initial }", ".a,.b{all:initial}");
+    // `!important` declarations live in their own cascade band.
+    minify_test(".foo { color: red !important; all: unset }", ".foo{all:unset;color:red!important}");
+    minify_test(".foo { color: red; all: unset !important }", ".foo{color:red;all:unset!important}");
+    minify_test(".foo { color: red !important; all: unset !important }", ".foo{all:unset!important}");
+    // Custom properties, `direction` and `unicode-bidi` survive in every form.
+    minify_test(".foo { --x: 1; all: unset; --x: 2 }", ".foo{--x:1;all:unset;--x:2}");
+    minify_test(".foo { --x: 1; all: unset; --y: 2 }", ".foo{--x:1;all:unset;--y:2}");
+    minify_test(".foo { direction: var(--d); unicode-bidi: var(--u); all: unset }", ".foo{direction:var(--d);unicode-bidi:var(--u);all:unset}");
+    minify_test(".foo { direction: rtl; unicode-bidi: isolate; all: unset; color: red }", ".foo{all:unset;color:red;direction:rtl;unicode-bidi:isolate}");
+    // A typed `direction`/`unicode-bidi` stays ahead of a later unparsed one.
+    minify_test(".foo { direction: rtl; direction: var(--d) }", ".foo{direction:rtl;direction:var(--d)}");
+    minify_test(".foo { direction: var(--d); direction: rtl }", ".foo{direction:var(--d);direction:rtl}");
+    minify_test(".foo { unicode-bidi: embed; unicode-bidi: var(--u) }", ".foo{unicode-bidi:embed;unicode-bidi:var(--u)}");
+    minify_test(".foo { direction: ltr; color: red; direction: rtl }", ".foo{color:red;direction:rtl}");
+    minify_test(".foo { unicode-bidi: Bidi-Override }", ".foo{unicode-bidi:bidi-override}");
+    minify_test(".foo { unicode-bidi: isolate-override; unicode-bidi: plaintext }", ".foo{unicode-bidi:plaintext}");
+    // Logical properties compiled for old targets are dropped with the rest.
+    prefix_test(
+      ".foo { margin-inline-start: 1px; all: unset }",
+      indoc`
+        .foo {
+          all: unset;
+        }
+      `,
+      { safari: 8 << 16 },
+    );
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(


### PR DESCRIPTION
### Problem
- The CSS minifier hoists `all` above the declarations before it. `.a { font: 12px serif; all: initial }` prints as `.a { all: initial; font: 12px serif }`, so `font` is no longer reset. The same holds for margin, border, background and every other buffered shorthand, with and without `--minify`.
- `all` is missing from the property name table in `src/css/properties/properties_generated.rs`, so it parses as an unknown property. `DeclarationHandler::handle_property` (`src/css/declaration.rs`) pushes it at once, while the handlers flush what they buffer later, in `finalize()`.

### Fix
- Parse `all` as `Property::All`. A non-keyword value falls back to `Unparsed`. `Property::eql` now compares the keyword.
- Port `handle_all` from lightningcss. On `all`, replace the handler with a fresh one. This drops every buffered value and every declaration emitted so far in the block, except custom properties, `direction` and `unicode-bidi`. Like upstream, `direction` and the new `unicode-bidi` property are written once at the end of the block. An unparsed `all` resets the block only when it uses `var()`/`env()`. Any other value is invalid, so it stays in place and resets nothing.
- Unlike upstream, an unparsed `direction`, `unicode-bidi` or `all` keeps its cascade position, and custom properties are not deduplicated (see Notes).
- Self-reviewed: 4 concerns raised, 2 addressed by dropping the custom property dedup, 2 left for later with reasons in Notes.
- Verified: `test/js/bun/css/css.test.ts` (25 of the 43 new cases fail on bun 1.4.2), the rest of `test/js/bun/css/`, `test/bundler/css/` and `test/bundler/esbuild/css.test.ts`.

### Background
- `DeclarationBlock::minify` feeds each declaration to `DeclarationHandler`. One sub-handler per shorthand group buffers its longhands and emits the shortest form in `finalize()`, after the declarations no handler claimed.
- `all: <keyword>` sets every property except `direction`, `unicode-bidi` and custom properties ([css-cascade-5](https://drafts.csswg.org/css-cascade-5/#all-shorthand)), so only declarations after it in a block still apply.
- lightningcss added `unicode-bidi` with its `all` handling (parcel-bundler/lightningcss@d7aeff3). Bun had ported the unused `direction` field only.

<details><summary>Notes</summary>

Repro on bun 1.4.3:

```sh
printf '.a { font: 12px serif; all: initial }\n.b { margin: 0; all: unset; color: red }' > all.css
bun build all.css            # .a { all: initial; font: 12px serif } .b { all: unset; color: red; margin: 0 }
bun build --minify all.css   # .a{all:initial;font:12px serif}.b{all:unset;color:red;margin:0}
```

With this change: `.a{all:initial}.b{all:unset;color:red}`.

The upstream tests from `test_all()` in lightningcss `src/lib.rs` are ported verbatim and pass with the same expected output.

`Property::eql` returned `true` for any two `All` values. That was harmless while `Property::All` was only the moved-out-slot placeholder in `DeclarationBlock::minify`. Once `all` parses to `Property::All` it would merge `.a { all: initial } .b { all: unset }` into one rule, so it now compares the keyword.

Output changes beyond `all`:
- `direction` and `unicode-bidi` move to the end of their block and a repeated one is deduplicated (`direction: ltr; color: red; direction: rtl` becomes `color: red; direction: rtl`), as in lightningcss. A typed value seen before an unparsed one (`direction: rtl; direction: var(--d)`) is flushed first so the order is kept.
- `unicode-bidi` keywords are normalized to lower case like other keyword properties.
- `transition: ALL 1s` prints `all` in lower case, since `all` is now a known property id. `transition: 1s` already defaulted to `PropertyId::All`, so the explicit and the implicit form now compare equal.

Review concerns left out of this change, on purpose:
- Upstream carries custom properties across `all` through a name-to-index map that also collapses a repeated custom property to its last value at its first position. A first version of this change ported that too. It interacts badly with two things in Bun today: the `--buncss-*` vars that `ColorSchemeHandler` re-emits when a merged block is re-minified (#38512), and the name-blind custom property comparison in `StyleRule::is_duplicate` (#33684). Both made a later declaration lose. So `reset_for_all` walks the emitted declarations instead, and custom properties are left as written, as on 1.4.3.
- Rules already staged in `PropertyHandlerContext` before `all` (an `@supports` color fallback for an unparsed `color`, `:lang()` rules from a flushed logical border group) still come out. lightningcss behaves the same. Unstaging them per importance band needs the band tracking from #38597 first.
- A source lint that checks the name table in `from_name_and_prefix` against `PropertyIdTag::name()` would have caught the missing `all` entry. Not added here.
- Upstream also adds `@supports` color fallbacks for custom property values. Bun does not generate those today and this change does not add them.

`!important` declarations go through a separate handler, so `color: red !important; all: unset` keeps both, as the cascade requires.

`cargo clippy -p bun_css` and `cargo fmt --check` are clean.
</details>
