### PR TITLE
webcore: clone() keeps the Blob behind an unread native body stream instead of teeing it

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5997,6 +5997,25 @@ fn resolve_file_stat(store: &RefPtr<Store>) {
     }
 }
 
+/// Whether a second Blob over `store` reads the same bytes from the start.
+/// Memory and S3 do. A path does when it names a regular file (each read
+/// opens it again); it is stat'd here if that is not yet known. A file
+/// descriptor never does: its offset, and for a pipe its bytes, are shared.
+pub(crate) fn store_reads_repeatably(store: &RefPtr<Store>) -> bool {
+    match Store::data_mut(store).tag() {
+        store::DataTag::Bytes | store::DataTag::S3 => true,
+        store::DataTag::File => {
+            if let PathOrFileDescriptor::Fd(_) = Store::data_mut(store).as_file().pathlike {
+                return false;
+            }
+            if Store::data_mut(store).as_file().seekable.is_none() {
+                resolve_file_stat(store);
+            }
+            Store::data_mut(store).as_file().seekable != Some(false)
+        }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // toStringWithBytes / toString / toJSON / toFormData / toArrayBuffer{View}
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -370,6 +370,24 @@ impl PendingValue {
         None
     }
 
+    /// [`Self::to_any_blob`] for `clone()`: the stream is the wrapper's cached
+    /// `.body` when there is one, and it is detached afterwards so a reference
+    /// the caller still holds reads as locked, the state a tee leaves it in.
+    fn take_blob_from_unread_stream(
+        &mut self,
+        global: &JSGlobalObject,
+        cached: Option<ReadableStream>,
+    ) -> Option<AnyBlob> {
+        if self.promise.is_some() || self.on_receive_value.is_some() {
+            return None;
+        }
+        let mut stream = cached.or_else(|| self.readable.get())?;
+        let blob = stream.to_any_blob(global)?;
+        stream.force_detach(global);
+        self.readable.deinit();
+        Some(blob)
+    }
+
     fn set_promise(
         &mut self,
         global_this: &JSGlobalObject,
@@ -1526,11 +1544,16 @@ impl Value {
         global_this: &JSGlobalObject,
         readable: Option<&mut ReadableStream>,
     ) -> JsResult<Value> {
-        // Tee a Locked body before any blob extraction: `to_blob_if_possible()`
-        // would `.done()` an already-materialized `.body` stream, leaving the
-        // user-visible cached stream empty instead of a live tee branch.
-        if matches!(self, Value::Locked(_)) {
-            return self.tee(global_this, readable);
+        // A native blob, file, or fully buffered byte stream that nothing has
+        // read goes back to being a Blob, so both bodies share one store (and
+        // its type) instead of pumping the bytes through a JS tee. The owner
+        // must then drop its cached `.body` (`sync_body_stream_caches`).
+        // Anything else is teed.
+        if let Value::Locked(locked) = self {
+            match locked.take_blob_from_unread_stream(global_this, readable.as_deref().copied()) {
+                Some(blob) => *self = Value::from(blob),
+                None => return self.tee(global_this, readable),
+            }
         }
 
         self.to_blob_if_possible();
@@ -1651,9 +1674,29 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         }
     }
 
+    /// After `clone()` replaced this body's stream: point the wrapper's cached
+    /// `body` at the tee branch now in `Locked.readable`, or, when the clone
+    /// moved an unread native stream back into a Blob, forget the detached
+    /// stream so `.body` is rebuilt from that Blob.
+    fn sync_body_stream_caches(&self, this_value: JSValue, global_this: &JSGlobalObject) {
+        match self.get_body_value() {
+            Value::Locked(locked) => {
+                if let Some(readable) = locked.readable.get() {
+                    Self::body_set_cached(this_value, global_this, readable.value);
+                }
+            }
+            _ => {
+                if Self::stream_get_cached(this_value).is_some() {
+                    Self::stream_set_cached(this_value, global_this, JSValue::ZERO);
+                    Self::body_set_cached(this_value, global_this, JSValue::ZERO);
+                }
+            }
+        }
+    }
+
     /// Shared tail of `do_clone`: after the clone's `to_js` ran
     /// `check_body_stream_ref`, sync both wrappers' cached `body` slots to
-    /// their respective teed streams, then migrate the original's
+    /// their respective streams, then migrate the original's
     /// `Locked.readable` into its own `js.gc.stream`.
     fn sync_cloned_body_stream_caches(
         &self,
@@ -1666,17 +1709,13 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 Self::body_set_cached(js_wrapper, global_this, cloned_stream);
             }
         }
-        if let Value::Locked(locked) = self.get_body_value() {
-            if let Some(readable) = locked.readable.get() {
-                Self::body_set_cached(this_value, global_this, readable.value);
-            }
-        }
+        self.sync_body_stream_caches(this_value, global_this);
         self.check_body_stream_ref(global_this);
     }
 
-    /// Shared body-clone for `clone_into` / `clone_value`: tee through the
-    /// JS-side cached stream when present, then repoint this owner's
-    /// `body`/`stream` cache slots at the fresh branch in `locked.readable`.
+    /// Shared body-clone for `clone_into` / `clone_value`: clone through the
+    /// JS-side cached stream when present, then resync this owner's
+    /// `body`/`stream` cache slots with whatever the body now holds.
     fn clone_body_value_via_cached_stream(&self, global_this: &JSGlobalObject) -> JsResult<Value> {
         let cloned = 'brk: {
             if let Some(js_ref) = self.js_ref() {
@@ -1692,11 +1731,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
             self.get_body_value().clone(global_this)?
         };
         if let Some(js_ref) = self.js_ref() {
-            if let Value::Locked(locked) = self.get_body_value() {
-                if let Some(readable) = locked.readable.get() {
-                    Self::body_set_cached(js_ref, global_this, readable.value);
-                }
-            }
+            self.sync_body_stream_caches(js_ref, global_this);
         }
         self.check_body_stream_ref(global_this);
         Ok(cloned)

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -17,7 +17,6 @@ use bun_http_types::MimeType::MimeType;
 use crate::jsc::HTTPHeaderName;
 pub use crate::webcore::InternalBlob;
 use crate::webcore::form_data::AsyncFormDataExt as _;
-use crate::webcore::node_types::PathOrFileDescriptor;
 use bun_core::String as BunString;
 use bun_core::{Utf8Bytes, WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
 use bun_jsc::JsCell;
@@ -383,17 +382,14 @@ impl PendingValue {
             return None;
         }
         let mut stream = cached.or_else(|| self.readable.get())?;
-        // Two Blobs over one file descriptor (a pipe, a socket, stdin) would
-        // compete for its bytes, so an fd-backed stream stays teed. A path is
-        // opened again for every read, as for a cloned `Bun.file()` body.
+        // Two Blobs over a pipe, a tty, or any fd would compete for its bytes,
+        // so a stream over such a file stays teed.
         if let Some(reader) = stream.ptr.file() {
             let webcore::file_reader::Lazy::Blob(store) = reader.lazy.get() else {
                 return None;
             };
-            if let blob::store::Data::File(file) = &store.data {
-                if let PathOrFileDescriptor::Fd(_) = file.pathlike {
-                    return None;
-                }
+            if !blob::store_reads_repeatably(store) {
+                return None;
             }
         }
         let blob = stream.to_any_blob(global)?;
@@ -1578,6 +1574,14 @@ impl Value {
         }
 
         if let Value::Blob(b) = self {
+            if b.store()
+                .is_some_and(|store| !blob::store_reads_repeatably(store))
+            {
+                // A pipe or other fd yields its bytes once: read it as one
+                // stream and tee that.
+                self.to_readable_stream(global_this)?;
+                return self.tee(global_this, None);
+            }
             return Ok(Value::Blob(b.dupe_with_content_type(false)));
         }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -17,6 +17,7 @@ use bun_http_types::MimeType::MimeType;
 use crate::jsc::HTTPHeaderName;
 pub use crate::webcore::InternalBlob;
 use crate::webcore::form_data::AsyncFormDataExt as _;
+use crate::webcore::node_types::PathOrFileDescriptor;
 use bun_core::String as BunString;
 use bun_core::{Utf8Bytes, WTFStringImpl, WTFStringImplExt as _, WTFStringImplStruct};
 use bun_jsc::JsCell;
@@ -382,6 +383,19 @@ impl PendingValue {
             return None;
         }
         let mut stream = cached.or_else(|| self.readable.get())?;
+        // Two Blobs over one file descriptor (a pipe, a socket, stdin) would
+        // compete for its bytes, so an fd-backed stream stays teed. A path is
+        // opened again for every read, as for a cloned `Bun.file()` body.
+        if let Some(reader) = stream.ptr.file() {
+            let webcore::file_reader::Lazy::Blob(store) = reader.lazy.get() else {
+                return None;
+            };
+            if let blob::store::Data::File(file) = &store.data {
+                if let PathOrFileDescriptor::Fd(_) = file.pathlike {
+                    return None;
+                }
+            }
+        }
         let blob = stream.to_any_blob(global)?;
         stream.force_detach(global);
         self.readable.deinit();

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 
 test("Request with streaming body can be cloned", async () => {
@@ -1133,18 +1133,20 @@ describe("clone() of a body over an unread native stream keeps the Blob behind i
     });
   });
 
-  // A file descriptor yields its bytes once. Two Blobs over stdin would
-  // compete for them, so an fd-backed stream is still teed and both bodies
+  // A pipe yields its bytes once, so two Blobs over it would compete for
+  // them. A body over such a store is read as one stream and teed instead,
+  // whether it was given as a stream or as the Blob itself, and both bodies
   // see the whole input.
-  test("a body over Bun.stdin.stream() is still teed", async () => {
+  async function cloneInChild(bodyExpr: string, args: string[] = []) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
-        `const r = new Response(Bun.stdin.stream());
+        `const r = new Response(${bodyExpr});
          const c = r.clone();
          const [a, b] = await Promise.all([r.text(), c.text()]);
          console.log(JSON.stringify([a, b]));`,
+        ...args,
       ],
       env: bunEnv,
       stdin: "pipe",
@@ -1156,11 +1158,29 @@ describe("clone() of a body over an unread native stream keeps the Blob behind i
     proc.stdin.write("world");
     await proc.stdin.end();
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-      stdout: `["hello world","hello world"]`,
-      stderr: "",
-      exitCode: 0,
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+  const bothBodiesReadStdin = { stdout: `["hello world","hello world"]`, stderr: "", exitCode: 0 };
+
+  test("a body over Bun.stdin.stream() is still teed", async () => {
+    expect(await cloneInChild("Bun.stdin.stream()")).toEqual(bothBodiesReadStdin);
+  });
+
+  test("a body over Bun.stdin itself is teed, not duped", async () => {
+    expect(await cloneInChild("Bun.stdin")).toEqual(bothBodiesReadStdin);
+  });
+
+  // The same store kind reached by path: stat says it is not a regular file.
+  test.skipIf(isWindows)("a body over a FIFO opened by path is still teed", async () => {
+    const fifo = join(tempDirWithFiles("body-clone-fifo", {}), "body.fifo");
+    expect(Bun.spawnSync({ cmd: ["mkfifo", fifo] }).exitCode).toBe(0);
+    await using writer = Bun.spawn({
+      cmd: ["sh", "-c", `printf 'hello world' > "$1"`, "sh", fifo],
+      stdout: "ignore",
+      stderr: "inherit",
     });
+    expect(await cloneInChild("Bun.file(process.argv.at(-1)).stream()", [fifo])).toEqual(bothBodiesReadStdin);
+    expect(await writer.exited).toBe(0);
   });
 });
 

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1089,9 +1089,9 @@ describe("clone() of a body over an unread native stream keeps the Blob behind i
   });
 
   test("Request over Bun.file().stream()", async () => {
-    expect(
-      await typesAndText(new Request("http://example.com/", { method: "POST", body: file().stream() })),
-    ).toEqual(expected);
+    expect(await typesAndText(new Request("http://example.com/", { method: "POST", body: file().stream() }))).toEqual(
+      expected,
+    );
   });
 
   test("Response over Bun.file() after .body was observed", async () => {
@@ -1130,6 +1130,36 @@ describe("clone() of a body over an unread native stream keeps the Blob behind i
     expect(results).toEqual({
       "/direct": ["text/html;charset=utf-8", "<p>hi</p>"],
       "/clone": ["text/html;charset=utf-8", "<p>hi</p>"],
+    });
+  });
+
+  // A file descriptor yields its bytes once. Two Blobs over stdin would
+  // compete for them, so an fd-backed stream is still teed and both bodies
+  // see the whole input.
+  test("a body over Bun.stdin.stream() is still teed", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = new Response(Bun.stdin.stream());
+         const c = r.clone();
+         const [a, b] = await Promise.all([r.text(), c.text()]);
+         console.log(JSON.stringify([a, b]));`,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    proc.stdin.write("hello ");
+    await proc.stdin.flush();
+    proc.stdin.write("world");
+    await proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: `["hello world","hello world"]`,
+      stderr: "",
+      exitCode: 0,
     });
   });
 });

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDirWithFiles } from "harness";
+import { join } from "node:path";
 
 test("Request with streaming body can be cloned", async () => {
   const stream = new ReadableStream({
@@ -908,9 +909,19 @@ describe.concurrent("clone() after `.body` was observed returns a fresh tee bran
   //     Blob-backed stream
   //   - new Response(ReadableStream) → Locked with a user stream already
   //     rooted in the JS-side stream slot
+  //   - new Response(Bun.file()) → Blob over a file store, then .body
+  //     materializes a file-backed stream
+  //   - new Response(Bun.file().stream()) → Locked with an unread
+  //     file-backed stream
   const N = 8192;
   const payload = Buffer.alloc(N, "a");
+  const fileDir = tempDirWithFiles("body-clone-observe", { "payload.bin": payload });
   const cases: Array<[string, () => Promise<Request | Response>]> = [
+    ["Response with a Bun.file() body", async () => new Response(Bun.file(join(fileDir, "payload.bin")))],
+    [
+      "Response with a Bun.file() stream body",
+      async () => new Response(Bun.file(join(fileDir, "payload.bin")).stream()),
+    ],
     [
       "fetch() Response with a buffered body",
       async () => {
@@ -1051,6 +1062,75 @@ test("new Request(src, init) with a user ReadableStream body: both derived and s
     twoArg: { derived: [1, 2, 3], src: [1, 2, 3] },
     oneArg: { derived: [1, 2, 3], src: [1, 2, 3] },
     fromResponse: { derived: [1, 2, 3], src: [1, 2, 3] },
+  });
+});
+
+// The readers and Bun.serve move an unread Bun.file()/Blob stream back into
+// the Blob it came from, type included. clone() must do the same instead of
+// teeing it into two plain JS streams, or the clone (and, once `.body` was
+// observed, the original too) answers differently from an un-cloned body.
+describe("clone() of a body over an unread native stream keeps the Blob behind it", () => {
+  const dir = tempDirWithFiles("body-clone-type", { "page.html": "<p>hi</p>" });
+  const file = () => Bun.file(join(dir, "page.html"));
+  const typed = () => new Blob(["<p>hi</p>"], { type: "text/html;charset=utf-8" });
+
+  async function typesAndText(original: Request | Response) {
+    const clone = original.clone();
+    const [a, b] = await Promise.all([original.blob(), clone.blob()]);
+    return { original: [a.type, await a.text()], clone: [b.type, await b.text()] };
+  }
+  const expected = {
+    original: ["text/html;charset=utf-8", "<p>hi</p>"],
+    clone: ["text/html;charset=utf-8", "<p>hi</p>"],
+  };
+
+  test("Response over Bun.file().stream()", async () => {
+    expect(await typesAndText(new Response(file().stream()))).toEqual(expected);
+  });
+
+  test("Request over Bun.file().stream()", async () => {
+    expect(
+      await typesAndText(new Request("http://example.com/", { method: "POST", body: file().stream() })),
+    ).toEqual(expected);
+  });
+
+  test("Response over Bun.file() after .body was observed", async () => {
+    const response = new Response(file());
+    expect(response.body).toBeInstanceOf(ReadableStream);
+    expect(await typesAndText(response)).toEqual(expected);
+  });
+
+  test("Response over a typed Blob after .body was observed", async () => {
+    const response = new Response(typed());
+    expect(response.body).toBeInstanceOf(ReadableStream);
+    expect(await typesAndText(response)).toEqual(expected);
+  });
+
+  test("the stream given to the constructor is locked after clone() and .body is a fresh stream", async () => {
+    const stream = file().stream();
+    const response = new Response(stream);
+    expect(response.body).toBe(stream);
+    const clone = response.clone();
+    expect(stream.locked).toBe(true);
+    expect(response.body).not.toBe(stream);
+    expect(await Promise.all([response.text(), clone.text()])).toEqual(["<p>hi</p>", "<p>hi</p>"]);
+  });
+
+  test("Bun.serve sends the file's Content-Type for a cloned Response over Bun.file().stream()", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req =>
+        new URL(req.url).pathname === "/clone" ? new Response(file().stream()).clone() : new Response(file().stream()),
+    });
+    const results: Record<string, [string | null, string]> = {};
+    for (const path of ["/direct", "/clone"]) {
+      const res = await fetch(new URL(path, server.url));
+      results[path] = [res.headers.get("content-type"), await res.text()];
+    }
+    expect(results).toEqual({
+      "/direct": ["text/html;charset=utf-8", "<p>hi</p>"],
+      "/clone": ["text/html;charset=utf-8", "<p>hi</p>"],
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `new Response(Bun.file("a.html").stream())` answers `blob().type === "text/html;charset=utf-8"` and Bun.serve sends that Content-Type. After `.clone()` both bodies answer `""` and Bun.serve sends none. A `Bun.file()` or typed `Blob` body loses it too once `.body` was observed first.
- Cause: `Value::clone_with_readable_stream` (`src/runtime/webcore/Body.rs`) tees every stream-backed body through JS, so the store behind an unread native stream (MIME type, sendfile path) is gone on both sides. The Blob arm has the mirror bug: `new Response(Bun.stdin).clone()` dupes a Blob over fd 0 and the clone reads `""`.

### Fix
- `clone()` decides per store. A store that reads the same twice (memory, S3, a regular file by path) is duped. An unread native stream first moves back into its Blob through `ReadableStream::to_any_blob`, as the readers and Bun.serve already do. A store that yields its bytes once (any fd, a FIFO by path) is read as one stream and teed. JS streams and partly read bodies tee as before.
- The pre-clone stream is detached, so a held reference reads as locked, as after a tee. The cached `.body` is cleared and rebuilt from the Blob (the #33779 guarantees hold).
- Correct because both bodies now resolve to what the un-cloned body resolves to, so every consumer answers the clone as it answers the original.
- Verified: `test/js/web/fetch/body-clone.test.ts` (13 new tests, 6 fail on stock bun) and the neighbouring body, response, request, FormData, blob, serve and fetch suites. Self-reviewed: 2 concerns raised, both addressed.

### Background
- A body `Value` is a `Blob` (memory, `Bun.file()` store, S3), a string or byte buffer, or `Locked` (a `ReadableStream`). `new Response(stream)` is `Locked`, as is any body once `.body` ran.
- A native stream over a Blob or an unopened file holds a ref to its `Store`. `to_any_blob` turns it back into a Blob without reading it.
- The JS wrapper caches `.body` and its stream. A clone that changes what the body holds must resync both (#33779).

<details><summary>Notes</summary>

- Ledger context: content-type propagation matrix, member "`new Response(Bun.file(p).stream())`: type recovered for the direct return, dropped by `.clone()`; Bun.serve `/direct text/html`, `/clone null`". Expected: clone == original.
- `store_reads_repeatably()` (`Blob.rs`, next to `resolve_file_stat`): Bytes and S3 are repeatable; a `File` over an fd never is (reads share the fd offset, and a pipe's bytes are gone once read: `new Response(Bun.file(fd)).clone()` read `""` on the second body even for a regular file); a `File` over a path is stat'd once if `seekable` is unknown and is repeatable unless stat says it is not a regular file. A missing path stays repeatable (both bodies fail the same way).
- Probes: with an fd-only guard, `new Response(Bun.file(fifoPath).stream()).clone()` hung on the second open while stock's tee delivered the bytes to both; `new Response(Bun.stdin).clone()` gives `["hello world", ""]` on stock. Both are tests now (posix for the FIFO).
- Not changed here, left for a maintainer call: `new Response(new Blob([..], { type }).stream())` puts the type into the header list at construction (undici: `null`) because `Value::from_js` moves a memory-blob stream into its Blob eagerly, while a file stream stays `Locked` until first use, so its headers stay `null`. Making file streams eager too would route `fetch(url, { body: Bun.file(p).stream() })` through the file-blob upload path (a synchronous whole-file read over https, `fetch.rs` "TODO: make this async + lazy") instead of a streamed upload, so it is not done here.
- Side effect worth knowing: `Response` derives a missing `Content-Type` header lazily from a Blob body on first `.headers` access. For `new Response(file.stream())`, calling `.clone()` before the first `.headers` access therefore makes `content-type: text/html` appear on both. Header derivation is already order-dependent today (`.body` or `.text()` before `.headers` drops it, see #32913); this adds no new mechanism.
- Suites run locally on the debug+ASAN build: body-clone (76/76), body (476), response, request, body-stream (9086), FormData (149), blob (110), bun-serve-static (46), regression 18547/02368/2993/25648, serve.test.ts -t "clone|type|Content|file" (84), fetch.test.ts -t clone. `request-clone-leak.test.ts` and `request-method-getter.test.ts` time out at 5 s per test on this build for the constructor-only cases too; unrelated.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body-clone.test.ts

<!-- robobun:evidence:end -->