### PR TITLE
Hand transpiled modules back to the module loader in request order

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -201,8 +201,7 @@ pub struct RuntimeTranspilerStore {
     pub(crate) generation_number: AtomicU32,
     pub(crate) store: TranspilerJobStore,
     pub enabled: bool,
-    /// Scheduled jobs no pool thread has started, oldest first. Pool threads
-    /// start them in this order (see [`TranspileRunner`]).
+    /// Jobs no pool thread has started, oldest first; see [`TranspileRunner`].
     unstarted: Guarded<VecDeque<UnstartedJob>>,
     /// Finished jobs, pushed by pool threads in completion order.
     pub(crate) queue: Queue,
@@ -230,12 +229,10 @@ impl Default for RuntimeTranspilerStore {
     }
 }
 
-/// Hands finished jobs back to JSC strictly in the order `transpile()`
-/// scheduled them, not in the order pool threads finish them. JSC evaluates a
-/// module graph in the microtask drain after its last fetch settles, so the
-/// settle order decides which of several concurrently loading graphs (two
-/// `import()` calls in one tick, say) evaluates first. Scheduling order makes
-/// that the same on every run. Transpiling itself stays parallel.
+/// Hands finished jobs back to JSC in the order `transpile()` scheduled them,
+/// not the order pool threads finish them, so that which of several
+/// concurrently loading module graphs JSC evaluates first (it evaluates a graph
+/// once its last fetch settles) is the same on every run.
 #[derive(Default)]
 struct FulfillOrder {
     next_seq: u64,
@@ -285,9 +282,8 @@ impl FulfillOrder {
     }
 }
 
-/// One per scheduled job. Runs the oldest unstarted job rather than its own,
-/// so a burst of imports starts transpiling in request order even though the
-/// pool runs tasks newest-first, which keeps `FulfillOrder`'s waits short.
+/// One per scheduled job. Runs the oldest unstarted job, not its own, so a
+/// burst starts in request order although the pool runs tasks newest-first.
 struct TranspileRunner {
     store: *const RuntimeTranspilerStore,
     task: WorkPoolTask,
@@ -360,36 +356,39 @@ impl RuntimeTranspilerStore {
     /// Each fulfilment is a JS entry of its own: an error one leaves pending is
     /// reported here and the drain goes on. The VM's termination ends it; jobs
     /// not yet fulfilled stay parked for a later drain or the teardown release.
-    // Note: takes `NonNull` rather than `&mut` for `event_loop`/`vm`
-    // because `&mut self` already aliases `vm.transpiler_store` (this `Self` is
-    // a field of `VirtualMachine`). Field-level derefs only.
-    pub fn run_from_js_thread(
-        &mut self,
+    ///
+    /// # Safety
+    /// JS thread; `this` is the live VM's store. Fulfilment and the drain run
+    /// JS, which can call `transpile()` or tick the loop into this function
+    /// again, so `this` is only dereferenced between those calls, never across.
+    pub unsafe fn run_from_js_thread(
+        this: *mut Self,
         event_loop: NonNull<EventLoop>,
         global: &JSGlobalObject,
         vm: NonNull<VirtualMachine>,
     ) {
-        let batch = self.queue.pop_batch();
-        let mut iter = batch.iterator();
-        while let Some(job) = NonNull::new(iter.next()) {
-            // SAFETY: a live finished job; the pool thread never touches `seq`.
-            let seq = unsafe { (*job.as_ptr()).seq };
-            bun_core::scoped_log!(
-                RuntimeTranspilerStore,
-                "finished({}, seq {}, next to fulfill {})",
-                // SAFETY: as above.
-                bstr::BStr::new(unsafe { (*job.as_ptr()).path.text }),
-                seq,
-                self.order.next_to_fulfill
-            );
-            self.order.park(seq, job);
+        // SAFETY: per fn contract; no JS runs while the batch is parked.
+        unsafe {
+            let batch = (*this).queue.pop_batch();
+            let mut iter = batch.iterator();
+            while let Some(job) = NonNull::new(iter.next()) {
+                // a live finished job; the pool thread never touches `seq`.
+                let seq = (*job.as_ptr()).seq;
+                bun_core::scoped_log!(
+                    RuntimeTranspilerStore,
+                    "finished({}, seq {}, next to fulfill {})",
+                    bstr::BStr::new((*job.as_ptr()).path.text),
+                    seq,
+                    (*this).order.next_to_fulfill
+                );
+                (*this).order.park(seq, job);
+            }
         }
         // SAFETY: `vm` is the live owning VM (caller is the JS-thread tick loop).
         let jsc_vm = unsafe { (*vm.as_ptr()).jsc_vm() };
         let mut first = true;
-        // Fulfilment and the drain enter JS, which may re-enter this function,
-        // so the next job is looked up afresh each turn.
-        while self.order.next_is_ready() {
+        // SAFETY (every `(*this)` below): per fn contract, a fresh short deref.
+        while unsafe { (*this).order.next_is_ready() } {
             if !first {
                 // if there are more, we need to drain the microtasks from the previous run
                 // SAFETY: `event_loop` is the VM's live event-loop self-pointer.
@@ -400,7 +399,7 @@ impl RuntimeTranspilerStore {
                 }
             }
             first = false;
-            let Some(job) = self.order.take_next() else {
+            let Some(job) = (unsafe { (*this).order.take_next() }) else {
                 break;
             };
             // SAFETY: `job` is a live finished job this thread popped from the queue.

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -5,6 +5,7 @@ use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::collections::VecDeque;
 
 use bun_alloc::Arena;
 use bun_ast::Loader;
@@ -200,10 +201,25 @@ pub struct RuntimeTranspilerStore {
     pub(crate) generation_number: AtomicU32,
     pub(crate) store: TranspilerJobStore,
     pub enabled: bool,
+    /// Scheduled jobs no pool thread has started yet, oldest first. Each
+    /// scheduled job also puts one [`TranspileRunner`] on the pool, and each
+    /// runner starts the oldest job here rather than a fixed one, so a burst of
+    /// jobs starts in scheduling order whatever order the pool runs its tasks
+    /// in. That keeps a finished job's wait for its turn (below) short.
+    unstarted: Guarded<VecDeque<UnstartedJob>>,
+    /// Finished jobs, pushed by pool threads in completion order.
     pub(crate) queue: Queue,
+    /// JS thread only. Hands finished jobs back to JSC in scheduling order;
+    /// see [`FulfillOrder`].
+    order: FulfillOrder,
 }
 
 pub type Queue = UnboundedQueue<TranspilerJob>;
+
+struct UnstartedJob(NonNull<TranspilerJob>);
+// SAFETY: the job slot is handed to whichever pool thread starts it; see
+// `TranspileRunner`.
+unsafe impl Send for UnstartedJob {}
 
 impl Default for RuntimeTranspilerStore {
     fn default() -> Self {
@@ -211,8 +227,106 @@ impl Default for RuntimeTranspilerStore {
             generation_number: AtomicU32::new(0),
             store: TranspilerJobStore::init(),
             enabled: true,
+            unstarted: Guarded::new(VecDeque::new()),
             queue: Queue::new(),
+            order: FulfillOrder::default(),
         }
+    }
+}
+
+/// Finished jobs go back to JSC strictly in the order `transpile()` scheduled
+/// them, not in the order pool threads happen to finish them.
+///
+/// The order in which fetches settle is the one input to JSC's module loader
+/// that used to depend on thread timing. Everything the loader does after a
+/// fetch settles (parse, request the imports, and, once the last fetch of a
+/// graph is in, link and evaluate it) runs on the JS thread in microtasks, and
+/// each hand-back is followed by a microtask drain. So with fetches settling in
+/// scheduling order, the order in which concurrently loading graphs evaluate
+/// (two `import()` calls in one tick, say), and which error a graph with
+/// several bad modules reports, are functions of the module graph alone and
+/// come out the same on every run: a graph evaluates right after the hand-back
+/// of the last module it was still waiting for. For graphs that share no
+/// modules that puts the shallower graph first and graphs of equal depth in
+/// the order they were requested, as node does. Transpiling stays parallel.
+#[derive(Default)]
+struct FulfillOrder {
+    /// Sequence number for the next job `transpile()` schedules.
+    next_seq: u64,
+    /// Sequence number of the next job to hand back.
+    next_to_fulfill: u64,
+    /// Finished jobs waiting for an older one to finish; slot `i` holds the
+    /// job with sequence number `next_to_fulfill + i`.
+    parked: VecDeque<Option<NonNull<TranspilerJob>>>,
+}
+
+impl FulfillOrder {
+    fn schedule(&mut self) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        seq
+    }
+
+    fn park(&mut self, seq: u64, job: NonNull<TranspilerJob>) {
+        let slot = seq
+            .checked_sub(self.next_to_fulfill)
+            .expect("a finished transpile job is never older than the next one to hand back")
+            as usize;
+        if self.parked.len() <= slot {
+            self.parked.resize(slot + 1, None);
+        }
+        debug_assert!(self.parked[slot].is_none());
+        self.parked[slot] = Some(job);
+    }
+
+    fn next_is_ready(&self) -> bool {
+        matches!(self.parked.front(), Some(Some(_)))
+    }
+
+    fn take_next(&mut self) -> Option<NonNull<TranspilerJob>> {
+        if !self.next_is_ready() {
+            return None;
+        }
+        self.next_to_fulfill += 1;
+        let job = self.parked.pop_front().flatten();
+        if self.parked.is_empty() && self.parked.capacity() > 1024 {
+            self.parked = VecDeque::new();
+        }
+        job
+    }
+
+    fn take_all_parked(&mut self) -> impl Iterator<Item = NonNull<TranspilerJob>> + use<> {
+        core::mem::take(&mut self.parked).into_iter().flatten()
+    }
+}
+
+/// A pool task that transpiles the oldest job no thread has started yet; see
+/// `RuntimeTranspilerStore::unstarted`.
+struct TranspileRunner {
+    store: *const RuntimeTranspilerStore,
+    task: WorkPoolTask,
+}
+
+bun_threading::owned_task!(TranspileRunner, task);
+
+impl TranspileRunner {
+    #[allow(clippy::boxed_local)] // `owned_task!`'s required signature
+    fn run_owned(self: Box<Self>) {
+        let job = {
+            // SAFETY: the store is a field of the VM, which outlives every
+            // unstarted job (each holds a ticket the VM's teardown waits for),
+            // and there is one unstarted job per runner not yet run.
+            // `unstarted` is only touched under its lock.
+            let mut unstarted = unsafe { (*self.store).unstarted.lock() };
+            let job = unstarted.pop_front();
+            if unstarted.is_empty() && unstarted.capacity() > 1024 {
+                *unstarted = VecDeque::new();
+            }
+            job.expect("one unstarted transpile job per runner")
+        };
+        // SAFETY: the slot is live and no other thread touches it until it is
+        // dispatched back to the JS thread.
+        unsafe { TranspilerJob::run_from_worker_thread(job.0) };
     }
 }
 
@@ -234,29 +348,36 @@ impl RuntimeTranspilerStore {
     /// turn of the wait): jobs already handed back whose completion will not
     /// run release their source, log and module promise here instead. Queued ⇒
     /// the pool thread's last touch of the slot was the push (its ticket was
-    /// moved out first), so the slot is this thread's again.
+    /// moved out first), so the slot is this thread's again. Parked jobs were
+    /// popped by an earlier drain and are this thread's already.
     pub fn release_queued_jobs_for_teardown(&mut self) {
         let batch = self.queue.pop_batch();
         let mut iter = batch.iterator();
-        loop {
-            let job = iter.next();
-            if job.is_null() {
-                break;
-            }
-            // SAFETY: a live job popped from the intrusive queue; see fn doc.
-            unsafe {
-                (*job).promise.deinit();
-                (*job).reset_for_pool();
-                self.store.put(job);
-            }
+        while let Some(job) = NonNull::new(iter.next()) {
+            self.release_unfulfilled(job);
+        }
+        for job in self.order.take_all_parked() {
+            self.release_unfulfilled(job);
         }
     }
 
-    /// Fulfil every completed job's module promise. This drain is a dispatcher:
-    /// each fulfilment is a JS entry of its own, so what one leaves pending is
-    /// folded here and the drain goes on; the VM's termination ends it, with
-    /// the rest of the batch back on the queue (each still has its own posted
-    /// task, or the teardown release, to pick it up).
+    fn release_unfulfilled(&mut self, job: NonNull<TranspilerJob>) {
+        let job = job.as_ptr();
+        // SAFETY: a finished job this thread owns again; see
+        // `release_queued_jobs_for_teardown`.
+        unsafe {
+            (*job).promise.deinit();
+            (*job).reset_for_pool();
+            self.store.put(job);
+        }
+    }
+
+    /// Fulfil the module promise of every finished job whose turn has come (see
+    /// [`FulfillOrder`]). This drain is a dispatcher: each fulfilment is a JS
+    /// entry of its own, so what one leaves pending is folded here and the
+    /// drain goes on; the VM's termination ends it, with the jobs not yet
+    /// fulfilled left parked (a later drain, or the teardown release, picks
+    /// them up).
     // Note: takes `NonNull` rather than `&mut` for `event_loop`/`vm`
     // because `&mut self` already aliases `vm.transpiler_store` (this `Self` is
     // a field of `VirtualMachine`). Field-level derefs only.
@@ -267,47 +388,50 @@ impl RuntimeTranspilerStore {
         vm: NonNull<VirtualMachine>,
     ) {
         let batch = self.queue.pop_batch();
+        let mut iter = batch.iterator();
+        while let Some(job) = NonNull::new(iter.next()) {
+            // SAFETY: a live finished job; `seq` was written in `transpile()`
+            // and the pool thread does not touch it.
+            let seq = unsafe { (*job.as_ptr()).seq };
+            bun_core::scoped_log!(
+                RuntimeTranspilerStore,
+                "finished({}, seq {}, next to fulfill {})",
+                // SAFETY: as above.
+                bstr::BStr::new(unsafe { (*job.as_ptr()).path.text }),
+                seq,
+                self.order.next_to_fulfill
+            );
+            self.order.park(seq, job);
+        }
         // SAFETY: `vm` is the live owning VM (caller is the JS-thread tick loop).
         let jsc_vm = unsafe { (*vm.as_ptr()).jsc_vm() };
-        let mut iter = batch.iterator();
-        let mut job = iter.next();
         let mut first = true;
-        while !job.is_null() {
+        // Fulfilment and the drain both enter JS, which may schedule more jobs
+        // or re-enter this function, so the next job is looked up afresh on
+        // every turn and taken only right before it is fulfilled.
+        while self.order.next_is_ready() {
             if !first {
                 // if there are more, we need to drain the microtasks from the previous run
                 // SAFETY: `event_loop` is the VM's live event-loop self-pointer.
                 let drained =
                     unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
                 if drained.is_err() {
-                    self.requeue(job, &mut iter);
                     return;
                 }
             }
             first = false;
-            // SAFETY: `job` is a live job popped from the intrusive queue.
-            let fulfilled = unsafe { (*job).run_from_js_thread() };
-            job = iter.next();
+            let Some(job) = self.order.take_next() else {
+                break;
+            };
+            // SAFETY: `job` is a live finished job this thread popped from the queue.
+            let fulfilled = unsafe { (*job.as_ptr()).run_from_js_thread() };
             if let Err(err) = fulfilled {
                 if crate::task::report_error_or_terminate(global, err).is_err() {
-                    self.requeue(job, &mut iter);
                     return;
                 }
             }
         }
         // immediately after this is called, the microtasks will be drained again.
-    }
-
-    /// Put `job` and the rest of a popped batch back: each still has its posted
-    /// task (or the teardown release) to pick it up.
-    fn requeue(
-        &mut self,
-        mut job: *mut TranspilerJob,
-        iter: &mut unbounded_queue::BatchIterator<TranspilerJob>,
-    ) {
-        while let Some(unrun) = NonNull::new(job) {
-            job = iter.next();
-            self.queue.push(unrun);
-        }
     }
 
     pub fn transpile(
@@ -343,47 +467,65 @@ impl RuntimeTranspilerStore {
             }
         }
 
+        let seq = self.order.schedule();
+
         // Build the job by value and `get_init` it into the hive — the `Box`
         // alloc, `JSInternalPromise::create`, and `StrongOptional::create`
         // above all happen *before* the slot is claimed, so an OOM/throw on
         // that path no longer leaves a claimed-but-uninit `TranspilerJob` (which
         // carries `Log`/`String`/`StrongOptional` drop glue) for the next
         // `put()` to drop.
-        let job: *mut TranspilerJob = self
-            .store
-            .get_init(TranspilerJob {
-                non_threadsafe_input_specifier: input_specifier,
-                path: owned_path,
-                global_this: BackRef::new(global_object),
-                non_threadsafe_referrer: referrer,
-                vm,
-                ticket: None,
-                log: bun_ast::Log::init(),
-                loader,
-                promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
-                poll_ref: KeepAlive::default(),
-                resolved_source,
-                generation_number: self.generation_number.load(Ordering::SeqCst),
-                parse_error: None,
-                work_task: WorkPoolTask {
-                    node: Default::default(),
-                    callback: TranspilerJob::run_from_worker_thread,
-                },
-                next: unbounded_queue::Link::new(),
-            })
-            .as_ptr();
+        let job: NonNull<TranspilerJob> = self.store.get_init(TranspilerJob {
+            non_threadsafe_input_specifier: input_specifier,
+            path: owned_path,
+            global_this: BackRef::new(global_object),
+            non_threadsafe_referrer: referrer,
+            vm,
+            ticket: None,
+            log: bun_ast::Log::init(),
+            loader,
+            promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
+            poll_ref: KeepAlive::default(),
+            resolved_source,
+            generation_number: self.generation_number.load(Ordering::SeqCst),
+            seq,
+            parse_error: None,
+            next: unbounded_queue::Link::new(),
+        });
         if cfg!(debug_assertions) {
             bun_core::scoped_log!(
                 RuntimeTranspilerStore,
-                "transpile({}, {}, async)",
+                "transpile({}, {}, async, seq {})",
                 bstr::BStr::new(path.text),
                 // SAFETY: job fully initialized above
-                <&'static str>::from(unsafe { (*job).loader })
+                <&'static str>::from(unsafe { (*job.as_ptr()).loader }),
+                seq
             );
         }
-        // SAFETY: job fully initialized above
-        unsafe { (*job).schedule() };
+        self.schedule(job);
         promise.cast::<c_void>()
+    }
+
+    fn schedule(&mut self, job: NonNull<TranspilerJob>) {
+        // SAFETY: job fully initialized by `transpile()`; JS thread, and the VM
+        // owns the store this slot lives in.
+        let vm = unsafe {
+            // Note: the KeepAlive takes an `EventLoopCtx` vtable; resolve it
+            // via the `get_vm_ctx` hook (registered by `bun_runtime::init`).
+            (*job.as_ptr()).poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
+            let vm = (*job.as_ptr()).vm;
+            (*job.as_ptr()).ticket = Some((*vm).ticket());
+            vm
+        };
+        // `lock()`, not `get_mut()`: pool threads pop through a raw pointer
+        // to the store, so `&mut self` does not make this thread exclusive.
+        self.unstarted.lock().push_back(UnstartedJob(job));
+        WorkPool::schedule_new(TranspileRunner {
+            // SAFETY: BACKREF — the VM owns the store and outlives the runner
+            // (see `TranspileRunner::run_owned`).
+            store: unsafe { ptr::addr_of!((*vm).transpiler_store) },
+            task: WorkPoolTask::default(),
+        });
     }
 }
 
@@ -418,11 +560,12 @@ pub struct TranspilerJob {
     pub global_this: BackRef<JSGlobalObject>,
     pub(crate) poll_ref: KeepAlive,
     pub(crate) generation_number: u32,
+    /// Position in the store's scheduling order; see [`FulfillOrder`].
+    pub(crate) seq: u64,
     pub(crate) log: bun_ast::Log,
     pub(crate) parse_error: Option<crate::CrateError>,
     /// Moved out by `run_from_js_thread`; dropped with the slot otherwise.
     pub(crate) resolved_source: ResolvedSource,
-    pub(crate) work_task: WorkPoolTask,
     /// INTRUSIVE — `UnboundedQueue<TranspilerJob>` link.
     pub(crate) next: unbounded_queue::Link<TranspilerJob>,
 }
@@ -557,27 +700,18 @@ impl TranspilerJob {
         )
     }
 
-    fn schedule(&mut self) {
-        // Note: the KeepAlive takes an
-        // `EventLoopCtx` vtable; resolve it via the `get_vm_ctx` hook (registered by
-        // `bun_runtime::init`).
-        self.poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
-        // SAFETY: JS thread; the VM owns the store this slot lives in.
-        self.ticket = Some(unsafe { (*self.vm).ticket() });
-        WorkPool::schedule(&raw mut self.work_task);
-    }
-
-    unsafe fn run_from_worker_thread(work_task: *mut WorkPoolTask) {
-        // SAFETY: only reachable via `WorkPoolTask::callback` (unsafe-fn-ptr
-        // slot — safe-fn coerces) for the `work_task` field initialised in
-        // `transpile`; the WorkPool calls back with exactly that field, so
-        // `from_field_ptr!` recovers the live `TranspilerJob` parent.
-        let this = unsafe { bun_core::from_field_ptr!(TranspilerJob, work_task, work_task) };
+    /// Pool thread, from a [`TranspileRunner`].
+    ///
+    /// # Safety
+    /// `this` is a job `RuntimeTranspilerStore::schedule` queued and no thread
+    /// has started.
+    unsafe fn run_from_worker_thread(this: NonNull<TranspilerJob>) {
+        let this = this.as_ptr();
         // The slot lives inside the VM, which waits for this ticket, so it is
         // alive throughout. Transpile only while the VM still runs script;
         // either way hand the job back to the JS thread, which completes or
         // releases it.
-        // SAFETY: as above; set in `schedule`.
+        // SAFETY: per fn contract; set in `schedule`.
         let ticket =
             unsafe { (*this).ticket.take() }.expect("scheduled transpile job holds a ticket");
         if ticket.script_allowed() {

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -212,8 +212,9 @@ pub struct RuntimeTranspilerStore {
 pub type Queue = UnboundedQueue<TranspilerJob>;
 
 struct UnstartedJob(NonNull<TranspilerJob>);
-// SAFETY: the job slot is handed to whichever pool thread starts it; see
-// `TranspileRunner`.
+// SAFETY: a slot in the VM's store, queued together with a `TranspileRunner`
+// whose `Ticket` the VM's teardown waits for; only the pool thread that pops
+// it touches it until it is dispatched back to the JS thread.
 unsafe impl Send for UnstartedJob {}
 
 impl Default for RuntimeTranspilerStore {
@@ -284,20 +285,22 @@ impl FulfillOrder {
 
 /// One per scheduled job. Runs the oldest unstarted job, not its own, so a
 /// burst starts in request order although the pool runs tasks newest-first.
+/// Holds the VM's `Ticket` from `schedule` until that job is dispatched back.
 struct TranspileRunner {
     store: *const RuntimeTranspilerStore,
+    ticket: crate::Ticket,
     task: WorkPoolTask,
 }
 
+// SAFETY: carries a `Ticket`; the VM (and `store`, a field of it) outlives it.
 bun_threading::owned_task!(TranspileRunner, task);
 
 impl TranspileRunner {
     #[allow(clippy::boxed_local)] // `owned_task!`'s required signature
     fn run_owned(self: Box<Self>) {
         let job = {
-            // SAFETY: each unstarted job holds a ticket the VM's teardown
-            // waits for, so the VM (and its store) is alive; one job is queued
-            // per runner, so the pop cannot come back empty.
+            // SAFETY: `self.ticket` keeps the VM and its store alive; one job
+            // is queued per runner, so the pop cannot come back empty.
             let mut unstarted = unsafe { (*self.store).unstarted.lock() };
             let job = unstarted.pop_front();
             if unstarted.is_empty() && unstarted.capacity() > 1024 {
@@ -307,7 +310,7 @@ impl TranspileRunner {
         };
         // SAFETY: the slot is live and no other thread touches it until it is
         // dispatched back to the JS thread.
-        unsafe { TranspilerJob::run_from_worker_thread(job.0) };
+        unsafe { TranspilerJob::run_from_worker_thread(job.0, &self.ticket) };
     }
 }
 
@@ -328,8 +331,8 @@ impl RuntimeTranspilerStore {
     /// VM teardown (JS thread, heap alive, script forbidden; called on every
     /// turn of the wait): jobs already handed back whose completion will not
     /// run release their source, log and module promise here instead. Queued ⇒
-    /// the pool thread's last touch of the slot was the push (its ticket was
-    /// moved out first), so the slot is this thread's again. So are parked jobs.
+    /// the pool thread's last touch of the slot was the push (the ticket lives
+    /// in the runner), so the slot is this thread's again. So are parked jobs.
     pub fn release_queued_jobs_for_teardown(&mut self) {
         let batch = self.queue.pop_batch();
         let mut iter = batch.iterator();
@@ -460,7 +463,6 @@ impl RuntimeTranspilerStore {
             global_this: BackRef::new(global_object),
             non_threadsafe_referrer: referrer,
             vm,
-            ticket: None,
             log: bun_ast::Log::init(),
             loader,
             promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
@@ -490,15 +492,15 @@ impl RuntimeTranspilerStore {
         // thread; the VM owns the store the slot lives in.
         let vm = unsafe {
             (*job.as_ptr()).poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
-            let vm = (*job.as_ptr()).vm;
-            (*job.as_ptr()).ticket = Some((*vm).ticket());
-            vm
+            (*job.as_ptr()).vm
         };
         // Pool threads pop through a raw pointer, so lock even with `&mut self`.
         self.unstarted.lock().push_back(UnstartedJob(job));
+        // SAFETY: JS thread; `vm` is the live VM that owns this store.
+        let (store, ticket) = unsafe { (ptr::addr_of!((*vm).transpiler_store), (*vm).ticket()) };
         WorkPool::schedule_new(TranspileRunner {
-            // SAFETY: BACKREF — the VM owns the store and outlives the runner.
-            store: unsafe { ptr::addr_of!((*vm).transpiler_store) },
+            store,
+            ticket,
             task: WorkPoolTask::default(),
         });
     }
@@ -528,10 +530,6 @@ pub struct TranspilerJob {
     // raw pointers/BackRefs are used (BACKREF — VM owns the
     // store and outlives every job).
     pub(crate) vm: *mut VirtualMachine,
-    /// Held from `schedule` until the pool thread has dispatched the job back:
-    /// the job's own slot, the transpiler it copies and the store queue it
-    /// pushes to are all VM-owned, and the VM's teardown waits for the ticket.
-    pub(crate) ticket: Option<crate::Ticket>,
     pub global_this: BackRef<JSGlobalObject>,
     pub(crate) poll_ref: KeepAlive,
     pub(crate) generation_number: u32,
@@ -617,8 +615,8 @@ impl TranspilerJob {
         // replacement a second time).
     }
 
-    /// Pool thread: hand the slot back. `ticket` was moved out of `self`
-    /// first — the JS thread may reuse the slot the moment it is queued.
+    /// Pool thread: hand the slot back. `ticket` is the runner's, not in the
+    /// slot: the JS thread may reuse the slot the moment it is queued.
     fn dispatch_to_main_thread(&mut self, ticket: &crate::Ticket) {
         let vm = self.vm;
         // SAFETY: the VM outlives the ticket (it owns the store).
@@ -677,22 +675,19 @@ impl TranspilerJob {
 
     /// # Safety
     /// Pool thread only; `this` was queued by `RuntimeTranspilerStore::schedule`
-    /// and no thread has started it.
-    unsafe fn run_from_worker_thread(this: NonNull<TranspilerJob>) {
+    /// and no thread has started it. `ticket` is the runner's, for this VM.
+    unsafe fn run_from_worker_thread(this: NonNull<TranspilerJob>, ticket: &crate::Ticket) {
         let this = this.as_ptr();
-        // The slot lives inside the VM, which waits for this ticket, so it is
+        // The slot lives inside the VM, which waits for `ticket`, so it is
         // alive throughout. Transpile only while the VM still runs script;
         // either way hand the job back to the JS thread, which completes or
         // releases it.
-        // SAFETY: per fn contract; set in `schedule`.
-        let ticket =
-            unsafe { (*this).ticket.take() }.expect("scheduled transpile job holds a ticket");
         if ticket.script_allowed() {
             // SAFETY: live slot, exclusively ours until dispatched.
-            unsafe { (*this).run(&ticket) };
+            unsafe { (*this).run(ticket) };
         } else {
             // SAFETY: as above.
-            unsafe { (*this).dispatch_to_main_thread(&ticket) };
+            unsafe { (*this).dispatch_to_main_thread(ticket) };
         }
     }
 

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -201,16 +201,12 @@ pub struct RuntimeTranspilerStore {
     pub(crate) generation_number: AtomicU32,
     pub(crate) store: TranspilerJobStore,
     pub enabled: bool,
-    /// Scheduled jobs no pool thread has started yet, oldest first. Each
-    /// scheduled job also puts one [`TranspileRunner`] on the pool, and each
-    /// runner starts the oldest job here rather than a fixed one, so a burst of
-    /// jobs starts in scheduling order whatever order the pool runs its tasks
-    /// in. That keeps a finished job's wait for its turn (below) short.
+    /// Scheduled jobs no pool thread has started, oldest first. Pool threads
+    /// start them in this order (see [`TranspileRunner`]).
     unstarted: Guarded<VecDeque<UnstartedJob>>,
     /// Finished jobs, pushed by pool threads in completion order.
     pub(crate) queue: Queue,
-    /// JS thread only. Hands finished jobs back to JSC in scheduling order;
-    /// see [`FulfillOrder`].
+    /// JS thread only. The order finished jobs go back to JSC in.
     order: FulfillOrder,
 }
 
@@ -234,29 +230,18 @@ impl Default for RuntimeTranspilerStore {
     }
 }
 
-/// Finished jobs go back to JSC strictly in the order `transpile()` scheduled
-/// them, not in the order pool threads happen to finish them.
-///
-/// The order in which fetches settle is the one input to JSC's module loader
-/// that used to depend on thread timing. Everything the loader does after a
-/// fetch settles (parse, request the imports, and, once the last fetch of a
-/// graph is in, link and evaluate it) runs on the JS thread in microtasks, and
-/// each hand-back is followed by a microtask drain. So with fetches settling in
-/// scheduling order, the order in which concurrently loading graphs evaluate
-/// (two `import()` calls in one tick, say), and which error a graph with
-/// several bad modules reports, are functions of the module graph alone and
-/// come out the same on every run: a graph evaluates right after the hand-back
-/// of the last module it was still waiting for. For graphs that share no
-/// modules that puts the shallower graph first and graphs of equal depth in
-/// the order they were requested, as node does. Transpiling stays parallel.
+/// Hands finished jobs back to JSC strictly in the order `transpile()`
+/// scheduled them, not in the order pool threads finish them. JSC evaluates a
+/// module graph in the microtask drain after its last fetch settles, so the
+/// settle order decides which of several concurrently loading graphs (two
+/// `import()` calls in one tick, say) evaluates first. Scheduling order makes
+/// that the same on every run. Transpiling itself stays parallel.
 #[derive(Default)]
 struct FulfillOrder {
-    /// Sequence number for the next job `transpile()` schedules.
     next_seq: u64,
     /// Sequence number of the next job to hand back.
     next_to_fulfill: u64,
-    /// Finished jobs waiting for an older one to finish; slot `i` holds the
-    /// job with sequence number `next_to_fulfill + i`.
+    /// Finished jobs waiting for an older one; slot `i` is job `next_to_fulfill + i`.
     parked: VecDeque<Option<NonNull<TranspilerJob>>>,
 }
 
@@ -300,8 +285,9 @@ impl FulfillOrder {
     }
 }
 
-/// A pool task that transpiles the oldest job no thread has started yet; see
-/// `RuntimeTranspilerStore::unstarted`.
+/// One per scheduled job. Runs the oldest unstarted job rather than its own,
+/// so a burst of imports starts transpiling in request order even though the
+/// pool runs tasks newest-first, which keeps `FulfillOrder`'s waits short.
 struct TranspileRunner {
     store: *const RuntimeTranspilerStore,
     task: WorkPoolTask,
@@ -313,10 +299,9 @@ impl TranspileRunner {
     #[allow(clippy::boxed_local)] // `owned_task!`'s required signature
     fn run_owned(self: Box<Self>) {
         let job = {
-            // SAFETY: the store is a field of the VM, which outlives every
-            // unstarted job (each holds a ticket the VM's teardown waits for),
-            // and there is one unstarted job per runner not yet run.
-            // `unstarted` is only touched under its lock.
+            // SAFETY: each unstarted job holds a ticket the VM's teardown
+            // waits for, so the VM (and its store) is alive; one job is queued
+            // per runner, so the pop cannot come back empty.
             let mut unstarted = unsafe { (*self.store).unstarted.lock() };
             let job = unstarted.pop_front();
             if unstarted.is_empty() && unstarted.capacity() > 1024 {
@@ -348,8 +333,7 @@ impl RuntimeTranspilerStore {
     /// turn of the wait): jobs already handed back whose completion will not
     /// run release their source, log and module promise here instead. Queued ⇒
     /// the pool thread's last touch of the slot was the push (its ticket was
-    /// moved out first), so the slot is this thread's again. Parked jobs were
-    /// popped by an earlier drain and are this thread's already.
+    /// moved out first), so the slot is this thread's again. So are parked jobs.
     pub fn release_queued_jobs_for_teardown(&mut self) {
         let batch = self.queue.pop_batch();
         let mut iter = batch.iterator();
@@ -372,12 +356,10 @@ impl RuntimeTranspilerStore {
         }
     }
 
-    /// Fulfil the module promise of every finished job whose turn has come (see
-    /// [`FulfillOrder`]). This drain is a dispatcher: each fulfilment is a JS
-    /// entry of its own, so what one leaves pending is folded here and the
-    /// drain goes on; the VM's termination ends it, with the jobs not yet
-    /// fulfilled left parked (a later drain, or the teardown release, picks
-    /// them up).
+    /// Fulfil the module promise of every finished job whose turn has come.
+    /// Each fulfilment is a JS entry of its own: an error one leaves pending is
+    /// reported here and the drain goes on. The VM's termination ends it; jobs
+    /// not yet fulfilled stay parked for a later drain or the teardown release.
     // Note: takes `NonNull` rather than `&mut` for `event_loop`/`vm`
     // because `&mut self` already aliases `vm.transpiler_store` (this `Self` is
     // a field of `VirtualMachine`). Field-level derefs only.
@@ -390,8 +372,7 @@ impl RuntimeTranspilerStore {
         let batch = self.queue.pop_batch();
         let mut iter = batch.iterator();
         while let Some(job) = NonNull::new(iter.next()) {
-            // SAFETY: a live finished job; `seq` was written in `transpile()`
-            // and the pool thread does not touch it.
+            // SAFETY: a live finished job; the pool thread never touches `seq`.
             let seq = unsafe { (*job.as_ptr()).seq };
             bun_core::scoped_log!(
                 RuntimeTranspilerStore,
@@ -406,9 +387,8 @@ impl RuntimeTranspilerStore {
         // SAFETY: `vm` is the live owning VM (caller is the JS-thread tick loop).
         let jsc_vm = unsafe { (*vm.as_ptr()).jsc_vm() };
         let mut first = true;
-        // Fulfilment and the drain both enter JS, which may schedule more jobs
-        // or re-enter this function, so the next job is looked up afresh on
-        // every turn and taken only right before it is fulfilled.
+        // Fulfilment and the drain enter JS, which may re-enter this function,
+        // so the next job is looked up afresh each turn.
         while self.order.next_is_ready() {
             if !first {
                 // if there are more, we need to drain the microtasks from the previous run
@@ -507,22 +487,18 @@ impl RuntimeTranspilerStore {
     }
 
     fn schedule(&mut self, job: NonNull<TranspilerJob>) {
-        // SAFETY: job fully initialized by `transpile()`; JS thread, and the VM
-        // owns the store this slot lives in.
+        // SAFETY: `job` was fully initialized by `transpile()` on this, the JS
+        // thread; the VM owns the store the slot lives in.
         let vm = unsafe {
-            // Note: the KeepAlive takes an `EventLoopCtx` vtable; resolve it
-            // via the `get_vm_ctx` hook (registered by `bun_runtime::init`).
             (*job.as_ptr()).poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
             let vm = (*job.as_ptr()).vm;
             (*job.as_ptr()).ticket = Some((*vm).ticket());
             vm
         };
-        // `lock()`, not `get_mut()`: pool threads pop through a raw pointer
-        // to the store, so `&mut self` does not make this thread exclusive.
+        // Pool threads pop through a raw pointer, so lock even with `&mut self`.
         self.unstarted.lock().push_back(UnstartedJob(job));
         WorkPool::schedule_new(TranspileRunner {
-            // SAFETY: BACKREF — the VM owns the store and outlives the runner
-            // (see `TranspileRunner::run_owned`).
+            // SAFETY: BACKREF — the VM owns the store and outlives the runner.
             store: unsafe { ptr::addr_of!((*vm).transpiler_store) },
             task: WorkPoolTask::default(),
         });
@@ -700,11 +676,9 @@ impl TranspilerJob {
         )
     }
 
-    /// Pool thread, from a [`TranspileRunner`].
-    ///
     /// # Safety
-    /// `this` is a job `RuntimeTranspilerStore::schedule` queued and no thread
-    /// has started.
+    /// Pool thread only; `this` was queued by `RuntimeTranspilerStore::schedule`
+    /// and no thread has started it.
     unsafe fn run_from_worker_thread(this: NonNull<TranspilerJob>) {
         let this = this.as_ptr();
         // The slot lives inside the VM, which waits for this ticket, so it is

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -373,8 +373,15 @@ pub(crate) fn run_task(
             vm.modules.on_poll();
         }
         task_tag::RuntimeTranspilerStore => {
-            let store = cast!(RuntimeTranspilerStore);
-            store.run_from_js_thread(el.into(), global, vm.into());
+            // SAFETY: §Dispatch — tag identifies pointee; the VM's own store.
+            unsafe {
+                RuntimeTranspilerStore::run_from_js_thread(
+                    cast_ptr!(RuntimeTranspilerStore),
+                    el.into(),
+                    global,
+                    vm.into(),
+                )
+            };
         }
 
         // ── hot-reload (early-returns from the drain loop) ───────────────

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -32,7 +32,13 @@
     ]
   },
   "src/jsc/RuntimeTranspilerStore.rs": {
-    "WorkPool::schedule*": 1
+    "WorkPool::schedule*": 1,
+    "owned_task!": [
+      "TranspileRunner"
+    ],
+    "unsafe impl Send": [
+      "UnstartedJob"
+    ]
   },
   "src/jsc/TopExceptionScope.rs": {
     "unsafe impl Send": [

--- a/test/js/bun/resolve/concurrent-dynamic-import.test.ts
+++ b/test/js/bun/resolve/concurrent-dynamic-import.test.ts
@@ -77,9 +77,8 @@ describe.concurrent("concurrent dynamic imports of disjoint graphs evaluate in a
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const results: string[] = JSON.parse(stdout.trim());
     expect(exitCode).toBe(0);
-    return results;
+    return JSON.parse(stdout.trim()) as string[];
   }
 
   test("equal depth: import() call order, even when the first graph is slower to transpile", async () => {

--- a/test/js/bun/resolve/concurrent-dynamic-import.test.ts
+++ b/test/js/bun/resolve/concurrent-dynamic-import.test.ts
@@ -43,12 +43,15 @@ describe.concurrent("concurrent dynamic imports of disjoint graphs evaluate in a
   const rounds = 5;
   // Padded modules take longer to transpile, so completion order alone would
   // put the padded graph last regardless of its shape.
-  const padding = Array.from({ length: 50 }, (_, i) => `export function pad${i}(x) { return x * ${i} + 1; }`).join("\n");
+  const padding = Array.from({ length: 50 }, (_, i) => `export function pad${i}(x) { return x * ${i} + 1; }`).join(
+    "\n",
+  );
 
   function chain(files: Record<string, string>, name: string, round: number, depth: number, pad: string) {
     for (let i = 1; i <= depth; i++) {
       const next = i < depth ? `import "./${name}${i + 1}_${round}.mjs";\n` : "";
-      files[`${name}${i}_${round}.mjs`] = `${next}globalThis.order.push("${name}${i}");\n${pad}\nexport const v = ${i};\n`;
+      files[`${name}${i}_${round}.mjs`] =
+        `${next}globalThis.order.push("${name}${i}");\n${pad}\nexport const v = ${i};\n`;
     }
   }
 

--- a/test/js/bun/resolve/concurrent-dynamic-import.test.ts
+++ b/test/js/bun/resolve/concurrent-dynamic-import.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // Two dynamic imports of the same specifier issued before the first async
@@ -29,4 +29,88 @@ test("concurrent dynamic imports of the same module both resolve", async () => {
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);
+});
+
+// Module sources are transpiled on a thread pool. The order in which two
+// independent import() graphs finish loading, and therefore the order JSC
+// evaluates them in, used to follow whichever pool thread finished first, so
+// the same program produced a different evaluation order from run to run.
+// Transpile results are now handed back to the loader in request order, which
+// makes the evaluation order a function of the graphs alone. For graphs that
+// share no modules the shallower graph evaluates first and equal-depth graphs
+// evaluate in import() call order, which is also the order node produces.
+describe.concurrent("concurrent dynamic imports of disjoint graphs evaluate in a deterministic order", () => {
+  const rounds = 5;
+  // Padded modules take longer to transpile, so completion order alone would
+  // put the padded graph last regardless of its shape.
+  const padding = Array.from({ length: 50 }, (_, i) => `export function pad${i}(x) { return x * ${i} + 1; }`).join("\n");
+
+  function chain(files: Record<string, string>, name: string, round: number, depth: number, pad: string) {
+    for (let i = 1; i <= depth; i++) {
+      const next = i < depth ? `import "./${name}${i + 1}_${round}.mjs";\n` : "";
+      files[`${name}${i}_${round}.mjs`] = `${next}globalThis.order.push("${name}${i}");\n${pad}\nexport const v = ${i};\n`;
+    }
+  }
+
+  function entry(first: string, second: string) {
+    return `
+      const results = [];
+      for (let round = 0; round < ${rounds}; round++) {
+        globalThis.order = [];
+        await Promise.all([import("./${first}_" + round + ".mjs"), import("./${second}_" + round + ".mjs")]);
+        results.push(globalThis.order.join(" "));
+      }
+      console.log(JSON.stringify(results));
+    `;
+  }
+
+  async function run(files: Record<string, string>) {
+    using dir = tempDir("dyn-import-order", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const results: string[] = JSON.parse(stdout.trim());
+    expect(exitCode).toBe(0);
+    return results;
+  }
+
+  test("equal depth: import() call order, even when the first graph is slower to transpile", async () => {
+    const files: Record<string, string> = { "entry.mjs": entry("a1", "b1") };
+    for (let round = 0; round < rounds; round++) {
+      chain(files, "a", round, 4, padding);
+      chain(files, "b", round, 4, "");
+    }
+    const results = await run(files);
+    expect(results).toEqual(Array(rounds).fill("a4 a3 a2 a1 b4 b3 b2 b1"));
+  });
+
+  test("different depth: the shallower graph first", async () => {
+    const files: Record<string, string> = { "entry.mjs": entry("a1", "b1") };
+    for (let round = 0; round < rounds; round++) {
+      chain(files, "a", round, 5, "");
+      chain(files, "b", round, 2, padding);
+    }
+    const results = await run(files);
+    expect(results).toEqual(Array(rounds).fill("b2 b1 a5 a4 a3 a2 a1"));
+  });
+
+  test("wide and shallow before narrow and deep", async () => {
+    const files: Record<string, string> = { "entry.mjs": entry("w_root", "b1") };
+    for (let round = 0; round < rounds; round++) {
+      let imports = "";
+      for (let i = 1; i <= 5; i++) {
+        imports += `import "./w${i}_${round}.mjs";\n`;
+        files[`w${i}_${round}.mjs`] = `globalThis.order.push("w${i}");\n${padding}\nexport const v = ${i};\n`;
+      }
+      files[`w_root_${round}.mjs`] = `${imports}globalThis.order.push("w");\nexport const v = 0;\n`;
+      chain(files, "b", round, 3, "");
+    }
+    const results = await run(files);
+    expect(results).toEqual(Array(rounds).fill("w1 w2 w3 w4 w5 w b3 b2 b1"));
+  });
 });


### PR DESCRIPTION
### Problem
- Two `import()` calls issued in the same tick for disjoint graphs evaluate in a different order from run to run. Node's order is stable. The module-graph fuzzer found 26 of 40 random graphs run-dependent on 1.4.3.
- Cause: `RuntimeTranspilerStore::run_from_js_thread` (`src/jsc/RuntimeTranspilerStore.rs`) fulfilled each fetch promise as soon as its pool thread finished. JSC evaluates a graph when its last fetch settles, so thread timing picked the order.

### Fix
- Hand finished jobs back to JSC strictly in the order `transpile()` scheduled them (`FulfillOrder`). An early finisher is parked until the older jobs are in. Transpiling stays parallel.
- Start jobs oldest-first: each job puts a `TranspileRunner` on the pool that runs the oldest unstarted job, so the hand-back does not wait on the newest job of a burst.
- Correct because the settle order was the loader's only thread-timing input. A graph now evaluates right after the hand-back of the last module it waited for. For graphs that share no modules that is node's order. See Notes for where it is not.
- Verified: `test/js/bun/resolve/concurrent-dynamic-import.test.ts` (3 new cases fail on 1.4.3, match node v26). Fuzzer: 0 of 100 graphs nondeterministic, 66 before.

### Background
- `RuntimeTranspilerStore` transpiles off-thread every ES module fetched after the entry point. `transpile()` hands JSC's fetch hook a promise, and the JS thread fulfils it once the pool thread is done, then drains microtasks.
- JSC's loader is promise driven: a top-level load evaluates its graph in the microtask drain after its last fetch settles.
- `WorkPool` tasks go on a Treiber stack, so a burst runs newest-first.

<details><summary>Notes</summary>

**Open question for review.** Request order gives run-to-run determinism for free on typical startup, but it is node's order only when the concurrent graphs share no modules. Two places differ from node and from `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1` (the synchronous path), deterministically:

- Shared dependency: `import('./b1'); import('./a1')` with `b1 -> [shared, b2]` and `a1 -> [shared]`. Node and the sync path: `shared b2 b1 a1 B A`. This change: `shared a1 A b2 b1 B` (A's graph is complete when `shared` lands, before `b2`). Stock: a coin flip between the two.
- `.then` interleaving: `import('./m1').then(L1); import('./m2').then(L2)` with single-module graphs. Node and the sync path: `m1 m2 L1 L2`. Async transpiler, before and after this change: `m1 L1 m2 L2`, because every hand-back is followed by a full microtask drain. The three `bundler_splitting.test.ts` cases pinned to the sync-path interleaving (d6cfb58) fail without the flag both before and after, so the flag stays there.

Reproducing the sync path's order would take level-batched settlement (hold a graph level's hand-backs and drain once), which costs pipelining on large graphs. If that is the bar, this PR is the wrong shape. This also touches the same code as #40383 and would need to be redone on top of it if that lands first.

Startup cost, release builds without LTO, prebuilt WebKit, interleaved A/B on a loaded 16-core host (noise is about ±5%):

| graph | before (min / median) | after (min / median) |
|---|---|---|
| `import * as _ from "lodash-es"` (650 files) | 44 / 65 ms | 48 / 62 ms |
| entry imports 300 modules with 3 leaves each (1200 files) | 115 / 155 ms | 120 / 159 ms |
| 20 chains of depth 15, 2 leaves per node (900 files) | 99 / 122 ms | 97 / 130 ms |
| 40 concurrent `import()` of depth-4 chains (640 files) | 74 / 103 ms | 72 / 108 ms |
| one 740 KB module first, then 100 small modules with 3 leaves each, transpiler cache off | 101 / 141 ms | 117 / 167 ms |
| same, transpiler cache on (the default, files of 50 KB and up are cached) | 88 / 115 ms | 76 / 114 ms |
| 5000 sequential `await import()` of one file with a query string | 70 µs each | 42-70 µs each |

The one measurable cost is a cold-cache graph where a large module is requested before many small ones: the small modules' imports are not discovered until the large one is transpiled. With the runtime transpiler cache on that case is flat. A follow-up that discovers a module's imports from the transpile result, before JSC parses it, would remove that wait and the JSC round trip per module.

An intermediate design ordered the hand-back only between different top-level loads and left jobs of one graph unordered. It kept full pipelining but still leaked: a graph that piggybacks on a registry entry another graph created completes when that other graph's job lands, and a graph with two failing modules reported whichever error landed first. The fuzzer caught the first case (3 of 40 graphs). Request order is the only total order the JS thread can apply without that leak, because later requests always sort after everything pending.

Repro from the report:

```sh
cd "$(mktemp -d)"; echo '{"name":"r"}' > package.json
for c in a b; do for i in 1 2 3 4; do echo "import \"./$c$((i+1)).mjs\"; globalThis.t.push(\"$c$i\"); export const v=1;" > $c$i.mjs; done
  echo "globalThis.t.push(\"${c}5\"); export const v=1;" > ${c}5.mjs; done
echo 'globalThis.t=[]; process.on("exit",()=>console.log(t.join(" "))); import("./a1.mjs"); import("./b1.mjs");' > entry.mjs
for i in $(seq 40); do bun entry.mjs; done | sort | uniq -c
```

Before: a mix of `a5 a4 a3 a2 a1 b5 b4 b3 b2 b1` and `b5 ... a1`. After: the first line 40 times, the same as node.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/concurrent-dynamic-import.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/177] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/177] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /wo
... (truncated)

release without fix: 3 FAILED
bun test v1.4.2 (744846f84)

test/js/bun/resolve/concurrent-dynamic-import.test.ts:
(pass) concurrent dynamic imports of the same module both resolve [10.38ms]
 96 |     for (let round = 0; round < rounds; round++) {
 97 |       chain(files, "a", round, 5, "");
 98 |       chain(files, "b", round, 2, padding);
 99 |     }
100 |     const results = await run(files);
101 |     expect(results).toEqual(Array(rounds).fill("b2 b1 a5 a4 a3 a2 a1"));
                          ^
error: expect(received).toEqual(expected)

  [
-   "b2 b1 a5 a4 a3 a2 a1",
-   "b2 b1 a5 a4 a3 a2 a1",
-   "b2 b1 a5 a4 a3 a2 a1",
-   "b2 b1 a5 a4 a3 a2 a1",
-   "b2 b1 a5 a4 a3 a2 a1",
+   "a5 a4 a3 a2 a1 b2 b1",
+   "a5 a4 a3 a2 a1 b2 b1",
+   "a5 a4 a3 a2 a1 b2 b1",
+   "a5 a4 a3 a2 a1 b2 b1",
+   "a5 a4 a3 a2 a1 b2 b1",
  ]

- Expected  - 5
+ Received  + 5

      at <anonymous> (/workspace/bun/test/js/bun/resolve/concurrent-dynamic-import.test.ts:101:21)
(fail) concurrent dynamic imports of disjoint graphs evaluate in a deterministic order > different depth: the shallower graph first [14.35ms]
111 |       }
112 |       files[`w_root_${round}.mjs`] = `${imports}globalThis.order.push("w");\nexport
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/resolve/concurrent-dynamic-import.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/resolve/concurrent-dynamic-import.test.ts:
(pass) concurrent dynamic imports of the same module both resolve [419.66ms]
(pass) concurrent dynamic imports of disjoint graphs evaluate in a deterministic order > different depth: the shallower graph first [811.12ms]
(pass) concurrent dynamic imports of disjoint graphs evaluate in a deterministic order > wide and shallow before narrow and deep [811.41ms]
(pass) concurrent dynamic imports of disjoint graphs evaluate in a deterministic order > equal depth: import() call order, even when the first graph is slower to transpile [1212.55ms]

 4 pass
 0 fail
 12 expect() calls
Ran 4 tests across 1 file. [4.51s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f1883c2a0c
  features     baseline

23 deps, 131 codegen, 1172 objects in 732ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] mkdir stamps
[2/1248] mkdir codegen
[3/1248] mkdir obj
[4/1248] mkdir pch
[5/1248] install /workspace/bun
bun install v1.4.2 (744846f84)

Checked 22 installs across 61 packages (no changes) [11.00ms]
[6/1248] install /workspace/bun/packages/bun-error
bun install v1.4.2 (744846f84)

Checked 1 install across 2 packages (no changes) [1.00ms]
[7/1248] gen ErrorCode+*.h
[8/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.2 (744846f84)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[9/1248] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[10/1248] fetch picohttpparser
[picohttpparser] up to date
[11/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[12/1248] fetch tinycc
[tinycc] up to date
[13/1248] gen bindgenv2
[14/1248] gen .bind.ts → GeneratedBindin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/RuntimeTranspilerStore.rs                  | 304 ++++++++++++++-------
 src/runtime/dispatch.rs                            |  11 +-
 .../source-lints/vm-thread-door.inventory.json     |   8 +-
 .../bun/resolve/concurrent-dynamic-import.test.ts  |  88 +++++-
 4 files changed, 306 insertions(+), 105 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/RuntimeTranspilerStore.rs                            18     43     21
src/runtime/dispatch.rs                                       3      1     18
test/internal/source-lints/vm-thread-door.inventory.json      0      0     21
test/js/bun/resolve/concurrent-dynamic-import.test.ts         3      4     18
```

</details>

<!-- robobun:evidence:end -->