### PR TITLE
bundler: define __promiseAll when an unwrapped file awaits two async ESM wrappers

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -3538,29 +3538,6 @@ impl<'a> LinkerContext<'a> {
                 // This depends on the "__esm" symbol and declares the "init_foo" symbol
                 // for similar reasons to the CommonJS closure above.
 
-                // Count async dependencies to determine if we need __promiseAll
-                let mut async_import_count: usize = 0;
-                {
-                    let import_records =
-                        self.graph.ast.items_import_records()[source_index as usize].as_slice();
-                    let meta_flags = self.graph.meta.items_flags();
-
-                    for record in import_records {
-                        if !record.source_index.is_valid() {
-                            continue;
-                        }
-                        let other_flags = meta_flags[record.source_index.get() as usize];
-                        if other_flags.is_async_or_has_async_dependency {
-                            async_import_count += 1;
-                            if async_import_count >= 2 {
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                let needs_promise_all = async_import_count >= 2;
-
                 let esm_parts: &[u32] = if wrapper_ref.is_valid()
                     && self.options.output_format != Format::InternalBakeDev
                 {
@@ -3569,25 +3546,9 @@ impl<'a> LinkerContext<'a> {
                     &[]
                 };
 
-                let promise_all_parts: &[u32] = if needs_promise_all
-                    && wrapper_ref.is_valid()
-                    && self.options.output_format != Format::InternalBakeDev
-                {
-                    self.top_level_symbols_to_parts_for_runtime(self.promise_all_runtime_ref)
-                } else {
-                    &[]
-                };
-
-                // generate a dummy part that depends on the "__esm" and optionally "__promiseAll" symbols
-                let mut dependencies =
-                    DependencyList::init_capacity(esm_parts.len() + promise_all_parts.len());
+                // generate a dummy part that depends on the "__esm" symbol
+                let mut dependencies = DependencyList::init_capacity(esm_parts.len());
                 for &part in esm_parts {
-                    dependencies.append_assume_capacity(Dependency {
-                        part_index: part,
-                        source_index: bun_ast::Index::RUNTIME,
-                    });
-                }
-                for &part in promise_all_parts {
                     dependencies.append_assume_capacity(Dependency {
                         part_index: part,
                         source_index: bun_ast::Index::RUNTIME,
@@ -3626,19 +3587,6 @@ impl<'a> LinkerContext<'a> {
                             crate::Index::RUNTIME,
                         )
                         .expect("OOM");
-
-                    // Only mark __promiseAll as used if we have multiple async dependencies
-                    if needs_promise_all {
-                        self.graph
-                            .generate_symbol_import_and_use(
-                                source_index,
-                                part_index,
-                                self.promise_all_runtime_ref,
-                                1,
-                                crate::Index::RUNTIME,
-                            )
-                            .expect("OOM");
-                    }
                 }
             }
             WrapKind::None => {}

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1068,8 +1068,7 @@ pub(crate) fn scan_imports_and_exports(
             );
 
             let parts_len = col_ref!(parts_list)[id].len() as usize;
-            // Counted across the whole file: `InsideWrapperPrefix::append_async_dependency`
-            // joins every `await init_x()` after the first into one `await __promiseAll([...])`.
+            // Per file, not per part: see `InsideWrapperPrefix::append_async_dependency`.
             let mut async_esm_init_count: u32 = 0;
             for part_index in 0..parts_len {
                 let mut to_esm_uses: u32 = 0;

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -1068,11 +1068,15 @@ pub(crate) fn scan_imports_and_exports(
             );
 
             let parts_len = col_ref!(parts_list)[id].len() as usize;
+            // Counted across the whole file: `InsideWrapperPrefix::append_async_dependency`
+            // joins every `await init_x()` after the first into one `await __promiseAll([...])`.
+            let mut async_esm_init_count: u32 = 0;
             for part_index in 0..parts_len {
                 let mut to_esm_uses: u32 = 0;
                 let mut to_common_js_uses: u32 = 0;
                 let mut runtime_require_uses: u32 = 0;
                 let mut preload_uses: u32 = 0;
+                let mut promise_all_uses: u32 = 0;
 
                 // Imports of wrapped files must depend on the wrapper
                 // Iterate by index so each iteration re-borrows
@@ -1205,6 +1209,16 @@ pub(crate) fn scan_imports_and_exports(
                                 1,
                                 Index::source(other_source_index),
                             )?;
+
+                            if kind == ImportKind::Stmt
+                                && other_flags.wrap == WrapKind::Esm
+                                && other_flags.is_async_or_has_async_dependency
+                            {
+                                async_esm_init_count += 1;
+                                if async_esm_init_count >= 2 {
+                                    promise_all_uses = 1;
+                                }
+                            }
                         }
 
                         // This is an ES6 import of a CommonJS module, so it needs the
@@ -1405,6 +1419,13 @@ pub(crate) fn scan_imports_and_exports(
                         Index::part(part_index as u32),
                         b"__preload",
                         preload_uses,
+                    )?;
+
+                    this.graph.generate_runtime_symbol_import_and_use(
+                        source_index,
+                        Index::part(part_index as u32),
+                        b"__promiseAll",
+                        promise_all_uses,
                     )?;
                 }
             }

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -451,9 +451,7 @@ describe("bundler", () => {
     },
     onAfterBundle(api) {
       const bundled = api.readFile("out.js");
-      expect(bundled).toMatch(
-        /await\s+__promiseAll\s*\(\s*\[\s*init_a\(\),\s*init_b\(\),\s*init_c\(\)\s*\]\s*\)/,
-      );
+      expect(bundled).toMatch(/await\s+__promiseAll\s*\(\s*\[\s*init_a\(\),\s*init_b\(\),\s*init_c\(\)\s*\]\s*\)/);
       expect(bundled).toContain("var __promiseAll = ");
     },
   });
@@ -504,8 +502,8 @@ describe("bundler", () => {
   });
 
   // Only `import` statements join the `await __promiseAll([...])`. An `import()`
-  // of a second async module prints its own `init_c().then(...)` and does not
-  // need the helper.
+  // of a second async module calls `init_c()` where the expression is and does
+  // not need the helper.
   itBundled("bundler/__promiseAll is tree-shaken when a wrapper's second async dependency is an import()", {
     files: {
       "/entry.js": `

--- a/test/bundler/bundler_promiseall_deadcode.test.ts
+++ b/test/bundler/bundler_promiseall_deadcode.test.ts
@@ -397,4 +397,138 @@ describe("bundler", () => {
       expect(bundled).not.toMatch(/await\s+__promiseAll\s*\(/);
     },
   });
+
+  // The importer below is not wrapped (nothing `import()`s or `require()`s it),
+  // so its `await __promiseAll([...])` is printed at the top level of the chunk.
+  // The `import()` calls are what make p.js and q.js lazily wrapped (`init_p`,
+  // `init_q`), and their top-level await makes those wrappers async.
+  itBundled("bundler/__promiseAll is defined when an unwrapped entry awaits two async ESM wrappers", {
+    files: {
+      "/entry.js": `
+        import "./p.js";
+        import "./q.js";
+        import("./p.js");
+        import("./q.js");
+        console.log("entry");
+      `,
+      "/p.js": `
+        await Promise.resolve();
+        console.log("p");
+        export const p = 1;
+      `,
+      "/q.js": `
+        await Promise.resolve();
+        console.log("q");
+        export const q = 1;
+      `,
+    },
+    run: {
+      stdout: "p\nq\nentry",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/await\s+__promiseAll\s*\(\s*\[\s*init_p\(\),\s*init_q\(\)\s*\]\s*\)/);
+      expect(bundled).toContain("var __promiseAll = ");
+    },
+  });
+
+  itBundled("bundler/__promiseAll is defined when an unwrapped entry awaits three async ESM wrappers", {
+    files: {
+      "/entry.js": `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        console.log(a, b, c);
+        const mods = await Promise.all([import("./a.js"), import("./b.js"), import("./c.js")]);
+        console.log(mods.map(m => Object.keys(m)).join());
+      `,
+      "/a.js": `export const a = await Promise.resolve("A");`,
+      "/b.js": `export const b = await Promise.resolve("B");`,
+      "/c.js": `export const c = await Promise.resolve("C");`,
+    },
+    run: {
+      stdout: "A B C\na,b,c",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(
+        /await\s+__promiseAll\s*\(\s*\[\s*init_a\(\),\s*init_b\(\),\s*init_c\(\)\s*\]\s*\)/,
+      );
+      expect(bundled).toContain("var __promiseAll = ");
+    },
+  });
+
+  itBundled("bundler/__promiseAll is defined when an unwrapped non-entry file awaits two async ESM wrappers", {
+    files: {
+      "/entry.js": `
+        import { joined } from "./mid.js";
+        console.log(joined);
+        const [{ a }, { b }] = await Promise.all([import("./a.js"), import("./b.js")]);
+        console.log(a + b === joined);
+      `,
+      "/mid.js": `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        export const joined = a + b;
+      `,
+      "/a.js": `export const a = await Promise.resolve("A");`,
+      "/b.js": `export const b = await Promise.resolve("B");`,
+    },
+    run: {
+      stdout: "AB\ntrue",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/\/\/ mid\.js\s+await\s+__promiseAll\s*\(\s*\[\s*init_a\(\),\s*init_b\(\)\s*\]\s*\)/);
+      expect(bundled).toContain("var __promiseAll = ");
+    },
+  });
+
+  itBundled("bundler/__promiseAll is tree-shaken when an unwrapped entry awaits one async ESM wrapper", {
+    files: {
+      "/entry.js": `
+        import { a } from "./a.js";
+        console.log(a);
+        console.log(Object.keys(await import("./a.js")).join());
+      `,
+      "/a.js": `export const a = await Promise.resolve("A");`,
+    },
+    run: {
+      stdout: "A\na",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/await\s+init_a\(\);/);
+      expect(bundled).not.toContain("__promiseAll");
+    },
+  });
+
+  // Only `import` statements join the `await __promiseAll([...])`. An `import()`
+  // of a second async module prints its own `init_c().then(...)` and does not
+  // need the helper.
+  itBundled("bundler/__promiseAll is tree-shaken when a wrapper's second async dependency is an import()", {
+    files: {
+      "/entry.js": `
+        const { run } = await import("./lazy.js");
+        await run();
+      `,
+      "/lazy.js": `
+        import { a } from "./a.js";
+        export async function run() {
+          const { c } = await import("./c.js");
+          console.log(a, c);
+        }
+      `,
+      "/a.js": `export const a = await Promise.resolve("A");`,
+      "/c.js": `export const c = await Promise.resolve("C");`,
+    },
+    run: {
+      stdout: "A C",
+    },
+    onAfterBundle(api) {
+      const bundled = api.readFile("out.js");
+      expect(bundled).toMatch(/var init_lazy = __esm\(async \(\) => \{\s*await\s+init_a\(\);/);
+      expect(bundled).not.toContain("__promiseAll");
+    },
+  });
 });


### PR DESCRIPTION
### Problem
- A file that is not wrapped and imports two or more top-level-await modules that are also `import()`ed prints `await __promiseAll([...])`, but the bundle never defines the helper. `bun build` exits 0 and the output throws `ReferenceError: __promiseAll is not defined`.
- Cause: `should_remove_import_export_stmt` (`src/bundler/LinkerContext.rs:2301`) joins the awaits for any importer. Only the `WrapKind::Esm` arm of `create_wrapper_for_file` (`LinkerContext.rs:3541`) marked `__promiseAll` as used, so for an unwrapped importer tree shaking dropped the helper.

### Fix
- Step 6 of `scan_imports_and_exports` now counts, per importing file, the `import` statements whose target is an async ESM wrapper. From the second one on, the part gets a `__promiseAll` runtime use, next to the `__toESM` and `__reExport` uses.
- The count in `create_wrapper_for_file` is removed. The step 6 count covers wrapped importers too, and skips `import()` and `require()` records, which never join the `await`.
- Verified: `test/bundler/bundler_promiseall_deadcode.test.ts` (5 new cases, 4 fail on stock bun), plus six neighbouring suites (see Notes).
- Self-reviewed: 4 concerns, 2 addressed, 2 declined (print an unbound `Promise.all` and delete the helper, the shape #41601 proposes, see Notes).

### Background
- Without `--splitting`, a module that something `import()`s is wrapped: `var init_a = __esm(async () => {...})`. A static `import` of it becomes `init_a()`, awaited when the module or a dependency has top-level await.
- #22704 made a file await several async dependencies together through the runtime helper `__promiseAll` (`src/runtime.js`).
- Tree shaking keeps a runtime helper only if a live part records a use of it (`generate_runtime_symbol_import_and_use`).

<details><summary>Notes</summary>

Repro (1.4.2 and 1.4.3-canary.1+f42e98025):

```sh
printf 'await Promise.resolve();\nconsole.log("p");\nexport const p = 1;\n' > p.js
printf 'await Promise.resolve();\nconsole.log("q");\nexport const q = 1;\n' > q.js
printf 'import "./p.js";\nimport "./q.js";\nimport("./p.js"); import("./q.js");\nconsole.log("entry");\n' > entry.js
bun build ./entry.js --outfile=out.mjs && bun out.mjs
# ReferenceError: __promiseAll is not defined
```

With this change the same bundle defines `var __promiseAll = (args) => Promise.all(args);` and prints `p`, `q`, `entry` under bun and node, with and without `--minify`.

Relationship to #41601: that open PR reworks the order in which a wrapper evaluates its dependencies and replaces `__promiseAll` with an unbound `Promise.all`, which removes this bug as a side effect. This PR is the standalone fix for the `ReferenceError` and does not change evaluation order. If #41601 lands first, this one is redundant and I will close it. Earlier standalone attempts were #36189 (closed in favour of #33337) and #33337 (closed in favour of #41601), so the error is still on `main`.

Alternative shape, considered and not taken here: print `await Promise.all([...])` through an unbound `Promise` symbol (the renamer already reserves `Promise`, and `unbound_module_ref` is the pattern) and delete `__promiseAll` from `src/runtime.js` and `src/ast/runtime.rs`. That removes the liveness bookkeeping instead of adding a counter, but it drops the helper #22704 introduced and renumbers the runtime import table, and #41601 carries exactly that change. This PR keeps the helper so that the fix stays two hunks.

Precision of the count. The count runs over all parts of a file before tree shaking. The printer joins the `await`s within one printed part range. The two differ only toward a defined but unused 45-byte helper, in two cases: one of the two import parts is tree-shaken or lands in a separate part range, or one of the statements is an un-aliased `export * from` of an async wrapper. That last form does not go through `should_remove_import_export_stmt`: `convertStmtsForChunk.rs:273` prints a bare `init_x()` for it with no `await` (esbuild prints the same), so a consumer of such a re-export can read its bindings before the module finished. That is a separate, pre-existing ordering bug which #41601 addresses, and this PR leaves that site alone. The reverse mismatch, a printed `__promiseAll` with no definition, cannot happen: every part that holds the second or a later qualifying import carries the use, and a part must be live to be printed.

New tests, all in `test/bundler/bundler_promiseall_deadcode.test.ts`:
- unwrapped entry, two async wrappers (the repro): fails on stock bun
- unwrapped entry, three async wrappers (array append path): fails on stock bun
- unwrapped non-entry importer: fails on stock bun
- unwrapped entry, one async wrapper: control, no helper, passes both ways
- wrapped importer whose second async dependency is an `import()`: stock bun emitted an unused `var __promiseAll`, now it does not

The three existing cases in that file (wrapped importers from #22704) are unchanged and pass, including the inline snapshot that contains `var __promiseAll`.

Other suites run with the debug build, all green: `bundler_edgecase`, `bundler_dynamic_import_dce`, `bundler_cjs2esm`, `bundler_splitting`, `bundler_regressions`, `esbuild/default`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_promiseall_deadcode.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Cre
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_promiseall_deadcode.test.ts:
(pass) bundler > bundler/__promiseAll is tree-shaken when only one async import exists but __esm remains [25.08ms]
(pass) bundler > bundler/__promiseAll is included when multiple async imports exist with __esm [12.02ms]
(pass) bundler > bundler/__promiseAll is tree-shaken when no async imports despite circular deps with __esm [16.10ms]
426 |       stdout: "p\nq\nentry",
427 |     },
428 |     onAfterBundle(api) {
429 |       const bundled = api.readFile("out.js");
430 |       expect(bundled).toMatch(/await\s+__promiseAll\s*\(\s*\[\s*init_p\(\),\s*init_q\(\)\s*\]\s*\)/);
431 |       expect(bundled).toContain("var __promiseAll = ");
                            ^
error: expect(received).toContain(expected)

Expected to contain: "var __promiseAll = "
Received: "var __esm = (fn, res, err) => () => {\n  if (fn)\n    try {\n      res = fn(fn = 0);\n    } catch (e) {\n      err = [e];\n    }\n  if (err)\n    throw err[0];\n  return res;\n};\n\n// p.js\nvar init_p = __esm(async () => {\n  await Promise.resolve();\n  console.log(\"p\");\n});\n\n// q.js\nvar init_q = __esm(async () => {\n  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_promiseall_deadcode.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_promiseall_deadcode.test.ts:
(pass) bundler > bundler/__promiseAll is tree-shaken when only one async import exists but __esm remains [1138.66ms]
(pass) bundler > bundler/__promiseAll is included when multiple async imports exist with __esm [966.10ms]
(pass) bundler > bundler/__promiseAll is tree-shaken when no async imports despite circular deps with __esm [721.84ms]
(pass) bundler > bundler/__promiseAll is defined when an unwrapped entry awaits two async ESM wrappers [542.82ms]
(pass) bundler > bundler/__promiseAll is defined when an unwrapped entry awaits three async ESM wrappers [428.03ms]
(pass) bundler > bundler/__promiseAll is defined when an unwrapped non-entry file awaits two async ESM wrappers [466.48ms]
(pass) bundler > bundler/__promiseAll is tree-shaken when an unwrapped entry awaits one async ESM wrapper [392.45ms]
(pass) bundler > bundler/__promiseAll is tree-shaken when a wrapper's second async dependency is an import() [61
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     38cacdaaa2
  features     baseline

23 deps, 131 codegen, 1172 objects in 830ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [25.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [12.00ms]
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] gen bindgenv2
[6/1217] fetch zlib
[zlib] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [69.00ms]
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 15ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.ser
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       |  56 +--------
 .../linker_context/scanImportsAndExports.rs        |  21 ++++
 test/bundler/bundler_promiseall_deadcode.test.ts   | 132 +++++++++++++++++++++
 3 files changed, 155 insertions(+), 54 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/LinkerContext.rs                             4      2      9
src/bundler/linker_context/scanImportsAndExports.rs      3      3      9
test/bundler/bundler_promiseall_deadcode.test.ts         2      2      9
```

</details>

<!-- robobun:evidence:end -->