### PR TITLE
Bun.Cookie: refuse a Path or Domain longer than 1024 characters

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -45,8 +45,14 @@ ExceptionOr<Ref<Cookie>> Cookie::create(const String& name, const String& value,
     if (!isValidCookiePath(path)) {
         return Exception { TypeError, "Invalid cookie path: contains invalid characters"_s };
     }
+    if (path.length() > maxAttributeValueLength) {
+        return Exception { TypeError, "Invalid cookie path: longer than 1024 characters, so browsers would ignore it"_s };
+    }
     if (!isValidCookieDomain(domain)) {
         return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
+    }
+    if (domain.length() > maxAttributeValueLength) {
+        return Exception { TypeError, "Invalid cookie domain: longer than 1024 characters, so browsers would ignore it"_s };
     }
     return adoptRef(*new Cookie(name, value, domain, path, expires, secure, sameSite, httpOnly, maxAge, partitioned));
 }
@@ -102,6 +108,9 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
                 attributeName = trimmedAttribute.convertToASCIILowercase();
                 attributeValue = emptyString();
             }
+
+            if (attributeValue.length() > maxAttributeValueLength)
+                continue;
 
             // RFC 6265 5.2: each attribute is recorded independently, last occurrence wins.
             // Max-Age's precedence over Expires (5.3) governs the computed expiry time, so it

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -37,6 +37,9 @@ class Cookie : public RefCounted<Cookie> {
 public:
     ~Cookie();
     static constexpr int64_t emptyExpiresAtValue = std::numeric_limits<int64_t>::min();
+    // RFC 6265bis section 5.6: a user agent ignores a cookie attribute whose value is longer than this.
+    static constexpr unsigned maxAttributeValueLength = 1024;
+
     static ExceptionOr<Ref<Cookie>> create(const String& name, const String& value,
         const String& domain, const String& path,
         int64_t expires, bool secure, CookieSameSite sameSite,
@@ -70,6 +73,9 @@ public:
         if (!isValidCookieDomain(domain)) {
             return Exception { TypeError, "Invalid cookie domain: contains invalid characters"_s };
         }
+        if (domain.length() > maxAttributeValueLength) {
+            return Exception { TypeError, "Invalid cookie domain: longer than 1024 characters, so browsers would ignore it"_s };
+        }
         m_domain = domain;
         return {};
     }
@@ -79,6 +85,9 @@ public:
     {
         if (!isValidCookiePath(path)) {
             return Exception { TypeError, "Invalid cookie path: contains invalid characters"_s };
+        }
+        if (path.length() > maxAttributeValueLength) {
+            return Exception { TypeError, "Invalid cookie path: longer than 1024 characters, so browsers would ignore it"_s };
         }
         m_path = path;
         return {};

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -396,6 +396,72 @@ test("delete cookie invalid path option", () => {
   );
 });
 
+// RFC 6265bis section 5.6: a user agent ignores a cookie attribute whose value is longer
+// than 1024 octets. A longer Path or Domain would silently widen the cookie's scope, so
+// refuse to serialize it, and ignore it when parsing like a browser does.
+describe("cookie attribute values longer than 1024 characters", () => {
+  const path1024 = "/" + Buffer.alloc(1023, "p").toString();
+  const path1025 = path1024 + "p";
+  // 16 labels of 63 characters, each with a dot in front, is exactly 1024.
+  const labels = Array.from({ length: 16 }, () => Buffer.alloc(63, "d").toString()).join(".");
+  const domain1024 = "." + labels;
+  const domain1025 = "d." + labels;
+
+  test("1024 characters is accepted", () => {
+    expect(path1024).toHaveLength(1024);
+    expect(domain1024).toHaveLength(1024);
+    const cookie = new Bun.Cookie("a", "b", { path: path1024, domain: domain1024 });
+    expect(cookie.path).toBe(path1024);
+    expect(cookie.domain).toBe(domain1024);
+    expect(Bun.Cookie.parse(cookie.serialize()).toJSON()).toEqual(cookie.toJSON());
+
+    const map = new Bun.CookieMap();
+    map.set("a", "b", { path: path1024, domain: domain1024 });
+    map.delete("c", { path: path1024, domain: domain1024 });
+    expect(map.toSetCookieHeaders()).toEqual([
+      `a=b; Domain=${domain1024}; Path=${path1024}; SameSite=Lax`,
+      `c=; Domain=${domain1024}; Path=${path1024}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+    ]);
+  });
+
+  test("a longer path throws", () => {
+    const message = "Invalid cookie path: longer than 1024 characters, so browsers would ignore it";
+    expect(() => new Bun.Cookie("a", "b", { path: path1025 })).toThrow(message);
+    expect(() => Bun.Cookie.from("a", "b", { path: path1025 })).toThrow(message);
+    expect(() => new Bun.Cookie({ name: "a", value: "b", path: path1025 })).toThrow(message);
+    expect(() => new Bun.CookieMap().set("a", "b", { path: path1025 })).toThrow(message);
+    expect(() => new Bun.CookieMap().set({ name: "a", value: "b", path: path1025 })).toThrow(message);
+    expect(() => new Bun.CookieMap().delete("a", { path: path1025 })).toThrow(message);
+    const cookie = new Bun.Cookie("a", "b");
+    expect(() => {
+      cookie.path = path1025;
+    }).toThrow(message);
+    expect(cookie.path).toBe("/");
+  });
+
+  test("a longer domain throws", () => {
+    const message = "Invalid cookie domain: longer than 1024 characters, so browsers would ignore it";
+    expect(() => new Bun.Cookie("a", "b", { domain: domain1025 })).toThrow(message);
+    expect(() => Bun.Cookie.from("a", "b", { domain: domain1025 })).toThrow(message);
+    expect(() => new Bun.Cookie({ name: "a", value: "b", domain: domain1025 })).toThrow(message);
+    expect(() => new Bun.CookieMap().set("a", "b", { domain: domain1025 })).toThrow(message);
+    expect(() => new Bun.CookieMap().set({ name: "a", value: "b", domain: domain1025 })).toThrow(message);
+    expect(() => new Bun.CookieMap().delete("a", { domain: domain1025 })).toThrow(message);
+    const cookie = new Bun.Cookie("a", "b");
+    expect(() => {
+      cookie.domain = domain1025;
+    }).toThrow(message);
+    expect(cookie.domain).toBeNull();
+  });
+
+  test("Cookie.parse ignores the attribute instead of throwing", () => {
+    const cookie = Bun.Cookie.parse(`a=b; Path=${path1025}; Domain=${domain1025}; Secure`);
+    expect(cookie.path).toBe("/");
+    expect(cookie.domain).toBeNull();
+    expect(cookie.secure).toBe(true);
+  });
+});
+
 describe("Bun.CookieMap constructor", () => {
   test("throws for invalid array", () => {
     expect(() => new Bun.CookieMap([["abc defg =fhaingj809读写汉字学中文"]])).toThrowErrorMatchingInlineSnapshot(


### PR DESCRIPTION
### Problem
- `req.cookies.set("s", "v", { path: "/" + "p".repeat(1100) })` emits a 1101-byte `Path`. RFC 6265bis section 5.6 tells a user agent to ignore an attribute value longer than 1024 octets, and Chromium does (boundary exact: 1024 is kept, 1025 is dropped). The browser stores `{name: "s", path: "/"}` and sends the cookie origin-wide, while `Bun.Cookie` says it is scoped to the sub-path. A long `Domain` is ignored the same way and the cookie becomes host-only.
- The cause: `isValidCookiePath` / `isValidCookieDomain` in `src/jsc/bindings/Cookie.cpp` check characters only, so nothing on the write path knows the limit.

### Fix
- `Cookie::create`, `setPath` and `setDomain` throw `TypeError: Invalid cookie path: longer than 1024 characters, so browsers would ignore it` (and the `domain` twin). That covers `new Bun.Cookie`, `Bun.Cookie.from`, the `path`/`domain` setters, `CookieMap.set` and `CookieMap.delete`. It is the same shape as the existing `Invalid cookie path: contains invalid characters`: refuse to serialize a cookie a browser will not store as described.
- `Cookie.parse` skips an over-long attribute instead of throwing, like a browser (the same two-line hunk as #41964, so the two merge cleanly in either order).
- This is the one policy call from the review of #41964, split out so it can be merged or closed on its own: it is a new cap on an application-controlled value, but the value it caps cannot be honored by any conforming browser, and the failure is silent and widens scope. @Jarred-Sumner, your call.
- Verified: `test/js/bun/cookie/cookie.test.ts` ("cookie attribute values longer than 1024 characters", 4 tests, 3 fail on 1.4.3). All of `test/js/bun/cookie/`, `test/js/bun/http/bun-serve-cookies.test.ts` and `test/js/bun/util/cookie.test.js` pass.

### Background
- `Bun.Cookie` is the object behind `req.cookies.set()` in `Bun.serve` routes and behind `Bun.CookieMap`. `serialize()` produces the `Set-Cookie` line.
- A `Set-Cookie` attribute a user agent cannot use is ignored, not fatal: the cookie is still stored, with the default for that attribute. For `Path` the default is the request URL's directory, for `Domain` it is host-only. So an ignored `Path` makes the cookie visible to more URLs than intended, not fewer.
- Path and domain are ASCII-only after the existing character check, so characters and octets are the same count here.

<details><summary>Notes</summary>

- Reach is small: a DNS name cannot exceed 253 octets, so the domain limit is only reachable with an already-invalid domain, and there is no known producer of 1 KB cookie paths. The argument for the throw is the direction of the failure (scope widens silently), not its frequency.
- Not in this PR, same family: the 4096-octet name+value limit from the same RFC section. Browsers drop the whole cookie above it. A throw there would also affect non-browser clients that accept larger cookies, so it is left for a separate decision.
- #32982 (accept uppercase domains, reject malformed labels) touches the same validators. Whichever lands second is a small rebase.

</details>
