### PR TITLE
bun test: keep collecting a file's tests when an unhandled error lands during collection

### DIFF
--- a/docs/test/runtime-behavior.mdx
+++ b/docs/test/runtime-behavior.mdx
@@ -87,7 +87,7 @@ test("test without timeout", async () => {
 
 ### Unhandled Errors
 
-`bun test` tracks unhandled promise rejections and errors that occur between tests. If any occur, `bun test` exits with a non-zero code even when no test failed. In both examples below the error happens while the file is being loaded, so the file's tests are not run at all.
+`bun test` tracks unhandled promise rejections and errors that occur between tests. If any occur, `bun test` exits with a non-zero code even when no test failed. In both examples below the error happens while the file is being loaded: it is reported as an unhandled error and the file's tests still run.
 
 This helps catch errors in asynchronous code that might otherwise go unnoticed:
 
@@ -107,8 +107,8 @@ test("test 2", () => {
   expect(true).toBe(true);
 });
 
-// bun test reports this as "Unhandled error between tests", does not run
-// this file's tests (0 pass, 1 error), and exits with code 1
+// bun test reports this as "Unhandled error between tests", still runs both
+// tests (2 pass, 1 error), and exits with code 1
 ```
 
 ### Promise Rejections
@@ -122,8 +122,8 @@ test("test 1", () => {
   expect(1).toBe(1);
 });
 
-// bun test reports this as "Unhandled error between tests", does not run
-// this file's tests, and exits with code 1
+// bun test reports this as "Unhandled error between tests", still runs
+// "test 1" (1 pass, 1 error), and exits with code 1
 Promise.reject(new Error("Unhandled rejection"));
 ```
 

--- a/src/runtime/test_runner/Collection.rs
+++ b/src/runtime/test_runner/Collection.rs
@@ -259,10 +259,7 @@ impl Collection {
         let _g = group::begin();
 
         let RefDataValue::Collection { .. } = data else {
-            // Not a describe() callback's own throw or rejection: the error comes from
-            // work the collector does not track (a timer an earlier file leaked, a stray
-            // rejected promise) while the file's top level or a describe() callback is
-            // still running. No scope fails and collection continues.
+            // Not a describe() callback's own throw or rejection (see jest::on_unhandled_rejection).
             return HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests;
         };
 

--- a/src/runtime/test_runner/Collection.rs
+++ b/src/runtime/test_runner/Collection.rs
@@ -254,9 +254,17 @@ impl Collection {
 
     pub(crate) fn handle_uncaught_exception(
         &mut self,
-        _: &RefDataValue,
+        data: &RefDataValue,
     ) -> HandleUncaughtExceptionResult {
         let _g = group::begin();
+
+        let RefDataValue::Collection { .. } = data else {
+            // Not a describe() callback's own throw or rejection: the error comes from
+            // work the collector does not track (a timer an earlier file leaked, a stray
+            // rejected promise) while the file's top level or a describe() callback is
+            // still running. No scope fails and collection continues.
+            return HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests;
+        };
 
         self.active_scope_mut().failed = true;
 

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -603,6 +603,13 @@ pub(crate) mod on_unhandled_rejection {
             // re-borrows. Const→mut projection is centralized in `buntest_as_mut`
             // pending the BunTestPtr interior-mut reshape (see bun_test.rs).
             let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
+            if buntest.phase == bun_test::Phase::Collection {
+                // The file's top level or a describe() callback is still running. Report
+                // the error and keep collecting. Queueing a result here would drive the
+                // collector as if the describe() callback in flight had completed.
+                buntest.on_uncaught_exception(global_object, Some(rejection), true, &RefDataValue::Start);
+                return;
+            }
             // mark unhandled errors as belonging to the currently active test. note that this can be misleading.
             let mut current_state_data = buntest.get_current_state_data();
             // split entry()/sequence() borrows via raw-ptr capture (per-use reborrow).

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -604,9 +604,7 @@ pub(crate) mod on_unhandled_rejection {
             // pending the BunTestPtr interior-mut reshape (see bun_test.rs).
             let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
             if buntest.phase == bun_test::Phase::Collection {
-                // The file's top level or a describe() callback is still running. Report
-                // the error and keep collecting. Queueing a result here would drive the
-                // collector as if the describe() callback in flight had completed.
+                // Keep collecting: a queued result here would complete the describe() callback in flight.
                 buntest.on_uncaught_exception(global_object, Some(rejection), true, &RefDataValue::Start);
                 return;
             }

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -748,4 +748,137 @@ test("my-test", () => {
       expect(output).toContain("Ran 1 test across 1 file");
     });
   }
+
+  // An error that lands while a file is still collecting (its top level or a
+  // describe() callback is running) must not stop that file's tests from being
+  // collected and run, and must not move them into another file.
+  test.concurrent("from a finished file's timer, while the next file is in a top-level await", async () => {
+    using test_dir = tempDir("unhandled-cross-file-collection", {
+      "a.test.js": /*js*/ `
+        import { test, expect } from "bun:test";
+        test("a leaks a throwing timer", () => {
+          setTimeout(() => {
+            globalThis.__aTimerFired = true;
+            throw new Error("## late throw from a ##");
+          }, 10);
+          expect(1).toBe(1);
+        });
+      `,
+      "b.test.js": /*js*/ `
+        import { test, expect } from "bun:test";
+        // stands for a top-level \`await startServer()\` or fixture import
+        do {
+          await Bun.sleep(5);
+        } while (!globalThis.__aTimerFired);
+        test("b1 failing", () => { expect(1).toBe(2); });
+        test("b2", () => { expect(2).toBe(2); });
+      `,
+      "package.json": "{}",
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "./a.test.js", "./b.test.js"],
+      cwd: String(test_dir),
+      stdout: "ignore",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [output, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(output.match(/^error: ## late throw from a ##$/gm)).toHaveLength(1);
+    expect(output).toContain("Unhandled error between tests");
+    expect(output).not.toContain("Cannot call test()");
+    expect(output).toMatch(/\(fail\) b1 failing/);
+    expect(output).toMatch(/\(pass\) b2/);
+    expect(output).toContain("\n 2 pass\n");
+    expect(output).toContain("\n 1 fail\n");
+    expect(output).toContain("\n 1 error\n");
+    expect(output).toContain("Ran 3 tests across 2 files");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("from a finished file's timer, while the next file awaits in a describe() callback", async () => {
+    using test_dir = tempDir("unhandled-cross-file-describe", {
+      "a.test.js": /*js*/ `
+        import { test, expect } from "bun:test";
+        test("a leaks a throwing timer", () => {
+          setTimeout(() => {
+            globalThis.__aTimerFired = true;
+            throw new Error("## late throw from a ##");
+          }, 10);
+          expect(1).toBe(1);
+        });
+      `,
+      "b.test.js": /*js*/ `
+        import { test, expect, describe } from "bun:test";
+        describe("waits", async () => {
+          do {
+            await Bun.sleep(5);
+          } while (!globalThis.__aTimerFired);
+          test("b1 failing", () => { expect(1).toBe(2); });
+          test("b2", () => { expect(2).toBe(2); });
+        });
+        test("b3", () => { expect(3).toBe(3); });
+      `,
+      "c.test.js": /*js*/ `
+        import { test, expect } from "bun:test";
+        await Bun.sleep(20);
+        test("c1", () => { expect(1).toBe(1); });
+      `,
+      "package.json": "{}",
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "./a.test.js", "./b.test.js", "./c.test.js"],
+      cwd: String(test_dir),
+      stdout: "ignore",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [output, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(output.match(/^error: ## late throw from a ##$/gm)).toHaveLength(1);
+    expect(output).not.toContain("Cannot call test()");
+    // b1 and b2 stay in b.test.js, inside their describe, and nothing leaks into c.test.js
+    const perFile = output.split(/\n(?=\S+\.test\.js:\n)/g).map(s => s.trim());
+    expect(perFile.find(s => s.startsWith("b.test.js:"))).toMatch(
+      /Unhandled error between tests[\s\S]+\(fail\) waits > b1 failing[\s\S]+\(pass\) waits > b2[\s\S]+\(pass\) b3/,
+    );
+    expect(perFile.find(s => s.startsWith("c.test.js:"))).toMatch(/^c\.test\.js:\n\(pass\) c1 [^\n]+\n\n 4 pass\n/);
+    expect(output).toContain("\n 1 fail\n");
+    expect(output).toContain("\n 1 error\n");
+    expect(output).toContain("Ran 5 tests across 3 files");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("from the file's own top level, before its tests are scheduled", async () => {
+    using test_dir = tempDir("unhandled-own-top-level", {
+      "my-test.test.js": /*js*/ `
+        import { test, expect } from "bun:test";
+        Promise.reject(new Error("## stray top-level rejection ##"));
+        test("t1 failing", () => { expect(1).toBe(2); });
+        test("t2", () => { expect(2).toBe(2); });
+      `,
+      "package.json": "{}",
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "./my-test.test.js"],
+      cwd: String(test_dir),
+      stdout: "ignore",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [output, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(output.match(/^error: ## stray top-level rejection ##$/gm)).toHaveLength(1);
+    expect(output).toContain("Unhandled error between tests");
+    expect(output).toMatch(/\(fail\) t1 failing/);
+    expect(output).toMatch(/\(pass\) t2/);
+    expect(output).toContain("\n 1 pass\n");
+    expect(output).toContain("\n 1 fail\n");
+    expect(output).toContain("\n 1 error\n");
+    expect(output).toContain("Ran 2 tests across 1 file");
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -767,9 +767,10 @@ test("my-test", () => {
       "b.test.js": /*js*/ `
         import { test, expect } from "bun:test";
         // stands for a top-level \`await startServer()\` or fixture import
-        do {
+        for (let waited = 0; !globalThis.__aTimerFired; waited += 5) {
+          if (waited > 2000) throw new Error("a.test.js's timer did not fire within 2s");
           await Bun.sleep(5);
-        } while (!globalThis.__aTimerFired);
+        }
         test("b1 failing", () => { expect(1).toBe(2); });
         test("b2", () => { expect(2).toBe(2); });
       `,
@@ -815,9 +816,10 @@ test("my-test", () => {
       "b.test.js": /*js*/ `
         import { test, expect, describe } from "bun:test";
         describe("waits", async () => {
-          do {
+          for (let waited = 0; !globalThis.__aTimerFired; waited += 5) {
+            if (waited > 2000) throw new Error("a.test.js's timer did not fire within 2s");
             await Bun.sleep(5);
-          } while (!globalThis.__aTimerFired);
+          }
           test("b1 failing", () => { expect(1).toBe(2); });
           test("b2", () => { expect(2).toBe(2); });
         });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -856,38 +856,198 @@ test("my-test", () => {
     expect(output).toContain("Ran 5 tests across 3 files");
     expect(exitCode).toBe(1);
   });
+});
 
-  test.concurrent("from the file's own top level, before its tests are scheduled", async () => {
-    using test_dir = tempDir("unhandled-own-top-level", {
-      "my-test.test.js": /*js*/ `
-        import { test, expect } from "bun:test";
-        Promise.reject(new Error("## stray top-level rejection ##"));
-        test("t1 failing", () => { expect(1).toBe(2); });
-        test("t2", () => { expect(2).toBe(2); });
-      `,
+// An unhandled rejection or uncaught exception that lands while a file is still
+// registering its tests does not belong to any describe() callback. It is reported
+// as an unhandled error and the file's tests still run.
+describe.concurrent("unhandled error during collection does not drop the file's tests", () => {
+  test("from module top level, a .each table, and a describe body", async () => {
+    using dir = tempDir("unhandled-collection", {
       "package.json": "{}",
+      // Flush left, no blank lines: the code frames below are part of the snapshot.
+      "stray.test.ts": [
+        `import { describe, expect, test } from "bun:test";`,
+        `Promise.reject(new Error("stray-top-level"));`,
+        `test.each([[Promise.reject(new Error("stray-each-row"))], [Promise.resolve(1)]])("row %#", value => {`,
+        `  expect(value).toBeInstanceOf(Promise);`,
+        `});`,
+        `describe("d", () => {`,
+        `  Promise.reject(new Error("stray-in-describe"));`,
+        `  test("t1", () => {});`,
+        `  describe("inner", () => {`,
+        `    test("t2", () => {});`,
+        `  });`,
+        `});`,
+        `test("failing", () => {`,
+        `  expect(1).toBe(2);`,
+        `});`,
+      ].join("\n"),
     });
 
     await using proc = spawn({
-      cmd: [bunExe(), "test", "./my-test.test.js"],
-      cwd: String(test_dir),
-      stdout: "ignore",
-      stderr: "pipe",
+      cmd: [bunExe(), "test", "./stray.test.ts"],
+      cwd: String(dir),
       env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-    const [output, exitCode] = await Promise.all([
-      proc.stderr.text().then(s => s.replaceAll("\r\n", "\n")),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n`);
+    expect(normalizeBunSnapshot(stderr, dir)).toMatchInlineSnapshot(`
+      "stray.test.ts:
 
-    expect(output.match(/^error: ## stray top-level rejection ##$/gm)).toHaveLength(1);
-    expect(output).toContain("Unhandled error between tests");
-    expect(output).toMatch(/\(fail\) t1 failing/);
-    expect(output).toMatch(/\(pass\) t2/);
-    expect(output).toContain("\n 1 pass\n");
-    expect(output).toContain("\n 1 fail\n");
-    expect(output).toContain("\n 1 error\n");
-    expect(output).toContain("Ran 2 tests across 1 file");
+      # Unhandled error between tests
+      -------------------------------
+      1 | import { describe, expect, test } from "bun:test";
+      2 | Promise.reject(new Error("stray-top-level"));
+                             ^
+      error: stray-top-level
+            at <dir>/stray.test.ts:2:20
+      -------------------------------
+
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | import { describe, expect, test } from "bun:test";
+      2 | Promise.reject(new Error("stray-top-level"));
+      3 | test.each([[Promise.reject(new Error("stray-each-row"))], [Promise.resolve(1)]])("row %#", value => {
+                                         ^
+      error: stray-each-row
+            at <dir>/stray.test.ts:3:32
+      -------------------------------
+
+
+      # Unhandled error between tests
+      -------------------------------
+      2 | Promise.reject(new Error("stray-top-level"));
+      3 | test.each([[Promise.reject(new Error("stray-each-row"))], [Promise.resolve(1)]])("row %#", value => {
+      4 |   expect(value).toBeInstanceOf(Promise);
+      5 | });
+      6 | describe("d", () => {
+      7 |   Promise.reject(new Error("stray-in-describe"));
+                               ^
+      error: stray-in-describe
+          at <anonymous> (file:NN:NN)
+      -------------------------------
+
+      (pass) row 0
+      (pass) row 1
+      (pass) d > t1
+      (pass) d > inner > t2
+       9 |   describe("inner", () => {
+      10 |     test("t2", () => {});
+      11 |   });
+      12 | });
+      13 | test("failing", () => {
+      14 |   expect(1).toBe(2);
+                       ^
+      error: expect(received).toBe(expected)
+
+      Expected: 2
+      Received: 1
+          at <anonymous> (file:NN:NN)
+      (fail) failing
+
+       4 pass
+       1 fail
+       3 errors
+       3 expect() calls
+      Ran 5 tests across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("from a --preload module", async () => {
+    using dir = tempDir("unhandled-collection-preload", {
+      "package.json": "{}",
+      // Flush left, no blank lines: the code frames below are part of the snapshot.
+      "preload.ts": [
+        `Promise.reject(new Error("stray-preload-rejection"));`,
+        `queueMicrotask(() => {`,
+        `  throw new Error("stray-preload-exception");`,
+        `});`,
+      ].join("\n"),
+      "a.test.ts": [
+        `import { expect, test } from "bun:test";`,
+        `test("a1", () => {`,
+        `  expect(1).toBe(2);`,
+        `});`,
+        `test("a2", async () => {`,
+        `  await 0;`,
+        `});`,
+      ].join("\n"),
+      "b.test.ts": [
+        `import { describe, test } from "bun:test";`,
+        `describe("d", () => {`,
+        `  test("b1", () => {});`,
+        `});`,
+      ].join("\n"),
+    });
+
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "test",
+        "--preload",
+        "./preload.ts",
+        "--reporter=junit",
+        "--reporter-outfile=junit.xml",
+        "./a.test.ts",
+        "./b.test.ts",
+      ],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n`);
+    expect(normalizeBunSnapshot(stderr, dir)).toMatchInlineSnapshot(`
+      "a.test.ts:
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | Promise.reject(new Error("stray-preload-rejection"));
+      2 | queueMicrotask(() => {
+      3 |   throw new Error("stray-preload-exception");
+                                                     ^
+      error: stray-preload-exception
+          at <anonymous> (file:NN:NN)
+      -------------------------------
+
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | Promise.reject(new Error("stray-preload-rejection"));
+                             ^
+      error: stray-preload-rejection
+            at <dir>/preload.ts:1:20
+      -------------------------------
+
+      1 | import { expect, test } from "bun:test";
+      2 | test("a1", () => {
+      3 |   expect(1).toBe(2);
+                      ^
+      error: expect(received).toBe(expected)
+
+      Expected: 2
+      Received: 1
+          at <anonymous> (file:NN:NN)
+      (fail) a1
+      (pass) a2
+
+      b.test.ts:
+      (pass) d > b1
+
+       2 pass
+       1 fail
+       2 errors
+       1 expect() calls
+      Ran 3 tests across 2 files."
+    `);
+    const junit = await Bun.file(join(String(dir), "junit.xml")).text();
+    expect([...junit.matchAll(/<testcase name="([^"]+)"/g)].map(m => m[1]).sort()).toEqual(["a1", "a2", "b1"]);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -783,7 +783,10 @@ test("my-test", () => {
       stderr: "pipe",
       env: bunEnv,
     });
-    const [output, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [output, exitCode] = await Promise.all([
+      proc.stderr.text().then(s => s.replaceAll("\r\n", "\n")),
+      proc.exited,
+    ]);
 
     expect(output.match(/^error: ## late throw from a ##$/gm)).toHaveLength(1);
     expect(output).toContain("Unhandled error between tests");
@@ -835,7 +838,10 @@ test("my-test", () => {
       stderr: "pipe",
       env: bunEnv,
     });
-    const [output, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [output, exitCode] = await Promise.all([
+      proc.stderr.text().then(s => s.replaceAll("\r\n", "\n")),
+      proc.exited,
+    ]);
 
     expect(output.match(/^error: ## late throw from a ##$/gm)).toHaveLength(1);
     expect(output).not.toContain("Cannot call test()");
@@ -869,7 +875,10 @@ test("my-test", () => {
       stderr: "pipe",
       env: bunEnv,
     });
-    const [output, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [output, exitCode] = await Promise.all([
+      proc.stderr.text().then(s => s.replaceAll("\r\n", "\n")),
+      proc.exited,
+    ]);
 
     expect(output.match(/^error: ## stray top-level rejection ##$/gm)).toHaveLength(1);
     expect(output).toContain("Unhandled error between tests");


### PR DESCRIPTION
### Problem
- An unhandled error that lands while a file is still collecting makes that file's tests vanish. A top-level `Promise.reject(...)`, a rejected promise in a `.each` table, or a `--preload` that rejects gives `Ran 0 tests`. A leaked timer from the previous file that throws during this file's top-level `await` gives `Cannot call test() after the test run has completed`. #37968 reports the same knock-on under `--isolate` after its `epoll_ctl` error lands during a file's load.
- Cause: `on_unhandled_rejection` (`src/runtime/test_runner/jest.rs:594`) handled `Phase::Collection` like `Phase::Execution`. It failed the active scope (the root scope at the top level), then stepped the collector as if the `describe()` callback in flight had completed. With none in flight, the file went to `Done` with zero tests.

### Fix
- In `Phase::Collection`, `on_unhandled_rejection` reports an unhandled error between tests and leaves the collector alone. The exit code stays 1.
- `Collection::handle_uncaught_exception` fails the active scope only for `RefDataValue::Collection`, which is what a `describe()` callback's own throw or rejection passes.
- Behavior change, needs a reviewer's yes: a stray error while an async `describe()` awaits, or a stray rejection a sync `describe()` body created, no longer drops that describe's tests. Vitest does the same. `node --test` does the same unless the describe's own async work threw (see Notes).
- Verified: `test/js/bun/test/test-test.test.ts`, four new cases, all fail on 1.4.3-canary. Two of them and the docs update come from #41998, which this PR replaces.

### Background
- `bun test` runs a file in two phases. Collection evaluates the module, then runs the queued `describe()` callbacks one at a time. A `RefDataValue::Collection` result means "the callback in flight completed". Execution runs what was collected.
- In default mode all files share one global. A callback that an earlier file left behind runs while a later file is active. `--isolate` fences those (#41831).

<details><summary>Notes</summary>

- Same-file variants fixed by the same change: `Promise.reject(x); test(...)` at the top level ran zero tests; `setTimeout(() => { throw }, 10); await Bun.sleep(50); test(...)` hit the `Cannot call test()` path.
- Phantom tests, verified on stock 1.4.3: `a.test.ts` has `describe("outer", async () => { setTimeout(() => { throw }, 10); await Bun.sleep(50); test("d1"); test("d2") })`, `b.test.ts` has a top-level `await Bun.sleep(100)`. The stray error advanced the collector past the awaiting callback, which abandoned it, so `d1` and `d2` were registered, reported and run under `b.test.ts`. With this change they stay in `a.test.ts`.
- The error is still printed and counted in every case, so the exit code stays 1.
- Other runners, for `describe("d", async () => { await x; test("t1"); test("t2") }); test("t3")` with an unhandled error landing during the `await`. Vitest 5.0.0: `t1`, `t2`, `t3` run and pass, `Errors 1 error`, exit 1, whether the timer or rejection was created at the top level or inside the describe body. Node v26.3.0 `--test`: when the error comes from outside the describe (a top-level timer or `Promise.reject`), suite `d` passes with `t1` and `t2`, and the file is failed with "A resource generated asynchronous activity after the test ended". Node fails suite `d` only when the error comes from the describe's own async context (a timer or rejection created inside its body), which it attributes through async hooks. `bun test` has no such origin tracking, so this PR takes the Vitest line: a stray error never fails a pending describe.
- #41998 fixed the same two functions. It differed only in the pending async `describe()` case, where it kept today's behaviour (fail the describe, step the collector). That keeps the phantom-test path above and lets a late settle of the abandoned describe promise step the collector while another callback is in flight. Its `.each`, describe-body and `--preload` tests and its docs update are carried over here unchanged and pass on this branch.
- A `describe()` callback whose returned promise never settles hangs collection today (`describe("d", () => new Promise(() => {}))` never finishes on 1.4.3). Before this change an unrelated unhandled error ended that wait (and dropped the describe). Now it does not.
- Not addressed here, and not addressable without an origin marker: which file a late error is attributed to. The error from `a.test.ts` still prints under `b.test.ts:` with `a.test.ts` in its stack. And when the next file has no top-level `await`, the late error lands during that file's execution phase and fails whichever of its tests is running then; that path (`Execution::handle_uncaught_exception`) is unchanged.
- #37968 itself (the `EEXIST ... epoll_ctl` error under `--isolate`) is not fixed here; only its knock-on, the loading file's tests vanishing behind `Cannot call describe() after the test run has completed`, goes away.
- Suites run on the debug build: `test/js/bun/test/{test-test,describe,bun_test,nested-describes,failure-skip,jest-hooks,test-on-test-finished,done-async}.test.ts`, `test/cli/test/{bun-test,test-timeout-behavior,isolation,test-filter-lifecycle-snapshot}.test.ts`, `test/js/node/test_runner/node-test.test.ts`. `test/regression/issue/10139.test.ts` times out on the debug build with and without this change (128 MB bundle in 5 s).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts

<!-- robobun:evidence:end -->