### PR TITLE
shell: resolve commands on the shell environment's PATH, not the startup snapshot, and scope VAR=value prefixes to one command

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -339,6 +339,13 @@ import { $ } from "bun";
 await $`echo $FOO`.env({ ...process.env, FOO: "bar" }); // bar
 ```
 
+<Note>
+  The object you pass to `.env()` or `$.env()` replaces the whole environment. It does not add to it. Spread
+  `process.env` to keep variables such as `PATH` and `HOME`. When the environment has no `PATH`, Bun looks up commands
+  the way `node:child_process` does: in `/usr/bin:/bin` on macOS and Linux, and on the current `PATH` of the Bun process
+  on Windows.
+</Note>
+
 To change the default environment variables for all commands, call `$.env`:
 
 ```js

--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -351,13 +351,13 @@ To change the default environment variables for all commands, call `$.env`:
 ```js
 import { $ } from "bun";
 
-$.env({ FOO: "bar" });
+$.env({ ...process.env, FOO: "bar" });
 
 // the globally-set $FOO
 await $`echo $FOO`; // bar
 
 // the locally-set $FOO
-await $`echo $FOO`.env({ FOO: "baz" }); // baz
+await $`echo $FOO`.env({ ...process.env, FOO: "baz" }); // baz
 ```
 
 To reset the environment variables to the default, call `$.env()` with no arguments:
@@ -365,7 +365,7 @@ To reset the environment variables to the default, call `$.env()` with no argume
 ```js
 import { $ } from "bun";
 
-$.env({ FOO: "bar" });
+$.env({ ...process.env, FOO: "bar" });
 
 // the globally-set $FOO
 await $`echo $FOO`; // bar

--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -46,13 +46,19 @@ declare module "bun" {
     /**
      * Change the default environment variables for shells created by this instance.
      *
+     * The object replaces the whole environment. It does not add to
+     * `process.env`. Spread `process.env` to keep variables such as `PATH`.
+     * Without a `PATH`, commands are looked up like `node:child_process`
+     * does: in `/usr/bin:/bin` on POSIX, and on the current `PATH` of this
+     * process on Windows.
+     *
      * @param newEnv Default environment variables to use for shells created by this instance
      * @default process.env
      *
      * @example
      * ```js
      * import {$} from 'bun';
-     * $.env({ BUN: "bun" });
+     * $.env({ ...process.env, BUN: "bun" });
      * await $`echo $BUN`;
      * // "bun"
      * ```
@@ -98,6 +104,10 @@ declare module "bun" {
 
       /**
        * Set environment variables for the shell.
+       *
+       * The object replaces the whole environment. It does not add to
+       * `process.env`. Spread `process.env` to keep variables such as `PATH`.
+       *
        * @param newEnv The new environment variables
        *
        * @example

--- a/src/runtime/shell/EnvMap.rs
+++ b/src/runtime/shell/EnvMap.rs
@@ -96,6 +96,11 @@ impl EnvMap {
         self.map.ensure_total_capacity(new_capacity).expect("OOM");
     }
 
+    pub(crate) fn clear(&mut self) {
+        self.deref_strings();
+        self.map.clear_retaining_capacity();
+    }
+
     /// NOTE: Make sure you deref the string when done!
     pub fn get(&self, key: EnvStr) -> Option<EnvStr> {
         let val = *self.map.get(&key)?;

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -147,9 +147,6 @@ impl ParsedShellScript {
         // errdefer env.deinit() — Drop on early-return handles this.
         env.ensure_total_capacity(object_iter.len);
 
-        // If the env object does not include a $PATH, it must disable path lookup for argv[0]
-        // PATH = "";
-
         while let Some((key, value)) = object_iter.next()? {
             if value.is_undefined() {
                 continue;

--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -5,7 +5,6 @@
 //! are processed.
 
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
-use crate::shell::env_str::EnvStr;
 use crate::shell::interpreter::{Interpreter, NodeId};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -203,16 +202,9 @@ struct SearchEnv {
 impl SearchEnv {
     fn load(interp: &Interpreter, cmd: NodeId) -> Self {
         let shell = Builtin::shell(interp, cmd);
-        // `EnvMap::get` refs the returned string; balance it.
-        let path_env = shell
-            .export_env
-            .get(EnvStr::init_slice(b"PATH"))
-            .map(|s| {
-                let v = s.slice().to_vec();
-                s.deref();
-                v
-            })
-            .unwrap_or_default();
+        let path = shell.command_path();
+        let path_env = path.slice().to_vec();
+        path.deref();
         Self {
             path_env,
             cwd: shell.cwd().to_vec(),

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2082,12 +2082,8 @@ impl ShellExecEnv {
             })
     }
 
-    /// `$PATH` for resolving an external command name: a `PATH=... cmd`
-    /// prefix, else the exported env (what the child will see), else
-    /// [`default_path_for_unset_env`](crate::shell::subproc::default_path_for_unset_env).
-    /// The environment snapshot taken at startup is never consulted:
-    /// `export_env` was built from the live `process.env` (or from `.env()`),
-    /// so a `PATH` missing there is missing on purpose. Deref the result.
+    /// `$PATH` for resolving a command name: a `PATH=... cmd` prefix, else
+    /// `export_env`, else the platform default. Deref the result.
     pub(crate) fn command_path(&self) -> crate::shell::env_str::EnvStr {
         let key = crate::shell::env_str::EnvStr::init_slice(b"PATH");
         self.cmd_local_env

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2083,19 +2083,17 @@ impl ShellExecEnv {
     }
 
     /// `$PATH` for resolving an external command name: a `PATH=... cmd`
-    /// prefix, else the exported env (what the child will see), else the
-    /// platform default for an env without `PATH`. The process's own `PATH`
-    /// is not consulted: `export_env` was built from it (or from `.env()`),
-    /// so a missing `PATH` here is deliberate. Deref the result.
+    /// prefix, else the exported env (what the child will see), else
+    /// [`default_path_for_unset_env`](crate::shell::subproc::default_path_for_unset_env).
+    /// The environment snapshot taken at startup is never consulted:
+    /// `export_env` was built from the live `process.env` (or from `.env()`),
+    /// so a `PATH` missing there is missing on purpose. Deref the result.
     pub(crate) fn command_path(&self) -> crate::shell::env_str::EnvStr {
-        use crate::shell::env_str::EnvStr;
-        let key = EnvStr::init_slice(b"PATH");
+        let key = crate::shell::env_str::EnvStr::init_slice(b"PATH");
         self.cmd_local_env
             .get(key)
             .or_else(|| self.export_env.get(key))
-            .unwrap_or_else(|| {
-                EnvStr::init_slice(crate::shell::subproc::default_path_for_unset_env())
-            })
+            .unwrap_or_else(crate::shell::subproc::default_path_for_unset_env)
     }
 }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2081,6 +2081,22 @@ impl ShellExecEnv {
                 })
             })
     }
+
+    /// `$PATH` for resolving an external command name: a `PATH=... cmd`
+    /// prefix, else the exported env (what the child will see), else the
+    /// platform default for an env without `PATH`. The process's own `PATH`
+    /// is not consulted: `export_env` was built from it (or from `.env()`),
+    /// so a missing `PATH` here is deliberate. Deref the result.
+    pub(crate) fn command_path(&self) -> crate::shell::env_str::EnvStr {
+        use crate::shell::env_str::EnvStr;
+        let key = EnvStr::init_slice(b"PATH");
+        self.cmd_local_env
+            .get(key)
+            .or_else(|| self.export_env.get(key))
+            .unwrap_or_else(|| {
+                EnvStr::init_slice(crate::shell::subproc::default_path_for_unset_env())
+            })
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -470,15 +470,16 @@ impl Cmd {
         {
             let env = interp.as_cmd_mut(this).base.shell_mut();
             let mut iter = env.export_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
+            spawn_args.fill_env(&mut iter);
             let mut iter = env.cmd_local_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
+            spawn_args.fill_env(&mut iter);
         }
 
-        // Resolve argv[0] via PATH (`bun_which::which`).
+        // Resolve argv[0] via the shell's PATH (`bun_which::which`).
         let resolved: Option<Vec<u8>> = {
+            let path = interp.as_cmd(this).base.shell().command_path();
             let mut path_buf = bun_paths::path_buffer_pool::get();
-            match bun_which::which(&mut *path_buf, spawn_args.path, spawn_args.cwd, &first_arg) {
+            let found = match bun_which::which(&mut *path_buf, path.slice(), spawn_args.cwd, &first_arg) {
                 Some(z) => Some(z.as_bytes().to_vec()),
                 None if &first_arg[..] == b"bun" || &first_arg[..] == b"bun-debug" => {
                     bun_core::self_exe_path()
@@ -486,7 +487,9 @@ impl Cmd {
                         .map(|z| z.as_bytes().to_vec())
                 }
                 None => None,
-            }
+            };
+            path.deref();
+            found
         };
         let Some(mut resolved) = resolved else {
             // writeFailingError("bun: command not found: {s}\n") →

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -479,15 +479,16 @@ impl Cmd {
         let resolved: Option<Vec<u8>> = {
             let path = interp.as_cmd(this).base.shell().command_path();
             let mut path_buf = bun_paths::path_buffer_pool::get();
-            let found = match bun_which::which(&mut *path_buf, path.slice(), spawn_args.cwd, &first_arg) {
-                Some(z) => Some(z.as_bytes().to_vec()),
-                None if &first_arg[..] == b"bun" || &first_arg[..] == b"bun-debug" => {
-                    bun_core::self_exe_path()
-                        .ok()
-                        .map(|z| z.as_bytes().to_vec())
-                }
-                None => None,
-            };
+            let found =
+                match bun_which::which(&mut *path_buf, path.slice(), spawn_args.cwd, &first_arg) {
+                    Some(z) => Some(z.as_bytes().to_vec()),
+                    None if &first_arg[..] == b"bun" || &first_arg[..] == b"bun-debug" => {
+                        bun_core::self_exe_path()
+                            .ok()
+                            .map(|z| z.as_bytes().to_vec())
+                    }
+                    None => None,
+                };
             path.deref();
             found
         };

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -237,6 +237,9 @@ impl Cmd {
             );
             match interp.as_cmd(this).state {
                 CmdState::Idle => {
+                    // `VAR=value cmd` assignments belong to one command; drop
+                    // the ones an earlier command in this shell env left.
+                    interp.as_cmd_mut(this).base.shell_mut().cmd_local_env.clear();
                     if !n.assigns.is_empty() {
                         interp.as_cmd_mut(this).state = CmdState::ExpandingAssigns;
                         let child = Assigns::init(interp, shell, n.assigns, this, AssignCtx::Cmd);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -237,8 +237,7 @@ impl Cmd {
             );
             match interp.as_cmd(this).state {
                 CmdState::Idle => {
-                    // `VAR=value cmd` assignments belong to one command; drop
-                    // the ones an earlier command in this shell env left.
+                    // A `VAR=value cmd` prefix applies to one command only.
                     let shell_env = interp.as_cmd_mut(this).base.shell_mut();
                     shell_env.cmd_local_env.clear();
                     if !n.assigns.is_empty() {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -239,7 +239,8 @@ impl Cmd {
                 CmdState::Idle => {
                     // `VAR=value cmd` assignments belong to one command; drop
                     // the ones an earlier command in this shell env left.
-                    interp.as_cmd_mut(this).base.shell_mut().cmd_local_env.clear();
+                    let shell_env = interp.as_cmd_mut(this).base.shell_mut();
+                    shell_env.cmd_local_env.clear();
                     if !n.assigns.is_empty() {
                         interp.as_cmd_mut(this).state = CmdState::ExpandingAssigns;
                         let child = Assigns::init(interp, shell, n.assigns, this, AssignCtx::Cmd);

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1421,17 +1421,27 @@ impl<'a> SpawnArgs<'a> {
     }
 }
 
-/// `$PATH` to search for a command when the shell environment has none, as
-/// for a shell started without `PATH`: `_PATH_DEFPATH` on POSIX (what
-/// `execvp` and libuv use; Android often has no `PATH`), nothing on Windows.
-/// An explicit `PATH=` is not this case: it stays empty and searches nothing.
-pub(crate) fn default_path_for_unset_env() -> &'static [u8] {
-    if cfg!(unix) {
+/// `$PATH` to search for a command when the shell environment has none, the
+/// same search `node:child_process` (libuv) does for an `env` without `PATH`:
+/// `_PATH_DEFPATH` on POSIX (Android often has no `PATH` at all), and on
+/// Windows the process's current `PATH`, which libuv also copies into such a
+/// child's environment block. An explicit `PATH=` is not this case: it stays
+/// empty and searches nothing. Deref the result.
+pub(crate) fn default_path_for_unset_env() -> sh::EnvStr {
+    #[cfg(windows)]
+    {
+        match bun_sys::windows::getenv_w(bun_core::w!("PATH\0")) {
+            Some(path) => sh::EnvStr::init_ref_counted(
+                bun_core::strings::to_utf8_alloc(&path).into_boxed_slice(),
+            ),
+            None => sh::EnvStr::init_slice(b""),
+        }
+    }
+    #[cfg(not(windows))]
+    {
         // SAFETY: `BUN_DEFAULT_PATH_FOR_SPAWN` is a NUL-terminated C-string
         // constant with static storage.
-        unsafe { core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN) }.to_bytes()
-    } else {
-        b""
+        sh::EnvStr::init_slice(unsafe { core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN) }.to_bytes())
     }
 }
 

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1342,9 +1342,7 @@ impl Readable {
 // ───────────────────────────────────────────────────────────────────────────
 
 pub struct SpawnArgs<'a> {
-    /// Shared borrow: arena alloc methods take `&self`, and a `&'a Arena`
-    /// (being `Copy`) lets `fill_env` hand back `&'a [u8]` slices without
-    /// the unsafe pointer round-trip the `&'a mut Arena` reborrow forced.
+    /// Owns the `K=V\0` lines `fill_env` pushes into `env_array`.
     pub(crate) arena: &'a Arena,
     /// `[*:null]?[*:0]const u8` argv view for `spawn_process`. Built by the
     /// caller from `Cmd.args` (each `Vec<u8>` NUL-terminated) so this struct
@@ -1365,7 +1363,6 @@ pub struct SpawnArgs<'a> {
     pub(crate) redirect_stdout: Option<jsc::PinnedArrayBuffer>,
     pub(crate) redirect_stderr: Option<jsc::PinnedArrayBuffer>,
     pub(crate) lazy: bool,
-    pub path: &'a [u8],
     // ipc_mode: IPCMode,
     // ipc_callback: JSValue,
 }
@@ -1388,22 +1385,6 @@ impl<'a> SpawnArgs<'a> {
             redirect_stdout: None,
             redirect_stderr: None,
             lazy: false,
-            // PATH unset → fall back to _PATH_DEFPATH on POSIX (Android often
-            // has no PATH). PATH="" (explicit empty) is preserved — that's a
-            // deliberate "search nothing" and substituting a default would
-            // change argv[0] resolution on existing platforms.
-            // SAFETY: `event_loop.env()` returns the long-lived `*mut Loader`
-            // owned by the VM (valid for the lifetime of the spawn args), and
-            // `BUN_DEFAULT_PATH_FOR_SPAWN` is a NUL-terminated C-string constant.
-            path: unsafe {
-                if let Some(p) = (*event_loop.env()).get(b"PATH") {
-                    p
-                } else if cfg!(unix) {
-                    core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN).to_bytes()
-                } else {
-                    b""
-                }
-            },
             // .ipc_mode = IPCMode.none,
             // .ipc_callback = .zero,
         };
@@ -1415,22 +1396,12 @@ impl<'a> SpawnArgs<'a> {
         out
     }
 
-    /// `object_iter` should be a some type with the following fields:
-    /// - `next() bool`
-    pub(crate) fn fill_env<const DISABLE_PATH_LOOKUP_FOR_ARV0: bool>(
-        &mut self,
-        env_iter: &mut crate::shell::env_map::Iterator<'_>,
-    ) {
+    pub(crate) fn fill_env(&mut self, env_iter: &mut crate::shell::env_map::Iterator<'_>) {
         self.override_env = true;
         // Note: `bun_collections::array_hash_map::Iter` doesn't impl
         // `ExactSizeIterator`; use `size_hint` for the reservation.
         self.env_array
             .reserve_exact(env_iter.size_hint().0.saturating_sub(self.env_array.len()));
-
-        if DISABLE_PATH_LOOKUP_FOR_ARV0 {
-            // If the env object does not include a $PATH, it must disable path lookup for argv[0]
-            self.path = b"";
-        }
 
         while let Some(entry) = env_iter.next() {
             let key = entry.key_ptr.slice();
@@ -1439,23 +1410,28 @@ impl<'a> SpawnArgs<'a> {
             // Build a NUL-terminated `key=value` string in the spawn arena.
             // Bumpalo owns the bytes; freed when the spawn arena is reset.
             let len = key.len() + 1 + value.len();
-            // `self.arena: &'a Arena` is `Copy`, so binding it yields the full
-            // `'a` lifetime independent of the `&mut self` reborrow — the
-            // returned slice is naturally `&'a mut [u8]`.
-            let arena: &'a Arena = self.arena;
-            let line: &'a mut [u8] = arena.alloc_slice_fill_default(len + 1);
+            let line: &mut [u8] = self.arena.alloc_slice_fill_default(len + 1);
             line[..key.len()].copy_from_slice(key);
             line[key.len()] = b'=';
             line[key.len() + 1..len].copy_from_slice(value);
             line[len] = 0;
-            let line: &'a [u8] = line;
-
-            if key == b"PATH" {
-                self.path = &line[b"PATH=".len()..len];
-            }
 
             self.env_array.push(line.as_ptr().cast::<c_char>());
         }
+    }
+}
+
+/// `$PATH` to search for a command when the shell environment has none, as
+/// for a shell started without `PATH`: `_PATH_DEFPATH` on POSIX (what
+/// `execvp` and libuv use; Android often has no `PATH`), nothing on Windows.
+/// An explicit `PATH=` is not this case: it stays empty and searches nothing.
+pub(crate) fn default_path_for_unset_env() -> &'static [u8] {
+    if cfg!(unix) {
+        // SAFETY: `BUN_DEFAULT_PATH_FOR_SPAWN` is a NUL-terminated C-string
+        // constant with static storage.
+        unsafe { core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN) }.to_bytes()
+    } else {
+        b""
     }
 }
 

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1441,7 +1441,9 @@ pub(crate) fn default_path_for_unset_env() -> sh::EnvStr {
     {
         // SAFETY: `BUN_DEFAULT_PATH_FOR_SPAWN` is a NUL-terminated C-string
         // constant with static storage.
-        sh::EnvStr::init_slice(unsafe { core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN) }.to_bytes())
+        sh::EnvStr::init_slice(
+            unsafe { core::ffi::CStr::from_ptr(BUN_DEFAULT_PATH_FOR_SPAWN) }.to_bytes(),
+        )
     }
 }
 

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1421,12 +1421,9 @@ impl<'a> SpawnArgs<'a> {
     }
 }
 
-/// `$PATH` to search for a command when the shell environment has none, the
-/// same search `node:child_process` (libuv) does for an `env` without `PATH`:
-/// `_PATH_DEFPATH` on POSIX (Android often has no `PATH` at all), and on
-/// Windows the process's current `PATH`, which libuv also copies into such a
-/// child's environment block. An explicit `PATH=` is not this case: it stays
-/// empty and searches nothing. Deref the result.
+/// `$PATH` to search when the shell environment has none, as `node:child_process`
+/// does: `_PATH_DEFPATH` on POSIX, the process's current `PATH` on Windows.
+/// Deref the result.
 pub(crate) fn default_path_for_unset_env() -> sh::EnvStr {
     #[cfg(windows)]
     {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3564,3 +3564,72 @@ test.skipIf(isWindows)("external command resolution without a PATH does not use 
   });
   expect(exitCode).toBe(0);
 });
+
+// Windows spells the variable `Path`, and the shell env map is case-insensitive
+// there, so the lookup must not depend on the key casing. It must also not fall
+// back to the launch PATH when the shell environment has no PATH under any casing.
+describe.concurrent.skipIf(!isWindows)("external command resolution on Windows", () => {
+  const envWithoutPath: Record<string, string> = {};
+  for (const [key, value] of Object.entries(bunEnv)) {
+    if (key.toLowerCase() !== "path" && value !== undefined) envWithoutPath[key] = value;
+  }
+  const processPath = process.env.PATH!;
+  const toolDir = (name: string, message: string) =>
+    tempDir(`shell-argv0-${name}`, { [`${name}.cmd`]: `@echo ${message}\r\n` });
+
+  test(".env() with a Path key", async () => {
+    using dir = toolDir("onlyintool-pathkey", "from-Path-key");
+    const { stdout, stderr, exitCode } = await $`onlyintool-pathkey`
+      .env({ ...envWithoutPath, Path: `${dir};${processPath}` })
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim()).toBe("from-Path-key");
+    expect(exitCode).toBe(0);
+  });
+
+  test("export PATH when the environment has Path", async () => {
+    using dir = toolDir("onlyintool-export", "from-export");
+    const { stdout, stderr, exitCode } = await $`export PATH=${`${dir};${processPath}`}; onlyintool-export`
+      .env({ ...envWithoutPath, Path: processPath })
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim()).toBe("from-export");
+    expect(exitCode).toBe(0);
+  });
+
+  test("process.env.PATH changed or deleted at runtime, .env() without PATH", async () => {
+    using launchDir = toolDir("onlyintool-launch", "should-not-run");
+    using runtimeDir = toolDir("onlyintool-runtime", "from-runtime");
+    const fixture = /* ts */ `
+      import { $ } from "bun";
+      const results = {};
+      const run = async (label, pending) => {
+        const { exitCode, stdout, stderr } = await pending;
+        results[label] = { exitCode, stdout: stdout.toString().trim(), stderr: stderr.toString().trim() };
+      };
+      const envWithoutPath = Object.fromEntries(Object.entries(process.env).filter(([key]) => key.toLowerCase() !== "path"));
+      await run("env() without PATH", $\`onlyintool-launch\`.env(envWithoutPath).quiet().nothrow());
+      process.env.PATH = ${JSON.stringify(String(runtimeDir))} + ";" + process.env.PATH;
+      await run("runtime PATH", $\`onlyintool-runtime\`.quiet().nothrow());
+      delete process.env.PATH;
+      await run("deleted PATH", $\`onlyintool-launch\`.quiet().nothrow());
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...envWithoutPath, Path: `${launchDir};${processPath}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "env() without PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyintool-launch" },
+      "runtime PATH": { exitCode: 0, stdout: "from-runtime", stderr: "" },
+      "deleted PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyintool-launch" },
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3566,8 +3566,9 @@ test.skipIf(isWindows)("external command resolution without a PATH does not use 
 });
 
 // Windows spells the variable `Path`, and the shell env map is case-insensitive
-// there, so the lookup must not depend on the key casing. It must also not fall
-// back to the launch PATH when the shell environment has no PATH under any casing.
+// there, so the lookup must not depend on the key casing. With no PATH under any
+// casing, the lookup uses the process's current PATH (what libuv also gives the
+// child), never the environment snapshot taken at startup.
 describe.concurrent.skipIf(!isWindows)("external command resolution on Windows", () => {
   const envWithoutPath: Record<string, string> = {};
   for (const [key, value] of Object.entries(bunEnv)) {
@@ -3599,9 +3600,11 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows",
     expect(exitCode).toBe(0);
   });
 
-  test("process.env.PATH changed or deleted at runtime, .env() without PATH", async () => {
-    using launchDir = toolDir("onlyintool-launch", "should-not-run");
+  test("process.env.PATH changed or deleted at runtime, with and without PATH in .env()", async () => {
+    using launchDir = toolDir("onlyintool-launch", "from-launch");
     using runtimeDir = toolDir("onlyintool-runtime", "from-runtime");
+    // `onlyintool-launch` is on the PATH the fixture starts with, `onlyintool-runtime`
+    // only on the PATH it sets at runtime.
     const fixture = /* ts */ `
       import { $ } from "bun";
       const results = {};
@@ -3610,11 +3613,12 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows",
         results[label] = { exitCode, stdout: stdout.toString().trim(), stderr: stderr.toString().trim() };
       };
       const envWithoutPath = Object.fromEntries(Object.entries(process.env).filter(([key]) => key.toLowerCase() !== "path"));
-      await run("env() without PATH", $\`onlyintool-launch\`.env(envWithoutPath).quiet().nothrow());
       process.env.PATH = ${JSON.stringify(String(runtimeDir))} + ";" + process.env.PATH;
       await run("runtime PATH", $\`onlyintool-runtime\`.quiet().nothrow());
+      await run("runtime PATH, env() without PATH", $\`onlyintool-runtime\`.env(envWithoutPath).quiet().nothrow());
       delete process.env.PATH;
       await run("deleted PATH", $\`onlyintool-launch\`.quiet().nothrow());
+      await run("deleted PATH, env() without PATH", $\`onlyintool-launch\`.env(envWithoutPath).quiet().nothrow());
       console.log(JSON.stringify(results));
     `;
     await using proc = Bun.spawn({
@@ -3626,9 +3630,10 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows",
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({
-      "env() without PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyintool-launch" },
       "runtime PATH": { exitCode: 0, stdout: "from-runtime", stderr: "" },
+      "runtime PATH, env() without PATH": { exitCode: 0, stdout: "from-runtime", stderr: "" },
       "deleted PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyintool-launch" },
+      "deleted PATH, env() without PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyintool-launch" },
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3603,8 +3603,8 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows",
     if (key.toLowerCase() !== "path" && value !== undefined) envWithoutPath[key] = value;
   }
   const processPath = process.env.PATH!;
-  const toolDir = (name: string, message: string) =>
-    tempDir(`shell-argv0-${name}`, { [`${name}.cmd`]: `@echo ${message}\r\n` });
+  const toolDir = (name: string, message: string, dirPrefix = name) =>
+    tempDir(`shell-argv0-${dirPrefix}`, { [`${name}.cmd`]: `@echo ${message}\r\n` });
 
   test(".env() with a Path key", async () => {
     using dir = toolDir("onlyintool-pathkey", "from-Path-key");
@@ -3617,6 +3617,19 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows",
     expect(exitCode).toBe(0);
   });
 
+  // `{ ...process.env, PATH }` on Windows: the spread contributes `Path`, the
+  // later `PATH` key must win.
+  test(".env() with PATH added to an env that already has Path", async () => {
+    using dir = toolDir("onlyintool-bothkeys", "from-PATH-over-Path");
+    const { stdout, stderr, exitCode } = await $`onlyintool-bothkeys`
+      .env({ ...envWithoutPath, Path: processPath, PATH: `${dir};${processPath}` })
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim()).toBe("from-PATH-over-Path");
+    expect(exitCode).toBe(0);
+  });
+
   test("export PATH when the environment has Path", async () => {
     using dir = toolDir("onlyintool-export", "from-export");
     const { stdout, stderr, exitCode } = await $`export PATH=${`${dir};${processPath}`}; onlyintool-export`
@@ -3625,6 +3638,43 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows",
       .nothrow();
     expect(stderr.toString()).toBe("");
     expect(stdout.toString().trim()).toBe("from-export");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a PATH= prefix beats export PATH", async () => {
+    using prefixDir = toolDir("onlyintool-priority", "from-prefix", "priority-prefix");
+    using exportDir = toolDir("onlyintool-priority", "from-export", "priority-export");
+    const exportPath = `${exportDir};${processPath}`;
+    const prefixPath = `${prefixDir};${processPath}`;
+    const { stdout, stderr, exitCode } =
+      await $`export PATH=${exportPath}; PATH=${prefixPath} onlyintool-priority; onlyintool-priority`
+        .env({ ...envWithoutPath, Path: processPath })
+        .quiet()
+        .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString().trim().split(/\r?\n/)).toEqual(["from-prefix", "from-export"]);
+    expect(exitCode).toBe(0);
+  });
+
+  // `bun run <script>` runs package.json scripts through the Bun shell on
+  // Windows, with the shell environment seeded from the process environment.
+  test("export PATH in a package.json script", async () => {
+    using dir = toolDir("onlyintool-script", "from-script");
+    using project = tempDir("shell-argv0-project", {
+      "package.json": JSON.stringify({
+        scripts: { tool: `export PATH='${dir};${processPath}'; onlyintool-script` },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--silent", "run", "tool"],
+      env: { ...envWithoutPath, Path: processPath },
+      cwd: String(project),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("from-script");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3521,7 +3521,7 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
   }
 });
 
-test.skipIf(isWindows)("external command resolution without a PATH does not use the process's launch PATH", async () => {
+test.skipIf(isWindows)("external command resolution without a PATH ignores the launch PATH", async () => {
   using dir = tempDir("shell-argv0-nopath", {
     "onlyinlaunchpath": "#!/bin/sh\necho should-not-run\n",
   });
@@ -3633,7 +3633,11 @@ describe.concurrent.skipIf(!isWindows)("external command resolution on Windows",
       "runtime PATH": { exitCode: 0, stdout: "from-runtime", stderr: "" },
       "runtime PATH, env() without PATH": { exitCode: 0, stdout: "from-runtime", stderr: "" },
       "deleted PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyintool-launch" },
-      "deleted PATH, env() without PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyintool-launch" },
+      "deleted PATH, env() without PATH": {
+        exitCode: 1,
+        stdout: "",
+        stderr: "bun: command not found: onlyintool-launch",
+      },
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3520,3 +3520,47 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
     expect(exitCode).toBe(0);
   }
 });
+
+test.skipIf(isWindows)("external command resolution without a PATH does not use the process's launch PATH", async () => {
+  using dir = tempDir("shell-argv0-nopath", {
+    "onlyinlaunchpath": "#!/bin/sh\necho should-not-run\n",
+  });
+  chmodSync(join(String(dir), "onlyinlaunchpath"), 0o755);
+
+  // The tool is on the PATH this child starts with. The fixture then runs the
+  // shell with an environment that has no PATH, in two ways. Neither may find
+  // the tool, and both still search the platform default (_PATH_DEFPATH),
+  // like execvp() and node:child_process do. `which` must agree.
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    const results = {};
+    const run = async (label, pending) => {
+      const { exitCode, stdout, stderr } = await pending;
+      results[label] = { exitCode, stdout: stdout.toString().trim(), stderr: stderr.toString().trim() };
+    };
+    await run("env() without PATH", $\`onlyinlaunchpath\`.env({}).quiet().nothrow());
+    delete process.env.PATH;
+    await run("deleted PATH", $\`onlyinlaunchpath\`.quiet().nothrow());
+    await run("deleted PATH, which", $\`which onlyinlaunchpath\`.quiet().nothrow());
+    await run("deleted PATH, default", $\`sh -c "echo from-default-path"\`.quiet().nothrow());
+    const whichSh = await $\`which sh\`.quiet().nothrow();
+    results["deleted PATH, which default"] = { exitCode: whichSh.exitCode, endsWithSh: whichSh.stdout.toString().trim().endsWith("/sh") };
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, PATH: `${dir}:${bunEnv.PATH}` },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    "env() without PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyinlaunchpath" },
+    "deleted PATH": { exitCode: 1, stdout: "", stderr: "bun: command not found: onlyinlaunchpath" },
+    "deleted PATH, which": { exitCode: 1, stdout: "which: onlyinlaunchpath not found", stderr: "" },
+    "deleted PATH, default": { exitCode: 0, stdout: "from-default-path", stderr: "" },
+    "deleted PATH, which default": { exitCode: 0, endsWithSh: true },
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1190,10 +1190,10 @@ booga"
 
       let procEnv = JSON.parse(str1);
       expect(procEnv).toEqual({ ...bunEnv, BAZ: "1", FOO: "bar" });
+      // `export FOO` persists; the `BAZ=1` prefix belonged to the first command only.
       procEnv = JSON.parse(str2);
       expect(procEnv).toEqual({
         ...bunEnv,
-        BAZ: "1",
         FOO: "bar",
         BUN_TEST_VAR: "1",
       });
@@ -3563,6 +3563,34 @@ test.skipIf(isWindows)("external command resolution without a PATH ignores the l
     "deleted PATH, which default": { exitCode: 0, endsWithSh: true },
   });
   expect(exitCode).toBe(0);
+});
+
+test.skipIf(isWindows)("a VAR=value prefix applies to its own command only", async () => {
+  using dir = tempDir("shell-prefix-scope", {
+    "onlyintool": "#!/bin/sh\necho from-onlyintool\n",
+    "empty/.keep": "",
+  });
+  chmodSync(join(String(dir), "onlyintool"), 0o755);
+  const env = { ...bunEnv, PATH: `${dir}:${bunEnv.PATH}` };
+
+  {
+    // the environment of a later command
+    const { stdout, stderr, exitCode } = await $`FOO=leak true; printenv FOO`.env(env).quiet().nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString()).toBe("");
+    expect(exitCode).toBe(1);
+  }
+
+  {
+    // the PATH lookup of a later command, and of `which`
+    const { stdout, stderr, exitCode } = await $`PATH=${dir}/empty true; onlyintool; which onlyintool`
+      .env(env)
+      .quiet()
+      .nothrow();
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString()).toBe(`from-onlyintool\n${dir}/onlyintool\n`);
+    expect(exitCode).toBe(0);
+  }
 });
 
 // Windows spells the variable `Path`, and the shell env map is case-insensitive

--- a/test/js/bun/shell/commands/which.test.ts
+++ b/test/js/bun/shell/commands/which.test.ts
@@ -55,6 +55,20 @@ test.concurrent("which searches $PATH for bare names and the shell cwd for ./ na
   expect(exitCode).toBe(0);
 });
 
+// `which` resolves through the same PATH that running the command uses, so a
+// `PATH=... which tool` prefix assignment counts, for that command only.
+test.concurrent("which honors a PATH= prefix assignment", async () => {
+  using dir = tempDir("which-prefix", searchTree);
+  const { pathDir } = searchDirs(String(dir));
+
+  const { stdout, exitCode } = await $`PATH=${pathDir} which tool; which tool`
+    .env({ ...bunEnv, PATH: "" })
+    .quiet()
+    .nothrow();
+  expect(stdout.toString()).toBe(`${join(pathDir, exe)}\nwhich: tool not found\n`);
+  expect(exitCode).toBe(1);
+});
+
 test.skipIf(isWindows)("which with an absolute path at the platform path length limit reports not found", async () => {
   const fixture = /* ts */ `
     import { $ } from "bun";


### PR DESCRIPTION
### Problem
- `` $`tool` `` runs a `tool` found only on the PATH Bun started with, after `delete process.env.PATH` or with an `.env({...})` object without `PATH`. `node:child_process`, `Bun.spawn({ env })` and the shell's `which` say not found. On Windows (key `Path`), `export PATH=...` and runtime `process.env.PATH` edits never reached the lookup.
- Cause: `SpawnArgs::default` seeded the lookup PATH from the startup environment snapshot (`src/runtime/shell/subproc.rs`), and `fill_env` overrode it only for a key spelled exactly `PATH`. `cmd_local_env` was also never cleared, so a `VAR=value cmd` prefix reached every later command.

### Fix
- One lookup, `ShellExecEnv::command_path()`: a `PATH=... cmd` prefix, then the exported environment (case-insensitive on Windows), else `_PATH_DEFPATH` on POSIX and the process's current `PATH` on Windows. `Cmd.rs` and `which` call it. A command clears `cmd_local_env` when it starts.
- Correct because `Bun.spawn({ env })` (#16067), `node:child_process` and libuv apply this rule to an env without `PATH`, and bash scopes a prefix assignment to its command. `PATH=""` still searches nothing.
- Behavior change on POSIX: `$.env({ FOO })` plus a command outside `/usr/bin:/bin` now fails with `bun: command not found`. Docs and types now say `.env()` replaces the environment. The `export var` test expected the prefix leak and is updated.
- Replaces #40565 (same refactor, kept the snapshot fallback, now closed). Its Windows-only tests are carried over here. Self-reviewed, see Notes. Verified: the new shell tests fail on 1.4.3 and pass here, Linux x64 and Windows x64.

### Background
- Each `` $`...` `` builds a shell whose `export_env` copies `process.env` at call time, or the `.env()` object. `cmd_local_env` holds `VAR=value cmd` prefixes.
- `_PATH_DEFPATH` (`/usr/bin:/bin`) is what `execvp` searches when `PATH` is unset. libuv on Windows searches the parent's current `PATH` instead.

<details><summary>Notes</summary>

Repro on Linux with 1.4.3-canary (`d` is a temp dir with an executable `w5891hi`, `PATH=$d:$PATH bun repro.mjs`):

```
after `delete process.env.PATH`:
  child_process.spawnSync("w5891hi")               -> ENOENT
  Bun.spawnSync(["w5891hi"], { env: process.env }) -> throws ENOENT
  $`w5891hi`                                       -> RAN (exit 0)   <- the bug
  $`which w5891hi`                                 -> which: w5891hi not found
with `process.env.PATH = ""` the shell already reported `command not found`; only an absent key fell back.
```

Real node 26 for comparison: an env without `PATH` finds `/usr/bin` tools and not the temp dir tool; `PATH=""` finds nothing. bash and dash set a default `PATH` when started without one.

Windows x64 probe (canary b52d3e590 vs this branch), `process.env` exposes the key as `Path`:

```
                                          canary               this branch
.env({ ...env, Path: dir;... })   tool    command not found    runs
export PATH=dir;... (env has Path) tool   command not found    runs
process.env.PATH = dir;...  then  tool    command not found    runs
.env(envWithoutPath)   launch-PATH tool   runs                 runs (current process PATH)
delete process.env.PATH;  launch tool     runs                 command not found
PATH=dir cmd prefix, .env({ PATH })       runs                 runs
```

On Windows `process.env` writes go through `SetEnvironmentVariableW`, so the current process `PATH` reflects runtime edits and deletes. On POSIX they do not reach the native environment (#40846 tracks `Bun.which` / `Bun.spawn` reading the startup snapshot), one more reason the POSIX arm does not consult the process environment at all.

`which` changes with it: `PATH=<dir> which tool` now searches `<dir>` (bash does the same), and `which` in an environment without `PATH` uses the same default as running the command.

Prefix scope: `FOO=leak true; printenv FOO` printed `leak` and `PATH=/nonexistent true; sh -c 'echo hi'` failed with `command not found: sh` on 1.4.3, because `cmd_local_env` kept the prefix for the rest of the script (the Zig implementation did the same). bash, dash and POSIX scope the assignment to the one command. `Cmd` now clears `cmd_local_env` when it starts, which covers the child environment, the argv[0] lookup and `which`. The `bunshell > variables > export var` test asserted that a later command still saw `BAZ=1` from an earlier prefix; its expectation is updated with a comment. The never-instantiated `DISABLE_PATH_LOOKUP_FOR_ARV0` generic on `fill_env` and the dangling `// PATH = "";` note in `ParsedShellScript.rs` go away with `SpawnArgs.path`.

Not addressed here, tracked separately: #32202 (a `VAR=value cmd` prefix for a variable that is also exported produces two entries in the child's environment block).

Self-review asks that this revision addresses: carry a `PATH=<dir> which tool` test (`commands/which.test.ts`), keep a prefix assignment from reaching later commands now that `which` reads `cmd_local_env`, stop the docs examples from modelling the minimal-object pattern right below the new note, use the process's current `PATH` on Windows instead of searching nothing, and state the relation to #40565 here and on that PR.

Tests carried over from #40565 (Windows-only, in the `external command resolution on Windows` block): `.env()` with `PATH` added to an object that already has `Path` (the `{ ...process.env, PATH }` pattern), a `PATH=` prefix over `export PATH` (extended to check that the next command uses the exported `PATH` again), and `export PATH` in a package.json script run by `bun run`. All three fail with `bun: command not found` on 1.4.3-canary (d745f03c0) and pass with this branch on Windows x64. The `which falls back to the process PATH` test from #40565 is not carried over: it asserts the startup-snapshot fallback that this PR removes on POSIX, and `external command resolution without a PATH ignores the launch PATH` covers the new rule.

Suites run with the debug build. Linux x64: `test/js/bun/shell/bunshell.test.ts`, `test/js/bun/shell/commands/`, `bunshell-instance`, `bunshell-default`, `exec`, `test/js/bun/spawn/spawn-path.test.ts`, `test/cli/install/bun-run.test.ts` (the only failures are two `ls` permission tests that fail as root on main too). Windows x64: `bunshell.test.ts`, `commands/which.test.ts`, `commands/`, `bunshell-instance`, `bunshell-file`, `exec`, `test/cli/install/bun-run.test.ts` (pre-existing: five `tilde_expansion` tests that need `HOME`, one `rm` test that trips on a debug-only warning).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/commands/which.test.ts, test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->
