### PR TITLE
sql, redis: call tls.checkServerIdentity, honor tls.servername, send SNI from RedisClient

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4650,7 +4650,7 @@ declare module "bun" {
     /**
      * Alias of {@link serverName} (the `node:tls` spelling). `serverName` wins if both are set.
      */
-    servername?: string;
+    servername?: string | undefined;
 
     /**
      * Sets `OPENSSL_RELEASE_BUFFERS` to 1.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4648,6 +4648,11 @@ declare module "bun" {
     serverName?: string;
 
     /**
+     * Alias of {@link serverName} (the `node:tls` spelling). `serverName` wins if both are set.
+     */
+    servername?: string;
+
+    /**
      * Sets `OPENSSL_RELEASE_BUFFERS` to 1.
      * Reduces overall performance but saves some memory.
      * @default false

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -35,9 +35,23 @@ declare module "bun" {
     enableOfflineQueue?: boolean;
 
     /**
-     * TLS options
+     * TLS options. `true` (or a `rediss://` URL) enables TLS with the default
+     * options. `serverName` sets the SNI and the name the certificate is
+     * verified against (by default the URL host).
      */
-    tls?: boolean | Bun.TLSOptions;
+    tls?:
+      | boolean
+      | (Bun.TLSOptions & {
+          /**
+           * Replaces the built-in check of the server certificate against
+           * `serverName`, as in `tls.connect()`. It runs once the certificate
+           * chain is verified, and not at all with `rejectUnauthorized: false`.
+           * @param hostname The name the certificate is expected to match
+           * @param cert The server's certificate
+           * @returns An `Error` to refuse the connection, or `undefined` to accept it
+           */
+          checkServerIdentity?: NonNullable<import("node:tls").ConnectionOptions["checkServerIdentity"]>;
+        });
 
     /**
      * Whether to enable auto-pipelining

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -50,7 +50,7 @@ declare module "bun" {
            * @param cert The server's certificate
            * @returns An `Error` to refuse the connection, or `undefined` to accept it
            */
-          checkServerIdentity?: NonNullable<import("node:tls").ConnectionOptions["checkServerIdentity"]>;
+          checkServerIdentity?: NonNullable<import("node:tls").ConnectionOptions["checkServerIdentity"]> | undefined;
         });
 
     /**

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -201,6 +201,24 @@ declare module "bun" {
       onclose?: ((err: Error | null) => void) | undefined;
     }
 
+    /**
+     * TLS options for a PostgreSQL or MySQL connection
+     */
+    interface TLSOptions extends Bun.TLSOptions {
+      /**
+       * Replaces the built-in check of the server certificate against
+       * `serverName` (by default the connection's hostname), as in
+       * `tls.connect()`. It runs once the certificate chain is verified, under
+       * the `verify-ca` and `verify-full` SSL modes. Like `ca`, setting it
+       * turns certificate verification on unless an SSL mode or
+       * `rejectUnauthorized: false` says otherwise.
+       * @param hostname The name the certificate is expected to match
+       * @param cert The server's certificate
+       * @returns An `Error` to refuse the connection, or `undefined` to accept it
+       */
+      checkServerIdentity?: NonNullable<import("node:tls").ConnectionOptions["checkServerIdentity"]> | undefined;
+    }
+
     interface PostgresOrMySQLOptions {
       /**
        * Connection URL, for example `postgres://user:pass@localhost:5432/mydb`

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -514,6 +514,14 @@ impl SSL {
         }
     }
 
+    /// Sets the SNI host name a client connection sends in its ClientHello.
+    /// Call before the handshake starts. `false` if BoringSSL rejects the name
+    /// (empty or longer than 255 bytes).
+    pub fn set_servername(&mut self, hostname: &core::ffi::CStr) -> bool {
+        // SAFETY: `self` is a live SSL; BoringSSL copies `hostname`.
+        unsafe { SSL_set_tlsext_host_name(self, hostname.as_ptr()) == 1 }
+    }
+
     /// The peer's leaf certificate, borrowed from this SSL's cert chain.
     pub fn peer_leaf_certificate(&mut self) -> Option<&mut X509> {
         // SAFETY: the chain and its entries are owned by this SSL and outlive

--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -514,9 +514,7 @@ impl SSL {
         }
     }
 
-    /// Sets the SNI host name a client connection sends in its ClientHello.
-    /// Call before the handshake starts. `false` if BoringSSL rejects the name
-    /// (empty or longer than 255 bytes).
+    /// Client side: the SNI host name to send. Set it before the handshake; `false` if BoringSSL rejects it.
     pub fn set_servername(&mut self, hostname: &core::ffi::CStr) -> bool {
         // SAFETY: `self` is a live SSL; BoringSSL copies `hostname`.
         unsafe { SSL_set_tlsext_host_name(self, hostname.as_ptr()) == 1 }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -2118,8 +2118,7 @@ function parseOptions(
     if (checkServerIdentity !== undefined && !$isCallable(checkServerIdentity)) {
       throw $ERR_INVALID_ARG_TYPE("tls.checkServerIdentity", "function", checkServerIdentity);
     }
-    // Options that only make sense with certificate verification request it,
-    // unless verification is explicitly turned off.
+    // These options imply certificate verification unless it is explicitly turned off.
     if (
       sslMode < SSLMode.verify_ca &&
       (rejectUnauthorized === true || (rejectUnauthorized !== false && (tls.ca || tls.caFile || checkServerIdentity)))

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -2114,15 +2114,15 @@ function parseOptions(
   }
 
   if ($isObject(tls)) {
-    if (tls.checkServerIdentity !== undefined && !$isCallable(tls.checkServerIdentity)) {
-      throw $ERR_INVALID_ARG_TYPE("tls.checkServerIdentity", "function", tls.checkServerIdentity);
+    const { checkServerIdentity, rejectUnauthorized } = tls;
+    if (checkServerIdentity !== undefined && !$isCallable(checkServerIdentity)) {
+      throw $ERR_INVALID_ARG_TYPE("tls.checkServerIdentity", "function", checkServerIdentity);
     }
     // Options that only make sense with certificate verification request it,
     // unless verification is explicitly turned off.
     if (
       sslMode < SSLMode.verify_ca &&
-      (tls.rejectUnauthorized === true ||
-        (tls.rejectUnauthorized !== false && (tls.ca || tls.caFile || tls.checkServerIdentity)))
+      (rejectUnauthorized === true || (rejectUnauthorized !== false && (tls.ca || tls.caFile || checkServerIdentity)))
     ) {
       sslMode = SSLMode.verify_full;
     }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -2113,13 +2113,22 @@ function parseOptions(
     }
   }
 
-  if ($isObject(tls) && sslMode < SSLMode.verify_ca) {
-    if (tls.rejectUnauthorized === true || (tls.rejectUnauthorized !== false && (tls.ca || tls.caFile))) {
+  if ($isObject(tls)) {
+    if (tls.checkServerIdentity !== undefined && !$isCallable(tls.checkServerIdentity)) {
+      throw $ERR_INVALID_ARG_TYPE("tls.checkServerIdentity", "function", tls.checkServerIdentity);
+    }
+    // Options that only make sense with certificate verification request it,
+    // unless verification is explicitly turned off.
+    if (
+      sslMode < SSLMode.verify_ca &&
+      (tls.rejectUnauthorized === true ||
+        (tls.rejectUnauthorized !== false && (tls.ca || tls.caFile || tls.checkServerIdentity)))
+    ) {
       sslMode = SSLMode.verify_full;
     }
   }
 
-  if (sslMode !== SSLMode.disable && !tls?.serverName) {
+  if (sslMode !== SSLMode.disable && !tls?.serverName && !tls?.servername) {
     if (hostname) {
       tls = { ...tls, serverName: hostname };
     } else if (tls) {

--- a/src/jsc/TlsServerIdentity.rs
+++ b/src/jsc/TlsServerIdentity.rs
@@ -1,0 +1,80 @@
+//! Server-identity verification for TLS clients whose handshake callback runs
+//! on the JS thread (`Bun.SQL`, `RedisClient`). Either Node's built-in
+//! hostname match, or the user's `tls.checkServerIdentity(hostname, cert)`.
+//!
+//! `Err` carries the value the caller fails the connection with.
+
+use bun_boringssl as boringssl;
+
+use crate::{ErrorCode, JSGlobalObject, JSValue, JsResult};
+
+// Implemented in JSX509Certificate.cpp. `X509`/`JSGlobalObject` are opaque
+// `repr(C)` handles; `&mut`/`&` are ABI-identical to non-null pointers.
+unsafe extern "C" {
+    safe fn Bun__X509__toJSLegacyEncoding(
+        cert: &mut boringssl::c::X509,
+        global_object: &JSGlobalObject,
+    ) -> JSValue;
+}
+
+/// The legacy certificate object of `tls.getPeerCertificate()` (`subject`,
+/// `subjectaltname`, `fingerprint256`, `raw`, ...). Borrows `cert`.
+pub fn x509_to_legacy_object(
+    cert: &mut boringssl::c::X509,
+    global: &JSGlobalObject,
+) -> JsResult<JSValue> {
+    crate::from_js_host_call(global, || Bun__X509__toJSLegacyEncoding(cert, global))
+}
+
+/// Node's built-in check: `hostname` must match a name in the peer's leaf
+/// certificate. Fails with `ERR_TLS_CERT_ALTNAME_INVALID` and Node's reason
+/// text.
+pub fn check_builtin(
+    global: &JSGlobalObject,
+    ssl: &mut boringssl::c::SSL,
+    hostname: &[u8],
+) -> Result<(), JSValue> {
+    if boringssl::check_server_identity(ssl, hostname) {
+        return Ok(());
+    }
+    let mut reason = String::new();
+    // Infallible: the writer is a `String`.
+    let _ = boringssl::write_server_identity_mismatch_reason(ssl, hostname, &mut reason);
+    Err(altname_invalid(global, &reason))
+}
+
+/// Calls the user's `tls.checkServerIdentity(hostname, cert)` in place of the
+/// built-in check, as Node and `fetch` do. Fails with the `Error` it returns,
+/// or with whatever it throws.
+pub fn check_with_callback(
+    global: &JSGlobalObject,
+    callback: JSValue,
+    ssl: &mut boringssl::c::SSL,
+    hostname: &[u8],
+) -> Result<(), JSValue> {
+    let Some(cert) = ssl.peer_leaf_certificate() else {
+        return Err(altname_invalid(global, "the peer presented no certificate"));
+    };
+    let js_cert = x509_to_legacy_object(cert, global).map_err(|e| global.take_exception(e))?;
+    let js_hostname = crate::bun_string_jsc::create_utf8_for_js(global, hostname)
+        .map_err(|e| global.take_exception(e))?;
+    let result = {
+        let _scope = global.bun_vm().enter_event_loop_scope();
+        callback.call(global, JSValue::UNDEFINED, &[js_hostname, js_cert])
+    };
+    let result = result.map_err(|e| global.take_exception(e))?;
+    // > Returns <Error> object [...] on failure. On success, returns <undefined>.
+    if result.is_any_error() {
+        return Err(result);
+    }
+    Ok(())
+}
+
+fn altname_invalid(global: &JSGlobalObject, reason: &str) -> JSValue {
+    global
+        .err(
+            ErrorCode::TLS_CERT_ALTNAME_INVALID,
+            format_args!("Hostname/IP does not match certificate's altnames: {reason}"),
+        )
+        .to_js()
+}

--- a/src/jsc/TlsServerIdentity.rs
+++ b/src/jsc/TlsServerIdentity.rs
@@ -1,15 +1,10 @@
-//! Server-identity verification for TLS clients whose handshake callback runs
-//! on the JS thread (`Bun.SQL`, `RedisClient`). Either Node's built-in
-//! hostname match, or the user's `tls.checkServerIdentity(hostname, cert)`.
-//!
-//! `Err` carries the value the caller fails the connection with.
+//! `tls.checkServerIdentity` and the built-in hostname check for JS-thread TLS clients (`Bun.SQL`, `RedisClient`).
 
 use bun_boringssl as boringssl;
 
 use crate::{ErrorCode, JSGlobalObject, JSValue, JsResult};
 
-// Implemented in JSX509Certificate.cpp. `X509`/`JSGlobalObject` are opaque
-// `repr(C)` handles; `&mut`/`&` are ABI-identical to non-null pointers.
+// JSX509Certificate.cpp. Opaque `repr(C)` handles: `&mut`/`&` are ABI-identical to non-null pointers.
 unsafe extern "C" {
     safe fn Bun__X509__toJSLegacyEncoding(
         cert: &mut boringssl::c::X509,
@@ -17,8 +12,7 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-/// The legacy certificate object of `tls.getPeerCertificate()` (`subject`,
-/// `subjectaltname`, `fingerprint256`, `raw`, ...). Borrows `cert`.
+/// The `tls.getPeerCertificate()`-style object for `cert` (borrowed, not adopted).
 pub fn x509_to_legacy_object(
     cert: &mut boringssl::c::X509,
     global: &JSGlobalObject,
@@ -26,9 +20,7 @@ pub fn x509_to_legacy_object(
     crate::from_js_host_call(global, || Bun__X509__toJSLegacyEncoding(cert, global))
 }
 
-/// Node's built-in check: `hostname` must match a name in the peer's leaf
-/// certificate. Fails with `ERR_TLS_CERT_ALTNAME_INVALID` and Node's reason
-/// text.
+/// Node's default check of `hostname` against the peer certificate; `ERR_TLS_CERT_ALTNAME_INVALID` on mismatch.
 pub fn check_builtin(
     global: &JSGlobalObject,
     ssl: &mut boringssl::c::SSL,
@@ -43,9 +35,7 @@ pub fn check_builtin(
     Err(altname_invalid(global, &reason))
 }
 
-/// Calls the user's `tls.checkServerIdentity(hostname, cert)` in place of the
-/// built-in check, as Node and `fetch` do. Fails with the `Error` it returns,
-/// or with whatever it throws.
+/// Runs the user's `tls.checkServerIdentity(hostname, cert)`; fails with the `Error` it returns or anything it throws.
 pub fn check_with_callback(
     global: &JSGlobalObject,
     callback: JSValue,

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -445,6 +445,8 @@ pub mod js_property_iterator;
 pub mod node_compile_cache;
 #[path = "SystemError.rs"]
 pub mod system_error;
+#[path = "TlsServerIdentity.rs"]
+pub mod tls_server_identity;
 #[path = "URL.rs"]
 pub mod url;
 #[path = "VM.rs"]

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1786,8 +1786,9 @@ fn get_s3_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JsResult
 fn get_valkey_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
     use crate::valkey_jsc::JSValkeyClient;
 
+    // No options object, so no `tls.checkServerIdentity` to store.
     let valkey = match JSValkeyClient::create_no_js_no_pubsub(global_this, &[JSValue::UNDEFINED]) {
-        Ok(p) => p,
+        Ok((p, _)) => p,
         Err(jsc::JsError::Thrown) => return JSValue::ZERO,
         Err(err) => {
             let _ =

--- a/src/runtime/api/bun/x509.rs
+++ b/src/runtime/api/bun/x509.rs
@@ -1,11 +1,7 @@
 use bun_boringssl_sys::X509;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
-pub fn to_js(cert: &mut X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-    bun_jsc::from_js_host_call(global_object, || {
-        Bun__X509__toJSLegacyEncoding(cert, global_object)
-    })
-}
+pub use bun_jsc::tls_server_identity::x509_to_legacy_object as to_js;
 
 pub(crate) fn to_js_object(cert: &mut X509, global_object: &JSGlobalObject) -> JsResult<JSValue> {
     Ok(Bun__X509__toJS(cert, global_object))
@@ -14,9 +10,5 @@ pub(crate) fn to_js_object(cert: &mut X509, global_object: &JSGlobalObject) -> J
 // `X509`/`JSGlobalObject` are opaque `repr(C)` handles; `&mut`/`&` are
 // ABI-identical to non-null pointers, so the validity proof is in the type.
 unsafe extern "C" {
-    safe fn Bun__X509__toJSLegacyEncoding(
-        cert: &mut X509,
-        global_object: &JSGlobalObject,
-    ) -> JSValue;
     safe fn Bun__X509__toJS(cert: &mut X509, global_object: &JSGlobalObject) -> JSValue;
 }

--- a/src/runtime/api/sql.classes.ts
+++ b/src/runtime/api/sql.classes.ts
@@ -61,8 +61,8 @@ for (const type of types) {
       },
       values:
         type === "PostgresSQL"
-          ? ["onconnect", "onclose", "queries", "onnotification"]
-          : ["onconnect", "onclose", "queries"],
+          ? ["onconnect", "onclose", "queries", "checkServerIdentity", "onnotification"]
+          : ["onconnect", "onclose", "queries", "checkServerIdentity"],
     }),
   );
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -8,7 +8,7 @@ use bun_io::KeepAlive;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSArray, JSGlobalObject, JSMap, JSPromise, JSValue, JsCell,
-    JsRef, JsResult,
+    JsRef, JsResult, tls_server_identity,
 };
 use bun_ptr::{AsCtxPtr, BackRef, RefPtr};
 use bun_uws as uws;
@@ -477,12 +477,14 @@ impl JSValkeyClient {
     }
 
     /// Create a Valkey client that does not have an associated JS object nor a SubscriptionCtx.
+    /// Also returns `tls.checkServerIdentity` (or `undefined`) for the caller
+    /// to store on the JS object.
     ///
     /// This whole client needs a refactor.
     pub(crate) fn create_no_js_no_pubsub(
         global_object: &JSGlobalObject,
         arguments: &[JSValue],
-    ) -> JsResult<*mut JSValkeyClient> {
+    ) -> JsResult<(*mut JSValkeyClient, JSValue)> {
         let global_object = GlobalRef::from(global_object);
         let vm: &'static VirtualMachine = global_object.bun_vm();
         let vm_ref = vm;
@@ -686,8 +688,9 @@ impl JSValkeyClient {
 
         bun_core::analytics::Features::VALKEY.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
 
+        let check_server_identity = options.check_server_identity;
         // `_subscription_ctx` is a placeholder here; properly initialized later by `create()`.
-        Ok(JSValkeyClient::new(JSValkeyClient {
+        let client = JSValkeyClient::new(JSValkeyClient {
             ref_count: bun_ptr::RefCount::init(),
             _subscription_ctx: JsCell::new(SubscriptionCtx::default()),
             client: JsCell::new(valkey::ValkeyClient {
@@ -740,7 +743,8 @@ impl JSValkeyClient {
             _secure: JsCell::new(None),
             timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
             reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
-        }))
+        });
+        Ok((client, check_server_identity))
     }
 
     pub(crate) fn create(
@@ -748,12 +752,16 @@ impl JSValkeyClient {
         arguments: &[JSValue],
         js_this: JSValue,
     ) -> JsResult<*mut JSValkeyClient> {
-        let new_client_ptr = JSValkeyClient::create_no_js_no_pubsub(global_object, arguments)?;
+        let (new_client_ptr, check_server_identity) =
+            JSValkeyClient::create_no_js_no_pubsub(global_object, arguments)?;
         // SAFETY: just allocated above
         let new_client = unsafe { &*new_client_ptr };
 
         // Initially, we only need to hold a weak reference to the JS object.
         new_client.this_value.set(JsRef::init_weak(js_this));
+        if check_server_identity.is_callable() {
+            Js::check_server_identity_set_cached(js_this, global_object, check_server_identity);
+        }
 
         // Need to associate the subscription context, after the JS ref has been populated.
         new_client
@@ -1516,6 +1524,81 @@ impl JSValkeyClient {
         Ok(())
     }
 
+    /// The name the server certificate must match: `tls.serverName`, else the
+    /// URL host (brackets stripped from IPv6 literals so IP SANs match).
+    /// Empty for unix sockets without a `serverName`.
+    fn tls_hostname(&self) -> &[u8] {
+        let client = self.client.get();
+        if let Some(server_name) = client.tls.server_name() {
+            return server_name;
+        }
+        match &client.address {
+            valkey::Address::Host { host, .. } => {
+                if host.len() >= 2 && host[0] == b'[' && host[host.len() - 1] == b']' {
+                    &host[1..host.len() - 1]
+                } else {
+                    host
+                }
+            }
+            valkey::Address::Unix(_) => b"",
+        }
+    }
+
+    fn ssl(&self) -> *mut boringssl::c::SSL {
+        self.client
+            .get()
+            .socket
+            .get_native_handle()
+            .unwrap_or(core::ptr::null_mut())
+            .cast()
+    }
+
+    /// Sends `tls_hostname()` as SNI. IP literals are skipped (RFC 6066).
+    fn set_sni(&self) {
+        let hostname = self.tls_hostname();
+        if hostname.is_empty() || bun_core::ip_address::is_ip_address(hostname) {
+            return;
+        }
+        let hostname = bun_core::ZBox::from_bytes(hostname);
+        let ssl = self.ssl();
+        if ssl.is_null() {
+            return;
+        }
+        // SAFETY: `ssl` is the live `SSL*` of the socket that just opened, not
+        // yet handshaking; `hostname` is NUL-terminated and copied by BoringSSL.
+        unsafe { boringssl::c::SSL_set_tlsext_host_name(ssl, hostname.as_ptr()) };
+    }
+
+    /// After the chain verified: `tls.checkServerIdentity` when the user set
+    /// one, else the built-in match of `tls_hostname()` against the
+    /// certificate (skipped for unix sockets with no `serverName`).
+    fn verify_server_identity(&self) -> Result<(), JSValue> {
+        let global: &JSGlobalObject = &self.global_object;
+        let hostname = self.tls_hostname().to_vec();
+        // SAFETY: in the handshake callback the native handle is the live `SSL*`.
+        let Some(ssl) = (unsafe { self.ssl().as_mut() }) else {
+            return Err(global
+                .err(
+                    jsc::ErrorCode::REDIS_CONNECTION_CLOSED,
+                    format_args!("TLS handshake finished without a socket"),
+                )
+                .to_js());
+        };
+        let callback = self
+            .this_value
+            .get()
+            .try_get()
+            .and_then(Js::check_server_identity_get_cached)
+            .filter(|cb| cb.is_callable());
+        if let Some(callback) = callback {
+            return tls_server_identity::check_with_callback(global, callback, ssl, &hostname);
+        }
+        if hostname.is_empty() {
+            return Ok(());
+        }
+        tls_server_identity::check_builtin(global, ssl, &hostname)
+    }
+
     pub(crate) fn send(
         &self,
         global_this: &JSGlobalObject,
@@ -1668,6 +1751,9 @@ impl<const SSL: bool> SocketHandler<SSL> {
 
     pub(crate) fn on_open(this: &JSValkeyClient, socket: SocketType<SSL>) -> JsResult<()> {
         this.client_mut().socket = Self::socket(socket);
+        if SSL {
+            this.set_sni();
+        }
         this.client_mut().on_open(Self::socket(socket))
     }
 
@@ -1696,74 +1782,30 @@ impl<const SSL: bool> SocketHandler<SSL> {
         let _guard = this.ref_guard();
         let _update = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
         let vm = this.client.get().vm;
-        if handshake_success {
-            if this.client.get().tls.reject_unauthorized(vm) {
-                // only reject the connection if reject_unauthorized == true
-                if ssl_error.error_no != 0 {
-                    // Certificate chain validation failed.
-                    return Self::fail_handshake_with_verify_error(this, vm, &ssl_error);
-                }
-
-                // Certificate chain is valid; verify the hostname matches the
-                // certificate. Prefer the SNI servername if one was set, otherwise
-                // fall back to the host from the connection URL. Unix-domain
-                // sockets have no hostname to verify, so skip the identity check
-                // for redis+tls+unix:// / valkey+tls+unix:// connections.
-                let ssl_ptr: *mut boringssl::c::SSL = this
-                    .client
-                    .get()
-                    .socket
-                    .get_native_handle()
-                    .unwrap_or(core::ptr::null_mut())
-                    .cast();
-                // SAFETY: SSL_get_servername returns null or NUL-terminated.
-                let mut hostname: &[u8] = if let Some(servername) =
-                    unsafe { boringssl::c::SSL_get_servername(ssl_ptr, 0).as_ref() }
-                {
-                    // SAFETY: NUL-terminated
-                    unsafe { bun_core::ffi::cstr(std::ptr::from_ref(servername).cast()) }.to_bytes()
-                } else {
-                    match &this.client.get().address {
-                        valkey::Address::Host { host, .. } => &host[..],
-                        valkey::Address::Unix(_) => b"",
-                    }
-                };
-                // URL.host() serialises IPv6 literals with surrounding brackets
-                // (e.g. "[::1]"). Strip them so checkServerIdentity can recognise
-                // the value as an IP and match against IP SAN entries; this
-                // mirrors what connectAnon already does before getaddrinfo.
-                if hostname.len() >= 2
-                    && hostname[0] == b'['
-                    && hostname[hostname.len() - 1] == b']'
-                {
-                    hostname = &hostname[1..hostname.len() - 1];
-                }
-                if !hostname.is_empty()
-                    // SAFETY: in the TLS handshake-success path the socket's native
-                    // handle is a live `SSL*`.
-                    && !boringssl::check_server_identity(unsafe { &mut *ssl_ptr }, hostname)
-                {
-                    let err = this
-                        .global_object
-                        .err(
-                            jsc::ErrorCode::TLS_CERT_ALTNAME_INVALID,
-                            format_args!(
-                                "Hostname/IP does not match certificate's altnames: Host: {}",
-                                bstr::BStr::new(hostname)
-                            ),
-                        )
-                        .to_js();
-                    return Self::fail_handshake(this, vm, err);
-                }
-            }
-            this.client_mut().start()?;
-        } else {
+        if !handshake_success {
             // if we are here is because the server rejected us, and the error_no is the cause of
             // this no matter if reject_unauthorized is false, because we were disconnected by the
             // server
             return Self::fail_handshake_with_verify_error(this, vm, &ssl_error);
         }
-        Ok(())
+        if this.client.get().tls.reject_unauthorized(vm) {
+            // only reject the connection if reject_unauthorized == true
+            if ssl_error.error_no != 0 {
+                // Certificate chain validation failed.
+                return Self::fail_handshake_with_verify_error(this, vm, &ssl_error);
+            }
+            // Certificate chain is valid; verify the server identity. May run
+            // user JS (`tls.checkServerIdentity`), which can close this client.
+            if let Err(err) = this.verify_server_identity() {
+                return Self::fail_handshake(this, vm, err);
+            }
+            if this.client.get().status != valkey::Status::Connecting
+                || this.client.get().socket.is_closed()
+            {
+                return Ok(());
+            }
+        }
+        this.client_mut().start()
     }
 
     fn fail_handshake_with_verify_error(
@@ -1930,14 +1972,24 @@ impl Options {
                     valkey::TLS::None
                 };
             } else if tls.is_object() {
-                // SAFETY: `bun_vm()` returns the live per-global VM pointer.
-                if let Some(ssl_config) =
-                    SSLConfig::from_js(global_object.bun_vm(), global_object, tls)?
+                if let Some(callback) = tls.get(global_object, "checkServerIdentity")?
+                    && !callback.is_undefined()
                 {
-                    this.tls = valkey::TLS::Custom(Box::new(ssl_config));
-                } else {
-                    return Err(global_object.throw_invalid_argument_type("tls", "tls", "object"));
+                    if !callback.is_callable() {
+                        return Err(global_object.throw_invalid_argument_type(
+                            "tls",
+                            "tls.checkServerIdentity",
+                            "function",
+                        ));
+                    }
+                    this.check_server_identity = callback;
                 }
+                // An object with no TLS option set still asks for TLS, with
+                // every option at its default (as `tls: true`).
+                this.tls = match SSLConfig::from_js(global_object.bun_vm(), global_object, tls)? {
+                    Some(ssl_config) => valkey::TLS::Custom(Box::new(ssl_config)),
+                    None => valkey::TLS::Enabled,
+                };
             } else {
                 return Err(global_object.throw_invalid_argument_type(
                     "tls",

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1544,29 +1544,17 @@ impl JSValkeyClient {
         }
     }
 
-    fn ssl(&self) -> *mut boringssl::c::SSL {
-        self.client
-            .get()
-            .socket
-            .get_native_handle()
-            .unwrap_or(core::ptr::null_mut())
-            .cast()
-    }
-
     /// Sends `tls_hostname()` as SNI. IP literals are skipped (RFC 6066).
+    /// Runs from `on_open`, before the ClientHello is written.
     fn set_sni(&self) {
         let hostname = self.tls_hostname();
         if hostname.is_empty() || bun_core::ip_address::is_ip_address(hostname) {
             return;
         }
         let hostname = bun_core::ZBox::from_bytes(hostname);
-        let ssl = self.ssl();
-        if ssl.is_null() {
-            return;
+        if let Some(ssl) = self.client.get().socket.ssl_mut() {
+            ssl.set_servername(hostname.as_cstr());
         }
-        // SAFETY: `ssl` is the live `SSL*` of the socket that just opened, not
-        // yet handshaking; `hostname` is NUL-terminated and copied by BoringSSL.
-        unsafe { boringssl::c::SSL_set_tlsext_host_name(ssl, hostname.as_ptr()) };
     }
 
     /// After the chain verified: `tls.checkServerIdentity` when the user set
@@ -1574,9 +1562,9 @@ impl JSValkeyClient {
     /// certificate (skipped for unix sockets with no `serverName`).
     fn verify_server_identity(&self) -> Result<(), JSValue> {
         let global: &JSGlobalObject = &self.global_object;
+        // Owned: the user callback below may re-enter this client.
         let hostname = self.tls_hostname().to_vec();
-        // SAFETY: in the handshake callback the native handle is the live `SSL*`.
-        let Some(ssl) = (unsafe { self.ssl().as_mut() }) else {
+        let Some(ssl) = self.client.get().socket.ssl_mut() else {
             return Err(global
                 .err(
                     jsc::ErrorCode::REDIS_CONNECTION_CLOSED,

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -476,9 +476,7 @@ impl JSValkeyClient {
         Self::create(global_object, callframe.arguments(), js_this)
     }
 
-    /// Create a Valkey client that does not have an associated JS object nor a SubscriptionCtx.
-    /// Also returns `tls.checkServerIdentity` (or `undefined`) for the caller
-    /// to store on the JS object.
+    /// Create a client with no JS object and no SubscriptionCtx; also returns `tls.checkServerIdentity` for the JS object.
     ///
     /// This whole client needs a refactor.
     pub(crate) fn create_no_js_no_pubsub(
@@ -1524,9 +1522,7 @@ impl JSValkeyClient {
         Ok(())
     }
 
-    /// The name the server certificate must match: `tls.serverName`, else the
-    /// URL host (brackets stripped from IPv6 literals so IP SANs match).
-    /// Empty for unix sockets without a `serverName`.
+    /// `tls.serverName`, else the URL host without IPv6 brackets; empty for a unix socket with no `serverName`.
     fn tls_hostname(&self) -> &[u8] {
         let client = self.client.get();
         if let Some(server_name) = client.tls.server_name() {
@@ -1544,8 +1540,7 @@ impl JSValkeyClient {
         }
     }
 
-    /// Sends `tls_hostname()` as SNI. IP literals are skipped (RFC 6066).
-    /// Runs from `on_open`, before the ClientHello is written.
+    /// Sends `tls_hostname()` as SNI unless it is an IP literal (RFC 6066); runs before the ClientHello.
     fn set_sni(&self) {
         let hostname = self.tls_hostname();
         if hostname.is_empty() || bun_core::ip_address::is_ip_address(hostname) {
@@ -1557,9 +1552,7 @@ impl JSValkeyClient {
         }
     }
 
-    /// After the chain verified: `tls.checkServerIdentity` when the user set
-    /// one, else the built-in match of `tls_hostname()` against the
-    /// certificate (skipped for unix sockets with no `serverName`).
+    /// `tls.checkServerIdentity` if set, else the built-in match against `tls_hostname()` (none for a bare unix socket).
     fn verify_server_identity(&self) -> Result<(), JSValue> {
         let global: &JSGlobalObject = &self.global_object;
         // Owned: the user callback below may re-enter this client.
@@ -1782,8 +1775,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
                 // Certificate chain validation failed.
                 return Self::fail_handshake_with_verify_error(this, vm, &ssl_error);
             }
-            // Certificate chain is valid; verify the server identity. May run
-            // user JS (`tls.checkServerIdentity`), which can close this client.
+            // Chain is valid; the identity check may run user JS, which can close this client.
             if let Err(err) = this.verify_server_identity() {
                 return Self::fail_handshake(this, vm, err);
             }
@@ -1972,8 +1964,7 @@ impl Options {
                     }
                     this.check_server_identity = callback;
                 }
-                // An object with no TLS option set still asks for TLS, with
-                // every option at its default (as `tls: true`).
+                // An object with no recognized option still enables TLS, with defaults (as `tls: true`).
                 this.tls = match SSLConfig::from_js(global_object.bun_vm(), global_object, tls)? {
                     Some(ssl_config) => valkey::TLS::Custom(Box::new(ssl_config)),
                     None => valkey::TLS::Enabled,

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -5,7 +5,7 @@ use bun_jsc::{
     JsRef, JsResult,
 };
 
-use super::js_valkey::{JSValkeyClient, SubscriptionCtx};
+use super::js_valkey::{JSValkeyClient, Js, SubscriptionCtx};
 use super::protocol_jsc as protocol;
 use super::valkey;
 use super::valkey_command_body::{Args as CommandArgs, Command, Meta as CommandMeta};
@@ -2078,8 +2078,6 @@ impl JSValkeyClient {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let _ = frame;
-
         let new_client_ptr = this.clone_without_connecting(global)?;
         // SAFETY: clone_without_connecting returns a freshly allocated, leaked
         // JSValkeyClient (heap::alloc); valid for the rest of this scope.
@@ -2090,6 +2088,9 @@ impl JSValkeyClient {
         new_client
             ._subscription_ctx
             .set(SubscriptionCtx::init(new_client)?);
+        if let Some(check_server_identity) = Js::check_server_identity_get_cached(frame.this()) {
+            Js::check_server_identity_set_cached(new_client_js, global, check_server_identity);
+        }
         // If the original client is already connected and not manually closed, start connecting the new client.
         if this.client.get().status == valkey::Status::Connected
             && !this.client.get().flags.is_manually_closed

--- a/src/runtime/valkey_jsc/valkey.classes.ts
+++ b/src/runtime/valkey_jsc/valkey.classes.ts
@@ -638,6 +638,6 @@ export default [
       xgroup: { fn: "xgroup", length: 2 },
       xsetid: { fn: "xsetid", length: 2 },
     },
-    values: ["onconnect", "onclose", "connectionPromise", "hello", "subscriptionCallbackMap"],
+    values: ["onconnect", "onclose", "connectionPromise", "hello", "subscriptionCallbackMap", "checkServerIdentity"],
   }),
 ];

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -135,6 +135,17 @@ impl TLS {
             _ => false,
         }
     }
+
+    /// `tls.serverName`: the SNI to send and the name the certificate must
+    /// match, in place of the URL host.
+    pub(crate) fn server_name(&self) -> Option<&[u8]> {
+        match self {
+            TLS::Custom(ssl_config) => ssl_config
+                .server_name_bytes()
+                .filter(|name| !name.is_empty()),
+            _ => None,
+        }
+    }
 }
 
 // Call sites only ever compare against `TLS::None` / `TLS::Enabled`; `SSLConfig`
@@ -155,6 +166,8 @@ pub struct Options {
     pub(crate) enable_auto_pipelining: bool,
 
     pub(crate) tls: TLS,
+    /// `tls.checkServerIdentity`, or `undefined`. Stored on the JS wrapper.
+    pub(crate) check_server_identity: JSValue,
 }
 
 impl Default for Options {
@@ -167,6 +180,7 @@ impl Default for Options {
             enable_offline_queue: true,
             enable_auto_pipelining: true,
             tls: TLS::None,
+            check_server_identity: JSValue::UNDEFINED,
         }
     }
 }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -136,8 +136,7 @@ impl TLS {
         }
     }
 
-    /// `tls.serverName`: the SNI to send and the name the certificate must
-    /// match, in place of the URL host.
+    /// `tls.serverName`: replaces the URL host as SNI and as the name the certificate must match.
     pub(crate) fn server_name(&self) -> Option<&[u8]> {
         match self {
             TLS::Custom(ssl_config) => ssl_config

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -476,6 +476,17 @@ pub mod api {
                 }
             }
 
+            /// [`server_name`](Self::server_name) as bytes; empty when unset.
+            pub(crate) fn server_name_bytes(&self) -> &[u8] {
+                let server_name = self.server_name();
+                if server_name.is_null() {
+                    return b"";
+                }
+                // SAFETY: NUL-terminated C string owned by the boxed SSLConfig
+                // for `self`'s lifetime.
+                unsafe { core::ffi::CStr::from_ptr(server_name) }.to_bytes()
+            }
+
             /// `SSLConfig.reject_unauthorized` — non-zero rejects on verify error.
             #[inline]
             pub(crate) fn reject_unauthorized(&self) -> i32 {

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -615,7 +615,7 @@ pub use bun_jsc::JsClass;
 
 pub mod codegen {
     ::bun_jsc::js_class_module!(JSPostgresSQLConnection = "PostgresSQLConnection"
-        as crate::postgres::PostgresSQLConnection { queries, onconnect, onclose, onnotification });
+        as crate::postgres::PostgresSQLConnection { queries, onconnect, onclose, checkServerIdentity, onnotification });
     ::bun_jsc::js_class_module!(
         JSPostgresSQLQuery = "PostgresSQLQuery" as crate::postgres::PostgresSQLQuery,
         impl_js_class {
@@ -627,7 +627,7 @@ pub mod codegen {
     );
 
     ::bun_jsc::js_class_module!(js_mysql_connection = "MySQLConnection"
-        as crate::mysql::js_my_sql_connection::JSMySQLConnection { queries, onconnect, onclose });
+        as crate::mysql::js_my_sql_connection::JSMySQLConnection { queries, onconnect, onclose, checkServerIdentity });
     pub use js_mysql_connection as JSMySQLConnection;
 
     ::bun_jsc::js_class_module!(

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -714,8 +714,7 @@ impl JSMySQLConnection {
         self.fail_with_js_value(instance);
     }
 
-    /// `tls.checkServerIdentity` when the user set one, else the built-in
-    /// hostname match when the ssl mode asks for it (verify-full).
+    /// `tls.checkServerIdentity` if set, else the built-in hostname match when `hostname_must_match` (verify-full).
     fn verify_server_identity(&self, hostname_must_match: bool) -> Result<(), JSValue> {
         let global: &JSGlobalObject = &self.global_object;
         // Owned: the user callback below may re-enter this connection.
@@ -935,8 +934,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
             TlsHandshakeStep::VerifyIdentity {
                 hostname_must_match,
             } => {
-                // May run user JS (`tls.checkServerIdentity`), which can close
-                // this connection.
+                // May run user JS (`tls.checkServerIdentity`), which can close this connection.
                 let _guard = this.ref_guard();
                 if let Err(err) = this.verify_server_identity(hostname_must_match) {
                     this.connection_mut().fail_tls_handshake();

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -27,9 +27,10 @@ use crate::mysql::protocol::error_packet_jsc::ErrorPacketJsc;
 // is intentionally NOT imported by name — that ident is taken in this module's
 // value namespace by the `declare_scope!` static and in the type namespace by
 // the `pub use JSMySQLConnection as MySQLConnection` re-export below.
-use super::my_sql_connection::{self as my_sql_connection};
+use super::my_sql_connection::{self as my_sql_connection, TlsHandshakeStep};
 use super::my_sql_statement::MySQLStatement;
 use super::protocol::result_set::{self as ResultSet};
+use bun_jsc::tls_server_identity;
 
 bun_core::declare_scope!(MySQLConnection, visible);
 
@@ -544,6 +545,13 @@ impl JSMySQLConnection {
             .with_mut(|r| r.set_strong(js_value, global_object));
         js::onconnect_set_cached(js_value, global_object, on_connect);
         js::onclose_set_cached(js_value, global_object, on_close);
+        if args.check_server_identity.is_callable() {
+            js::check_server_identity_set_cached(
+                js_value,
+                global_object,
+                args.check_server_identity,
+            );
+        }
 
         Ok(js_value)
     }
@@ -704,6 +712,37 @@ impl JSMySQLConnection {
     fn fail(&self, message: &[u8], err: AnyMySQLErrorT) {
         let instance = mysql_error_to_js(&self.global_object, message, err);
         self.fail_with_js_value(instance);
+    }
+
+    /// `tls.checkServerIdentity` when the user set one, else the built-in
+    /// hostname match when the ssl mode asks for it (verify-full).
+    fn verify_server_identity(&self, hostname_must_match: bool) -> Result<(), JSValue> {
+        let global: &JSGlobalObject = &self.global_object;
+        let (hostname, ssl_ptr) = {
+            let connection = self.connection.get();
+            (connection.tls_server_name().to_vec(), connection.ssl())
+        };
+        // SAFETY: in the handshake callback the native handle is the live `SSL*`.
+        let Some(ssl) = (unsafe { ssl_ptr.as_mut() }) else {
+            return Err(mysql_error_to_js(
+                global,
+                b"Failed to upgrade to TLS",
+                AnyMySQLErrorT::ConnectionFailed,
+            ));
+        };
+        let callback = self
+            .js_value
+            .get()
+            .try_get()
+            .and_then(js::check_server_identity_get_cached)
+            .filter(|cb| cb.is_callable());
+        if let Some(callback) = callback {
+            return tls_server_identity::check_with_callback(global, callback, ssl, &hostname);
+        }
+        if !hostname_must_match {
+            return Ok(());
+        }
+        tls_server_identity::check_builtin(global, ssl, &hostname)
     }
 
     pub(crate) fn on_connection_estabilished(&self) {
@@ -888,16 +927,32 @@ impl<const SSL: bool> SocketHandler<SSL> {
         success: i32,
         ssl_error: uws::us_bun_verify_error_t,
     ) {
-        let handshake_was_successful = match this.connection_mut().do_handshake(success, ssl_error)
+        match this
+            .connection_mut()
+            .begin_tls_handshake(success, &ssl_error)
         {
-            Ok(v) => v,
-            Err(e) => {
-                return this.fail_fmt(e, format_args!("Failed to send handshake response"));
+            TlsHandshakeStep::Failed => {
+                let v = crate::jsc::verify_error_to_js(&ssl_error, &this.global_object);
+                return this.fail_with_js_value(v);
             }
-        };
-        if !handshake_was_successful {
-            let v = crate::jsc::verify_error_to_js(&ssl_error, &this.global_object);
-            this.fail_with_js_value(v);
+            TlsHandshakeStep::VerifyIdentity {
+                hostname_must_match,
+            } => {
+                // May run user JS (`tls.checkServerIdentity`), which can close
+                // this connection.
+                let _guard = this.ref_guard();
+                if let Err(err) = this.verify_server_identity(hostname_must_match) {
+                    this.connection_mut().fail_tls_handshake();
+                    return this.fail_with_js_value(err);
+                }
+                if !this.connection.get().is_active() {
+                    return;
+                }
+            }
+            TlsHandshakeStep::Proceed => {}
+        }
+        if let Err(e) = this.connection_mut().finish_tls_handshake() {
+            this.fail_fmt(e, format_args!("Failed to send handshake response"));
         }
     }
 

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -718,12 +718,9 @@ impl JSMySQLConnection {
     /// hostname match when the ssl mode asks for it (verify-full).
     fn verify_server_identity(&self, hostname_must_match: bool) -> Result<(), JSValue> {
         let global: &JSGlobalObject = &self.global_object;
-        let (hostname, ssl_ptr) = {
-            let connection = self.connection.get();
-            (connection.tls_server_name().to_vec(), connection.ssl())
-        };
-        // SAFETY: in the handshake callback the native handle is the live `SSL*`.
-        let Some(ssl) = (unsafe { ssl_ptr.as_mut() }) else {
+        // Owned: the user callback below may re-enter this connection.
+        let hostname = self.connection.get().tls_server_name().to_vec();
+        let Some(ssl) = self.connection.get().ssl_mut() else {
             return Err(mysql_error_to_js(
                 global,
                 b"Failed to upgrade to TLS",

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -56,8 +56,7 @@ bun_core::define_scoped_log!(debug, MySQLConnection, visible);
 pub(crate) enum TlsHandshakeStep {
     /// The handshake or the certificate chain failed: fail with the verify error.
     Failed,
-    /// Verify the server identity (`tls.checkServerIdentity` if set, else the
-    /// built-in hostname match when `hostname_must_match`), then finish.
+    /// Run `tls.checkServerIdentity`, or the built-in hostname match if `hostname_must_match`, then finish.
     VerifyIdentity { hostname_must_match: bool },
     /// Nothing to verify: finish.
     Proceed,
@@ -399,9 +398,7 @@ impl MySQLConnection {
         true
     }
 
-    /// Records the TLS handshake result. The caller then does what the
-    /// returned step says; the identity check is split out because
-    /// `tls.checkServerIdentity` runs user JS, which must not hold `&mut self`.
+    /// Records the TLS handshake result; the identity step is the caller's because it may run user JS outside `&mut self`.
     pub(crate) fn begin_tls_handshake(
         &mut self,
         success: i32,
@@ -416,8 +413,7 @@ impl MySQLConnection {
         );
         self.sequence_id = self.sequence_id.wrapping_add(1);
         if success != 1 {
-            // if we are here is because server rejected us, and the error_no is the cause of this
-            // no matter if reject_unauthorized is false because we are disconnected by the server
+            // The server rejected us: `error_no` is the cause whatever reject_unauthorized says.
             self.tls_status = TLSStatus::SslFailed;
             return TlsHandshakeStep::Failed;
         }
@@ -425,9 +421,7 @@ impl MySQLConnection {
         if self.tls_config.reject_unauthorized() == 0 {
             return TlsHandshakeStep::Proceed;
         }
-        // follow the same rules as postgres
-        // https://github.com/porsager/postgres/blob/6ec85a432b17661ccacbdf7f765c651e88969d36/src/connection.js#L272-L279
-        // only reject the connection if reject_unauthorized == true
+        // Same rules as postgres (porsager/postgres src/connection.js): only the verify-* modes reject.
         match self.ssl_mode {
             SSLMode::VerifyCa | SSLMode::VerifyFull => {
                 if ssl_error.error_no != 0 {

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -52,6 +52,17 @@ use crate::jsc::api::server_config::SSLConfig;
 
 bun_core::define_scoped_log!(debug, MySQLConnection, visible);
 
+/// What [`MySQLConnection::begin_tls_handshake`] leaves for the caller to do.
+pub(crate) enum TlsHandshakeStep {
+    /// The handshake or the certificate chain failed: fail with the verify error.
+    Failed,
+    /// Verify the server identity (`tls.checkServerIdentity` if set, else the
+    /// built-in hostname match when `hostname_must_match`), then finish.
+    VerifyIdentity { hostname_must_match: bool },
+    /// Nothing to verify: finish.
+    Proceed,
+}
+
 pub struct MySQLConnection {
     socket: Socket,
     pub(crate) status: ConnectionState,
@@ -388,11 +399,14 @@ impl MySQLConnection {
         true
     }
 
-    pub(crate) fn do_handshake(
+    /// Records the TLS handshake result. The caller then does what the
+    /// returned step says; the identity check is split out because
+    /// `tls.checkServerIdentity` runs user JS, which must not hold `&mut self`.
+    pub(crate) fn begin_tls_handshake(
         &mut self,
         success: i32,
-        ssl_error: uws::us_bun_verify_error_t,
-    ) -> Result<bool, AnyMySQLError> {
+        ssl_error: &uws::us_bun_verify_error_t,
+    ) -> TlsHandshakeStep {
         bun_core::scoped_log!(
             MySQLConnection,
             "onHandshake: {} {} {:?}",
@@ -400,62 +414,61 @@ impl MySQLConnection {
             ssl_error.error_no,
             self.ssl_mode
         );
-        let handshake_success = success == 1;
         self.sequence_id = self.sequence_id.wrapping_add(1);
-        if handshake_success {
-            self.tls_status = TLSStatus::SslOk;
-            if self.tls_config.reject_unauthorized() != 0 {
-                // follow the same rules as postgres
-                // https://github.com/porsager/postgres/blob/6ec85a432b17661ccacbdf7f765c651e88969d36/src/connection.js#L272-L279
-                // only reject the connection if reject_unauthorized == true
-                match self.ssl_mode {
-                    SSLMode::VerifyCa | SSLMode::VerifyFull => {
-                        if ssl_error.error_no != 0 {
-                            self.tls_status = TLSStatus::SslFailed;
-                            return Ok(false);
-                        }
-
-                        // VerifyFull additionally requires the certificate identity to
-                        // match the intended host. Absence of a configured server name is
-                        // not a license to skip the check — fail closed.
-                        if self.ssl_mode == SSLMode::VerifyFull {
-                            let servername = self.tls_config.server_name();
-                            if servername.is_null() {
-                                self.tls_status = TLSStatus::SslFailed;
-                                return Ok(false);
-                            }
-                            // SAFETY: native handle of a connected TLS socket is `SSL*`.
-                            let ssl_ptr: *mut bun_boringssl_sys::SSL = self
-                                .socket
-                                .get_native_handle()
-                                .map(|h| h.cast())
-                                .unwrap_or(core::ptr::null_mut());
-                            // SAFETY: `server_name` is a NUL-terminated C string owned by
-                            // `tls_config` for the connection lifetime.
-                            let hostname = unsafe { bun_core::ffi::cstr(servername) }.to_bytes();
-                            if ssl_ptr.is_null()
-                                || !bun_boringssl::check_server_identity(
-                                    // SAFETY: `ssl_ptr` is non-null (checked by the short-circuit above) and live (handshake just succeeded).
-                                    unsafe { &mut *ssl_ptr },
-                                    hostname,
-                                )
-                            {
-                                self.tls_status = TLSStatus::SslFailed;
-                                return Ok(false);
-                            }
-                        }
-                    }
-                    // require is the same as prefer
-                    SSLMode::Require | SSLMode::Prefer | SSLMode::Disable => {}
+        if success != 1 {
+            // if we are here is because server rejected us, and the error_no is the cause of this
+            // no matter if reject_unauthorized is false because we are disconnected by the server
+            self.tls_status = TLSStatus::SslFailed;
+            return TlsHandshakeStep::Failed;
+        }
+        self.tls_status = TLSStatus::SslOk;
+        if self.tls_config.reject_unauthorized() == 0 {
+            return TlsHandshakeStep::Proceed;
+        }
+        // follow the same rules as postgres
+        // https://github.com/porsager/postgres/blob/6ec85a432b17661ccacbdf7f765c651e88969d36/src/connection.js#L272-L279
+        // only reject the connection if reject_unauthorized == true
+        match self.ssl_mode {
+            SSLMode::VerifyCa | SSLMode::VerifyFull => {
+                if ssl_error.error_no != 0 {
+                    self.tls_status = TLSStatus::SslFailed;
+                    return TlsHandshakeStep::Failed;
+                }
+                TlsHandshakeStep::VerifyIdentity {
+                    hostname_must_match: self.ssl_mode == SSLMode::VerifyFull,
                 }
             }
-            self.send_handshake_response()?;
-            return Ok(true);
+            // require is the same as prefer
+            SSLMode::Require | SSLMode::Prefer | SSLMode::Disable => TlsHandshakeStep::Proceed,
         }
+    }
+
+    pub(crate) fn fail_tls_handshake(&mut self) {
         self.tls_status = TLSStatus::SslFailed;
-        // if we are here is because server rejected us, and the error_no is the cause of this
-        // no matter if reject_unauthorized is false because we are disconnected by the server
-        Ok(false)
+    }
+
+    /// Sends the MySQL handshake response over the now-verified TLS socket.
+    pub(crate) fn finish_tls_handshake(&mut self) -> Result<(), AnyMySQLError> {
+        self.send_handshake_response()
+    }
+
+    /// `tls.serverName`: the SNI sent and the name the certificate must match.
+    pub(crate) fn tls_server_name(&self) -> &[u8] {
+        let server_name = self.tls_config.server_name();
+        if server_name.is_null() {
+            return b"";
+        }
+        // SAFETY: `server_name` is a NUL-terminated C string owned by
+        // `tls_config` for the connection lifetime.
+        unsafe { bun_core::ffi::cstr(server_name) }.to_bytes()
+    }
+
+    /// The live `SSL*` of the TLS socket, or null before the upgrade.
+    pub(crate) fn ssl(&self) -> *mut bun_boringssl_sys::SSL {
+        self.socket
+            .get_native_handle()
+            .map(|h| h.cast())
+            .unwrap_or(core::ptr::null_mut())
     }
 
     pub(crate) fn read_and_process_data(&mut self, data: &[u8]) -> Result<(), AnyMySQLError> {

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -454,21 +454,12 @@ impl MySQLConnection {
 
     /// `tls.serverName`: the SNI sent and the name the certificate must match.
     pub(crate) fn tls_server_name(&self) -> &[u8] {
-        let server_name = self.tls_config.server_name();
-        if server_name.is_null() {
-            return b"";
-        }
-        // SAFETY: `server_name` is a NUL-terminated C string owned by
-        // `tls_config` for the connection lifetime.
-        unsafe { bun_core::ffi::cstr(server_name) }.to_bytes()
+        self.tls_config.server_name_bytes()
     }
 
-    /// The live `SSL*` of the TLS socket, or null before the upgrade.
-    pub(crate) fn ssl(&self) -> *mut bun_boringssl_sys::SSL {
-        self.socket
-            .get_native_handle()
-            .map(|h| h.cast())
-            .unwrap_or(core::ptr::null_mut())
+    /// The `SSL` handle of the TLS socket; `None` before the upgrade.
+    pub(crate) fn ssl_mut(&self) -> Option<&mut bun_boringssl_sys::SSL> {
+        self.socket.ssl_mut()
     }
 
     pub(crate) fn read_and_process_data(&mut self, data: &[u8]) -> Result<(), AnyMySQLError> {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -901,18 +901,8 @@ impl PostgresSQLConnection {
     /// (verify-full only; verify-ca skips it by definition).
     fn verify_server_identity(&self) -> Result<(), JSValue> {
         let global = self.global();
-        let hostname: &[u8] = match self.tls_config.server_name() {
-            servername if servername.is_null() => b"",
-            // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
-            servername => unsafe { bun_core::ffi::cstr(servername) }.to_bytes(),
-        };
-        let ssl_ptr: *mut BoringSSL::c::SSL = self
-            .socket
-            .get()
-            .get_native_handle()
-            .map_or(core::ptr::null_mut(), |p| p.cast());
-        // SAFETY: in the handshake callback the native handle is the live `SSL*`.
-        let Some(ssl) = (unsafe { ssl_ptr.as_mut() }) else {
+        let hostname = self.tls_config.server_name_bytes();
+        let Some(ssl) = self.socket.get().ssl_mut() else {
             return Err(postgres_error_to_js(
                 global,
                 Some(b"Failed to upgrade to TLS"),

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -896,9 +896,7 @@ impl PostgresSQLConnection {
         }
     }
 
-    /// After the chain verified: `tls.checkServerIdentity` when the user set
-    /// one (verify-ca and verify-full), else the built-in hostname match
-    /// (verify-full only; verify-ca skips it by definition).
+    /// `tls.checkServerIdentity` if set (verify-ca and verify-full), else the built-in hostname match (verify-full only).
     fn verify_server_identity(&self) -> Result<(), JSValue> {
         let global = self.global();
         let hostname = self.tls_config.server_name_bytes();

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1,5 +1,6 @@
 use bun_collections::VecExt;
 use bun_jsc::JsCell;
+use bun_jsc::tls_server_identity;
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::sync::atomic::{AtomicU32, Ordering};
@@ -865,55 +866,72 @@ impl PostgresSQLConnection {
     pub(crate) fn on_handshake(&self, success: i32, ssl_error: uws::us_bun_verify_error_t) {
         debug!("onHandshake: {} {}", success, ssl_error.error_no);
         let handshake_success = success == 1;
-        if handshake_success {
-            if self.tls_config.reject_unauthorized() != 0 {
-                // only reject the connection if reject_unauthorized == true
-                match self.ssl_mode {
-                    // https://github.com/porsager/postgres/blob/6ec85a432b17661ccacbdf7f765c651e88969d36/src/connection.js#L272-L279
-                    SSLMode::VerifyCa | SSLMode::VerifyFull => {
-                        if ssl_error.error_no != 0 {
-                            let v = verify_error_to_js(&ssl_error, self.global());
-                            self.fail_with_js_value(v);
-                            return;
-                        }
-
-                        if self.ssl_mode == SSLMode::VerifyFull {
-                            let servername = self.tls_config.server_name();
-                            let ok = if servername.is_null() {
-                                false
-                            } else {
-                                // SAFETY: native handle of a connected TLS socket is `SSL*`.
-                                let ssl_ptr: *mut BoringSSL::c::SSL = self
-                                    .socket
-                                    .get()
-                                    .get_native_handle()
-                                    .map_or(core::ptr::null_mut(), |p| p.cast());
-                                // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
-                                let hostname =
-                                    unsafe { bun_core::ffi::cstr(servername) }.to_bytes();
-                                // SAFETY: `ssl_ptr` is the live SSL* of a connected TLS socket.
-                                !ssl_ptr.is_null()
-                                    && BoringSSL::check_server_identity(
-                                        unsafe { &mut *ssl_ptr },
-                                        hostname,
-                                    )
-                            };
-                            if !ok {
-                                let v = verify_error_to_js(&ssl_error, self.global());
-                                self.fail_with_js_value(v);
-                            }
-                        }
-                    }
-                    // require is the same as prefer
-                    SSLMode::Require | SSLMode::Prefer | SSLMode::Disable => {}
-                }
-            }
-        } else {
+        if !handshake_success {
             // if we are here is because server rejected us, and the error_no is the cause of this
             // no matter if reject_unauthorized is false because we are disconnected by the server
             let v = verify_error_to_js(&ssl_error, self.global());
             self.fail_with_js_value(v);
+            return;
         }
+        if self.tls_config.reject_unauthorized() == 0 {
+            return;
+        }
+        // only reject the connection if reject_unauthorized == true
+        match self.ssl_mode {
+            // https://github.com/porsager/postgres/blob/6ec85a432b17661ccacbdf7f765c651e88969d36/src/connection.js#L272-L279
+            SSLMode::VerifyCa | SSLMode::VerifyFull => {
+                if ssl_error.error_no != 0 {
+                    let v = verify_error_to_js(&ssl_error, self.global());
+                    self.fail_with_js_value(v);
+                    return;
+                }
+                // May run user JS (`tls.checkServerIdentity`).
+                let _guard = self.ref_guard();
+                if let Err(err) = self.verify_server_identity() {
+                    self.fail_with_js_value(err);
+                }
+            }
+            // require is the same as prefer
+            SSLMode::Require | SSLMode::Prefer | SSLMode::Disable => {}
+        }
+    }
+
+    /// After the chain verified: `tls.checkServerIdentity` when the user set
+    /// one (verify-ca and verify-full), else the built-in hostname match
+    /// (verify-full only; verify-ca skips it by definition).
+    fn verify_server_identity(&self) -> Result<(), JSValue> {
+        let global = self.global();
+        let hostname: &[u8] = match self.tls_config.server_name() {
+            servername if servername.is_null() => b"",
+            // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
+            servername => unsafe { bun_core::ffi::cstr(servername) }.to_bytes(),
+        };
+        let ssl_ptr: *mut BoringSSL::c::SSL = self
+            .socket
+            .get()
+            .get_native_handle()
+            .map_or(core::ptr::null_mut(), |p| p.cast());
+        // SAFETY: in the handshake callback the native handle is the live `SSL*`.
+        let Some(ssl) = (unsafe { ssl_ptr.as_mut() }) else {
+            return Err(postgres_error_to_js(
+                global,
+                Some(b"Failed to upgrade to TLS"),
+                AnyPostgresError::TLSUpgradeFailed,
+            ));
+        };
+        let callback = self
+            .js_value
+            .get()
+            .try_get()
+            .and_then(js::check_server_identity_get_cached)
+            .filter(|cb| cb.is_callable());
+        if let Some(callback) = callback {
+            return tls_server_identity::check_with_callback(global, callback, ssl, hostname);
+        }
+        if self.ssl_mode != SSLMode::VerifyFull {
+            return Ok(());
+        }
+        tls_server_identity::check_builtin(global, ssl, hostname)
     }
 
     pub(crate) fn on_timeout(&self) {
@@ -1272,6 +1290,9 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     this.js_value.set(crate::jsc::JsRef::init_weak(js_value));
     js::onconnect_set_cached(js_value, global_object, on_connect);
     js::onclose_set_cached(js_value, global_object, on_close);
+    if args.check_server_identity.is_callable() {
+        js::check_server_identity_set_cached(js_value, global_object, args.check_server_identity);
+    }
     bun_analytics::features::postgres_connections.fetch_add(1, Ordering::Relaxed);
     Ok(js_value)
 }

--- a/src/sql_jsc/shared/ConnectionCtorArgs.rs
+++ b/src/sql_jsc/shared/ConnectionCtorArgs.rs
@@ -42,6 +42,8 @@ pub(crate) struct ConnectionCtorArgs<M> {
     pub database_str: bun_core::String,
     pub ssl_mode: M,
     pub tls_config: SSLConfig,
+    /// `tls.checkServerIdentity`, or `undefined`. Kept alive by `arguments`.
+    pub check_server_identity: JSValue,
     /// Moves into the connection.
     pub secure: Option<OwnedSslCtx>,
 }
@@ -68,11 +70,18 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
 
         let tls_object = arguments[6];
         let mut tls_config = SSLConfig::default();
+        let mut check_server_identity = JSValue::UNDEFINED;
         let mut secure: Option<OwnedSslCtx> = None;
         if ssl_mode != modes[0] {
             tls_config = if tls_object.is_boolean() && tls_object.to_boolean() {
                 SSLConfig::default()
             } else if tls_object.is_object() {
+                // Validated as a function (or absent) by the JS layer.
+                if let Some(callback) = tls_object.get(global_object, "checkServerIdentity")?
+                    && callback.is_callable()
+                {
+                    check_server_identity = callback;
+                }
                 match SSLConfig::from_js(&mut *vm, global_object, tls_object) {
                     Ok(opt) => opt.unwrap_or_default(),
                     Err(_) => return Ok(None),
@@ -114,6 +123,7 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
             database_str,
             ssl_mode,
             tls_config,
+            check_server_identity,
             secure,
         }))
     }

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -950,6 +950,15 @@ impl AnySocket {
         }
     }
 
+    /// The `SSL` handle of a connected TLS socket; `None` for TCP.
+    #[inline]
+    pub fn ssl_mut(&self) -> Option<&mut bun_boringssl_sys::SSL> {
+        match self {
+            AnySocket::SocketTcp(_) => None,
+            AnySocket::SocketTls(s) => s.ssl_mut(),
+        }
+    }
+
     any_socket_forward! {
         fn is_closed(&self) -> bool;
         fn is_shutdown(&self) -> bool;

--- a/test/js/sql/sql-tls-server-identity.test.ts
+++ b/test/js/sql/sql-tls-server-identity.test.ts
@@ -1,0 +1,276 @@
+// `tls.checkServerIdentity`, `tls.serverName` / `tls.servername` and the
+// built-in hostname check for Bun.SQL over TLS (PostgreSQL and MySQL).
+//
+// These need a server that presents a certificate for a name of the test's
+// choosing, which the shared containers cannot do, so both adapters talk to a
+// minimal mock that upgrades to TLS and accepts the login. All wire-protocol
+// bytes come from test/js/sql/wire-frames.ts.
+
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+import { tls as localhostTls } from "harness";
+import { X509Certificate } from "node:crypto";
+import fs from "node:fs";
+import type net from "node:net";
+import path from "node:path";
+import tls from "node:tls";
+import {
+  MYSQL_CLIENT_SSL,
+  MYSQL_DEFAULT_CAPABILITIES,
+  listeningServer,
+  mysqlAckSessionSetup,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  pgAuthenticationOk,
+  pgReadyForQuery,
+  pgSSLResponse,
+} from "./wire-frames";
+
+// CN=agent1 (no SAN), signed by ca1: trusted through `ca1` but valid for no
+// host the tests dial, so only `serverName: "agent1"` or a custom
+// `checkServerIdentity` can accept it.
+const fixturesDir = path.join(import.meta.dirname, "..", "node", "tls", "fixtures");
+const agent1 = {
+  key: fs.readFileSync(path.join(fixturesDir, "agent1-key.pem"), "utf8"),
+  cert: fs.readFileSync(path.join(fixturesDir, "agent1-cert.pem"), "utf8"),
+  ca: fs.readFileSync(path.join(fixturesDir, "ca1-cert.pem"), "utf8"),
+};
+// The harness certificate: CN=server-bun, SAN localhost / 127.0.0.1 / ::1, self-signed.
+const localhost = { key: localhostTls.key, cert: localhostTls.cert, ca: localhostTls.cert };
+
+type ServerCert = { key: string; cert: string };
+type MockServer = {
+  url: string;
+  /** SNI of every completed TLS handshake, in order. */
+  servernames: (string | false)[];
+  close(): void;
+};
+
+/**
+ * Wraps `rawSocket` in a server-side TLSSocket once the plaintext prelude is
+ * done. Bytes already buffered past the prelude are TLS records: hand them to
+ * the TLS engine instead of the plaintext parser.
+ */
+function upgrade(rawSocket: net.Socket, cert: ServerCert, leftover: Buffer, servernames: (string | false)[]) {
+  rawSocket.pause();
+  if (leftover.length) rawSocket.unshift(leftover);
+  const socket = new tls.TLSSocket(rawSocket, { isServer: true, ...cert });
+  socket.on("secure", () => servernames.push(socket.servername));
+  socket.on("error", () => {});
+  return socket;
+}
+
+/** Answers SSLRequest with 'S', upgrades, then accepts any StartupMessage. */
+async function postgresServer(cert: ServerCert): Promise<MockServer> {
+  const servernames: (string | false)[] = [];
+  const { server, port } = await listeningServer(rawSocket => {
+    rawSocket.on("error", () => {});
+    rawSocket.once("data", (chunk: Buffer) => {
+      // SSLRequest is Int32(8) Int32(80877103); the client sends nothing else
+      // until it has the one-byte answer.
+      rawSocket.write(pgSSLResponse("S"));
+      const socket = upgrade(rawSocket, cert, chunk.subarray(8), servernames);
+      let startup = true;
+      socket.on("data", () => {
+        if (startup) {
+          startup = false;
+          socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        }
+      });
+    });
+  });
+  return { url: `postgres://u@127.0.0.1:${port}/db`, servernames, close: () => server.close() };
+}
+
+/** Advertises CLIENT_SSL, upgrades after the SSLRequest packet, then accepts the login. */
+async function mysqlServer(cert: ServerCert): Promise<MockServer> {
+  const servernames: (string | false)[] = [];
+  const { server, port } = await listeningServer(rawSocket => {
+    rawSocket.on("error", () => {});
+    rawSocket.write(mysqlHandshakeV10({ capabilities: MYSQL_DEFAULT_CAPABILITIES | MYSQL_CLIENT_SSL }));
+    let buffered = Buffer.alloc(0);
+    const onPlainData = (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk]);
+      if (buffered.length < 4) return;
+      const length = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+      if (buffered.length < 4 + length) return;
+      // The SSLRequest packet; the ClientHello may already follow it.
+      const leftover = buffered.subarray(4 + length);
+      buffered = Buffer.alloc(0);
+      rawSocket.removeListener("data", onPlainData);
+      const socket = upgrade(rawSocket, cert, leftover, servernames);
+      let authed = false;
+      socket.on("data", (chunk: Buffer) => {
+        buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+          if (!authed) {
+            authed = true;
+            socket.write(mysqlOkPacket(seq + 1));
+            return;
+          }
+          if (!mysqlAckSessionSetup(socket, payload)) socket.end();
+        });
+      });
+    };
+    rawSocket.on("data", onPlainData);
+  });
+  return { url: `mysql://u@127.0.0.1:${port}/db`, servernames, close: () => server.close() };
+}
+
+async function connect(url: string, tlsOptions: Bun.SQL.Options["tls"], sslmode = "verify-full"): Promise<unknown> {
+  await using sql = new SQL({ url: `${url}?sslmode=${sslmode}`, tls: tlsOptions, max: 1, idleTimeout: 1 });
+  return await sql.connect().then(
+    () => "CONNECTED",
+    e => e,
+  );
+}
+
+describe.each([
+  ["PostgreSQL", "postgres", postgresServer],
+  ["MySQL", "mysql", mysqlServer],
+] as const)("%s TLS server identity", (_, scheme, startServer) => {
+  async function withServer<T>(cert: ServerCert, fn: (server: MockServer) => Promise<T>): Promise<T> {
+    const server = await startServer(cert);
+    try {
+      return await fn(server);
+    } finally {
+      server.close();
+    }
+  }
+
+  test("verify-full rejects a trusted certificate issued for another host with ERR_TLS_CERT_ALTNAME_INVALID", async () => {
+    await withServer(agent1, async server => {
+      const err: any = await connect(server.url, { ca: agent1.ca });
+      expect(err?.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+      // Node's reason text names the host that was checked.
+      expect(err.message).toContain("127.0.0.1");
+    });
+  });
+
+  // `servername` is the node:tls spelling of the same option.
+  test.each(["serverName", "servername"] as const)(
+    "tls.%s sets the SNI and the name the certificate is verified against",
+    async key => {
+      await withServer(agent1, async server => {
+        expect(await connect(server.url, { ca: agent1.ca, [key]: "agent1" })).toBe("CONNECTED");
+        expect(server.servernames).toEqual(["agent1"]);
+      });
+    },
+  );
+
+  test("tls.checkServerIdentity is called with the hostname and certificate, and the Error it returns fails the connection", async () => {
+    await withServer(localhost, async server => {
+      const calls: [string, string, string][] = [];
+      const pin = new Error("PIN_MISMATCH");
+      const err = await connect(server.url, {
+        ca: localhost.ca,
+        checkServerIdentity: (hostname: string, cert: tls.PeerCertificate) => {
+          calls.push([hostname, cert.subject.CN, cert.fingerprint256]);
+          return pin;
+        },
+      });
+      expect(err).toBe(pin);
+      const fingerprint256 = new X509Certificate(localhost.cert).fingerprint256;
+      expect(calls).toEqual([["127.0.0.1", "server-bun", fingerprint256]]);
+    });
+  });
+
+  test("tls.checkServerIdentity replaces the built-in hostname check when it returns undefined", async () => {
+    await withServer(agent1, async server => {
+      const calls: [string, string][] = [];
+      const result = await connect(server.url, {
+        ca: agent1.ca,
+        checkServerIdentity: (hostname: string, cert: tls.PeerCertificate) => {
+          calls.push([hostname, cert.subject.CN]);
+          return undefined;
+        },
+      });
+      expect(result).toBe("CONNECTED");
+      expect(calls).toEqual([["127.0.0.1", "agent1"]]);
+    });
+  });
+
+  test("tls.checkServerIdentity receives tls.serverName as the hostname", async () => {
+    await withServer(agent1, async server => {
+      const hostnames: string[] = [];
+      const result = await connect(server.url, {
+        ca: agent1.ca,
+        serverName: "agent1",
+        checkServerIdentity: (hostname: string) => {
+          hostnames.push(hostname);
+          return undefined;
+        },
+      });
+      expect(result).toBe("CONNECTED");
+      expect(hostnames).toEqual(["agent1"]);
+    });
+  });
+
+  test("an exception thrown by tls.checkServerIdentity fails the connection", async () => {
+    await withServer(localhost, async server => {
+      const thrown = new TypeError("from checkServerIdentity");
+      const err = await connect(server.url, {
+        ca: localhost.ca,
+        checkServerIdentity: () => {
+          throw thrown;
+        },
+      });
+      expect(err).toBe(thrown);
+    });
+  });
+
+  test("tls.checkServerIdentity also runs under sslmode=verify-ca", async () => {
+    await withServer(agent1, async server => {
+      const pin = new Error("PIN_MISMATCH");
+      expect(await connect(server.url, { ca: agent1.ca, checkServerIdentity: () => pin }, "verify-ca")).toBe(pin);
+      // Without a callback verify-ca does not check the hostname.
+      expect(await connect(server.url, { ca: agent1.ca }, "verify-ca")).toBe("CONNECTED");
+    });
+  });
+
+  test("tls.checkServerIdentity requests certificate verification like tls.ca does", async () => {
+    // No `ca` and no verify-* sslmode: the callback alone turns verification
+    // on, so the untrusted self-signed chain fails before the callback runs.
+    await withServer(localhost, async server => {
+      let calls = 0;
+      const err: any = await connect(
+        server.url,
+        {
+          checkServerIdentity: () => {
+            calls++;
+            return undefined;
+          },
+        },
+        "prefer",
+      );
+      expect(err?.code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+      expect(calls).toBe(0);
+    });
+  });
+
+  test("tls.checkServerIdentity is not called when rejectUnauthorized is false", async () => {
+    await withServer(agent1, async server => {
+      let calls = 0;
+      const result = await connect(
+        server.url,
+        {
+          ca: agent1.ca,
+          rejectUnauthorized: false,
+          checkServerIdentity: () => {
+            calls++;
+            return new Error("unreachable");
+          },
+        },
+        "require",
+      );
+      expect(result).toBe("CONNECTED");
+      expect(calls).toBe(0);
+    });
+  });
+
+  test("tls.checkServerIdentity must be a function", () => {
+    expect(() => new SQL({ url: `${scheme}://u@127.0.0.1:1/db`, tls: { checkServerIdentity: "nope" as any } })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+});

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -56,14 +56,34 @@ function fakeServer(serverOpts: tls.TlsOptions): tls.Server {
   return server;
 }
 
-async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => Promise<T>, host?: string): Promise<T> {
+async function withServer<T>(
+  serverOpts: tls.TlsOptions,
+  fn: (port: number, server: tls.Server) => Promise<T>,
+  host?: string,
+): Promise<T> {
   const server = fakeServer(serverOpts);
   server.listen(0, host);
   await once(server, "listening");
   try {
-    return await fn((server.address() as AddressInfo).port);
+    return await fn((server.address() as AddressInfo).port, server);
   } finally {
     server.close();
+  }
+}
+
+/** The SNI names the server saw, one entry per completed handshake. */
+function recordServernames(server: tls.Server): (string | false)[] {
+  const names: (string | false)[] = [];
+  server.on("secureConnection", socket => names.push(socket.servername));
+  return names;
+}
+
+async function ping(url: string, tlsOptions: Bun.RedisOptions["tls"]): Promise<unknown> {
+  const client = new RedisClient(url, { autoReconnect: false, connectionTimeout: 5000, tls: tlsOptions });
+  try {
+    return await client.send("PING", []);
+  } finally {
+    client.close();
   }
 }
 
@@ -238,5 +258,160 @@ describe("RedisClient TLS hostname verification", () => {
         client.close();
       }
     });
+  });
+});
+
+describe("RedisClient tls.serverName", () => {
+  test("sends the URL host as SNI by default", async () => {
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async (port, server) => {
+      const servernames = recordServernames(server);
+      expect(await ping(`rediss://localhost:${port}`, { ca: localhostTls.cert })).toBe("PONG");
+      expect(servernames).toEqual(["localhost"]);
+    });
+  });
+
+  test("does not send an IP literal as SNI", async () => {
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async (port, server) => {
+      const servernames = recordServernames(server);
+      expect(await ping(`rediss://127.0.0.1:${port}`, { ca: localhostTls.cert })).toBe("PONG");
+      // One handshake, no SNI.
+      expect(servernames.map(Boolean)).toEqual([false]);
+    });
+  });
+
+  // `servername` is the node:tls spelling of the same option.
+  test.each(["serverName", "servername"] as const)(
+    "%s sets the SNI and the name the certificate is verified against",
+    async key => {
+      // The server presents CN=agent1; dialing 127.0.0.1 only verifies when the
+      // client checks the certificate against "agent1" instead of the URL host.
+      await withServer({ key: serverKey, cert: serverCert }, async (port, server) => {
+        const servernames = recordServernames(server);
+        expect(await ping(`rediss://127.0.0.1:${port}`, { ca, [key]: "agent1" })).toBe("PONG");
+        expect(servernames).toEqual(["agent1"]);
+      });
+    },
+  );
+
+  test("serverName that does not match the certificate is rejected", async () => {
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async port => {
+      const err: any = await ping(`rediss://localhost:${port}`, { ca: localhostTls.cert, serverName: "agent1" }).then(
+        () => null,
+        e => e,
+      );
+      expect(err?.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+      expect(err.message).toContain("agent1");
+    });
+  });
+});
+
+describe("RedisClient tls.checkServerIdentity", () => {
+  test("is called with the hostname and certificate, and the Error it returns rejects the connection", async () => {
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async port => {
+      const calls: [string, string][] = [];
+      const pin = new Error("PIN_MISMATCH");
+      const err = await ping(`rediss://localhost:${port}`, {
+        ca: localhostTls.cert,
+        checkServerIdentity: (hostname: string, cert: tls.PeerCertificate) => {
+          calls.push([hostname, cert.subject.CN]);
+          return pin;
+        },
+      }).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBe(pin);
+      // The harness certificate: CN=server-bun, SAN localhost/127.0.0.1/::1.
+      expect(calls).toEqual([["localhost", "server-bun"]]);
+    });
+  });
+
+  test("replaces the built-in hostname check when it returns undefined", async () => {
+    // CN=agent1 does not match "localhost": only the callback can accept it.
+    await withServer({ key: serverKey, cert: serverCert }, async port => {
+      const calls: [string, string][] = [];
+      const result = await ping(`rediss://localhost:${port}`, {
+        ca,
+        checkServerIdentity: (hostname: string, cert: tls.PeerCertificate) => {
+          calls.push([hostname, cert.subject.CN]);
+          return undefined;
+        },
+      });
+      expect(result).toBe("PONG");
+      expect(calls).toEqual([["localhost", "agent1"]]);
+    });
+  });
+
+  test("receives tls.serverName as the hostname", async () => {
+    await withServer({ key: serverKey, cert: serverCert }, async port => {
+      const hostnames: string[] = [];
+      const result = await ping(`rediss://127.0.0.1:${port}`, {
+        ca,
+        serverName: "agent1",
+        checkServerIdentity: (hostname: string) => {
+          hostnames.push(hostname);
+          return undefined;
+        },
+      });
+      expect(result).toBe("PONG");
+      expect(hostnames).toEqual(["agent1"]);
+    });
+  });
+
+  test("an exception thrown by the callback rejects the connection", async () => {
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async port => {
+      const thrown = new TypeError("from checkServerIdentity");
+      const err = await ping(`rediss://localhost:${port}`, {
+        ca: localhostTls.cert,
+        checkServerIdentity: () => {
+          throw thrown;
+        },
+      }).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBe(thrown);
+    });
+  });
+
+  test("is not called when the certificate chain fails to verify", async () => {
+    // No `ca`: the self-signed localhost certificate is untrusted. A tls object
+    // whose only member is the callback still enables TLS with default options.
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async port => {
+      let calls = 0;
+      const err: any = await ping(`rediss://localhost:${port}`, {
+        checkServerIdentity: () => {
+          calls++;
+          return undefined;
+        },
+      }).then(
+        () => null,
+        e => e,
+      );
+      expect(err?.code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+      expect(calls).toBe(0);
+    });
+  });
+
+  test("is not called when rejectUnauthorized is false", async () => {
+    await withServer({ key: serverKey, cert: serverCert }, async port => {
+      let calls = 0;
+      const result = await ping(`rediss://localhost:${port}`, {
+        ca,
+        rejectUnauthorized: false,
+        checkServerIdentity: () => {
+          calls++;
+          return new Error("unreachable");
+        },
+      });
+      expect(result).toBe("PONG");
+      expect(calls).toBe(0);
+    });
+  });
+
+  test("must be a function", () => {
+    expect(() => new RedisClient("rediss://localhost:6379", { tls: { checkServerIdentity: "nope" as any } })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.SQL` (PostgreSQL, MySQL) and `RedisClient` accept `tls.checkServerIdentity` and never call it. `fetch`, `tls.connect` and `https` call it, and `docs/runtime/sql.mdx` documents it for `Bun.SQL`. A pin callback shared across these doors is dropped at the database doors with no error. Fixes #41856.
- `Bun.SQL` ignores the node:tls spelling `tls.servername`. The option normalizer in `src/js/internal/sql/shared.ts` only looks at `serverName`, then adds `serverName: <url host>`, which wins over `servername` in the native parser. `RedisClient` sends no SNI at all and ignores `tls.serverName` for both SNI and the identity check.
- A built-in hostname mismatch in `Bun.SQL` (`sslmode=verify-full`) failed with an error whose `code` and `message` were empty (`verify_error_to_js` with `error_no == 0`).

### Fix
- New `bun_jsc::tls_server_identity` (`src/jsc/TlsServerIdentity.rs`): the built-in check (`ERR_TLS_CERT_ALTNAME_INVALID` with Node's reason text) and the callback check (fails with the `Error` the callback returns or throws). Postgres, MySQL and Valkey call it from their handshake callbacks, which already run on the JS thread. The callback lives in a GC-visited `values` slot on the JS wrapper.
- `Bun.SQL`: the callback runs once the chain verifies, under `verify-ca` and `verify-full`, in place of the built-in hostname match (Node semantics). Setting it requests verification like `ca` does, unless `rejectUnauthorized: false` or an explicit SSL mode says otherwise. `servername` is honored. MySQL's `do_handshake` is split so user JS never runs under `&mut MySQLConnection`.
- `RedisClient` (behavior change, on purpose): sends `serverName` (or `servername`), else the URL host, as SNI, where it sent none before (IP literals excepted), and verifies the certificate against that same name. A `tls` object with no recognized option now means TLS with defaults instead of `Expected tls to be a object`.
- Verified: `test/js/sql/sql-tls-server-identity.test.ts` (new, mock TLS Postgres and MySQL servers) and `test/js/valkey/valkey-tls-verify.test.ts` (13 new cases). 27 of the 41 cases fail on 1.4.3. Also ran the other SQL TLS mock tests and the valkey suites.

### Background
- `checkServerIdentity(hostname, cert)` is the node:tls hook that replaces the default hostname check after the chain verifies. It returns an `Error` to refuse the peer. Users pass it to pin a certificate or to accept a name the certificate does not carry.
- `Bun.SQL` maps `tls` options onto libpq-style SSL modes: `verify-ca` checks the chain, `verify-full` also checks the hostname. `tls: { ca }` or `rejectUnauthorized: true` already upgrade a lower mode to `verify-full`.
- Postgres and MySQL start in plaintext and upgrade the socket after an `SSLRequest` exchange (`adopt_tls`, which takes the SNI). Redis dials TLS directly through uSockets, which sets no SNI, so the client has to set it on the `SSL` in `on_open`, before the ClientHello, as `Bun.connect` and `fetch` do.
- Generated classes (`*.classes.ts`) can declare `values`: `WriteBarrier` slots on the C++ wrapper that the GC visits. Storing the callback there, instead of in a `Strong`, avoids a root that would keep a closure (and whatever it captures) alive in a cycle with the connection.

<details><summary>Notes</summary>

- Supersedes #33667 (the `ERR_TLS_CERT_ALTNAME_INVALID` part) and #36834 (the RedisClient SNI part). #41648 does the same for the WebSocket client; it can switch to `bun_jsc::tls_server_identity` once this lands. #40273 rewrites the same handshake functions to remove `unsafe`; the new code here already uses the safe accessors (`AnySocket::ssl_mut`, `SSL::set_servername`, `SSLConfig::server_name_bytes`), so whichever lands second has a small rebase.
- `sslmode=verify-ca` plus a callback: the callback runs (there is no built-in hostname check to replace in that mode). Below `verify-ca` with `rejectUnauthorized: false` the callback does not run, as in `fetch`.
- The hostname passed to the callback is `tls.serverName` when set, else the host being dialed (for `Bun.SQL` the normalizer already sets `serverName` to the URL host).
- A non-`Error` return value counts as success, as in `fetch`. A thrown value of any type fails the connection with that value.
- `RedisClient.duplicate()` copies the callback to the new client.
- `fetch` keeps its own copy of the callback invocation (`FetchTasklet.rs`): it runs off a DER copy after a thread hop, so it does not share this helper. `api::bun_x509::to_js` now re-exports the `bun_jsc` declaration of `Bun__X509__toJSLegacyEncoding`.
- Not changed here: `Bun.connect({ tls: { checkServerIdentity } })` (only the node:tls layer on top of it calls the callback), and the numeric-vs-string `minVersion` mismatch between the Bun-native and node-API doors.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/valkey/valkey-tls-verify.test.ts

<!-- robobun:evidence:end -->