### PR TITLE
fetch: key a forward-proxy keep-alive connection by its target origin

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -161,6 +161,7 @@ fn make_client<'a>(
         header_buf,
         url,
         connected_url: URL::default(),
+        served_target: None,
         verbose: HTTPVerboseLevel::None,
         // Note: DEFAULT_REDIRECT_COUNT (= 127) is crate-private in lib.rs;
         // duplicated as a literal here.
@@ -734,6 +735,7 @@ impl<'a> AsyncHTTP<'a> {
                     let client = &mut (*this).client;
                     client.url = original_url;
                     client.connected_url = URL::default();
+                    client.served_target = None;
                     client.method = original_method;
                     // Clone-owned (allocated after `ptr::read`).
                     drop(core::mem::take(&mut client.redirect));

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -227,8 +227,10 @@ pub struct PooledSocket<const SSL: bool> {
     /// strong ref while the socket is parked (the `RefPtr` *is* that ref).
     /// None for direct connections.
     pub(crate) proxy_tunnel: Option<RefPtr<ProxyTunnel>>,
-    /// Tunnel: the origin hostname (`hostname_buf` is the proxy). Unix TLS:
-    /// the hostname the handshake verified (`hostname_buf` is the path).
+    /// Proxy connection, tunneled or not: the target origin this connection
+    /// served (`hostname_buf` is the proxy). Unix TLS: the hostname the
+    /// handshake verified (`hostname_buf` is the path). Empty for a direct
+    /// connection, whose origin `hostname_buf` already names.
     pub(crate) target_hostname: Box<[u8]>,
     pub(crate) target_port: u16,
     /// Hash of the effective Proxy-Authorization value so that tunnels
@@ -667,12 +669,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 owner,
                 // Pool owns the tunnel ref transferred by the caller.
                 proxy_tunnel: tunnel,
-                target_hostname: if (had_tunnel || transport == Transport::Unix)
-                    && !target_hostname.is_empty()
-                {
-                    Box::<[u8]>::from(target_hostname)
-                } else {
+                target_hostname: if target_hostname.is_empty() {
                     Box::default()
+                } else {
+                    Box::<[u8]>::from(target_hostname)
                 },
                 target_port,
                 proxy_auth_hash,
@@ -839,19 +839,21 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 continue;
             }
 
-            if want_tunnel {
-                if socket.target_port != target_port {
-                    continue;
-                }
-                if !strings::eql_long(&socket.target_hostname, target_hostname, true) {
-                    continue;
-                }
-                // proxy_tunnel.is_some() guaranteed by want_tunnel match above.
-                if !required_for_target.admits(socket.proxy_tunnel.as_ref().unwrap().verification) {
-                    continue;
-                }
-            } else if transport == Transport::Unix
-                && !strings::eql_long(&socket.target_hostname, target_hostname, true)
+            // The target origin must match. A connection to a forward proxy
+            // carries the origin it served, tunneled or not: the proxy writes
+            // that origin's responses onto it, so another origin's request
+            // must not ride it. A TLS unix entry carries the hostname its
+            // handshake verified. Both sides are empty for a direct
+            // connection, whose origin `hostname` already names.
+            if socket.target_port != target_port
+                || !strings::eql_long(&socket.target_hostname, target_hostname, true)
+            {
+                continue;
+            }
+
+            // proxy_tunnel.is_some() guaranteed by want_tunnel match above.
+            if want_tunnel
+                && !required_for_target.admits(socket.proxy_tunnel.as_ref().unwrap().verification)
             {
                 continue;
             }
@@ -1036,14 +1038,14 @@ impl<const SSL: bool> HTTPContext<SSL> {
 
         client.flags.reused_socket_verification = PeerVerification::None;
         if client.is_keep_alive_possible() {
-            let want_tunnel = client.http_proxy.is_some() && client.url.is_https();
-            // CONNECT TCP target (writeProxyConnect line 346).
-            let target_hostname: &[u8] = if want_tunnel {
-                client.url.hostname
-            } else {
-                b""
-            };
-            let target_port: u16 = if want_tunnel {
+            let is_proxied = client.http_proxy.is_some();
+            let want_tunnel = is_proxied && client.url.is_https();
+            // The origin this connection talks to: the CONNECT TCP target
+            // (writeProxyConnect line 346) for a tunnel, the absolute-form
+            // request's origin for plain HTTP through the proxy. A proxy
+            // connection is keyed by it either way.
+            let target_hostname: &[u8] = if is_proxied { client.url.hostname } else { b"" };
+            let target_port: u16 = if is_proxied {
                 client.url.get_port_auto()
             } else {
                 0

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -796,6 +796,13 @@ pub struct HTTPClient<'a> {
     /// until `do_redirect` has released the socket, so it is freed there rather
     /// than at the assignment site. Also freed in `Drop` for error paths.
     pub(crate) prev_redirect: Vec<u8>,
+    /// Hostname and port of the hop the socket in hand just answered for,
+    /// parked by `handle_response_metadata` before it repoints `url` at the
+    /// redirect destination. `do_redirect` keys a proxy connection's pool
+    /// entry on it, because `url` no longer names the origin that connection
+    /// served. Borrows the previous hop's buffer, which `prev_redirect` keeps
+    /// alive until `do_redirect` has released the socket.
+    pub(crate) served_target: Option<(&'a [u8], u16)>,
     // Non-owning back-reference to a `Progress::Node` owned by the caller;
     // raw to avoid threading another lifetime param.
     pub progress_node: Option<NonNull<bun_core::Progress::Node>>,
@@ -2587,23 +2594,24 @@ impl<'a> HTTPClient<'a> {
         // redirect destination could then reuse a TLS session negotiated with the
         // original host. Close the tunnel on redirect; only pool the raw socket.
         //
-        // A plain-HTTP proxy connection has the same problem without a tunnel:
-        // the pool keys it by the origin it served, which is no longer readable
-        // here, so it would be parked under the redirect destination's origin
-        // and a later request to that origin could take a connection that
-        // answered for the original host. Close it too.
-        if self.proxy_tunnel.is_some() || self.http_proxy.is_some() {
-            if self.proxy_tunnel.is_some() {
-                bun_core::scoped_log!(fetch, "close the tunnel");
-                self.close_proxy_tunnel(true);
-            }
+        // A plain-HTTP proxy connection carries the same hazard without a
+        // tunnel: the pool keys it by the origin it served, and `url` no longer
+        // names that origin. `served_target` does.
+        if self.proxy_tunnel.is_some() {
+            bun_core::scoped_log!(fetch, "close the tunnel");
+            self.close_proxy_tunnel(true);
             GenHttpContext::<IS_SSL>::close_socket(socket);
         } else if self.is_keep_alive_possible()
             && self.is_request_fully_sent()
             && !socket.is_closed_or_has_error()
+            && (self.http_proxy.is_none() || self.served_target.is_some())
         {
             bun_core::scoped_log!(fetch, "Keep-Alive release in redirect");
             debug_assert!(!self.connected_url.hostname.is_empty());
+            let (target_hostname, target_port) = match self.served_target {
+                Some(served) if self.http_proxy.is_some() => served,
+                _ => (self.unix_tls_hostname::<IS_SSL>(), 0),
+            };
             Self::ssl_ctx_mut(ctx).release_socket(
                 socket,
                 self.flags.did_have_handshaking_error && !self.flags.reject_unauthorized,
@@ -2612,8 +2620,8 @@ impl<'a> HTTPClient<'a> {
                 self.connected_url.get_port_auto(),
                 self.tls_props.as_ref(),
                 None,
-                self.unix_tls_hostname::<IS_SSL>(),
-                0,
+                target_hostname,
+                target_port,
                 0,
                 None,
                 self.unix_socket_path,
@@ -2621,9 +2629,10 @@ impl<'a> HTTPClient<'a> {
         } else {
             GenHttpContext::<IS_SSL>::close_socket(socket);
         }
-        // Cleared after `release_socket` above, which keys the pool entry on it.
+        // Cleared after `release_socket` above, which keys the pool entry on them.
         self.unix_socket_path = b"";
         self.connected_url = URL::default();
+        self.served_target = None;
         // connected_url was the last borrower of the previous hop's URL buffer
         // (handleResponseMetadata already repointed this.url at the new one).
         self.prev_redirect = Vec::new();
@@ -4289,6 +4298,7 @@ impl<'a> HTTPClient<'a> {
         debug_assert!(self.redirect_type == FetchRedirect::Follow);
         self.unregister_abort_tracker();
         self.connected_url = URL::default();
+        self.served_target = None;
         self.prev_redirect = Vec::new();
         if self.remaining_redirect_count == 0 {
             self.fail(crate::Error::TooManyRedirects);
@@ -5044,6 +5054,7 @@ impl<'a> HTTPClient<'a> {
                             strings::without_trailing_slash(self.url.origin),
                             true,
                         );
+                        self.served_target = Some((self.url.hostname, self.url.get_port_auto()));
                         self.url = new_url;
                         // connected_url still borrows from the previous hop's buffer
                         // until doRedirect releases the socket, so park it in
@@ -5099,6 +5110,7 @@ impl<'a> HTTPClient<'a> {
                             strings::without_trailing_slash(self.url.origin),
                             true,
                         );
+                        self.served_target = Some((self.url.hostname, self.url.get_port_auto()));
                         self.url = new_url;
                         debug_assert!(self.prev_redirect.is_empty());
                         self.prev_redirect =
@@ -5121,6 +5133,7 @@ impl<'a> HTTPClient<'a> {
                         }
                         // SAFETY: self-borrow — `new_url` is moved into `self.redirect`
                         // below, which lives as long as `self` (≥ `'a`).
+                        self.served_target = Some((self.url.hostname, self.url.get_port_auto()));
                         self.url = unsafe { parsed_url.erase_lifetime() };
                         is_same_origin = strings::eql_case_insensitive_ascii(
                             strings::without_trailing_slash(self.url.origin),

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2586,9 +2586,17 @@ impl<'a> HTTPClient<'a> {
         // store it under the WRONG target hostname — a follow-up request to the
         // redirect destination could then reuse a TLS session negotiated with the
         // original host. Close the tunnel on redirect; only pool the raw socket.
-        if self.proxy_tunnel.is_some() {
-            bun_core::scoped_log!(fetch, "close the tunnel");
-            self.close_proxy_tunnel(true);
+        //
+        // A plain-HTTP proxy connection has the same problem without a tunnel:
+        // the pool keys it by the origin it served, which is no longer readable
+        // here, so it would be parked under the redirect destination's origin
+        // and a later request to that origin could take a connection that
+        // answered for the original host. Close it too.
+        if self.proxy_tunnel.is_some() || self.http_proxy.is_some() {
+            if self.proxy_tunnel.is_some() {
+                bun_core::scoped_log!(fetch, "close the tunnel");
+                self.close_proxy_tunnel(true);
+            }
             GenHttpContext::<IS_SSL>::close_socket(socket);
         } else if self.is_keep_alive_possible()
             && self.is_request_fully_sent()
@@ -4150,8 +4158,14 @@ impl<'a> HTTPClient<'a> {
                     proxy_tunnel::raw_as_mut(t.as_ptr()).detach_owner(&*self);
                 }
                 let had_tunnel = tunnel.is_some();
-                // target_hostname = url.hostname (the CONNECT TCP target at
-                // writeProxyConnect line 346).
+                // A proxy connection is keyed by the origin it served, so the
+                // pool cannot hand it to a request for a different origin:
+                // `url.hostname` is the CONNECT TCP target (writeProxyConnect
+                // line 346) for a tunnel, and the absolute-form request's
+                // origin for plain HTTP through the proxy. A unix entry keeps
+                // its TLS hostname instead; unix and proxy never combine.
+                let keyed_by_origin =
+                    (had_tunnel || self.http_proxy.is_some()) && self.unix_socket_path.is_empty();
                 Self::ssl_ctx_mut(ctx).release_socket(
                     socket,
                     self.flags.did_have_handshaking_error && !self.flags.reject_unauthorized,
@@ -4160,12 +4174,12 @@ impl<'a> HTTPClient<'a> {
                     self.connected_url.get_port_auto(),
                     self.tls_props.as_ref(),
                     tunnel,
-                    if had_tunnel {
+                    if keyed_by_origin {
                         self.url.hostname
                     } else {
                         self.unix_tls_hostname::<IS_SSL>()
                     },
-                    if had_tunnel {
+                    if keyed_by_origin {
                         self.url.get_port_auto()
                     } else {
                         0

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -2395,3 +2395,79 @@ describe("http_proxy env var scheme is case-insensitive", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// A forward proxy answers for every origin, so bun pools one connection per
+// proxy address. Without the target origin in the pool key, one connection
+// carries requests for several origins, and a response the proxy writes for
+// origin A is read as the answer to the next request written onto that
+// connection, which can be a request for origin B. The proxy below answers a
+// request that arrives on a connection which already serves another origin
+// with that other origin's answer: the wire shape of the cross-origin case.
+// The https-through-a-proxy path already keys its CONNECT tunnel by target
+// origin, so it was never affected.
+test("a proxy connection is not reused for a different target origin", async () => {
+  using originA = Bun.serve({ port: 0, fetch: () => new Response("unused") });
+  using originB = Bun.serve({ port: 0, fetch: () => new Response("unused") });
+  const a = `http://127.0.0.1:${originA.port}`;
+  const b = `http://127.0.0.1:${originB.port}`;
+
+  const log: Array<string> = [];
+  let connections = 0;
+  const proxy = net.createServer(clientSocket => {
+    const id = ++connections;
+    const served: Array<string> = [];
+    let buffered = "";
+    clientSocket.on("error", () => {});
+    clientSocket.on("data", chunk => {
+      buffered += chunk.toString();
+      for (let end = buffered.indexOf("\r\n\r\n"); end !== -1; end = buffered.indexOf("\r\n\r\n")) {
+        const target = buffered.slice(0, end).split(" ")[1];
+        buffered = buffered.slice(end + 4);
+        const origin = new URL(target).origin;
+        log.push(`${id} ${origin}`);
+        const answerFor = served.length > 0 ? served[0] : origin;
+        served.push(origin);
+        const body = `answer-for-${answerFor}`;
+        clientSocket.write(`HTTP/1.1 200 OK\r\nContent-Length: ${body.length}\r\n\r\n${body}`);
+      }
+    });
+  });
+  proxy.listen(0, "127.0.0.1");
+  await once(proxy, "listening");
+  const proxyUrl = `http://127.0.0.1:${(proxy.address() as net.AddressInfo).port}`;
+
+  try {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `for (const url of ${JSON.stringify([`${a}/1`, `${b}/2`, `${a}/3`])}) {
+           const res = await fetch(url, { proxy: ${JSON.stringify(proxyUrl)} });
+           console.log(await res.text());
+         }`,
+      ],
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Each response is the one the proxy wrote for the origin of that request.
+    expect(stdout.trim().split("\n")).toEqual([`answer-for-${a}`, `answer-for-${b}`, `answer-for-${a}`]);
+    // Origin B gets its own connection, and the second request to origin A
+    // still reuses the first connection: keep-alive is kept, not disabled.
+    expect(log).toEqual([`1 ${a}`, `2 ${b}`, `1 ${a}`]);
+    expect(exitCode).toBe(0);
+  } finally {
+    proxy.close();
+    await once(proxy, "close");
+  }
+});

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -53,12 +53,12 @@ async function createProxyServer(is_tls: boolean) {
       }
 
       // Absolute-form (non-tunneled) proxying. The client negotiates
-      // keep-alive on the proxy connection, so after a redirect the next
-      // request arrives on this same socket — forward every request that
-      // shows up, not just the first one. The reused proxy connection is
-      // keyed only by the proxy address, so consecutive requests may also
-      // target different origins; keep one upstream per destination at a
-      // time and reconnect when it changes.
+      // keep-alive on the proxy connection, so after a same-origin redirect
+      // the next request arrives on this same socket — forward every request
+      // that shows up, not just the first one. A reused proxy connection
+      // names one target origin (the pool keys it by that origin), but keep
+      // one upstream per destination and reconnect when it changes, so this
+      // mock proxy stays correct for a connection that does switch targets.
       let upstream: net.Socket | undefined;
       let upstreamKey = "";
       let upstreamConnected = false;
@@ -2465,6 +2465,86 @@ test("a proxy connection is not reused for a different target origin", async () 
     // Origin B gets its own connection, and the second request to origin A
     // still reuses the first connection: keep-alive is kept, not disabled.
     expect(log).toEqual([`1 ${a}`, `2 ${b}`, `1 ${a}`]);
+    expect(exitCode).toBe(0);
+  } finally {
+    proxy.close();
+    await once(proxy, "close");
+  }
+});
+
+// A followed redirect reuses the proxy connection that carried the 3xx
+// (#37451). The pool entry for that connection is keyed by the origin it
+// answered for, which `url` no longer names once the redirect is parsed, so a
+// cross-origin redirect must take a fresh connection for the hop and leave the
+// first connection parked under the first origin.
+test("a redirected proxy connection stays keyed to the origin it served", async () => {
+  using originA = Bun.serve({ port: 0, fetch: () => new Response("unused") });
+  using originB = Bun.serve({ port: 0, fetch: () => new Response("unused") });
+  const a = `http://127.0.0.1:${originA.port}`;
+  const b = `http://127.0.0.1:${originB.port}`;
+
+  const log: Array<string> = [];
+  let connections = 0;
+  const proxy = net.createServer(clientSocket => {
+    const id = ++connections;
+    let buffered = "";
+    clientSocket.on("error", () => {});
+    clientSocket.on("data", chunk => {
+      buffered += chunk.toString();
+      for (let end = buffered.indexOf("\r\n\r\n"); end !== -1; end = buffered.indexOf("\r\n\r\n")) {
+        const target = new URL(buffered.slice(0, end).split(" ")[1]);
+        buffered = buffered.slice(end + 4);
+        log.push(`${id} ${target.origin}${target.pathname}`);
+        if (target.pathname === "/same") {
+          clientSocket.write(`HTTP/1.1 302 Found\r\nLocation: ${target.origin}/ok\r\nContent-Length: 0\r\n\r\n`);
+        } else if (target.pathname === "/cross") {
+          clientSocket.write(`HTTP/1.1 302 Found\r\nLocation: ${b}/ok\r\nContent-Length: 0\r\n\r\n`);
+        } else {
+          clientSocket.write(`HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok`);
+        }
+      }
+    });
+  });
+  proxy.listen(0, "127.0.0.1");
+  await once(proxy, "listening");
+  const proxyUrl = `http://127.0.0.1:${(proxy.address() as net.AddressInfo).port}`;
+
+  try {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `for (const url of ${JSON.stringify([`${a}/same`, `${a}/cross`, `${b}/later`, `${a}/later`])}) {
+           const res = await fetch(url, { proxy: ${JSON.stringify(proxyUrl)} });
+           console.log(res.status, await res.text());
+         }`,
+      ],
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim().split("\n")).toEqual(["200 ok", "200 ok", "200 ok", "200 ok"]);
+    expect(log).toEqual([
+      // The same-origin hop rides the connection that carried the 302.
+      `1 ${a}/same`,
+      `1 ${a}/ok`,
+      // The cross-origin hop does not.
+      `1 ${a}/cross`,
+      `2 ${b}/ok`,
+      // Both connections stay parked under the origin each one served.
+      `2 ${b}/later`,
+      `1 ${a}/later`,
+    ]);
     expect(exitCode).toBe(0);
   } finally {
     proxy.close();


### PR DESCRIPTION
### Problem

- A plain-HTTP request through a forward proxy parks its connection under the proxy's address alone, so one connection carries requests for several target origins.
- A proxy that writes one extra response after origin A's reply then answers origin B's request with it: 30/30 in a loopback repro. The bytes arrive after bun wrote request B, so nothing at reuse time can see them.
- `existing_socket` and `release_socket` (`src/http/HTTPContext.rs`) fill in `target_hostname` and `target_port` for a CONNECT tunnel only.

### Fix

- Key every proxy connection by its target origin, tunnel or not. `find_in` compares `target_hostname` and `target_port` for every entry; a direct connection leaves both empty, so its key is unchanged.
- `do_redirect` runs after `url` already names the redirect destination, so the origin the connection answered for is parked in `HTTPClient::served_target`. A same-origin redirect still reuses that connection (#37451).
- Correct because a forward proxy writes one origin's responses onto the connection that asked for them. Same rule as bun's tunnel key, undici and Chromium.
- Cost: one connection per origin, not one shared. Verified: two new tests in `test/js/bun/http/proxy.test.ts` (both fail on 1.4.3-canary), plus the proxy, proxy-stress, fetch-keepalive and fetch-redirect suites.

### Background

- The keep-alive pool holds up to 64 idle sockets per HTTP thread, matched on hostname, port, TLS config, peer verification and ALPN.
- A forward proxy answers `GET http://origin/path` (absolute form) for any origin, so one connection to it can serve all of them.
- An https target goes through CONNECT instead: one tunnel per origin, which the pool already keys by that origin.

<details><summary>Notes</summary>

Repro (loopback, python3 stdlib): a proxy that answers absolute-form requests itself and, after any reply for origin A, sleeps `D` and writes one more `200` response. Client: `fetch(A)`, read it, `fetch(B)`, compare.

| injection delay D | cross-origin mis-attribution |
| --- | --- |
| 0.2 ms | 31/40 |
| 2 ms | 40/40 |
| 5 ms | 40/40 |
| 20 ms | 40/40 |
| 20 ms, plus a 2 ms or 10 ms gap before fetch B | 30/30 |

With this change: 0/30. The 100% rates at the longer delays rule out the other shape of this bug, an idle pooled socket reused while bytes already sit in its receive queue (that shape is #41987, which peeks the socket at checkout): at reuse time the queue is empty here, and the bytes arrive while bun waits for B's response. No check at checkout can see them, so the only boundary left is which requests may share the connection. The proxy's real answer for B arrives later on the then-idle socket and is dropped by the existing unexpected-data eviction.

Peers, same wire bytes: node v26.3.0 with `NODE_USE_ENV_PROXY=1` is 0/50, because undici CONNECT-tunnels even plain-http targets, one tunnel per origin, and keys its pool by origin even with `proxyTunnel: false`. Chromium parks a non-tunnelled proxy socket in a group keyed by the final destination inside the per-proxy pool. curl 8.17 (`-x P http://A --next -x P http://B`) is 20/20, the same as bun before this change; Go's `net/http` and urllib3 also share a forwarding-proxy connection across origins.

There are no tracker reports for this. It needs a proxy that emits a response nobody asked for: a hostile proxy, a desynced upstream, or smuggling through the proxy. `{ proxy, keepalive: false }` avoids it today, but that option does not reach `Bun.fetch`, workers, `Bun.S3Client` over an http endpoint, or `bun install` under `HTTP_PROXY`.

Incidental: before this change a direct request to a host and port that happen to equal the proxy's own could take a pooled plain-http proxy connection, because both keys were the proxy's address with an empty target. The target comparison now rejects that.

`served_target` borrows the previous hop's URL buffer. `prev_redirect` keeps that buffer alive until `do_redirect` has released the socket, the same lifetime `connected_url` already relies on there, and the field is cleared wherever `connected_url` is cleared (`do_redirect`, `do_redirect_multiplexed`, and the request-reuse reset in `AsyncHTTP`).

Worst case for reuse: more than 64 distinct plain-http origins round-robin through one proxy now churn the 64-slot pool instead of sharing one socket. That is the same LRU cliff bun already accepts for direct connections and for CONNECT tunnels.

Pre-existing failures in this environment, unchanged by the diff (they also fail with `USE_SYSTEM_BUN=1`): `proxy.test.js` "proxy non-TLS auth can fail" and "simultaneous proxy auth failures should not hang", plus the `fetch.test.ts` cases that need a non-root user, a `localhost` bind that resolves to `::1`, or more than 5 s under ASAN.

</details>
