### PR TITLE
bun:test fake timers: never move the fake clock backwards

### DIFF
--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use bun_threading::RwLock;
 
-use bun_core::Environment;
 use bun_core::Timespec;
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
 use crate::api::cron::CronJob;
@@ -253,17 +252,21 @@ impl FakeTimers {
         let _vm = global.bun_vm();
 
         // SAFETY: `next` was just popped from our heap; live until callback completes.
-        let now_el = unsafe { (*next).next };
-        let now = from_el_timespec(&now_el);
-        if Environment::CI_ASSERT {
-            let prev = CURRENT_TIME.get_timespec_now();
-            debug_assert!(prev.is_some());
-            debug_assert!(now.eql(&prev.unwrap()) || now.greater(&prev.unwrap()));
-        }
+        let deadline = from_el_timespec(unsafe { &(*next).next });
+        let current = CURRENT_TIME.get_timespec_now();
+        debug_assert!(current.is_some());
+        // A `jest` timer-control call made from inside an earlier callback of
+        // this drain can already have moved the clock past `deadline`. The
+        // timer then fires late, at the current time, like an overdue real
+        // timer: the fake clock never runs backwards.
+        let now = match current {
+            Some(current) if current.greater(&deadline) => current,
+            _ => deadline,
+        };
         CURRENT_TIME.set(global, &now, None);
         // SAFETY: `next` is live; `fire` takes `*mut Self` (noalias re-entrancy)
         // and an erased `*mut ()` for the VM.
-        let fired = unsafe { EventLoopTimer::fire(next, &now_el, bun_jsc::virtual_machine::VirtualMachine::get_mut_ptr().cast()) };
+        let fired = unsafe { EventLoopTimer::fire(next, &now, bun_jsc::virtual_machine::VirtualMachine::get_mut_ptr().cast()) };
         match fired {
             Ok(()) => Ok(()),
             Err(err) => bun_jsc::task::report_error_or_terminate(global, err)
@@ -445,7 +448,14 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     let target = current.add_ms_float(effective_advance);
 
     let advanced = FakeTimers::execute_until(global, target);
-    CURRENT_TIME.set(global, &target, None);
+    // A callback fired by the drain can itself have advanced the clock past
+    // `target`, or called `useRealTimers()`: never move the clock backwards.
+    if CURRENT_TIME
+        .get_timespec_now()
+        .is_some_and(|now| !now.greater(&target))
+    {
+        CURRENT_TIME.set(global, &target, None);
+    }
     advanced?;
 
     Ok(frame.this())

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -212,6 +212,105 @@ describe("clearAllTimers", () => {
     expect(() => vi.clearAllTimers()).toThrow("Fake timers are not active");
   });
 });
+describe("timer controls called from inside a timer callback", () => {
+  // A nested call can move the fake clock past timers that the outer call still
+  // has to fire. Those fire late, at the current time: the clock never runs
+  // backwards.
+  const T0 = 1_000_000;
+
+  test("advanceTimersByTime() in a setInterval callback during runAllTimers()", () => {
+    vi.useFakeTimers({ now: T0 });
+    const seen: [string, number, number][] = [];
+    let n = 0;
+    const interval = setInterval(() => {
+      n++;
+      seen.push(["interval " + n, Date.now() - T0, performance.now()]);
+      // An interval is not pending while its own callback runs, so this fires
+      // nothing and only moves the clock.
+      if (n == 1) vi.advanceTimersByTime(50);
+      if (n == 3) clearInterval(interval);
+    }, 10);
+    vi.runAllTimers();
+    // Tick 2 was due at 20, after tick 1 had moved the clock to 60.
+    expect(seen).toEqual([
+      ["interval 1", 10, 10],
+      ["interval 2", 60, 60],
+      ["interval 3", 70, 70],
+    ]);
+    expect(Date.now() - T0).toBe(70);
+    expect(performance.now()).toBe(70);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("runOnlyPendingTimers() in a setInterval callback during advanceTimersByTime()", () => {
+    vi.useFakeTimers({ now: T0 });
+    const seen: [string, number, number][] = [];
+    let n = 0;
+    const interval = setInterval(() => {
+      n++;
+      seen.push(["interval " + n, Date.now() - T0, performance.now()]);
+      if (n == 4) clearInterval(interval);
+      vi.runOnlyPendingTimers();
+    }, 1);
+    setTimeout(() => seen.push(["timeout", Date.now() - T0, performance.now()]), 10);
+    vi.advanceTimersByTime(10);
+    // Tick 1's runOnlyPendingTimers() fires the 10 ms timeout. Tick 2 was due
+    // at 2, so it fires late at 10 and reschedules for 11, past this advance.
+    expect(seen).toEqual([
+      ["interval 1", 1, 1],
+      ["timeout", 10, 10],
+      ["interval 2", 10, 10],
+    ]);
+    expect(Date.now() - T0).toBe(10);
+    expect(performance.now()).toBe(10);
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(1);
+    expect(seen.slice(3)).toEqual([["interval 3", 11, 11]]);
+    clearInterval(interval);
+  });
+
+  test.each([
+    ["advanceTimersByTime", 105],
+    ["advanceTimersToNextTimer", 50],
+    ["runOnlyPendingTimers", 50],
+    ["runAllTimers", 50],
+  ] as const)("%s() in a setTimeout callback during advanceTimersByTime()", (method, end) => {
+    vi.useFakeTimers({ now: T0 });
+    const seen: [string, number, number][] = [];
+    setTimeout(() => {
+      seen.push(["a", Date.now() - T0, performance.now()]);
+      if (method == "advanceTimersByTime") vi.advanceTimersByTime(100);
+      else vi[method]();
+      seen.push(["a after", Date.now() - T0, performance.now()]);
+    }, 5);
+    setTimeout(() => seen.push(["b", Date.now() - T0, performance.now()]), 50);
+    vi.advanceTimersByTime(10);
+    seen.push(["end", Date.now() - T0, performance.now()]);
+    // The nested call left the clock past the 10 ms mark this call advances
+    // to, so the clock stays where it is.
+    expect(seen).toEqual([
+      ["a", 5, 5],
+      ["b", 50, 50],
+      ["a after", end, end],
+      ["end", end, end],
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("useRealTimers() in a setTimeout callback during advanceTimersByTime()", () => {
+    const realDate = Date.now();
+    const realUptime = performance.now();
+    vi.useFakeTimers({ now: T0 });
+    setTimeout(() => vi.useRealTimers(), 5);
+    vi.advanceTimersByTime(2 ** 31);
+    expect(vi.isFakeTimers()).toBe(false);
+    // The end of advanceTimersByTime() must not pin the clock to the fake
+    // 2^31 ms mark: useRealTimers() already put the real clock back.
+    expect(Date.now()).toBeGreaterThanOrEqual(realDate);
+    expect(performance.now()).toBeGreaterThanOrEqual(realUptime);
+    expect(performance.now()).toBeLessThan(2 ** 31);
+  });
+});
 describe("AbortSignal.timeout", () => {
   const N = 500;
 


### PR DESCRIPTION
### Problem
- A timer callback that calls a `jest` timer control (reported: `jest.runOnlyPendingTimers()` in a `setInterval` callback during `jest.advanceTimersByTime(10)`) can move the fake clock past timers the outer drain still has to fire. Debug builds abort with `assertion failed: now.eql(&prev.unwrap()) || now.greater(&prev.unwrap())` in `FakeTimers::fire`. Release builds let `Date.now()` read 1, 10, 2, 3, 4 inside one advance.
- `FakeTimers::fire` (`src/runtime/test_runner/timers/FakeTimers.rs:252`) set the clock to each popped timer's deadline. `advance_timers_by_time` (`:448`) then set it to its own target. That also rewound a nested `advanceTimersByTime(100)` (105 back to 10) and re-pinned a fake `Date.now()` after a callback's `useRealTimers()`.

### Fix
- `fire()` fires a popped timer at `max(deadline, current time)`, like an overdue real timer. `advanceTimersByTime()` sets the clock to its target only when the clock is not past it and fake timers are still installed.
- Correct because the clock only moves forward and every timer due by the target still fires, in heap order. Jest 29 never rewinds either. Two unrelated differences from Jest stay, so the tests pin Bun's values (see Notes).
- Verified: `test/js/bun/test/fake-timers/fake-timers.test.ts` (7 new cases, all fail on 1.4.3). Also the rest of that directory, the cron, jsonwebtoken, `test-timers` and `--isolate` suites.
- Self-reviewed: 1 concern raised, 1 addressed (an advance that ends exactly on its target still re-syncs the clock, as before).

### Background
- The `jest` timer controls pop due timers from the fake heap and run them synchronously through `fire()`, which first sets the fake clock. `Date.now()`, `performance.now()` and new timer deadlines read that clock.
- A `setInterval` is out of the heap while its callback runs and goes back in afterwards, as in Node. A nested control cannot see it, and its next deadline can already be behind the clock.

<details><summary>Notes</summary>

Jest 29.7 (`@sinonjs/fake-timers`) on the shapes of the new tests, `T0 = useFakeTimers({ now })`:

| shape | Bun before | Bun after | Jest 29 |
|---|---|---|---|
| `setInterval(10)` whose first tick calls `advanceTimersByTime(50)`, cleared on tick 3, outer `runAllTimers()` | iv@10, iv@20, iv@30, clock 10, 60, 20, 30 (debug: abort) | iv@10, iv@60 (late), iv@70, ends at 70 | iv@10, then iv@20 and iv@30 nested inside tick 1, ends at 60 |
| `setInterval(1)` whose callback calls `runOnlyPendingTimers()`, plus `setTimeout(10)`, outer `advanceTimersByTime(10)` | iv@1, to@10, iv@2, iv@3, iv@4, ends at 10 (debug: abort) | iv@1, to@10, iv@10 (late), ends at 10, interval pending at 11 | iv@1, iv@2, iv@3, iv@4 (each nested one level deeper), to@10, ends at 40 |
| `setTimeout(5)` whose callback calls `advanceTimersByTime(100)`, plus `setTimeout(50)`, outer `advanceTimersByTime(10)` | a@5, b@50, a-after@105, ends at 10 | a@5, b@50, a-after@105, ends at 105 | a@5, b@50, a-after@105, ends at 110 |
| same, nested `runOnlyPendingTimers()` / `runAllTimers()` / `advanceTimersToNextTimer()` | a-after@50, ends at 10 | a-after@50, ends at 50 | a-after@50, ends at 55 |
| `setTimeout(5)` whose callback calls `useRealTimers()`, outer `advanceTimersByTime(2 ** 31)` | `Date.now()` is `T0 + 2^31` and `performance.now()` is `2^31` afterwards, `isFakeTimers()` false | both real | both real (Jest also still fires the old clock's remaining timers; Bun's `useRealTimers()` drops them, unchanged here) |

The two remaining differences from Jest:
- sinon's `doTick` shifts `tickTo` by however much `clock.now` moved during a callback. That exists to compensate for `setSystemTime()` inside a callback (sinon keys timers on the system time, Bun keys them on a separate monotonic clock and already handles that case by rebasing the `Date.now()` offset). A nested tick trips the same compensation, so the outer call keeps spending its remaining budget after the nested jump (110 instead of 105, and 40 in the interval case where every nesting level compensates). Jest's legacy timers do the same through `msToRun`.
- sinon reschedules an interval (`callAt += interval`) before it runs the callback, so a nested control sees the interval and fires it again, re-entering the callback recursively. Bun, like Node, keeps the interval out of the heap during its callback and re-inserts it afterwards.

Neither is about the clock running backwards. Matching either is a separate decision.

#38740 (per-VM fake clock) keeps the monotonicity assert in `fire()` and does not cover re-entrant controls. It also stops `advanceTimersByTime()` from re-pinning the clock after `useRealTimers()`, which the second hunk here does as well; the two will need a small textual merge.

`test/js/web/timers/setTimeout.test.js` / `setInterval.test.js` leak cases fail locally under the debug ASAN build with and without this change (RSS threshold); they do not use fake timers.
</details>
