### PR TITLE
bun test --isolate: do not run a finished file's socket handlers at the swap

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5108,15 +5108,26 @@ impl VirtualMachine {
         Ok(())
     }
 
+    /// The finished file's exit under `--isolate`. From here on JSC discards
+    /// microtasks queued against its realm and native code does not call its
+    /// functions, so neither the teardown that follows (stopping its servers,
+    /// closing its sockets, killing its children) nor work it left in flight
+    /// runs its script again. Runs before `stop_active_handles_for_test_isolation`.
+    pub fn retire_global_for_test_isolation(&mut self) {
+        debug_assert!(self.test_isolation_enabled);
+        Zig__GlobalObject__retireForTestIsolation(self.global());
+    }
+
     /// Replaces the global object between test files so each file runs in a fresh realm.
     ///
     /// Callers must run `bun_runtime::jsc_hooks::stop_active_handles_for_test_isolation(vm)`
     /// first so leaked watchers/servers are stopped (dropping their JS-side
     /// Strongs, which otherwise pin the outgoing global) before the blind
     /// socket-group close below. That helper lives in the higher-tier crate
-    /// and cannot be called from here.
+    /// and cannot be called from here. It also retires the outgoing global.
     pub fn swap_global_for_test_isolation(&mut self) {
         debug_assert!(self.test_isolation_enabled);
+        debug_assert!(self.global().to_js_value().is_from_retired_test_isolation_realm());
 
         // The finished file's workers, ports, channels and sockets are stopped
         // first (no events dispatched), before its socket groups and timers are
@@ -5178,9 +5189,8 @@ impl VirtualMachine {
         let _ = self.auto_killer.kill();
         self.auto_killer.clear();
 
-        // The outgoing file's exit: work it left in flight (thread-pool jobs,
-        // the children just killed) lands later and must not resume its script.
-        Zig__GlobalObject__retireForTestIsolation(self.global());
+        // Thread-pool jobs the outgoing file left in flight compare against
+        // this when they land (`Job::complete_erased`) and are released unrun.
         self.test_isolation_generation = self.test_isolation_generation.wrapping_add(1);
 
         // Generation-stale JS timers would otherwise release their pins only

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5127,7 +5127,11 @@ impl VirtualMachine {
     /// and cannot be called from here. It also retires the outgoing global.
     pub fn swap_global_for_test_isolation(&mut self) {
         debug_assert!(self.test_isolation_enabled);
-        debug_assert!(self.global().to_js_value().is_from_retired_test_isolation_realm());
+        debug_assert!(
+            self.global()
+                .to_js_value()
+                .is_from_retired_test_isolation_realm()
+        );
 
         // The finished file's workers, ports, channels and sockets are stopped
         // first (no events dispatched), before its socket groups and timers are

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -255,6 +255,9 @@ public:
     // Stopping: the stop has been requested (any thread; `!scriptAllowed()`). Stopped: it has been carried out on
     // this thread and JSC forbids execution. Either way no script may be entered on this VM.
     ALWAYS_INLINE bool isStoppingOrStopped(const JSC::VM& vm) const { return !scriptAllowed() || vm.executionForbidden(); }
+    // `bun test --isolate` has retired a finished file's realm on this VM (Zig__GlobalObject__retireForTestIsolation).
+    // Only then does the native→JS boundary (Bun__JSValue__call) look at the callee's realm.
+    bool hasRetiredTestIsolationRealm { false };
     Bun::JSCTaskScheduler deferredWorkTimer;
 
     // One slot per string of the executable's module-info string table,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4381,17 +4381,17 @@ extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::Glo
 }
 
 // `bun test --isolate`: JSC drops microtasks queued against the finished file's realm from here on
-// (as WebCore does for a stopped document), so work it left in flight cannot resume its script.
+// (as WebCore does for a stopped document) and Bun__JSValue__call no longer enters its functions,
+// so neither the swap's teardown nor work the file left in flight can resume its script.
 extern "C" void Zig__GlobalObject__retireForTestIsolation(Zig::GlobalObject* globalObject)
 {
     globalObject->setMicrotaskRunnability(JSC::QueuedTaskResult::Discard);
+    WebCore::clientData(globalObject->vm())->hasRetiredTestIsolationRealm = true;
 }
 
-// Whether `value` is an object of a realm retired above; native code does not call into one.
 extern "C" bool Bun__JSValue__isFromRetiredTestIsolationRealm(JSC::EncodedJSValue encodedValue)
 {
-    JSC::JSObject* object = JSC::JSValue::decode(encodedValue).getObject();
-    return object && object->globalObject()->microtaskRunnability() == JSC::QueuedTaskResult::Discard;
+    return Bun::isFromRetiredTestIsolationRealm(JSC::JSValue::decode(encodedValue));
 }
 
 extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObject)

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -855,6 +855,15 @@ namespace Bun {
 
 void putDirectNamed(JSC::VM&, JSC::JSObject*, ASCIILiteral name, JSC::JSValue);
 
+// `value` is an object of a realm that `bun test --isolate` retired (its file finished).
+// `Zig__GlobalObject__retireForTestIsolation` is what marks one, by the same
+// `microtaskRunnability` JSC reads to drop that realm's microtasks.
+ALWAYS_INLINE bool isFromRetiredTestIsolationRealm(JSC::JSValue value)
+{
+    JSC::JSObject* object = value.getObject();
+    return object && object->globalObject()->microtaskRunnability() == JSC::QueuedTaskResult::Discard;
+}
+
 ALWAYS_INLINE void* vm(Zig::GlobalObject* globalObject)
 {
     return globalObject->bunVM();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3279,7 +3279,8 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
     // WebCore: JSEventListener's isJSExecutionForbidden): once the VM's stop was requested or
     // teardown has forbidden script, a callback from any event source is a silent no-op rather
     // than each source checking.
-    if (WebCore::clientData(vm)->isStoppingOrStopped(vm)) [[unlikely]] {
+    auto* clientData = WebCore::clientData(vm);
+    if (clientData->isStoppingOrStopped(vm)) [[unlikely]] {
         RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsUndefined());
     }
@@ -3289,10 +3290,21 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
 
     JSC::JSValue jsThisObject = JSValue::decode(thisObject);
 
+    auto* wrapper = dynamicDowncast<AsyncContextFrame>(jsObject);
+    if (wrapper)
+        jsObject = wrapper->callback.get();
+
+    // Likewise a function of a file that `bun test --isolate` has finished with: the per-file swap
+    // was that file's exit (Zig__GlobalObject__retireForTestIsolation), so the handlers of the
+    // sockets and servers it left open do not run when the swap, or anything later, closes them.
+    if (clientData->hasRetiredTestIsolationRealm && Bun::isFromRetiredTestIsolationRealm(jsObject)) [[unlikely]] {
+        RETURN_IF_EXCEPTION(scope, {});
+        return JSValue::encode(jsUndefined());
+    }
+
     JSValue restoreAsyncContext;
     InternalFieldTuple* asyncContextData = nullptr;
-    if (auto* wrapper = dynamicDowncast<AsyncContextFrame>(jsObject)) {
-        jsObject = wrapper->callback.get();
+    if (wrapper) {
         asyncContextData = globalObject->m_asyncContextData.get();
         restoreAsyncContext = asyncContextData->getInternalField(0);
         asyncContextData->putInternalField(vm, 0, wrapper->context.get());

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1710,12 +1710,15 @@ fn stop_dns_for_vm_teardown() -> SweepResult {
     result
 }
 
-/// `--isolate` swap: a microtask still pending at end-of-file (queued by
-/// `tick_immediate_tasks` or `handle_rejected_promises`) can register new
-/// handles when it runs, so drain first so they land in the registry before it
-/// empties, then stop. (VM teardown must *not* drain here — its
-/// prepareForDestruction discards the pre-exit queues.)
+/// `--isolate` swap: the file has exited, so retire its global before anything
+/// is stopped. The drain then discards the microtasks still pending at
+/// end-of-file (queued by `tick_immediate_tasks` or `handle_rejected_promises`)
+/// instead of running them, and the close/error handlers of the servers and
+/// sockets stopped below and in `swap_global_for_test_isolation` do not run.
+/// (VM teardown must *not* drain here — its prepareForDestruction discards the
+/// pre-exit queues.)
 pub(crate) fn stop_active_handles_for_test_isolation(vm: &mut VirtualMachine) {
+    vm.retire_global_for_test_isolation();
     let _ = vm.event_loop_mut().drain_microtasks();
     let _ = stop_active_handles(vm, StopReason::TestIsolation);
 }

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1169,6 +1169,74 @@ describe.concurrent("--isolate: a finished file's late completions do not run in
   });
 });
 
+// The swap itself closes what the finished file left open: its listeners and
+// servers, then every socket. That used to call the file's close and error
+// handlers after the file had exited. What they did escaped the run (a throw
+// printed `error:` under the next file's header with exit code 0, a node:http
+// request in flight printed `socket hang up`), and what they created was the
+// next file's problem. The finished file's functions are not entered anymore.
+describe.concurrent("--isolate: a finished file's socket handlers do not run at the swap", () => {
+  const socketFixtures = {
+    "a-sockets.test.ts": `
+      import { test, expect } from "bun:test";
+      import { appendFileSync } from "node:fs";
+      import http from "node:http";
+      import { join } from "node:path";
+
+      const log = join(import.meta.dir, "handlers-ran");
+
+      test("leaves a connected socket pair whose close handlers throw", async () => {
+        const server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: {
+          data() {},
+          close() { appendFileSync(log, "listen close\\n"); throw new Error("server close handler threw"); },
+        }});
+        const { promise: opened, resolve } = Promise.withResolvers<void>();
+        await Bun.connect({ hostname: "127.0.0.1", port: server.port, socket: {
+          data() {},
+          open() { resolve(); },
+          close() { appendFileSync(log, "connect close\\n"); throw new Error("client close handler threw"); },
+        }});
+        await opened;
+        expect(server.port).toBeGreaterThan(0);
+      });
+
+      test("leaves a node:http request in flight with no error listener", async () => {
+        const { promise: received, resolve } = Promise.withResolvers<void>();
+        const server = http.createServer(() => resolve()); // never responds
+        await new Promise<void>(done => server.listen(0, "127.0.0.1", () => done()));
+        http.get("http://127.0.0.1:" + (server.address() as any).port);
+        await received;
+        expect(server.listening).toBe(true);
+      });
+    `,
+    "b-check.test.ts": `
+      import { test, expect } from "bun:test";
+      import { existsSync } from "node:fs";
+      import { join } from "node:path";
+
+      test("the previous file's close handlers did not run", () => {
+        expect(existsSync(join(import.meta.dir, "handlers-ran"))).toBe(false);
+      });
+    `,
+  };
+  const files = ["./a-sockets.test.ts", "./b-check.test.ts"];
+
+  test.each([
+    ["--isolate", ["--isolate"], {}],
+    // One worker takes both files (scale-up gated), so the same swap runs
+    // between files inside a --parallel worker.
+    ["--parallel", ["--parallel=2"], { BUN_TEST_PARALLEL_SCALE_MS: "60000" }],
+  ])("%s", async (_, args, env) => {
+    using dir = tempDir("isolate-swap-handlers", socketFixtures);
+    const { stderr, exitCode } = await runTests(String(dir), args, files, { ...bunEnv, ...env });
+    expect(stderr).not.toContain("close handler threw");
+    expect(stderr).not.toContain("socket hang up");
+    expect(normalizeBunSnapshot(stderr, dir)).toContain("3 pass");
+    expect(normalizeBunSnapshot(stderr, dir)).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+});
+
 // Each of these leaked handles used to pin its test file's ENTIRE global
 // object (and therefore the file's module graph) for the rest of a
 // `bun test --isolate` run, growing memory by one full global per file:


### PR DESCRIPTION
### Problem
- The `bun test --isolate` swap closes what the finished file left open: its listeners and servers, then every socket in the loop. That called the file's own close and error handlers after the file had exited.
- A handler that throws then printed `error:` under the next file's header, and the run still exited 0. A `node:http` request in flight printed `socket hang up`. A handler that creates something handed it to the next file.
- #41831 retires the realm after that teardown, so its fence covered microtasks and thread-pool completions, not these direct calls into the finished file.

### Fix
- Retire the realm first, at the top of `stop_active_handles_for_test_isolation`, before anything is stopped. The microtask drain that follows discards the file's pending reactions instead of running them.
- `Bun__JSValue__call` treats a callee of a retired realm the way it already treats a stopping VM: a silent no-op. It is the one native to JS boundary for the Rust side, so every event source is covered at once.
- The cost is one bool load per call, on a flag set only once `--isolate` has retired a realm. Without `--isolate` nothing changes.
- Verified: `test/cli/test/isolation.test.ts` (2 new cases fail on main, pass with the fix) and its 35 existing cases, including #41831's. Also `parallel.test.ts`, the `bun:test` suites, `node-http.test.ts` and `vm.test.ts`.

### Background
- `--isolate` runs each test file in a fresh `Zig::GlobalObject` on one `JSC::VM`. The swap between files is that file's exit.
- The old global lives while anything references it, so native code can still reach its functions: a socket keeps its handler object, a pending request its listeners.
- `Zig__GlobalObject__retireForTestIsolation` marks a realm by setting JSC's `microtaskRunnability` to `Discard`. The same bit identifies a retired realm here.

<details><summary>Notes</summary>

- Found while investigating a fuzz ledger report (#31051) that `--isolate` and `--parallel` exit 0 on a run where test code threw. #41831 covers the thread-pool half of that report. These are the calls its fence does not see, because they do not go through a microtask or `run_callback`.
- Repro before this change: file A calls `Bun.listen` plus `Bun.connect` with `close()` handlers that throw, file B does nothing. `bun test --isolate a.test.ts b.test.ts` prints both throws under `b.test.ts` with `2 pass 0 fail` and exit code 0. The same with `--parallel=2` on one worker. With a `node:http` request in flight instead, it prints `error: socket hang up (ECONNRESET)`.
- This also removes that noise from Bun's own suite: `bun test --isolate test/js/node/http/node-http.test.ts <any other file>` printed `socket hang up` on main.
- The retire now happens before `stop_active_handles_for_test_isolation`'s drain, so a microtask pending exactly at the file boundary is discarded rather than run. That matches the fence: the file has exited, and the only such microtasks are ones it leaked.
- Not covered: a `node:vm` context or a `ShadowRealm` that the finished file created is a separate global, which nothing retires. A handler of one still runs at the swap. Same gap as #41831.
- Also not changed: a throw that does reach the runner with no file active (from such a context) is printed but not counted, so it does not fail the run. That accounting is a separate fix, and with this change the swap no longer produces those errors itself.
- `parallel.test.ts` "each worker has a unique JEST_WORKER_ID" is timing-flaky on this container's debug ASAN build with and without the change. The `serve.test.ts` root-port and `bun:info` cases fail on main here too (the container runs as root).

</details>
